### PR TITLE
fetch participant state parallel

### DIFF
--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -10,6 +10,8 @@ use crate::protocol::ParticipantInfo;
 use crate::protocol::ProtocolState;
 use crate::web::StateView;
 use mpc_keys::hpke::Ciphered;
+use std::sync::Arc;
+use tokio::task::JoinSet;
 
 // TODO: this is a basic connection pool and does not do most of the work yet. This is
 //       mostly here just to facilitate offline node handling for now.
@@ -60,41 +62,77 @@ impl Pool {
         }
     }
 
-    pub async fn ping(&self) -> Participants {
+    // self typed Arc<Self> so it can be passed between tokio tasks
+    pub async fn ping(self: Arc<Self>) -> Participants {
+        // Check if the current active participants are still valid
         if let Some((ref active, timestamp)) = *self.current_active.read().await {
             if timestamp.elapsed() < self.refresh_active_timeout {
                 return active.clone();
             }
         }
 
-        let connections = self.connections.read().await;
+        let connections = self.connections.read().await.clone(); // Clone connections for iteration
+        let mut join_set = JoinSet::new();
+
+        // Spawn tasks for each participant
+        for (participant, info) in connections.iter() {
+            let participant = *participant;
+            let info = info.clone();
+            let self_clone = Arc::clone(&self); // Clone Arc for use inside tasks
+
+            join_set.spawn(async move {
+                match self_clone.fetch_participant_state(&info).await {
+                    Ok(state) => match self_clone.send_empty_msg(&participant, &info).await {
+                        Ok(()) => Ok((participant, state, info)),
+                        Err(e) => {
+                            tracing::warn!(
+                                "Send empty msg for participant {participant:?} with url {} has failed with error {e}.",
+                                info.url
+                            );
+                            Err(())
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!(
+                            "Fetch state for participant {participant:?} with url {} has failed with error {e}.",
+                            info.url
+                        );
+                        Err(())
+                    }
+                }
+            });
+        }
 
         let mut status = self.status.write().await;
         let mut participants = Participants::default();
-        for (participant, info) in connections.iter() {
-            match self.fetch_participant_state(info).await {
-                Ok(state) => match self.send_empty_msg(participant, info).await {
-                    Ok(()) => {
-                        status.insert(*participant, state);
-                        participants.insert(participant, info.clone());
-                    }
-                    Err(e) => {
-                        tracing::warn!("Send empty msg for participant {participant:?} with url {} has failed with error {e}.", info.url);
-                    }
-                },
+
+        // Process completed tasks
+        while let Some(result) = join_set.join_next().await {
+            match result {
+                Ok(Ok((participant, state, info))) => {
+                    status.insert(participant, state);
+                    participants.insert(&participant, info);
+                }
+                Ok(Err(())) => {
+                    // Already logged in task
+                }
                 Err(e) => {
-                    tracing::warn!("Fetch state for participant {participant:?} with url {} has failed with error {e}.", info.url);
+                    tracing::warn!("fetch participant state task panicked: {e}");
                 }
             }
         }
+
         drop(status);
 
+        // Update the active participants
         let mut active = self.current_active.write().await;
         *active = Some((participants.clone(), Instant::now()));
+
         participants
     }
 
-    pub async fn ping_potential(&self) -> Participants {
+    // self typed Arc<Self> so it can be passed between tokio tasks
+    pub async fn ping_potential(self: Arc<Self>) -> Participants {
         if let Some((ref active, timestamp)) = *self.potential_active.read().await {
             if timestamp.elapsed() < self.refresh_active_timeout {
                 return active.clone();
@@ -103,28 +141,62 @@ impl Pool {
 
         let connections = self.potential_connections.read().await;
 
+        let mut join_set = JoinSet::new();
+
+        // Spawn tasks for each participant
+        for (participant, info) in connections.iter() {
+            let participant = *participant;
+            let info = info.clone();
+            let self_clone = Arc::clone(&self); // Clone Arc for use inside tasks
+
+            join_set.spawn(async move {
+                match self_clone.fetch_participant_state(&info).await {
+                    Ok(state) => match self_clone.send_empty_msg(&participant, &info).await {
+                        Ok(()) => Ok((participant, state, info)),
+                        Err(e) => {
+                            tracing::warn!(
+                                "Send empty msg for participant {participant:?} with url {} has failed with error {e}.",
+                                info.url
+                            );
+                            Err(())
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!(
+                            "Fetch state for participant {participant:?} with url {} has failed with error {e}.",
+                            info.url
+                        );
+                        Err(())
+                    }
+                }
+            });
+        }
+
         let mut status = self.status.write().await;
         let mut participants = Participants::default();
-        for (participant, info) in connections.iter() {
-            match self.fetch_participant_state(info).await {
-                Ok(state) => match self.send_empty_msg(participant, info).await {
-                    Ok(()) => {
-                        status.insert(*participant, state);
-                        participants.insert(participant, info.clone());
-                    }
-                    Err(e) => {
-                        tracing::warn!("Send empty msg for participant {participant:?} with url {} has failed with error {e}.", info.url);
-                    }
-                },
+
+        // Process completed tasks
+        while let Some(result) = join_set.join_next().await {
+            match result {
+                Ok(Ok((participant, state, info))) => {
+                    status.insert(participant, state);
+                    participants.insert(&participant, info);
+                }
+                Ok(Err(())) => {
+                    // Already logged in task
+                }
                 Err(e) => {
-                    tracing::warn!("Fetch state for participant {participant:?} with url {} has failed with error {e}.", info.url);
+                    tracing::warn!("fetch participant state task panicked: {e}");
                 }
             }
         }
+
         drop(status);
 
+        // Update the active participants
         let mut potential_active = self.potential_active.write().await;
         *potential_active = Some((participants.clone(), Instant::now()));
+
         participants
     }
 


### PR DESCRIPTION
Using tokio JoinSet.
`pub async fn ping(self: Arc<Self>) -> Participants` takes in Arc<Self> so that it can be passed among different tasks when calling `join_set.spawn()`