### PR TITLE
Take two triples in atomic way

### DIFF
--- a/chain-signatures/node/src/protocol/message.rs
+++ b/chain-signatures/node/src/protocol/message.rs
@@ -264,7 +264,7 @@ impl MessageHandler for RunningState {
 
             // if triple id is in GC, remove these messages because the triple is currently
             // being GC'ed, where this particular triple has previously failed or been utilized.
-            !triple_manager.refresh_gc(id)
+            !triple_manager.refresh_gc(*id)
         });
         for (id, queue) in triple_messages {
             let protocol = match triple_manager

--- a/chain-signatures/node/src/protocol/message.rs
+++ b/chain-signatures/node/src/protocol/message.rs
@@ -343,7 +343,7 @@ impl MessageHandler for RunningState {
                 Err(
                     err @ (GenerationError::AlreadyGenerated
                     | GenerationError::TripleIsGarbageCollected(_)
-                    | GenerationError::TripleIsMissing(_)),
+                    | GenerationError::TripleStoreError(_)),
                 ) => {
                     // This triple has already been generated or removed from the triple manager, so we will have to bin
                     // the entirety of the messages we received for this presignature id, and have the other nodes timeout

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -489,8 +489,7 @@ impl PresignatureManager {
             match self.generators.entry(id) {
                 Entry::Vacant(entry) => {
                     tracing::info!(id, "joining protocol to generate a new presignature");
-                    let (triple0, triple1) = match triple_manager.take_two(&triple0, &triple1).await
-                    {
+                    let (triple0, triple1) = match triple_manager.take_two(triple0, triple1).await {
                         Ok(result) => result,
                         Err(error) => match error {
                             GenerationError::TripleIsGenerating(_) => {

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -131,8 +131,8 @@ pub enum GenerationError {
     AlreadyGenerated,
     #[error("cait-sith initialization error: {0}")]
     CaitSithInitializationError(#[from] InitializationError),
-    #[error("triple {0} is missing")]
-    TripleIsMissing(TripleId),
+    #[error("triple storage error: {0}")]
+    TripleStoreError(String),
     #[error("triple {0} is generating")]
     TripleIsGenerating(TripleId),
     #[error("triple {0} is in garbage collection")]
@@ -489,7 +489,8 @@ impl PresignatureManager {
             match self.generators.entry(id) {
                 Entry::Vacant(entry) => {
                     tracing::info!(id, "joining protocol to generate a new presignature");
-                    let (triple0, triple1) = match triple_manager.take_two(triple0, triple1).await {
+                    let (triple0, triple1) = match triple_manager.take_two(&triple0, &triple1).await
+                    {
                         Ok(result) => result,
                         Err(error) => match error {
                             GenerationError::TripleIsGenerating(_) => {
@@ -512,13 +513,13 @@ impl PresignatureManager {
                                 );
                                 return Err(error);
                             }
-                            GenerationError::TripleIsMissing(_) => {
+                            GenerationError::TripleStoreError(_) => {
                                 tracing::warn!(
                                     ?error,
                                     id,
                                     triple0,
                                     triple1,
-                                    "could not initiate non-introduced presignature: one triple is missing"
+                                    "could not initiate non-introduced presignature: triple store error"
                                 );
                                 return Err(error);
                             }

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -179,23 +179,23 @@ impl TripleManager {
         id0: &TripleId,
         id1: &TripleId,
     ) -> Result<(Triple, Triple), GenerationError> {
-        if self.generators.contains_key(&id0) {
+        if self.generators.contains_key(id0) {
             tracing::warn!(id0, "triple is generating");
             return Err(GenerationError::TripleIsGenerating(*id0));
-        } else if self.gc.contains_key(&id0) {
+        } else if self.gc.contains_key(id0) {
             tracing::warn!(id0, "triple is garbage collected");
             return Err(GenerationError::TripleIsGarbageCollected(*id0));
-        } else if self.generators.contains_key(&id1) {
+        } else if self.generators.contains_key(id1) {
             tracing::warn!(id1, "triple is generating");
             return Err(GenerationError::TripleIsGenerating(*id1));
-        } else if self.gc.contains_key(&id1) {
+        } else if self.gc.contains_key(id1) {
             tracing::warn!(id1, "triple is garbage collected");
             return Err(GenerationError::TripleIsGarbageCollected(*id1));
         }
 
         let (triple_0, triple_1) =
             self.triple_storage
-                .take_two(&id0, &id1)
+                .take_two(id0, id1)
                 .await
                 .map_err(|store_error| {
                     tracing::warn!(?store_error, "failed to take two triples");

--- a/chain-signatures/node/src/storage/error.rs
+++ b/chain-signatures/node/src/storage/error.rs
@@ -1,6 +1,4 @@
 use crate::protocol::presignature::PresignatureId;
-use crate::protocol::triple::TripleId;
-
 pub type StoreResult<T> = std::result::Result<T, StoreError>;
 
 #[derive(Debug, thiserror::Error)]
@@ -9,10 +7,10 @@ pub enum StoreError {
     Redis(#[from] redis::RedisError),
     #[error("storage connection error: {0}")]
     Connect(#[from] anyhow::Error),
-    #[error("missing triple: id={0}")]
-    TripleIsMissing(TripleId),
     #[error("missing presignature: {0}")]
     PresignatureIsMissing(PresignatureId),
     #[error("empty: {0}")]
     Empty(&'static str),
+    #[error("other: {0}")]
+    Other(String),
 }

--- a/chain-signatures/node/src/storage/triple_storage.rs
+++ b/chain-signatures/node/src/storage/triple_storage.rs
@@ -54,20 +54,103 @@ impl TripleStorage {
         Ok(result)
     }
 
-    pub async fn take(&self, id: &TripleId) -> StoreResult<Triple> {
+    pub async fn take_two(&self, id1: &TripleId, id2: &TripleId) -> StoreResult<(Triple, Triple)> {
         let mut conn = self.connect().await?;
-        let triple: Option<Triple> = conn.hget(self.triple_key(), id).await?;
-        let triple = triple.ok_or_else(|| StoreError::TripleIsMissing(*id))?;
-        conn.hdel::<&str, TripleId, ()>(&self.triple_key(), *id)
-            .await?;
-        Ok(triple)
+
+        let lua_script = r#"
+            -- Check if the given IDs belong to the mine triples set
+            if redis.call("SISMEMBER", KEYS[2], ARGV[1]) == 1 then
+                return {err = "Triple " .. ARGV[1] .. " cannot be taken as foreign"}
+            end
+    
+            if redis.call("SISMEMBER", KEYS[2], ARGV[2]) == 1 then
+                return {err = "Triple " .. ARGV[2] .. " cannot be taken as foreign"}
+            end
+    
+            -- Fetch the triples
+            local v1 = redis.call("HGET", KEYS[1], ARGV[1])
+            if not v1 then
+                return {err = "Triple " .. ARGV[1] .. " is missing"}
+            end
+    
+            local v2 = redis.call("HGET", KEYS[1], ARGV[2])
+            if not v2 then
+                return {err = "Triple " .. ARGV[2] .. " is missing"}
+            end
+    
+            -- Delete the triples from the hash map
+            redis.call("HDEL", KEYS[1], ARGV[1], ARGV[2])
+    
+            -- Return the triples
+            return {v1, v2}
+        "#;
+
+        let result: Result<(Option<Triple>, Option<Triple>), redis::RedisError> =
+            redis::Script::new(lua_script)
+                .key(self.triple_key())
+                .key(self.mine_key())
+                .arg(id1.to_string())
+                .arg(id2.to_string())
+                .invoke_async(&mut conn)
+                .await;
+
+        match result {
+            Ok((Some(triple1), Some(triple2))) => Ok((triple1, triple2)),
+            Ok(_) => Err(StoreError::Other(
+                "Unexpected Lua script result, must return full result or error".to_owned(),
+            )),
+            Err(err) => Err(StoreError::from(err)),
+        }
     }
 
-    pub async fn take_mine(&self) -> StoreResult<Triple> {
+    pub async fn take_two_mine(&self) -> StoreResult<(Triple, Triple)> {
         let mut conn = self.connect().await?;
-        let id: Option<TripleId> = conn.spop(self.mine_key()).await?;
-        let id = id.ok_or_else(|| StoreError::Empty("mine triple stockpile"))?;
-        self.take(&id).await
+
+        let lua_script = r#"
+            -- Check the number of elements in the set
+            local count = redis.call("SCARD", KEYS[1])
+    
+            if count < 2 then
+                return {err = "Mine triple stockpile does not have enough elements"}
+            end
+    
+            -- Pop two IDs atomically
+            local id1 = redis.call("SPOP", KEYS[1])
+            local id2 = redis.call("SPOP", KEYS[1])
+    
+            -- Retrieve the corresponding triples
+            local v1 = redis.call("HGET", KEYS[2], id1)
+            if not v1 then
+                return {err = "Triple " .. id1 .. " is missing"}
+            end
+    
+            local v2 = redis.call("HGET", KEYS[2], id2)
+            if not v2 then
+                return {err = "Triple " .. id2 .. " is missing"}
+            end
+    
+            -- Delete the triples from the hash map
+            redis.call("HDEL", KEYS[2], id1, id2)
+    
+            -- Return the triples as a response
+            return {v1, v2}
+        "#;
+
+        // TODO: can we get rid of option here?
+        let result: Result<(Option<Triple>, Option<Triple>), redis::RedisError> =
+            redis::Script::new(lua_script)
+                .key(self.mine_key())
+                .key(self.triple_key())
+                .invoke_async(&mut conn)
+                .await;
+
+        match result {
+            Ok((Some(triple1), Some(triple2))) => Ok((triple1, triple2)),
+            Ok(_) => Err(StoreError::Other(
+                "Unexpected Lua script result, must return full result or error".to_owned(),
+            )),
+            Err(err) => Err(StoreError::from(err)),
+        }
     }
 
     pub async fn len_generated(&self) -> StoreResult<usize> {

--- a/chain-signatures/node/src/storage/triple_storage.rs
+++ b/chain-signatures/node/src/storage/triple_storage.rs
@@ -107,11 +107,11 @@ impl TripleStorage {
         let mut conn = self.connect().await?;
 
         let lua_script = r#"
-            -- Check the number of elements in the set
+            -- Check the number of triples in the set
             local count = redis.call("SCARD", KEYS[1])
     
             if count < 2 then
-                return {err = "Mine triple stockpile does not have enough elements"}
+                return {err = "Mine triple stockpile does not have enough triples"}
             end
     
             -- Pop two IDs atomically
@@ -121,12 +121,12 @@ impl TripleStorage {
             -- Retrieve the corresponding triples
             local v1 = redis.call("HGET", KEYS[2], id1)
             if not v1 then
-                return {err = "Triple " .. id1 .. " is missing"}
+                return {err = "Unexpected behavior. Triple " .. id1 .. " is missing"}
             end
     
             local v2 = redis.call("HGET", KEYS[2], id2)
             if not v2 then
-                return {err = "Triple " .. id2 .. " is missing"}
+                return {err = "Unexpected behavior. Triple " .. id2 .. " is missing"}
             end
     
             -- Delete the triples from the hash map

--- a/chain-signatures/node/src/storage/triple_storage.rs
+++ b/chain-signatures/node/src/storage/triple_storage.rs
@@ -42,19 +42,19 @@ impl TripleStorage {
         Ok(())
     }
 
-    pub async fn contains(&self, id: &TripleId) -> StoreResult<bool> {
+    pub async fn contains(&self, id: TripleId) -> StoreResult<bool> {
         let mut conn = self.connect().await?;
         let result: bool = conn.hexists(self.triple_key(), id).await?;
         Ok(result)
     }
 
-    pub async fn contains_mine(&self, id: &TripleId) -> StoreResult<bool> {
+    pub async fn contains_mine(&self, id: TripleId) -> StoreResult<bool> {
         let mut conn = self.connect().await?;
         let result: bool = conn.sismember(self.mine_key(), id).await?;
         Ok(result)
     }
 
-    pub async fn take_two(&self, id1: &TripleId, id2: &TripleId) -> StoreResult<(Triple, Triple)> {
+    pub async fn take_two(&self, id1: TripleId, id2: TripleId) -> StoreResult<(Triple, Triple)> {
         let mut conn = self.connect().await?;
 
         let lua_script = r#"

--- a/integration-tests/chain-signatures/tests/cases/mod.rs
+++ b/integration-tests/chain-signatures/tests/cases/mod.rs
@@ -233,8 +233,8 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     let triple_2 = dummy_triple(triple_id_2);
 
     // Check that the storage is empty at the start
-    assert!(!triple_manager.contains(&triple_id_1).await);
-    assert!(!triple_manager.contains_mine(&triple_id_1).await);
+    assert!(!triple_manager.contains(triple_id_1).await);
+    assert!(!triple_manager.contains_mine(triple_id_1).await);
     assert_eq!(triple_manager.len_generated().await, 0);
     assert_eq!(triple_manager.len_mine().await, 0);
     assert!(triple_manager.is_empty().await);
@@ -244,23 +244,23 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     triple_manager.insert(triple_2, false).await;
 
     // Check that the storage contains the foreign triple
-    assert!(triple_manager.contains(&triple_id_1).await);
-    assert!(triple_manager.contains(&triple_id_2).await);
-    assert!(!triple_manager.contains_mine(&triple_id_1).await);
-    assert!(!triple_manager.contains_mine(&triple_id_2).await);
+    assert!(triple_manager.contains(triple_id_1).await);
+    assert!(triple_manager.contains(triple_id_2).await);
+    assert!(!triple_manager.contains_mine(triple_id_1).await);
+    assert!(!triple_manager.contains_mine(triple_id_2).await);
     assert_eq!(triple_manager.len_generated().await, 2);
     assert_eq!(triple_manager.len_mine().await, 0);
     assert_eq!(triple_manager.len_potential().await, 2);
 
     // Take triple and check that it is removed from the storage
     triple_manager
-        .take_two(&triple_id_1, &triple_id_2)
+        .take_two(triple_id_1, triple_id_2)
         .await
         .unwrap();
-    assert!(!triple_manager.contains(&triple_id_1).await);
-    assert!(!triple_manager.contains(&triple_id_2).await);
-    assert!(!triple_manager.contains_mine(&triple_id_1).await);
-    assert!(!triple_manager.contains_mine(&triple_id_2).await);
+    assert!(!triple_manager.contains(triple_id_1).await);
+    assert!(!triple_manager.contains(triple_id_2).await);
+    assert!(!triple_manager.contains_mine(triple_id_1).await);
+    assert!(!triple_manager.contains_mine(triple_id_2).await);
     assert_eq!(triple_manager.len_generated().await, 0);
     assert_eq!(triple_manager.len_mine().await, 0);
     assert_eq!(triple_manager.len_potential().await, 0);
@@ -273,20 +273,20 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     // Add mine triple and check that it is in the storage
     triple_manager.insert(mine_triple_1, true).await;
     triple_manager.insert(mine_triple_2, true).await;
-    assert!(triple_manager.contains(&mine_id_1).await);
-    assert!(triple_manager.contains(&mine_id_2).await);
-    assert!(triple_manager.contains_mine(&mine_id_1).await);
-    assert!(triple_manager.contains_mine(&mine_id_2).await);
+    assert!(triple_manager.contains(mine_id_1).await);
+    assert!(triple_manager.contains(mine_id_2).await);
+    assert!(triple_manager.contains_mine(mine_id_1).await);
+    assert!(triple_manager.contains_mine(mine_id_2).await);
     assert_eq!(triple_manager.len_generated().await, 2);
     assert_eq!(triple_manager.len_mine().await, 2);
     assert_eq!(triple_manager.len_potential().await, 2);
 
     // Take mine triple and check that it is removed from the storage
     triple_manager.take_two_mine().await.unwrap();
-    assert!(!triple_manager.contains(&mine_id_1).await);
-    assert!(!triple_manager.contains(&mine_id_2).await);
-    assert!(!triple_manager.contains_mine(&mine_id_1).await);
-    assert!(!triple_manager.contains_mine(&mine_id_2).await);
+    assert!(!triple_manager.contains(mine_id_1).await);
+    assert!(!triple_manager.contains(mine_id_2).await);
+    assert!(!triple_manager.contains_mine(mine_id_1).await);
+    assert!(!triple_manager.contains_mine(mine_id_2).await);
     assert_eq!(triple_manager.len_generated().await, 0);
     assert_eq!(triple_manager.len_mine().await, 0);
     assert!(triple_manager.is_empty().await);

--- a/integration-tests/chain-signatures/tests/cases/mod.rs
+++ b/integration-tests/chain-signatures/tests/cases/mod.rs
@@ -229,7 +229,7 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
 
     let triple_id_1: u64 = 1;
     let triple_1 = dummy_triple(triple_id_1);
-    let triple_id_2: u64 = 2;  
+    let triple_id_2: u64 = 2;
     let triple_2 = dummy_triple(triple_id_2);
 
     // Check that the storage is empty at the start

--- a/integration-tests/chain-signatures/tests/cases/mod.rs
+++ b/integration-tests/chain-signatures/tests/cases/mod.rs
@@ -229,7 +229,7 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
 
     let triple_id_1: u64 = 1;
     let triple_1 = dummy_triple(triple_id_1);
-    let triple_id_2: u64 = 2;
+    let triple_id_2: u64 = 2;  
     let triple_2 = dummy_triple(triple_id_2);
 
     // Check that the storage is empty at the start
@@ -254,7 +254,7 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
 
     // Take triple and check that it is removed from the storage
     triple_manager
-        .take_two(triple_id_1, triple_id_2)
+        .take_two(&triple_id_1, &triple_id_2)
         .await
         .unwrap();
     assert!(!triple_manager.contains(&triple_id_1).await);


### PR DESCRIPTION
Making all operations atomic prevents race conditions, especially in multithreaded and multi-node design. It also decreases the number of Redis calls and simplifies the code, although we lose some error types.

I plan to adopt this approach in other places if we stick with it.