### PR TITLE
fix: added triples and presigs back to storage and fix EXPIRE on used

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           docker pull ghcr.io/near/near-lake-indexer:node-2.3.0
           docker pull localstack/localstack:3.5.0
-          docker pull redis:7.0.15
+          docker pull redis:7.4.2
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,9 +52,9 @@ jobs:
 
       - name: Pull Relayer & Sandbox Docker Images
         run: |
-          docker pull ghcr.io/near/os-relayer:12ba6e35690df3979fce0b36a41d0ca0db9c0ab4
           docker pull ghcr.io/near/near-lake-indexer:node-2.3.0
           docker pull localstack/localstack:3.5.0
+          docker pull redis:7.4.2
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -642,6 +642,9 @@ impl SignatureManager {
                     participants = ?sig_participants.keys_vec(),
                     "intersection of stable participants and presignature participants is less than threshold, trashing presignature"
                 );
+                // TODO: do not insert back presignature when we have a clear model for data consistency
+                // between nodes and utilizing only presignatures that meet threshold requirements.
+                presignature_manager.insert(presignature, true, true).await;
                 continue;
             }
 

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -475,10 +475,10 @@ impl TripleManager {
         }
     }
 
-    pub async fn insert(&self, triple: Triple, mine: bool) {
+    pub async fn insert(&self, triple: Triple, mine: bool, back: bool) {
         let id = triple.id;
         tracing::debug!(id, mine, "inserting triple");
-        if let Err(e) = self.triple_storage.insert(triple, mine).await {
+        if let Err(e) = self.triple_storage.insert(triple, mine, back).await {
             tracing::warn!(?e, mine, "failed to insert triple");
         } else {
             self.gc.write().await.remove(&id);
@@ -753,7 +753,7 @@ impl TripleManager {
         }
 
         for (triple, mine) in triples {
-            self.insert(triple, mine).await;
+            self.insert(triple, mine, false).await;
         }
 
         messages

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -5,14 +5,7 @@
 Running integration tests requires you to have redis and sandbox docker images present on your machine:
 
 ```BASH
-docker pull ghcr.io/near/sandbox
-docker pull redis:7.0.15
-```
-
-For M1 you may want to pull the following image instead:
-
-```BASH
-docker pull ghcr.io/near/sandbox:latest-aarch64
+docker pull redis:7.4.2
 ```
 
 In case of authorization issues make sure you have logged into docker using your [access token](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic).

--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -605,7 +605,7 @@ impl Redis {
 
     pub async fn run(docker_client: &DockerClient, network: &str) -> Self {
         tracing::info!("Running Redis container...");
-        let container = GenericImage::new("redis", "7.0.15")
+        let container = GenericImage::new("redis", "7.4.2")
             .with_exposed_port(Self::DEFAULT_REDIS_PORT.tcp())
             .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
             .with_network(network)

--- a/integration-tests/tests/cases/mod.rs
+++ b/integration-tests/tests/cases/mod.rs
@@ -180,8 +180,8 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     assert!(triple_manager.is_empty().await);
     assert_eq!(triple_manager.len_potential().await, 0);
 
-    triple_manager.insert(triple_1.clone(), false).await;
-    triple_manager.insert(triple_2.clone(), false).await;
+    triple_manager.insert(triple_1.clone(), false, false).await;
+    triple_manager.insert(triple_2.clone(), false, false).await;
 
     // Check that the storage contains the foreign triple
     assert!(triple_manager.contains(triple_id_1).await);
@@ -208,9 +208,9 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     assert!(triple_storage.contains_used(triple_id_2).await.unwrap());
 
     // Attempt to re-insert used triples and check that it fails
-    triple_manager.insert(triple_1, false).await;
+    triple_manager.insert(triple_1, false, false).await;
     assert!(!triple_manager.contains(triple_id_1).await);
-    triple_manager.insert(triple_2, false).await;
+    triple_manager.insert(triple_2, false, false).await;
     assert!(!triple_manager.contains(triple_id_2).await);
 
     let mine_id_1: u64 = 3;
@@ -219,8 +219,12 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     let mine_triple_2 = dummy_triple(mine_id_2);
 
     // Add mine triple and check that it is in the storage
-    triple_manager.insert(mine_triple_1.clone(), true).await;
-    triple_manager.insert(mine_triple_2.clone(), true).await;
+    triple_manager
+        .insert(mine_triple_1.clone(), true, false)
+        .await;
+    triple_manager
+        .insert(mine_triple_2.clone(), true, false)
+        .await;
     assert!(triple_manager.contains(mine_id_1).await);
     assert!(triple_manager.contains(mine_id_2).await);
     assert!(triple_manager.contains_mine(mine_id_1).await);
@@ -243,9 +247,9 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     assert!(triple_storage.contains_used(mine_id_2).await.unwrap());
 
     // Attempt to re-insert used mine triples and check that it fails
-    triple_manager.insert(mine_triple_1, true).await;
+    triple_manager.insert(mine_triple_1, true, false).await;
     assert!(!triple_manager.contains(mine_id_1).await);
-    triple_manager.insert(mine_triple_2, true).await;
+    triple_manager.insert(mine_triple_2, true, false).await;
     assert!(!triple_manager.contains(mine_id_2).await);
 
     Ok(())
@@ -283,7 +287,9 @@ async fn test_presignature_persistence() -> anyhow::Result<()> {
     assert!(presignature_manager.is_empty().await);
     assert_eq!(presignature_manager.len_potential().await, 0);
 
-    presignature_manager.insert(presignature, false).await;
+    presignature_manager
+        .insert(presignature, false, false)
+        .await;
 
     // Check that the storage contains the foreign presignature
     assert!(presignature_manager.contains(&presignature_id).await);
@@ -306,14 +312,18 @@ async fn test_presignature_persistence() -> anyhow::Result<()> {
 
     // Attempt to re-insert used presignature and check that it fails
     let presignature = dummy_presignature(presignature_id);
-    presignature_manager.insert(presignature, false).await;
+    presignature_manager
+        .insert(presignature, false, false)
+        .await;
     assert!(!presignature_manager.contains(&presignature_id).await);
 
     let mine_presignature = dummy_presignature(2);
     let mine_presig_id: PresignatureId = mine_presignature.id;
 
     // Add mine presignature and check that it is in the storage
-    presignature_manager.insert(mine_presignature, true).await;
+    presignature_manager
+        .insert(mine_presignature, true, false)
+        .await;
     assert!(presignature_manager.contains(&mine_presig_id).await);
     assert!(presignature_manager.contains_mine(&mine_presig_id).await);
     assert_eq!(presignature_manager.len_generated().await, 1);
@@ -335,7 +345,9 @@ async fn test_presignature_persistence() -> anyhow::Result<()> {
 
     // Attempt to re-insert used mine presignature and check that it fails
     let mine_presignature = dummy_presignature(mine_presig_id);
-    presignature_manager.insert(mine_presignature, true).await;
+    presignature_manager
+        .insert(mine_presignature, true, false)
+        .await;
     assert!(!presignature_manager.contains(&mine_presig_id).await);
 
     Ok(())


### PR DESCRIPTION
- Adds back triple and presignatures to storage if they do not meet the threshold criteria. A new parameter `back` is added for cases where we are sure we want to add these back to storage. Mainly added back to circumvent the cases of inconsistency when one node decides to drop a triple and presignature but others do not or were not aware of it. In the current code, they would never drop these as they do not own them and will purely sit in storage. It's better to have the chance later to use them otherwise we'd still be at the same problem of taking up maximum amount of triples/presignatures we can have per the config.
- Updates to redis 7.4.2 in tests for `HEXPIRE` where `EXPIRE` was deleting the whole set before, which isn't ideal for when we want to expire per triple id or presignature id. Especially when a new triple or presignature gets used, the time to live on this set would get updated and effectively never get deleted.