### PR TITLE
feat: added faster linker for macos

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,4 +12,6 @@ rustflags = [
   "-L", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib",
   "-C", "link-arg=-undefined",
   "-C", "link-arg=dynamic_lookup",
+  "-C", "link-arg=-fuse-ld=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld",
+  "-C", "link-arg=-ld_new",
 ]


### PR DESCRIPTION
**NOTE**: requires at least Xcode 15 to be installed on your mac machine.

Goes from 11m to 5m fresh integration test build with this.