### PR TITLE
feat: add NodeId(id) to every log entry for integration-tests

### DIFF
--- a/chain-signatures/node/src/lib.rs
+++ b/chain-signatures/node/src/lib.rs
@@ -5,6 +5,7 @@ pub mod gcp;
 pub mod indexer;
 pub mod indexer_eth;
 pub mod kdf;
+pub mod logs;
 pub mod mesh;
 pub mod metrics;
 pub mod node_client;

--- a/chain-signatures/node/src/logs.rs
+++ b/chain-signatures/node/src/logs.rs
@@ -1,0 +1,82 @@
+use std::fmt;
+
+use tracing::{Event, Subscriber};
+use tracing_stackdriver::layer as stackdriver_layer;
+use tracing_subscriber::fmt::format::{Format, FormatEvent, Full};
+use tracing_subscriber::fmt::time::SystemTime;
+use tracing_subscriber::fmt::{format, FmtContext, FormatFields};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::{EnvFilter, Registry};
+
+/// This will whether this code is being ran on top of GCP or not.
+fn is_running_on_gcp() -> bool {
+    // Check if running in Google Cloud Run: https://cloud.google.com/run/docs/container-contract#services-env-vars
+    if std::env::var("K_SERVICE").is_ok() {
+        return true;
+    }
+
+    let resp = reqwest::blocking::Client::new()
+        .get("http://metadata.google.internal/computeMetadata/v1/instance/id")
+        .header("Metadata-Flavor", "Google")
+        .timeout(std::time::Duration::from_millis(200))
+        .send();
+
+    match resp {
+        Ok(resp) => resp.status().is_success(),
+        _ => false,
+    }
+}
+
+/// Formatter that adds the `NodeId({node_id})` to the log line. Useful for tests when
+/// multiple nodes are logging to the same std/err output.
+struct NodeIdFormatter {
+    fmt: Format<Full, SystemTime>,
+    repr: String,
+}
+
+impl NodeIdFormatter {
+    pub fn new(id: usize) -> Self {
+        Self {
+            fmt: Format::default(),
+            repr: format!("NodeId({id})"),
+        }
+    }
+}
+
+// Reference: https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/fmt/trait.FormatEvent.html
+impl<S, N> FormatEvent<S, N> for NodeIdFormatter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: format::Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        write!(&mut writer, "{} ", self.repr)?;
+        self.fmt.format_event(ctx, writer, event)
+    }
+}
+
+pub fn install_global(node_id: Option<usize>) {
+    // Install global collector configured based on RUST_LOG env var.
+    let base_subscriber = Registry::default().with(EnvFilter::from_default_env());
+
+    if let Some(node_id) = node_id {
+        let fmt_layer =
+            tracing_subscriber::fmt::layer().event_format(NodeIdFormatter::new(node_id));
+        let subscriber = base_subscriber.with(fmt_layer);
+        tracing::subscriber::set_global_default(subscriber).expect("Failed to set subscriber");
+    } else if is_running_on_gcp() {
+        let stackdriver = stackdriver_layer().with_writer(std::io::stderr);
+        let subscriber = base_subscriber.with(stackdriver);
+        tracing::subscriber::set_global_default(subscriber).expect("Failed to set subscriber");
+    } else {
+        let fmt_layer = tracing_subscriber::fmt::layer().with_thread_ids(true);
+        let subscriber = base_subscriber.with(fmt_layer);
+        tracing::subscriber::set_global_default(subscriber).expect("Failed to set subscriber");
+    }
+}

--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -46,6 +46,7 @@ impl Node {
     const CONTAINER_PORT: u16 = 3000;
 
     pub async fn run(
+        node_id: usize,
         ctx: &super::Context,
         cfg: &NodeConfig,
         account: &Account,
@@ -71,6 +72,7 @@ impl Node {
             .unwrap();
 
         Self::spawn(
+            node_id,
             ctx,
             NodeEnvConfig {
                 web_port: Self::CONTAINER_PORT,
@@ -98,7 +100,11 @@ impl Node {
         }
     }
 
-    pub async fn spawn(ctx: &super::Context, config: NodeEnvConfig) -> anyhow::Result<Self> {
+    pub async fn spawn(
+        node_id: usize,
+        ctx: &super::Context,
+        config: NodeEnvConfig,
+    ) -> anyhow::Result<Self> {
         let indexer_options = mpc_node::indexer::Options {
             s3_bucket: ctx.localstack.s3_bucket.clone(),
             s3_region: ctx.localstack.s3_region.clone(),
@@ -124,6 +130,7 @@ impl Node {
             indexer_options: indexer_options.clone(),
             indexer_eth_options,
             my_address: None,
+            debug_id: Some(node_id),
             storage_options: ctx.storage_options.clone(),
             sign_sk: Some(config.sign_sk.clone()),
             override_config: Some(OverrideConfig::new(serde_json::to_value(

--- a/integration-tests/src/local.rs
+++ b/integration-tests/src/local.rs
@@ -51,6 +51,7 @@ impl fmt::Debug for NodeEnvConfig {
 
 impl Node {
     pub async fn dry_run(
+        node_id: usize,
         ctx: &super::Context,
         account: &Account,
         cfg: &NodeConfig,
@@ -90,6 +91,7 @@ impl Node {
             indexer_options,
             indexer_eth_options,
             my_address: None,
+            debug_id: Some(node_id),
             storage_options: ctx.storage_options.clone(),
             override_config: Some(OverrideConfig::new(serde_json::to_value(
                 cfg.protocol.clone(),
@@ -125,6 +127,7 @@ impl Node {
     }
 
     pub async fn run(
+        node_id: usize,
         ctx: &super::Context,
         cfg: &NodeConfig,
         account: &Account,
@@ -148,6 +151,7 @@ impl Node {
         LakeIndexer::populate_proxy(&proxy_name, true, &rpc_address_proxied, &near_rpc).await?;
 
         Self::spawn(
+            node_id,
             ctx,
             NodeEnvConfig {
                 web_port,
@@ -162,7 +166,11 @@ impl Node {
         .await
     }
 
-    pub async fn spawn(ctx: &super::Context, config: NodeEnvConfig) -> anyhow::Result<Self> {
+    pub async fn spawn(
+        node_id: usize,
+        ctx: &super::Context,
+        config: NodeEnvConfig,
+    ) -> anyhow::Result<Self> {
         let web_port = config.web_port;
         let indexer_options = mpc_node::indexer::Options {
             s3_bucket: ctx.localstack.s3_bucket.clone(),
@@ -190,6 +198,7 @@ impl Node {
             indexer_options,
             indexer_eth_options,
             my_address: None,
+            debug_id: Some(node_id),
             storage_options: ctx.storage_options.clone(),
             override_config: Some(OverrideConfig::new(serde_json::to_value(
                 config.cfg.protocol.clone(),


### PR DESCRIPTION
Makes debugging what is going wrong with a specific node by introducing the `NodeId(id)` appended to every logline in integration tests. These will not appear on the actual prod environments.

For example:
```sh
NodeId(1) 2025-01-17T21:54:40.653693Z  INFO mpc_node::protocol::consensus: started(initializing): starting key generation as a part of the participant set
```