### PR TITLE
Triple/Presig/Signature protocol performance metrics

### DIFF
--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -483,6 +483,15 @@ pub(crate) static LATEST_BLOCK_NUMBER: LazyLock<IntGaugeVec> = LazyLock::new(|| 
         &["chain", "node_account_id"],
     )
     .unwrap()
+
+pub(crate) static PRESIGNATURE_BEFORE_POKE_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "multichain_presignature_before_poke_delay_sec",
+        "per presignature protocol, delay between generator cration and first poke that returns SendMany/SendPrivate",
+        &["node_account_id"],
+        Some(exponential_buckets(1.0, 1.5, 20).unwrap()),
+    )
+    .unwrap()
 });
 
 pub(crate) static NUM_UNIQUE_SIGN_REQUESTS: LazyLock<CounterVec> = LazyLock::new(|| {
@@ -490,6 +499,105 @@ pub(crate) static NUM_UNIQUE_SIGN_REQUESTS: LazyLock<CounterVec> = LazyLock::new
         "multichain_sign_requests_count_unique",
         "number of multichain sign requests, marked by sign requests indexed and deduped",
         &["chain", "node_account_id"],
+    )
+    .unwrap()
+
+pub(crate) static PRESIGNATURE_ACCRUED_WAIT_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "multichain_presignature_accrued_wait_delay_sec",
+        "per presignature protocol, total accrued wait time between each poke that returned SendMany/SendPrivate/Return",
+        &["node_account_id"],
+        Some(exponential_buckets(1.0, 1.5, 20).unwrap()),
+    )
+    .unwrap()
+});
+
+pub(crate) static TRIPLE_BEFORE_POKE_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "multichain_triple_before_poke_delay_sec",
+        "per triple protocol, delay between generator cration and first poke that returns SendMany/SendPrivate",
+        &["node_account_id"],
+        Some(exponential_buckets(1.0, 1.5, 20).unwrap()),
+    )
+    .unwrap()
+});
+
+pub(crate) static TRIPLE_ACCRUED_WAIT_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "multichain_triple_accrued_wait_delay_sec",
+        "per triple protocol, total accrued wait time between each poke that returned SendMany/SendPrivate/Return",
+        &["node_account_id"],
+        Some(exponential_buckets(1.0, 1.5, 20).unwrap()),
+    )
+    .unwrap()
+});
+
+pub(crate) static SIGNATURE_BEFORE_POKE_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "multichain_signature_before_poke_delay_sec",
+        "per signature protocol, delay between generator cration and first poke that returns SendMany/SendPrivate",
+        &["node_account_id"],
+        Some(exponential_buckets(1.0, 1.5, 20).unwrap()),
+    )
+    .unwrap()
+});
+
+pub(crate) static SIGNATURE_ACCRUED_WAIT_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "multichain_signature_accrued_wait_delay_sec",
+        "per signature protocol, total accrued wait time between each poke that returned SendMany/SendPrivate/Return",
+        &["node_account_id"],
+        Some(exponential_buckets(1.0, 1.5, 20).unwrap()),
+    )
+    .unwrap()
+});
+
+pub(crate) static TRIPLE_LATENCY_TOTAL: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "multichain_triple_latency_total_sec",
+        "Latency of multichain triple generation, start from generator creation, end when triple generation complete.",
+        &["node_account_id"],
+        Some(exponential_buckets(5.0, 1.5, 20).unwrap()),
+    )
+    .unwrap()
+});
+
+pub(crate) static TRIPLE_POKES_CNT: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "multichain_triple_pokes_cnt",
+        "total pokes per triple protocol",
+        &["node_account_id"],
+        None,
+    )
+    .unwrap()
+});
+
+pub(crate) static PRESIGNATURE_POKES_CNT: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "multichain_presignature_pokes_cnt",
+        "total pokes per presignature protocol",
+        &["node_account_id"],
+        None,
+    )
+    .unwrap()
+});
+
+pub(crate) static SIGNATURE_POKES_CNT: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "multichain_signature_pokes_cnt",
+        "total pokes per signature protocol",
+        &["node_account_id"],
+        None,
+    )
+    .unwrap()
+});
+
+pub(crate) static MSG_CLIENT_SEND_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "multichain_msg_client_send_delay_ms",
+        "Delay between message creation and sending to the client",
+        &["node_account_id"],
+        Some(exponential_buckets(0.5, 1.5, 20).unwrap()),
     )
     .unwrap()
 });

--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -483,6 +483,7 @@ pub(crate) static LATEST_BLOCK_NUMBER: LazyLock<IntGaugeVec> = LazyLock::new(|| 
         &["chain", "node_account_id"],
     )
     .unwrap()
+});
 
 pub(crate) static PRESIGNATURE_BEFORE_POKE_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
@@ -501,7 +502,7 @@ pub(crate) static NUM_UNIQUE_SIGN_REQUESTS: LazyLock<CounterVec> = LazyLock::new
         &["chain", "node_account_id"],
     )
     .unwrap()
-
+});
 
 pub(crate) static PRESIGNATURE_ACCRUED_WAIT_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(

--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -486,10 +486,10 @@ pub(crate) static LATEST_BLOCK_NUMBER: LazyLock<IntGaugeVec> = LazyLock::new(|| 
 
 pub(crate) static PRESIGNATURE_BEFORE_POKE_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
-        "multichain_presignature_before_poke_delay_sec",
-        "per presignature protocol, delay between generator cration and first poke that returns SendMany/SendPrivate",
+        "multichain_presignature_before_poke_delay_ms",
+        "per presignature protocol, delay between generator creation and first poke that returns SendMany/SendPrivate",
         &["node_account_id"],
-        Some(exponential_buckets(1.0, 1.5, 20).unwrap()),
+        Some(exponential_buckets(1.0, 1.5, 25).unwrap()),
     )
     .unwrap()
 });
@@ -505,50 +505,80 @@ pub(crate) static NUM_UNIQUE_SIGN_REQUESTS: LazyLock<CounterVec> = LazyLock::new
 
 pub(crate) static PRESIGNATURE_ACCRUED_WAIT_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
-        "multichain_presignature_accrued_wait_delay_sec",
+        "multichain_presignature_accrued_wait_delay_ms",
         "per presignature protocol, total accrued wait time between each poke that returned SendMany/SendPrivate/Return",
         &["node_account_id"],
-        Some(exponential_buckets(1.0, 1.5, 20).unwrap()),
+        Some(exponential_buckets(10.0, 1.5, 25).unwrap()),
+    )
+    .unwrap()
+});
+
+pub(crate) static PRESIGNATURE_POKE_CPU_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+    try_create_histogram_vec(
+        "multichain_presignature_poke_cpu_ms",
+        "per presignature protocol, per poke cpu time returned SendMany/SendPrivate/Return",
+        &["node_account_id"],
+        Some(exponential_buckets(1.0, 1.5, 5).unwrap()),
     )
     .unwrap()
 });
 
 pub(crate) static TRIPLE_BEFORE_POKE_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
-        "multichain_triple_before_poke_delay_sec",
-        "per triple protocol, delay between generator cration and first poke that returns SendMany/SendPrivate",
+        "multichain_triple_before_poke_delay_ms",
+        "per triple protocol, delay between generator creation and first poke that returns SendMany/SendPrivate",
         &["node_account_id"],
-        Some(exponential_buckets(1.0, 1.5, 20).unwrap()),
+        Some(exponential_buckets(1.0, 1.5, 25).unwrap()),
     )
     .unwrap()
 });
 
 pub(crate) static TRIPLE_ACCRUED_WAIT_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
-        "multichain_triple_accrued_wait_delay_sec",
+        "multichain_triple_accrued_wait_delay_ms",
         "per triple protocol, total accrued wait time between each poke that returned SendMany/SendPrivate/Return",
         &["node_account_id"],
-        Some(exponential_buckets(1.0, 1.5, 20).unwrap()),
+        Some(exponential_buckets(10.0, 1.5, 25).unwrap()),
+    )
+    .unwrap()
+});
+
+pub(crate) static TRIPLE_POKE_CPU_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+    try_create_histogram_vec(
+        "multichain_triple_poke_cpu_ms",
+        "per signature protocol, per poke cpu time",
+        &["node_account_id"],
+        Some(exponential_buckets(1.0, 1.5, 5).unwrap()),
     )
     .unwrap()
 });
 
 pub(crate) static SIGNATURE_BEFORE_POKE_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
-        "multichain_signature_before_poke_delay_sec",
-        "per signature protocol, delay between generator cration and first poke that returns SendMany/SendPrivate",
+        "multichain_signature_before_poke_delay_ms",
+        "per signature protocol, delay between generator creation and first poke that returns SendMany/SendPrivate",
         &["node_account_id"],
-        Some(exponential_buckets(1.0, 1.5, 20).unwrap()),
+        Some(exponential_buckets(1.0, 1.5, 25).unwrap()),
     )
     .unwrap()
 });
 
 pub(crate) static SIGNATURE_ACCRUED_WAIT_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
-        "multichain_signature_accrued_wait_delay_sec",
+        "multichain_signature_accrued_wait_delay_ms",
         "per signature protocol, total accrued wait time between each poke that returned SendMany/SendPrivate/Return",
         &["node_account_id"],
-        Some(exponential_buckets(1.0, 1.5, 20).unwrap()),
+        Some(exponential_buckets(10.0, 1.5, 25).unwrap()),
+    )
+    .unwrap()
+});
+
+pub(crate) static SIGNATURE_POKE_CPU_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+    try_create_histogram_vec(
+        "multichain_signature_poke_cpu_ms",
+        "per signature protocol, per poke cpu time returned SendMany/SendPrivate/Return",
+        &["node_account_id"],
+        Some(exponential_buckets(1.0, 1.5, 5).unwrap()),
     )
     .unwrap()
 });

--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -484,7 +484,7 @@ pub(crate) static LATEST_BLOCK_NUMBER: LazyLock<IntGaugeVec> = LazyLock::new(|| 
     )
     .unwrap()
 
-pub(crate) static PRESIGNATURE_BEFORE_POKE_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
+pub(crate) static PRESIGNATURE_BEFORE_POKE_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
         "multichain_presignature_before_poke_delay_sec",
         "per presignature protocol, delay between generator cration and first poke that returns SendMany/SendPrivate",
@@ -502,7 +502,8 @@ pub(crate) static NUM_UNIQUE_SIGN_REQUESTS: LazyLock<CounterVec> = LazyLock::new
     )
     .unwrap()
 
-pub(crate) static PRESIGNATURE_ACCRUED_WAIT_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
+
+pub(crate) static PRESIGNATURE_ACCRUED_WAIT_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
         "multichain_presignature_accrued_wait_delay_sec",
         "per presignature protocol, total accrued wait time between each poke that returned SendMany/SendPrivate/Return",
@@ -512,7 +513,7 @@ pub(crate) static PRESIGNATURE_ACCRUED_WAIT_DELAY: Lazy<HistogramVec> = Lazy::ne
     .unwrap()
 });
 
-pub(crate) static TRIPLE_BEFORE_POKE_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
+pub(crate) static TRIPLE_BEFORE_POKE_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
         "multichain_triple_before_poke_delay_sec",
         "per triple protocol, delay between generator cration and first poke that returns SendMany/SendPrivate",
@@ -522,7 +523,7 @@ pub(crate) static TRIPLE_BEFORE_POKE_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub(crate) static TRIPLE_ACCRUED_WAIT_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
+pub(crate) static TRIPLE_ACCRUED_WAIT_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
         "multichain_triple_accrued_wait_delay_sec",
         "per triple protocol, total accrued wait time between each poke that returned SendMany/SendPrivate/Return",
@@ -532,7 +533,7 @@ pub(crate) static TRIPLE_ACCRUED_WAIT_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub(crate) static SIGNATURE_BEFORE_POKE_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
+pub(crate) static SIGNATURE_BEFORE_POKE_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
         "multichain_signature_before_poke_delay_sec",
         "per signature protocol, delay between generator cration and first poke that returns SendMany/SendPrivate",
@@ -542,7 +543,7 @@ pub(crate) static SIGNATURE_BEFORE_POKE_DELAY: Lazy<HistogramVec> = Lazy::new(||
     .unwrap()
 });
 
-pub(crate) static SIGNATURE_ACCRUED_WAIT_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
+pub(crate) static SIGNATURE_ACCRUED_WAIT_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
         "multichain_signature_accrued_wait_delay_sec",
         "per signature protocol, total accrued wait time between each poke that returned SendMany/SendPrivate/Return",
@@ -552,7 +553,7 @@ pub(crate) static SIGNATURE_ACCRUED_WAIT_DELAY: Lazy<HistogramVec> = Lazy::new(|
     .unwrap()
 });
 
-pub(crate) static TRIPLE_LATENCY_TOTAL: Lazy<HistogramVec> = Lazy::new(|| {
+pub(crate) static TRIPLE_LATENCY_TOTAL: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
         "multichain_triple_latency_total_sec",
         "Latency of multichain triple generation, start from generator creation, end when triple generation complete.",
@@ -562,7 +563,7 @@ pub(crate) static TRIPLE_LATENCY_TOTAL: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub(crate) static TRIPLE_POKES_CNT: Lazy<HistogramVec> = Lazy::new(|| {
+pub(crate) static TRIPLE_POKES_CNT: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
         "multichain_triple_pokes_cnt",
         "total pokes per triple protocol",
@@ -572,7 +573,7 @@ pub(crate) static TRIPLE_POKES_CNT: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub(crate) static PRESIGNATURE_POKES_CNT: Lazy<HistogramVec> = Lazy::new(|| {
+pub(crate) static PRESIGNATURE_POKES_CNT: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
         "multichain_presignature_pokes_cnt",
         "total pokes per presignature protocol",
@@ -582,7 +583,7 @@ pub(crate) static PRESIGNATURE_POKES_CNT: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub(crate) static SIGNATURE_POKES_CNT: Lazy<HistogramVec> = Lazy::new(|| {
+pub(crate) static SIGNATURE_POKES_CNT: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
         "multichain_signature_pokes_cnt",
         "total pokes per signature protocol",
@@ -592,7 +593,7 @@ pub(crate) static SIGNATURE_POKES_CNT: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub(crate) static MSG_CLIENT_SEND_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
+pub(crate) static MSG_CLIENT_SEND_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
         "multichain_msg_client_send_delay_ms",
         "Delay between message creation and sending to the client",

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -561,10 +561,13 @@ impl PresignatureManager {
         let presignature_generator_success_metric =
             crate::metrics::NUM_TOTAL_HISTORICAL_PRESIGNATURE_GENERATORS_SUCCESS
                 .with_label_values(&[self.my_account_id.as_str()]);
+        let presignature_poke_cpu_time_metric = crate::metrics::PRESIGNATURE_POKE_CPU_TIME
+            .with_label_values(&[self.my_account_id.as_str()]);
 
         let mut remove = Vec::new();
         for (id, generator) in self.generators.iter_mut() {
             loop {
+                let generator_poke_time = Instant::now();
                 let action = match generator.poke() {
                     Ok(action) => action,
                     Err(e) => {
@@ -583,20 +586,6 @@ impl PresignatureManager {
                         break;
                     }
                     Action::SendMany(data) => {
-                        if generator.poked_latest.is_none() {
-                            let now = Instant::now();
-                            let start_time = generator.timestamp;
-                            presignature_before_poke_delay_metric
-                                .observe((now - start_time).as_secs_f64());
-                            generator.poked_latest = Some((now, Duration::from_millis(0), 1));
-                        } else {
-                            let (last_poked, total_wait, total_pokes) =
-                                generator.poked_latest.unwrap();
-                            let now = Instant::now();
-                            let elapsed = now - last_poked;
-                            generator.poked_latest =
-                                Some((now, total_wait + elapsed, total_pokes + 1));
-                        }
                         for to in generator.participants.iter() {
                             if *to == self.me {
                                 continue;
@@ -617,22 +606,25 @@ impl PresignatureManager {
                                 )
                                 .await;
                         }
+                        let (total_wait, total_pokes) =
+                            if let Some((last_poked, total_wait, total_pokes)) =
+                                &generator.poked_latest
+                            {
+                                (
+                                    *total_wait + (generator_poke_time - *last_poked),
+                                    total_pokes + 1,
+                                )
+                            } else {
+                                let start_time = generator.timestamp;
+                                presignature_before_poke_delay_metric
+                                    .observe((generator_poke_time - start_time).as_millis() as f64);
+                                (Duration::from_millis(0), 1)
+                            };
+                        generator.poked_latest = Some((Instant::now(), total_wait, total_pokes));
+                        presignature_poke_cpu_time_metric
+                            .observe(generator_poke_time.elapsed().as_millis() as f64);
                     }
                     Action::SendPrivate(to, data) => {
-                        if generator.poked_latest.is_none() {
-                            let now = Instant::now();
-                            let start_time = generator.timestamp;
-                            presignature_before_poke_delay_metric
-                                .observe((now - start_time).as_secs_f64());
-                            generator.poked_latest = Some((now, Duration::from_millis(0), 1));
-                        } else {
-                            let (last_poked, total_wait, total_pokes) =
-                                generator.poked_latest.unwrap();
-                            let now = Instant::now();
-                            let elapsed = now - last_poked;
-                            generator.poked_latest =
-                                Some((now, total_wait + elapsed, total_pokes + 1));
-                        }
                         channel
                             .send(
                                 self.me,
@@ -648,19 +640,25 @@ impl PresignatureManager {
                                 },
                             )
                             .await;
+                        let (total_wait, total_pokes) =
+                            if let Some((last_poked, total_wait, total_pokes)) =
+                                &generator.poked_latest
+                            {
+                                (
+                                    *total_wait + (generator_poke_time - *last_poked),
+                                    total_pokes + 1,
+                                )
+                            } else {
+                                let start_time = generator.timestamp;
+                                presignature_before_poke_delay_metric
+                                    .observe((generator_poke_time - start_time).as_millis() as f64);
+                                (Duration::from_millis(0), 1)
+                            };
+                        generator.poked_latest = Some((Instant::now(), total_wait, total_pokes));
+                        presignature_poke_cpu_time_metric
+                            .observe(generator_poke_time.elapsed().as_millis() as f64);
                     }
                     Action::Return(output) => {
-                        let now = Instant::now();
-                        if let Some((last_poked, total_wait, total_pokes)) = generator.poked_latest
-                        {
-                            let elapsed = now - last_poked;
-                            let total_wait = total_wait + elapsed;
-                            let total_pokes = total_pokes + 1;
-                            generator.poked_latest = Some((now, total_wait, total_pokes));
-                            presignature_accrued_wait_delay_metric
-                                .observe(total_wait.as_secs_f64());
-                            presignature_pokes_cnt_metric.observe(total_pokes as f64);
-                        }
                         tracing::info!(
                             id,
                             me = ?self.me,
@@ -685,6 +683,17 @@ impl PresignatureManager {
                         presignature_generator_success_metric.inc();
                         // Do not retain the protocol
                         remove.push(*id);
+                        if let Some((last_poked, total_wait, total_pokes)) = generator.poked_latest
+                        {
+                            let elapsed = generator_poke_time - last_poked;
+                            let total_wait = total_wait + elapsed;
+                            let total_pokes = total_pokes + 1;
+                            presignature_accrued_wait_delay_metric
+                                .observe(total_wait.as_millis() as f64);
+                            presignature_pokes_cnt_metric.observe(total_pokes as f64);
+                        }
+                        presignature_poke_cpu_time_metric
+                            .observe(generator_poke_time.elapsed().as_millis() as f64);
                         break;
                     }
                 }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -479,7 +479,7 @@ impl SignatureManager {
                     Action::SendMany(data) => {
                         if generator.poked_latest.is_none() {
                             let now = Instant::now();
-                            let start_time = generator.generator_timestamp;
+                            let start_time = generator.timestamp;
                             signature_before_poke_delay_metric
                                 .observe((now - start_time).as_secs_f64());
                             generator.poked_latest = Some((now, Duration::from_millis(0), 1));

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -491,7 +491,7 @@ impl SignatureManager {
                             generator.poked_latest =
                                 Some((now, total_wait + elapsed, total_pokes + 1));
                         }
-                        for to in generator.participants.iter() {
+                        for to in generator.request.participants.iter() {
                             if *to == self.me {
                                 continue;
                             }
@@ -515,7 +515,7 @@ impl SignatureManager {
                     Action::SendPrivate(to, data) => {
                         if generator.poked_latest.is_none() {
                             let now = Instant::now();
-                            let start_time = generator.generator_timestamp;
+                            let start_time = generator.timestamp;
                             signature_before_poke_delay_metric
                                 .observe((now - start_time).as_secs_f64());
                             generator.poked_latest = Some((now, Duration::from_millis(0), 1));

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -128,13 +128,32 @@ impl TripleGenerator {
         epoch: u64,
         channel: MessageChannel,
     ) -> GeneratorOutcome {
+        let triple_generator_failures_metric =
+            crate::metrics::TRIPLE_GENERATOR_FAILURES.with_label_values(&[my_account_id.as_str()]);
+        let triple_before_poke_delay_metric =
+            crate::metrics::TRIPLE_BEFORE_POKE_DELAY.with_label_values(&[my_account_id.as_str()]);
+        let triple_accrued_wait_delay_metric =
+            crate::metrics::TRIPLE_ACCRUED_WAIT_DELAY.with_label_values(&[my_account_id.as_str()]);
+        let triple_pokes_cnt_metric =
+            crate::metrics::TRIPLE_POKES_CNT.with_label_values(&[my_account_id.as_str()]);
+        let triple_latency_metric =
+            crate::metrics::TRIPLE_LATENCY.with_label_values(&[my_account_id.as_str()]);
+        let triple_latency_total_metric =
+            crate::metrics::TRIPLE_LATENCY_TOTAL.with_label_values(&[my_account_id.as_str()]);
+        let triple_generator_success_mine_metric =
+            crate::metrics::NUM_TOTAL_HISTORICAL_TRIPLE_GENERATIONS_MINE_SUCCESS
+                .with_label_values(&[my_account_id.as_str()]);
+        let triple_generator_success_metric =
+            crate::metrics::NUM_TOTAL_HISTORICAL_TRIPLE_GENERATORS_SUCCESS
+                .with_label_values(&[my_account_id.as_str()]);
+        let triple_poke_cpu_time_metric =
+            crate::metrics::TRIPLE_POKE_CPU_TIME.with_label_values(&[my_account_id.as_str()]);
         loop {
+            let generator_poke_time = Instant::now();
             let action = match self.poke().await {
                 Ok(action) => action,
                 Err(e) => {
-                    crate::metrics::TRIPLE_GENERATOR_FAILURES
-                        .with_label_values(&[my_account_id.as_str()])
-                        .inc();
+                    triple_generator_failures_metric.inc();
 
                     {
                         let timestamp = self.timestamp.read().await;
@@ -159,19 +178,6 @@ impl TripleGenerator {
                     break (self.id, Ok(None));
                 }
                 Action::SendMany(data) => {
-                    if self.poked_latest.is_none() {
-                        let now = Instant::now();
-                        let start_time = self.generator_created;
-                        crate::metrics::TRIPLE_BEFORE_POKE_DELAY
-                            .with_label_values(&[my_account_id.as_str()])
-                            .observe((now - start_time).as_secs_f64());
-                        self.poked_latest = Some((now, Duration::from_millis(0), 1));
-                    } else {
-                        let (last_poked, total_wait, total_pokes) = self.poked_latest.unwrap();
-                        let now = Instant::now();
-                        let elapsed = now - last_poked;
-                        self.poked_latest = Some((now, total_wait + elapsed, total_pokes + 1));
-                    }
                     for to in &self.participants {
                         if *to == me {
                             continue;
@@ -191,21 +197,23 @@ impl TripleGenerator {
                             )
                             .await;
                     }
+                    let (total_wait, total_pokes) =
+                        if let Some((last_poked, total_wait, total_pokes)) = self.poked_latest {
+                            (
+                                total_wait + (generator_poke_time - last_poked),
+                                total_pokes + 1,
+                            )
+                        } else {
+                            let start_time = self.generator_created;
+                            triple_before_poke_delay_metric
+                                .observe((generator_poke_time - start_time).as_millis() as f64);
+                            (Duration::from_millis(0), 1)
+                        };
+                    self.poked_latest = Some((Instant::now(), total_wait, total_pokes));
+                    triple_poke_cpu_time_metric
+                        .observe(generator_poke_time.elapsed().as_millis() as f64);
                 }
                 Action::SendPrivate(to, data) => {
-                    if self.poked_latest.is_none() {
-                        let now = Instant::now();
-                        let start_time = self.generator_created;
-                        crate::metrics::TRIPLE_BEFORE_POKE_DELAY
-                            .with_label_values(&[my_account_id.as_str()])
-                            .observe((now - start_time).as_secs_f64());
-                        self.poked_latest = Some((now, Duration::from_millis(0), 1));
-                    } else {
-                        let (last_poked, total_wait, total_pokes) = self.poked_latest.unwrap();
-                        let now = Instant::now();
-                        let elapsed = now - last_poked;
-                        self.poked_latest = Some((now, total_wait + elapsed, total_pokes + 1));
-                    }
                     channel
                         .send(
                             me,
@@ -218,22 +226,25 @@ impl TripleGenerator {
                                 timestamp: Utc::now().timestamp() as u64,
                             },
                         )
-                        .await
+                        .await;
+                    let (total_wait, total_pokes) =
+                        if let Some((last_poked, total_wait, total_pokes)) = self.poked_latest {
+                            (
+                                total_wait + (generator_poke_time - last_poked),
+                                total_pokes + 1,
+                            )
+                        } else {
+                            let start_time = self.generator_created;
+                            triple_before_poke_delay_metric
+                                .observe((generator_poke_time - start_time).as_millis() as f64);
+                            (Duration::from_millis(0), 1)
+                        };
+                    self.poked_latest = Some((Instant::now(), total_wait, total_pokes));
+                    triple_poke_cpu_time_metric
+                        .observe(generator_poke_time.elapsed().as_millis() as f64);
                 }
                 Action::Return(output) => {
                     let now = Instant::now();
-                    if let Some((last_poked, total_wait, total_pokes)) = self.poked_latest {
-                        let elapsed = now - last_poked;
-                        let total_wait = total_wait + elapsed;
-                        let total_pokes = total_pokes + 1;
-                        self.poked_latest = Some((now, total_wait, total_pokes));
-                        crate::metrics::TRIPLE_ACCRUED_WAIT_DELAY
-                            .with_label_values(&[my_account_id.as_str()])
-                            .observe(total_wait.as_secs_f64());
-                        crate::metrics::TRIPLE_POKES_CNT
-                            .with_label_values(&[my_account_id.as_str()])
-                            .observe(total_pokes as f64);
-                    }
                     let elapsed = {
                         let timestamp = self.timestamp.read().await;
                         timestamp.map(|t| now - t).unwrap_or_default()
@@ -251,20 +262,15 @@ impl TripleGenerator {
                     {
                         let timestamp = self.timestamp.read().await;
                         if let Some(start_time) = &*timestamp {
-                            crate::metrics::TRIPLE_LATENCY
-                                .with_label_values(&[my_account_id.as_str()])
-                                .observe((now - *start_time).as_secs_f64());
+                            triple_latency_metric.observe((now - *start_time).as_secs_f64());
                         }
                     }
 
                     // this measures from generator creation to finishing. TRIPLE_LATENCY instead starts from the first poke() on the generator
-                    crate::metrics::TRIPLE_LATENCY_TOTAL
-                        .with_label_values(&[my_account_id.as_str()])
+                    triple_latency_total_metric
                         .observe((now - self.generator_created).as_secs_f64());
 
-                    crate::metrics::NUM_TOTAL_HISTORICAL_TRIPLE_GENERATORS_SUCCESS
-                        .with_label_values(&[my_account_id.as_str()])
-                        .inc();
+                    triple_generator_success_metric.inc();
 
                     let triple = Triple {
                         id: self.id,
@@ -303,10 +309,18 @@ impl TripleGenerator {
                     );
 
                     if triple_is_mine {
-                        crate::metrics::NUM_TOTAL_HISTORICAL_TRIPLE_GENERATIONS_MINE_SUCCESS
-                            .with_label_values(&[my_account_id.as_str()])
-                            .inc();
+                        triple_generator_success_mine_metric.inc();
                     }
+
+                    if let Some((last_poked, total_wait, total_pokes)) = self.poked_latest {
+                        let elapsed = generator_poke_time - last_poked;
+                        let total_wait = total_wait + elapsed;
+                        let total_pokes = total_pokes + 1;
+                        triple_accrued_wait_delay_metric.observe(total_wait.as_millis() as f64);
+                        triple_pokes_cnt_metric.observe(total_pokes as f64);
+                    }
+                    triple_poke_cpu_time_metric
+                        .observe(generator_poke_time.elapsed().as_millis() as f64);
 
                     break (self.id, Ok(Some((triple, triple_is_mine))));
                 }


### PR DESCRIPTION
This PR adds the following metrics for triple, presig and signature protocol:
- accrued wait time per protocol: add up the wall clock time difference between pokes that return SendMany/SendPrivate/Return
- before poke delay per protocol: time between generator creation and first poke
- count of pokes per protocol: number of pokes that return SendMany/SendPrivate/Return, this is a best-effort estimate of the number of rounds of communication per protocol.

And add the following for messages:
- client send delay: time between message getting into inbox to message being ready to be sent over wire
