### PR TITLE
chore: remove linker requirements for macos

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,6 +12,4 @@ rustflags = [
   "-L", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib",
   "-C", "link-arg=-undefined",
   "-C", "link-arg=dynamic_lookup",
-  "-C", "link-arg=-fuse-ld=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld",
-  "-C", "link-arg=-ld_new",
 ]


### PR DESCRIPTION
No longer need these requirements because once we update macos xcode to 15 or later, these should be enabled by default