### PR TITLE
Update GC logic and purpose

### DIFF
--- a/chain-signatures/node/src/protocol/message.rs
+++ b/chain-signatures/node/src/protocol/message.rs
@@ -303,7 +303,7 @@ impl MessageHandler for RunningState {
             }
 
             // if presignature id is in GC, remove these messages because the presignature is currently
-            // being GC'ed, where this particular presignature has previously failed or been utilized.
+            // being GC'ed, where this particular presignature has previously failed or been generated.
             !presignature_manager.refresh_gc(id)
         });
         for (id, queue) in presignature_messages {

--- a/chain-signatures/node/src/protocol/message.rs
+++ b/chain-signatures/node/src/protocol/message.rs
@@ -247,8 +247,8 @@ impl MessageHandler for RunningState {
         let participants = &mesh_state.active_participants;
         let mut triple_manager = self.triple_manager.write().await;
 
-        // remove the triple_id that has already failed or taken from the triple_bins
-        // and refresh the timestamp of failed and taken
+        // Remove messages for triple generations that have already failed or completed,
+        // and refresh their timestamps.
         let triple_messages = queue.triple_bins.entry(self.epoch).or_default();
         triple_messages.retain(|id, queue| {
             if queue.is_empty()
@@ -262,7 +262,7 @@ impl MessageHandler for RunningState {
                 return false;
             }
 
-            // if triple id is in GC, remove these messages because the triple is currently
+            // If triple id is in GC, remove these messages because the triple is currently
             // being GC'ed, where this particular triple has previously failed or been utilized.
             !triple_manager.refresh_gc(*id)
         });

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -446,7 +446,7 @@ impl SignatureManager {
         let sign_request_identifier =
             SignRequestIdentifier::new(request_id, epsilon, request.payload);
         if self.completed.contains_key(&sign_request_identifier) {
-            tracing::warn!(sign_request_identifier = ?sign_request_identifier.clone(), presignature_id, "presignature has already been used to generate a signature");
+            tracing::warn!(sign_request_identifier = ?sign_request_identifier.clone(), "signature already generated or time out");
             return Err(GenerationError::AlreadyGenerated);
         }
         match self.generators.entry(sign_request_identifier.clone()) {


### PR DESCRIPTION
We should not replace in-memory GC with Redis, since it will create a lot of traffic (at least one call for each message in the system).
I've tried to optimize how GC works, now it is all about protocols. Each protocol can either finish or fail, and that is when we add its id to GC.

The only job for GC now is to prevent the recreation of finished or failed protocols. cc @ChaoticTempest 