### PR TITLE
Restrict triples and presignatures reusage

### DIFF
--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -222,6 +222,14 @@ impl PresignatureManager {
             .unwrap_or(false)
     }
 
+    pub async fn contains_used(&self, id: &PresignatureId) -> bool {
+        self.presignature_storage
+            .contains_used(id)
+            .await
+            .map_err(|e| tracing::warn!(?e, "failed to check if presignature is used"))
+            .unwrap_or(false)
+    }
+
     pub async fn take(&mut self, id: PresignatureId) -> Result<Presignature, GenerationError> {
         let presignature = self
             .presignature_storage

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -436,11 +436,9 @@ impl PresignatureManager {
                         participants = ?presig_participants.keys_vec(),
                         "running: the intersection of participants is less than the threshold"
                     );
-
-                    // Insert back the triples to be used later since this active set of
-                    // participants were not able to make use of these triples.
-                    triple_manager.insert(triple0, true).await;
-                    triple_manager.insert(triple1, true).await;
+                    // We are not inserting triples back to
+                    //    - prevent triple reusage
+                    //    - prevent a situation where we have a full stockpile of triples that can not be used
                 } else {
                     self.generate(
                         &presig_participants,

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -675,7 +675,7 @@ impl SignatureManager {
             }
 
             let Some(my_request) = my_requests.pop_front() else {
-                // TODO: we are loosing presignature now with no good reason
+                tracing::warn!("Unexpected state, no more requests to handle");
                 continue;
             };
 

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -639,7 +639,7 @@ impl SignatureManager {
             if sig_participants.len() < threshold {
                 tracing::warn!(
                     participants = ?sig_participants.keys_vec(),
-                    "intersection of stable participants and presignature participants is less than threshold, treshing presignature"
+                    "intersection of stable participants and presignature participants is less than threshold, trashing presignature"
                 );
                 continue;
             }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -486,8 +486,7 @@ impl SignatureManager {
                 ) {
                     Ok(generator) => generator,
                     Err((presignature, err @ InitializationError::BadParameters(_))) => {
-                        presignature_manager.insert(presignature, true).await;
-                        tracing::warn!(sign_request = ?sign_request_identifier, presignature_id, ?err, "failed to start signature generation");
+                        tracing::warn!(sign_request = ?sign_request_identifier, presignature.id, ?err, "failed to start signature generation");
                         return Err(GenerationError::CaitSithInitializationError(err));
                     }
                 };
@@ -629,7 +628,6 @@ impl SignatureManager {
             );
             return;
         }
-        let mut failed_presigs = Vec::new();
         while let Some(mut presignature) = {
             if self.failed.is_empty() && my_requests.is_empty() {
                 None
@@ -641,12 +639,10 @@ impl SignatureManager {
             if sig_participants.len() < threshold {
                 tracing::warn!(
                     participants = ?sig_participants.keys_vec(),
-                    "intersection of stable participants and presignature participants is less than threshold"
+                    "intersection of stable participants and presignature participants is less than threshold, treshing presignature"
                 );
-                failed_presigs.push(presignature);
                 continue;
             }
-            let presig_id = presignature.id;
 
             // NOTE: this prioritizes old requests first then tries to do new ones if there's enough presignatures.
             // TODO: we need to decide how to prioritize certain requests over others such as with gas or time of
@@ -664,11 +660,10 @@ impl SignatureManager {
                 {
                     tracing::warn!(
                         ?sign_request_identifier,
-                        presig_id,
+                        presignature.id,
                         ?err,
                         "failed to retry signature generation: trashing presignature"
                     );
-                    failed_presigs.push(presignature);
                     continue;
                 }
 
@@ -680,7 +675,7 @@ impl SignatureManager {
             }
 
             let Some(my_request) = my_requests.pop_front() else {
-                failed_presigs.push(presignature);
+                // TODO: we are loosing presignature now with no good reason
                 continue;
             };
 
@@ -694,16 +689,9 @@ impl SignatureManager {
                 my_request.time_added,
                 cfg,
             ) {
-                failed_presigs.push(presignature);
-                tracing::warn!(request_id = ?CryptoHash(my_request.request_id), presig_id, ?err, "failed to start signature generation: trashing presignature");
+                tracing::warn!(request_id = ?CryptoHash(my_request.request_id), presignature.id, ?err, "failed to start signature generation: trashing presignature");
                 continue;
             }
-        }
-
-        // add back the failed presignatures that were incompatible to be made into
-        // signatures due to failures or lack of participants.
-        for presignature in failed_presigs {
-            presignature_manager.insert(presignature, true).await;
         }
     }
 

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -170,6 +170,14 @@ impl TripleManager {
             .unwrap_or(false)
     }
 
+    pub async fn contains_used(&self, id: TripleId) -> bool {
+        self.triple_storage
+            .contains_used(id)
+            .await
+            .map_err(|e| tracing::warn!(?e, "failed to check if triple is used"))
+            .unwrap_or(false)
+    }
+
     /// Take two unspent triple by theirs id with no way to return it. Only takes
     /// if both of them are present.
     /// It is very important to NOT reuse the same triple twice for two different

--- a/chain-signatures/node/src/storage/presignature_storage.rs
+++ b/chain-signatures/node/src/storage/presignature_storage.rs
@@ -1,7 +1,7 @@
+use chrono::Duration;
 use deadpool_redis::{Connection, Pool};
 use near_sdk::AccountId;
 use redis::{AsyncCommands, FromRedisValue, RedisWrite, ToRedisArgs};
-use chrono::Duration;
 
 use crate::protocol::presignature::{Presignature, PresignatureId};
 use crate::storage::error::{StoreError, StoreResult};

--- a/chain-signatures/node/src/storage/triple_storage.rs
+++ b/chain-signatures/node/src/storage/triple_storage.rs
@@ -1,9 +1,9 @@
 use crate::protocol::triple::{Triple, TripleId};
 use crate::storage::error::{StoreError, StoreResult};
 
+use chrono::Duration;
 use deadpool_redis::{Connection, Pool};
 use redis::{AsyncCommands, FromRedisValue, RedisWrite, ToRedisArgs};
-use chrono::Duration;
 
 use near_account_id::AccountId;
 

--- a/integration-tests/tests/cases/mod.rs
+++ b/integration-tests/tests/cases/mod.rs
@@ -240,8 +240,8 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     assert!(triple_manager.is_empty().await);
     assert_eq!(triple_manager.len_potential().await, 0);
 
-    triple_manager.insert(triple_1, false).await;
-    triple_manager.insert(triple_2, false).await;
+    triple_manager.insert(triple_1.clone(), false).await;
+    triple_manager.insert(triple_2.clone(), false).await;
 
     // Check that the storage contains the foreign triple
     assert!(triple_manager.contains(triple_id_1).await);
@@ -279,8 +279,8 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     let mine_triple_2 = dummy_triple(mine_id_2);
 
     // Add mine triple and check that it is in the storage
-    triple_manager.insert(mine_triple_1, true).await;
-    triple_manager.insert(mine_triple_2, true).await;
+    triple_manager.insert(mine_triple_1.clone(), true).await;
+    triple_manager.insert(mine_triple_2.clone(), true).await;
     assert!(triple_manager.contains(mine_id_1).await);
     assert!(triple_manager.contains(mine_id_2).await);
     assert!(triple_manager.contains_mine(mine_id_1).await);
@@ -332,7 +332,7 @@ async fn test_presignature_persistence() -> anyhow::Result<()> {
         &presignature_storage,
     );
 
-    let presignature = dummy_presignature();
+    let presignature = dummy_presignature(1);
     let presignature_id: PresignatureId = presignature.id;
 
     // Check that the storage is empty at the start
@@ -365,10 +365,11 @@ async fn test_presignature_persistence() -> anyhow::Result<()> {
         .unwrap());
 
     // Attempt to re-insert used presignature and check that it fails
+    let presignature = dummy_presignature(presignature_id);
     presignature_manager.insert(presignature, false).await;
     assert!(!presignature_manager.contains(&presignature_id).await);
 
-    let mine_presignature = dummy_presignature();
+    let mine_presignature = dummy_presignature(2);
     let mine_presig_id: PresignatureId = mine_presignature.id;
 
     // Add mine presignature and check that it is in the storage
@@ -393,15 +394,16 @@ async fn test_presignature_persistence() -> anyhow::Result<()> {
         .unwrap());
 
     // Attempt to re-insert used mine presignature and check that it fails
+    let mine_presignature = dummy_presignature(mine_presig_id);
     presignature_manager.insert(mine_presignature, true).await;
     assert!(!presignature_manager.contains(&mine_presig_id).await);
 
     Ok(())
 }
 
-fn dummy_presignature() -> Presignature {
+fn dummy_presignature(id: u64) -> Presignature {
     Presignature {
-        id: 1,
+        id,
         output: PresignOutput {
             big_r: <Secp256k1 as CurveArithmetic>::AffinePoint::default(),
             k: <Secp256k1 as CurveArithmetic>::Scalar::ZERO,


### PR DESCRIPTION
We are having issues with the pre-signature usage. We should be 100% sure that is never the case. The same goes for triples.

In this PR, I've made the system strict. We should not allow the reinsertion of used triples and pre-signatures.
I've removed the reinsertion logic, it is seldom, but adds complexity to the logic.

Should fix https://github.com/sig-net/mpc/issues/40