### PR TITLE
Atomic insertion of presignatures and triples

### DIFF
--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -223,14 +223,6 @@ impl PresignatureManager {
     }
 
     pub async fn take(&mut self, id: PresignatureId) -> Result<Presignature, GenerationError> {
-        if self.contains_mine(&id).await {
-            tracing::error!(?id, "cannot take mine presignature as foreign owned");
-            return Err(GenerationError::PresignatureDenied(
-                id,
-                "cannot take mine presignature as foreign owned",
-            ));
-        }
-
         let presignature = self
             .presignature_storage
             .take(&id)

--- a/chain-signatures/node/src/storage/error.rs
+++ b/chain-signatures/node/src/storage/error.rs
@@ -1,4 +1,3 @@
-use crate::protocol::presignature::PresignatureId;
 pub type StoreResult<T> = std::result::Result<T, StoreError>;
 
 #[derive(Debug, thiserror::Error)]
@@ -7,8 +6,6 @@ pub enum StoreError {
     Redis(#[from] redis::RedisError),
     #[error("storage connection error: {0}")]
     Connect(#[from] anyhow::Error),
-    #[error("missing presignature: {0}")]
-    PresignatureIsMissing(PresignatureId),
     #[error("empty: {0}")]
     Empty(&'static str),
     #[error("other: {0}")]

--- a/chain-signatures/node/src/storage/presignature_storage.rs
+++ b/chain-signatures/node/src/storage/presignature_storage.rs
@@ -114,7 +114,7 @@ impl PresignatureStorage {
     
             local presig_id = redis.call("SPOP", mine_key)
             if not presig_id then
-                return {err = "Mine presignature stockpile does not have enough triples"}
+                return {err = "Mine presignature stockpile does not have enough presignatures"}
             end
     
             local presig_value = redis.call("HGET", presig_key, presig_id)

--- a/chain-signatures/node/src/storage/presignature_storage.rs
+++ b/chain-signatures/node/src/storage/presignature_storage.rs
@@ -54,7 +54,7 @@ impl PresignatureStorage {
             .key(self.presig_key())
             .arg(presignature.id)
             .arg(presignature)
-            .arg(mine)
+            .arg(mine.to_string())
             .invoke_async(&mut conn)
             .await?;
 

--- a/chain-signatures/node/src/storage/triple_storage.rs
+++ b/chain-signatures/node/src/storage/triple_storage.rs
@@ -55,7 +55,7 @@ impl TripleStorage {
             .key(self.triple_key())
             .arg(triple.id)
             .arg(triple)
-            .arg(mine)
+            .arg(mine.to_string())
             .invoke_async(&mut conn)
             .await?;
 


### PR DESCRIPTION
Insert and take operations must be atomic. Lua may seem an overhead when we have 2 simple operations, but I want to have a unified approach for storage and flexibility. Already planning to extend those scripts with additional checks.
Also, scripts can be preloaded to Redis, so there is no need to transfer and build them on each call. We may add that optimization when required.