### PR TITLE
eth indexer: subscribe to log events instead of pulling blocks

### DIFF
--- a/chain-signatures/contract-eth/README.md
+++ b/chain-signatures/contract-eth/README.md
@@ -42,7 +42,7 @@ npx hardhat node
 npx hardhat --network localhost run scripts/findAddress.js
 ```
 
-3. Make sure you have docker daemon running. Open another terminal window, go to `integration-tests/chain-signatures` and run the following command to start the MPC cluster:
+3. Make sure you have docker daemon running. Open another terminal window, go to `integration-tests` and run the following command to start the MPC cluster:
 ```bash
 cargo run -- setup-env --eth-contract-address <future-contract-address>
 ```

--- a/chain-signatures/contract-eth/README.md
+++ b/chain-signatures/contract-eth/README.md
@@ -37,28 +37,33 @@ To do a local end-to-end test, following these steps.
 npx hardhat node
 ```
 
-2. Make sure you have docker daemon running. Open another terminal window, go to `integration-tests/chain-signatures` and run the following command to start the MPC cluster:
+2. Figure out the contract address. Run and copy the "Future contract address" from the output:
 ```bash
-cargo run -- setup-env
+npx hardhat --network localhost run scripts/findAddress.js
 ```
 
-3. In MPC cluster log, search for log `voting for public key public_key=secp256k1:` and copy the public key after `secp256k1:`
+3. Make sure you have docker daemon running. Open another terminal window, go to `integration-tests/chain-signatures` and run the following command to start the MPC cluster:
+```bash
+cargo run -- setup-env --eth-contract-address <future-contract-address>
+```
 
-4. Open another terminal window, Then run the following command to config the mpc public key for deploying ethereum contract:
+4. In MPC cluster log, search for log `voting for public key public_key=secp256k1:` and copy the public key after `secp256k1:`
+
+5. Open another terminal window, Then run the following command to config the mpc public key for deploying ethereum contract:
 ```bash
 node scripts/convertPk.js <public_key>
 ```
 For example:
 ```bash
-node scripts/convertPk.js 4WDg9sxbEnMTrsSJo78ckEWJ3yTFitoLfiDnGReMuL3hoSwuSQyFp8nFq9uvdtWQh6cp2ZEDcvuHNKvyezyKVpP7
+node scripts/convertPk.js 37xNKgg4LvhuaMBPThHEZNp6VJHu8KsATkPrCKrsfbwQEas1erep8otiB37F99tvY5aM3s78uzix49t5BjxuBYzD
 ```
 
-5. Then run the following command to deploy the contract:
+6. Then run the following command to deploy the contract:
 ```bash
 npx hardhat ignition deploy ignition/modules/chainSignatures.js --parameters ignition/params.json --network localhost
 ```
 
-6. Then run the following command to request a signature from MPC:
+7. Then run the following command to request a signature from MPC:
 ```bash
 npx hardhat run scripts/requestSign.js --network localhost
 ```
@@ -81,7 +86,7 @@ npx hardhat --network sepolia run scripts/findAddress.js
 
 5. Make sure you have docker daemon running. Go to `integration-tests` and run the following command to start the MPC cluster connected to Ethereum Sepolia Testnet:
 ```bash
-cargo run -- setup-env --eth-rpc-url https://sepolia.infura.io/v3/<infura-api-key> --eth-account-sk <eth-account-secret-key-without-0x-prefix> --eth-contract-address <future-contract-address> --eth-start-block-height <latest-block-number>
+cargo run -- setup-env --eth-rpc-http-url https://sepolia.infura.io/v3/<infura-api-key> --eth-rpc-ws-url wss://sepolia.infura.io/ws/v3/<infura-api-key> --eth-account-sk <eth-account-secret-key-without-0x-prefix> --eth-contract-address <future-contract-address>
 ```
 
 6. In MPC cluster log, search for log `voting for public key public_key=secp256k1:` and copy the public key after `secp256k1:`

--- a/chain-signatures/contract-eth/README.md
+++ b/chain-signatures/contract-eth/README.md
@@ -50,7 +50,7 @@ node scripts/convertPk.js <public_key>
 ```
 For example:
 ```bash
-node scripts/convertPk.js 46sdkzwo46ga8B3K2J9i57akBsfgtFYbj4JzdnTuyhWiNaorz96qkExE3ei7djX25bzV6rmLJ435FJMpAYUs9JRg
+node scripts/convertPk.js 4WDg9sxbEnMTrsSJo78ckEWJ3yTFitoLfiDnGReMuL3hoSwuSQyFp8nFq9uvdtWQh6cp2ZEDcvuHNKvyezyKVpP7
 ```
 
 5. Then run the following command to deploy the contract:
@@ -92,7 +92,7 @@ node scripts/convertPk.js <public_key>
 ```
 For example:
 ```bash
-node scripts/convertPk.js 46sdkzwo46ga8B3K2J9i57akBsfgtFYbj4JzdnTuyhWiNaorz96qkExE3ei7djX25bzV6rmLJ435FJMpAYUs9JRg
+node scripts/convertPk.js pkqFQkRgYsZx4pNwuitXSDYAKsGML1P6JboVKP5qSG4HVatFHUqA8Fzcan49uxBZFyNwCHvr1tJo5KNJMcuWCQ6
 ```
 
 8. Then run the following command to deploy the contract to Ethereum Sepolia Testnet:

--- a/chain-signatures/contract-eth/hardhat.config.js
+++ b/chain-signatures/contract-eth/hardhat.config.js
@@ -24,7 +24,7 @@ module.exports = {
       loggingEnabled: true,
       mining: {
         auto: true,
-        interval: 4000,
+        interval: 3000,
       },
     },
     sepolia: {

--- a/chain-signatures/contract-eth/hardhat.config.js
+++ b/chain-signatures/contract-eth/hardhat.config.js
@@ -22,6 +22,7 @@ module.exports = {
     hardhat: {
       chainId: 31337,
       loggingEnabled: true,
+      // make local eth node auto-mine blocks every 3 seconds
       mining: {
         auto: true,
         interval: 3000,

--- a/chain-signatures/contract-eth/hardhat.config.js
+++ b/chain-signatures/contract-eth/hardhat.config.js
@@ -19,6 +19,14 @@ const SEPOLIA_PRIVATE_KEY = vars.get("SEPOLIA_PRIVATE_KEY", 'ac0974bec39a17e36ba
 module.exports = {
   solidity: "0.8.27",
   networks: {
+    hardhat: {
+      chainId: 31337,
+      loggingEnabled: true,
+      mining: {
+        auto: true,
+        interval: 4000,
+      },
+    },
     sepolia: {
       url: `https://sepolia.infura.io/v3/${INFURA_API_KEY}`,
       accounts: [SEPOLIA_PRIVATE_KEY],

--- a/chain-signatures/contract-eth/ignition/params.json
+++ b/chain-signatures/contract-eth/ignition/params.json
@@ -1,8 +1,8 @@
 {
     "ChainSignaturesModule": {
         "publicKey": {
-            "x": "0x727a05eeae8d360373456537a4a43c183a18a87ee7e66102b28aa6fc176e82b3",
-            "y": "0xeb642c6073293b3e71e28c442ea0e39f20163d4a548871aff88cbf6d2c906d14"
+            "x": "0xf711e8355f869d9db2c2ec9e9e0c8e0e0479283997badbec8d44aa0d225a1a05",
+            "y": "0xeb0df5d608d89fc4df11f0ddf1e3aa1b3971b645cc11bf0517a31401623d90e3"
         }
     }
 }

--- a/chain-signatures/contract-eth/ignition/params.json
+++ b/chain-signatures/contract-eth/ignition/params.json
@@ -1,8 +1,8 @@
 {
     "ChainSignaturesModule": {
         "publicKey": {
-            "x": "0xf711e8355f869d9db2c2ec9e9e0c8e0e0479283997badbec8d44aa0d225a1a05",
-            "y": "0xeb0df5d608d89fc4df11f0ddf1e3aa1b3971b645cc11bf0517a31401623d90e3"
+            "x": "0x715e462ba2bc293fe9736657d1f5d364409f0cb861be2ccc86b4901e159bcaac",
+            "y": "0x53d53780af62bfd5c40a614c9d314f9d8d374db783598572f1bd2aea7a47d715"
         }
     }
 }

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -215,9 +215,6 @@ pub fn run(cmd: Cli) -> anyhow::Result<()> {
                 rpc_client.clone(),
             )?;
 
-            let (eth_indexer_handle, eth_indexer) =
-                indexer_eth::run(&indexer_eth_options, &account_id, sign_tx, app_data_storage)?;
-
             let sign_sk = sign_sk.unwrap_or_else(|| account_sk.clone());
             let my_address = my_address
                 .map(|mut addr| {
@@ -262,7 +259,7 @@ pub fn run(cmd: Cli) -> anyhow::Result<()> {
                     key_storage,
                     triple_storage,
                     presignature_storage,
-                    indexer_eth_options.eth_rpc_url.clone(),
+                    indexer_eth_options.eth_rpc_http_url.clone(),
                     indexer_eth_options.eth_contract_address.clone(),
                     eth_account_sk,
                 );
@@ -273,19 +270,25 @@ pub fn run(cmd: Cli) -> anyhow::Result<()> {
                 let mesh_handle = tokio::spawn(mesh.run(contract_state.clone()));
                 let protocol_handle =
                     tokio::spawn(protocol.run(contract_state, config, mesh_state));
-                tracing::info!("protocol task spawned");
-                let web_handle =
-                    tokio::spawn(web::run(web_port, sender, state, indexer, eth_indexer));
+                tracing::info!("protocol thread spawned");
+                let cipher_sk = hpke::SecretKey::try_from_bytes(&hex::decode(cipher_sk)?)?;
+                let web_handle = tokio::spawn(async move {
+                    web::run(web_port, sender, cipher_sk, protocol_state, indexer).await
+                });
+                let eth_indexer_handle =
+                    tokio::spawn(
+                        async move { indexer_eth::run(&indexer_eth_options, sign_tx).await },
+                    );
                 tracing::info!("protocol http server spawned");
 
                 contract_handle.await??;
                 mesh_handle.await??;
                 protocol_handle.await??;
                 web_handle.await??;
+                eth_indexer_handle.await??;
                 tracing::info!("spinning down");
 
                 indexer_handle.join().unwrap()?;
-                eth_indexer_handle.join().unwrap()?;
 
                 anyhow::Ok(())
             })?;

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -250,7 +250,7 @@ pub fn run(cmd: Cli) -> anyhow::Result<()> {
                 let protocol = MpcSignProtocol::init(
                     my_address,
                     mpc_contract_id,
-                    account_id,
+                    account_id.clone(),
                     state.clone(),
                     rpc_client,
                     signer,
@@ -275,10 +275,9 @@ pub fn run(cmd: Cli) -> anyhow::Result<()> {
                 let web_handle = tokio::spawn(async move {
                     web::run(web_port, sender, cipher_sk, protocol_state, indexer).await
                 });
-                let eth_indexer_handle =
-                    tokio::spawn(
-                        async move { indexer_eth::run(&indexer_eth_options, sign_tx).await },
-                    );
+                let eth_indexer_handle = tokio::spawn(async move {
+                    indexer_eth::run(&indexer_eth_options, sign_tx, &account_id).await
+                });
                 tracing::info!("protocol http server spawned");
 
                 contract_handle.await??;

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -271,10 +271,7 @@ pub fn run(cmd: Cli) -> anyhow::Result<()> {
                 let protocol_handle =
                     tokio::spawn(protocol.run(contract_state, config, mesh_state));
                 tracing::info!("protocol thread spawned");
-                let cipher_sk = hpke::SecretKey::try_from_bytes(&hex::decode(cipher_sk)?)?;
-                let web_handle = tokio::spawn(async move {
-                    web::run(web_port, sender, cipher_sk, protocol_state, indexer).await
-                });
+                let web_handle = tokio::spawn(web::run(web_port, sender, state, indexer));
                 let eth_indexer_handle = tokio::spawn(async move {
                     indexer_eth::run(&indexer_eth_options, sign_tx, &account_id).await
                 });

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -272,9 +272,8 @@ pub fn run(cmd: Cli) -> anyhow::Result<()> {
                     tokio::spawn(protocol.run(contract_state, config, mesh_state));
                 tracing::info!("protocol thread spawned");
                 let web_handle = tokio::spawn(web::run(web_port, sender, state, indexer));
-                let eth_indexer_handle = tokio::spawn(async move {
-                    indexer_eth::run(&indexer_eth_options, sign_tx, &account_id).await
-                });
+                let eth_indexer_handle =
+                    tokio::spawn(indexer_eth::run(indexer_eth_options, sign_tx, account_id));
                 tracing::info!("protocol http server spawned");
 
                 contract_handle.await??;

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -1,56 +1,44 @@
 use crate::indexer::ContractSignRequest;
 use crate::protocol::Chain::Ethereum;
 use crate::protocol::SignRequest;
-use crate::storage::app_data_storage::AppDataStorage;
 use crypto_shared::kdf::derive_epsilon_eth;
 use crypto_shared::ScalarExt;
 use hex::ToHex;
 use k256::Scalar;
-use near_account_id::AccountId;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
-use std::sync::Arc;
-use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
-use tokio::sync::{mpsc, RwLock};
-use web3::{
-    types::{BlockNumber, FilterBuilder, Log, H160, H256, U256},
-    Web3,
-};
+use tokio::sync::mpsc;
+use web3::futures::StreamExt;
+use web3::types::{FilterBuilder, Log, H160, H256, U256};
 
 /// Configures Ethereum indexer.
 #[derive(Debug, Clone, clap::Parser)]
 #[group(id = "indexer_eth_options")]
 pub struct Options {
-    /// Ethereum RPC URL
-    #[clap(long, env("MPC_INDEXER_ETH_RPC_URL"))]
-    pub eth_rpc_url: String,
+    /// Ethereum WebSocket RPC URL
+    #[clap(long, env("MPC_INDEXER_ETH_RPC_WS_URL"))]
+    pub eth_rpc_ws_url: String,
+
+    /// Ethereum HTTP RPC URL
+    #[clap(long, env("MPC_INDEXER_ETH_RPC_HTTP_URL"))]
+    pub eth_rpc_http_url: String,
 
     /// The contract address to watch
     #[clap(long, env("MPC_INDEXER_ETH_CONTRACT_ADDRESS"))]
     pub eth_contract_address: String,
-
-    /// The amount of time before we consider the indexer behind
-    #[clap(long, env("MPC_INDEXER_ETH_BEHIND_THRESHOLD"), default_value = "180")]
-    pub eth_behind_threshold: u64,
-
-    /// The threshold to check if indexer needs restart
-    #[clap(long, env("MPC_INDEXER_ETH_RUNNING_THRESHOLD"), default_value = "300")]
-    pub eth_running_threshold: u64,
 }
 
 impl Options {
     pub fn into_str_args(self) -> Vec<String> {
         let mut args = Vec::new();
         args.extend([
-            "--eth-rpc-url".to_string(),
-            self.eth_rpc_url,
+            "--eth-rpc-ws-url".to_string(),
+            self.eth_rpc_ws_url,
+            "--eth-rpc-http-url".to_string(),
+            self.eth_rpc_http_url,
             "--eth-contract-address".to_string(),
             self.eth_contract_address,
-            "--eth-behind-threshold".to_string(),
-            self.eth_behind_threshold.to_string(),
-            "--eth-running-threshold".to_string(),
-            self.eth_running_threshold.to_string(),
         ]);
         args
     }
@@ -63,193 +51,60 @@ pub struct EthSignRequest {
     pub key_version: u32,
 }
 
-#[derive(Clone)]
-pub struct EthIndexer {
-    app_data_storage: AppDataStorage,
-    last_updated_timestamp: Arc<RwLock<Instant>>,
-    latest_block_timestamp: Arc<RwLock<Option<u64>>>,
-    running_threshold: Duration,
-    behind_threshold: Duration,
-}
-
-impl EthIndexer {
-    fn new(app_data_storage: AppDataStorage, options: &Options) -> Self {
-        Self {
-            app_data_storage: app_data_storage.clone(),
-            last_updated_timestamp: Arc::new(RwLock::new(Instant::now())),
-            latest_block_timestamp: Arc::new(RwLock::new(None)),
-            running_threshold: Duration::from_secs(options.eth_running_threshold),
-            behind_threshold: Duration::from_secs(options.eth_behind_threshold),
-        }
-    }
-
-    pub async fn last_processed_block(&self) -> Option<u64> {
-        match self.app_data_storage.last_processed_block_eth().await {
-            Ok(Some(block_height)) => Some(block_height),
-            Ok(None) => {
-                tracing::warn!("no last processed eth block found");
-                None
-            }
-            Err(err) => {
-                tracing::warn!(%err, "failed to get last processed eth block");
-                None
-            }
-        }
-    }
-
-    pub async fn set_last_processed_block(&self, block_height: u64) {
-        if let Err(err) = self
-            .app_data_storage
-            .set_last_processed_block_eth(block_height)
-            .await
-        {
-            tracing::error!(%err, "failed to set last processed eth block");
-        }
-    }
-
-    /// Check whether the indexer is on track with the latest block height from the chain.
-    pub async fn is_running(&self) -> bool {
-        self.last_updated_timestamp.read().await.elapsed() <= self.running_threshold
-    }
-
-    /// Check whether the indexer is behind with the latest block height from the chain.
-    pub async fn is_behind(&self) -> bool {
-        if let Some(latest_block_timestamp) = *self.latest_block_timestamp.read().await {
-            crate::util::is_elapsed_longer_than_timeout(
-                latest_block_timestamp,
-                self.behind_threshold.as_millis() as u64,
-            )
-        } else {
-            true
-        }
-    }
-
-    pub async fn is_stable(&self) -> bool {
-        !self.is_behind().await && self.is_running().await
-    }
-
-    async fn update_block_height_and_timestamp(&self, block_height: u64, block_timestamp: u64) {
-        tracing::debug!(block_height, "update_block_height_and_timestamp eth");
-        self.set_last_processed_block(block_height).await;
-        *self.last_updated_timestamp.write().await = Instant::now();
-        *self.latest_block_timestamp.write().await = Some(block_timestamp);
-    }
-}
-
-#[derive(Clone)]
-struct Context {
-    contract_address: H160,
-    node_account_id: AccountId,
-    web3: Web3<web3::transports::Http>,
-    sign_tx: mpsc::Sender<SignRequest>,
-    indexer: EthIndexer,
-}
-
-async fn handle_block(block_number: u64, ctx: &Context) -> anyhow::Result<()> {
-    let signature_requested_topic = H256::from_slice(&web3::signing::keccak256(
-        b"SignatureRequested(bytes32,address,uint256,uint256,string)",
-    ));
-
-    let filter = FilterBuilder::default()
-        .from_block(BlockNumber::Number(block_number.into()))
-        .to_block(BlockNumber::Number(block_number.into()))
-        .address(vec![ctx.contract_address])
-        .topics(Some(vec![signature_requested_topic]), None, None, None)
-        .build();
-
-    let block = ctx
-        .web3
-        .eth()
-        .block(web3::types::BlockId::Number(block_number.into()))
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("eth block {block_number} not found"))?;
-
-    let block_timestamp = block.timestamp.as_u64();
-
-    let logs = ctx.web3.eth().logs(filter).await?;
-    let logs_cnt = logs.len();
-    if logs_cnt > 0 {
-        tracing::debug!("found {logs_cnt} filtered logs");
-    }
-
-    let mut pending_requests = Vec::new();
-    // Get logs using filter
-    for log in logs {
-        let event = parse_event(&log)?;
-        tracing::debug!("found eth event: {:?}", event);
-        // Create sign request from event
-        let Some(payload) = Scalar::from_bytes(event.payload_hash) else {
-            tracing::warn!(
-                "eth `sign` did not produce payload hash correctly: {:?}",
-                event.payload_hash,
-            );
-            continue;
-        };
-        let request = ContractSignRequest {
-            payload,
-            path: event.path,
-            key_version: 0,
-            chain: Ethereum,
-        };
-
-        let epsilon = derive_epsilon_eth(
-            format!("0x{}", event.requester.encode_hex::<String>()),
-            &request.path,
+fn sign_request_from_filtered_log(log: web3::types::Log) -> anyhow::Result<SignRequest> {
+    let event = parse_event(&log)?;
+    tracing::debug!("found eth event: {:?}", event);
+    // Create sign request from event
+    let Some(payload) = Scalar::from_bytes(event.payload_hash) else {
+        tracing::warn!(
+            "eth `sign` did not produce payload hash correctly: {:?}",
+            event.payload_hash,
         );
-        let mut event_epsilon_bytes: [u8; 32] = [0; 32];
-        event.epsilon.to_big_endian(&mut event_epsilon_bytes);
-        let event_epsilon_scalar = Scalar::from_bytes(event_epsilon_bytes)
-            .ok_or(anyhow::anyhow!("failed to convert event epsilon to scalar"))?;
-        if epsilon != event_epsilon_scalar {
-            tracing::warn!(
-                "epsilon mismatch: derived={:?}, event={:?}",
-                epsilon,
-                event.epsilon
-            );
-            continue;
-        }
-        tracing::debug!(
-            "from epsilon: {:?} event epsilon: {:?}",
+        return Err(anyhow::anyhow!(
+            "failed to convert event payload hash to scalar"
+        ));
+    };
+    let request = ContractSignRequest {
+        payload,
+        path: event.path,
+        key_version: 0,
+        chain: Ethereum,
+    };
+    let epsilon = derive_epsilon_eth(
+        format!("0x{}", event.requester.encode_hex::<String>()),
+        &request.path,
+    );
+    let mut event_epsilon_bytes: [u8; 32] = [0; 32];
+    event.epsilon.to_big_endian(&mut event_epsilon_bytes);
+    let event_epsilon_scalar = Scalar::from_bytes(event_epsilon_bytes)
+        .ok_or(anyhow::anyhow!("failed to convert event epsilon to scalar"))?;
+    if epsilon != event_epsilon_scalar {
+        tracing::warn!(
+            "epsilon mismatch: derived={:?}, event={:?}",
             epsilon,
             event.epsilon
         );
-        // Use transaction hash as entropy
-        let entropy = log
-            .transaction_hash
-            .map(|h| *h.as_fixed_bytes())
-            .unwrap_or([0u8; 32]);
-
-        let sign_request = SignRequest {
-            request_id: event.request_id,
-            request,
-            epsilon,
-            entropy,
-            // TODO: use indexer timestamp instead.
-            time_added: Instant::now(),
-        };
-
-        pending_requests.push(sign_request);
+        return Err(anyhow::anyhow!("epsilon mismatch"));
     }
+    tracing::debug!(
+        "from epsilon: {:?} event epsilon: {:?}",
+        epsilon,
+        event.epsilon
+    );
+    // Use transaction hash as entropy
+    let entropy = log
+        .transaction_hash
+        .map(|h| *h.as_fixed_bytes())
+        .unwrap_or([0u8; 32]);
 
-    crate::metrics::NUM_SIGN_REQUESTS_ETH
-        .with_label_values(&[ctx.node_account_id.as_str()])
-        .inc_by(pending_requests.len() as f64);
-
-    for request in pending_requests {
-        if let Err(err) = ctx.sign_tx.send(request).await {
-            tracing::error!(?err, "failed to send the eth sign request into sign queue");
-        }
-    }
-
-    ctx.indexer
-        .update_block_height_and_timestamp(block_number, block_timestamp)
-        .await;
-
-    crate::metrics::LATEST_BLOCK_HEIGHT_ETH
-        .with_label_values(&[ctx.node_account_id.as_str()])
-        .set(block_number as i64);
-
-    Ok(())
+    Ok(SignRequest {
+        request_id: event.request_id,
+        request,
+        epsilon,
+        entropy,
+        // TODO: use indexer timestamp instead.
+        time_added: Instant::now(),
+    })
 }
 
 // Helper function to parse event logs
@@ -291,77 +146,66 @@ fn parse_event(log: &Log) -> anyhow::Result<SignatureRequestedEvent> {
     })
 }
 
-pub fn run(
-    options: &Options,
-    node_account_id: &AccountId,
-    sign_tx: mpsc::Sender<SignRequest>,
-    app_data_storage: AppDataStorage,
-) -> anyhow::Result<(JoinHandle<anyhow::Result<()>>, EthIndexer)> {
-    let transport = web3::transports::Http::new(&options.eth_rpc_url)?;
-    let web3 = Web3::new(transport);
-
+pub async fn run(options: &Options, sign_tx: mpsc::Sender<SignRequest>) -> anyhow::Result<()> {
     let contract_address = H160::from_str(&options.eth_contract_address)?;
 
-    let indexer = EthIndexer::new(app_data_storage, options);
-    let context = Context {
-        contract_address,
-        node_account_id: node_account_id.clone(),
-        web3,
-        sign_tx,
-        indexer: indexer.clone(),
-    };
+    let signature_requested_topic = H256::from_slice(&web3::signing::keccak256(
+        b"SignatureRequested(bytes32,address,uint256,uint256,string)",
+    ));
 
-    let join_handle = std::thread::spawn(move || {
-        let rt = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()?;
+    let filter = FilterBuilder::default()
+        .address(vec![contract_address])
+        .topics(Some(vec![signature_requested_topic]), None, None, None)
+        .build();
 
-        rt.block_on(async {
-            loop {
-                let latest_block = match context.web3.eth().block_number().await {
-                    Ok(block) => block.as_u64(),
-                    Err(err) => {
-                        tracing::warn!(%err, "failed to get latest eth block number");
-                        tokio::time::sleep(Duration::from_secs(5)).await;
-                        continue;
+    let eth_rpc_ws_url = options.eth_rpc_ws_url.clone();
+
+    loop {
+        match web3::transports::WebSocket::new(&eth_rpc_ws_url).await {
+            Ok(ws) => {
+                let web3_ws = web3::Web3::new(ws);
+
+                match web3_ws.eth_subscribe().subscribe_logs(filter.clone()).await {
+                    Ok(mut filtered_logs_sub) => {
+                        tracing::info!("Ethereum indexer connected and listening for logs");
+                        let mut heartbeat_interval = tokio::time::interval(Duration::from_secs(30));
+                        loop {
+                            tokio::select! {
+                                Some(log) = filtered_logs_sub.next() => {
+                                    match log {
+                                        Ok(log) => {
+                                            tracing::info!("Received new Ethereum log");
+
+                                            let sign_tx = sign_tx.clone();
+                                            if let Ok(sign_request) = sign_request_from_filtered_log(log) {
+                                                tokio::spawn(async move {
+                                                    if let Err(err) = sign_tx.send(sign_request).await {
+                                                        tracing::error!(?err, "Failed to send ETH sign request into queue");
+                                                    }
+                                                });
+                                            }
+                                        }
+                                        Err(err) => {
+                                            tracing::warn!("Ethereum log subscription error: {:?}", err);
+                                            break; // Exit loop and reconnect
+                                        }
+                                    }
+                                }
+                                _ = heartbeat_interval.tick() => {
+                                    tracing::info!("Ethereum indexer is still running...");
+                                }
+                            }
+                        }
                     }
-                };
-
-                let latest_handled_block =
-                    context.indexer.last_processed_block().await.unwrap_or(0);
-
-                const MAX_DELAYED_BLOCKS: u64 = 100;
-                let next_block_to_handle: u64 = {
-                    if latest_block - latest_handled_block < MAX_DELAYED_BLOCKS {
-                        latest_handled_block + 1
-                    } else {
-                        latest_block.saturating_sub(MAX_DELAYED_BLOCKS) + 1
-                    }
-                };
-
-                if latest_block % 100 == 0 {
-                    tracing::debug!(
-                        next_block_to_handle,
-                        latest_block,
-                        latest_handled_block,
-                        "Eth indexer running"
-                    )
-                }
-
-                if next_block_to_handle <= latest_block {
-                    if let Err(err) = handle_block(next_block_to_handle, &context).await {
-                        tracing::warn!(%err, "failed to handle eth block");
-                        tokio::time::sleep(Duration::from_secs(5)).await;
-                        continue;
-                    }
-                } else {
-                    tokio::time::sleep(Duration::from_secs(5)).await;
+                    Err(err) => tracing::warn!("Failed to subscribe to logs: {:?}", err),
                 }
             }
-        })
-    });
+            Err(err) => tracing::error!("Failed to connect to Ethereum WebSocket: {:?}", err),
+        }
 
-    Ok((join_handle, indexer))
+        tracing::warn!("Ethereum WebSocket disconnected, reconnecting in 5 seconds...");
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
 }
 
 #[derive(Debug)]

--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -457,15 +457,6 @@ pub(crate) static PROTOCOL_ITER_CNT: Lazy<CounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub(crate) static LATEST_BLOCK_HEIGHT_ETH: Lazy<IntGaugeVec> = Lazy::new(|| {
-    try_create_int_gauge_vec(
-        "multichain_latest_block_height_eth",
-        "Latest block height handled by the node on ethereum chain",
-        &["node_account_id"],
-    )
-    .unwrap()
-});
-
 pub(crate) static NUM_SIGN_REQUESTS_ETH: Lazy<CounterVec> = Lazy::new(|| {
     try_create_counter_vec(
         "multichain_sign_requests_count_eth",

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -164,7 +164,6 @@ impl MpcSignProtocol {
             signer_id = ?signer.account_id,
             "initializing protocol with parameters"
         );
-        let state = Arc::new(RwLock::new(NodeState::Starting));
         let transport = web3::transports::Http::new(&eth_rpc_http_url)
             .expect("failed to initialize eth client");
         let web3 = Web3::new(transport);

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -150,7 +150,7 @@ impl MpcSignProtocol {
         secret_storage: SecretNodeStorageBox,
         triple_storage: TripleStorage,
         presignature_storage: PresignatureStorage,
-        eth_rpc_url: String,
+        eth_rpc_http_url: String,
         eth_contract_address: String,
         eth_account_sk: String,
     ) -> Self {
@@ -164,8 +164,9 @@ impl MpcSignProtocol {
             signer_id = ?signer.account_id,
             "initializing protocol with parameters"
         );
-        let transport =
-            web3::transports::Http::new(&eth_rpc_url).expect("failed to initialize eth client");
+        let state = Arc::new(RwLock::new(NodeState::Starting));
+        let transport = web3::transports::Http::new(&eth_rpc_http_url)
+            .expect("failed to initialize eth client");
         let web3 = Web3::new(transport);
         let ctx = Ctx {
             my_address,

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -2,8 +2,7 @@ mod error;
 
 use self::error::Error;
 use crate::indexer::Indexer;
-use crate::protocol::message::SignedMessage;
-use crate::protocol::{Message, NodeState};
+use crate::protocol::NodeState;
 use crate::web::error::Result;
 use anyhow::Context;
 use axum::http::StatusCode;

--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -113,10 +113,9 @@ impl Node {
             behind_threshold: 120,
         };
         let indexer_eth_options = mpc_node::indexer_eth::Options {
-            eth_rpc_url: config.cfg.eth_rpc_url.clone(),
+            eth_rpc_ws_url: config.cfg.eth_rpc_ws_url.clone(),
+            eth_rpc_http_url: config.cfg.eth_rpc_http_url.clone(),
             eth_contract_address: config.cfg.eth_contract_address.clone(),
-            eth_behind_threshold: 120,
-            eth_running_threshold: 120,
         };
         let args = mpc_node::cli::Cli::Start {
             near_rpc: config.near_rpc.clone(),

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -32,7 +32,8 @@ pub struct NodeConfig {
     pub nodes: usize,
     pub threshold: usize,
     pub protocol: ProtocolConfig,
-    pub eth_rpc_url: String,
+    pub eth_rpc_ws_url: String,
+    pub eth_rpc_http_url: String,
     pub eth_contract_address: String,
     pub eth_account_sk: String,
 }
@@ -55,7 +56,8 @@ impl Default for NodeConfig {
                 },
                 ..Default::default()
             },
-            eth_rpc_url: "http://localhost:8545".to_string(),
+            eth_rpc_ws_url: "ws://localhost:8545".to_string(),
+            eth_rpc_http_url: "http://localhost:8545".to_string(),
             eth_contract_address: "0x5FbDB2315678afecb367f032d93F642f64180aa3".to_string(),
             eth_account_sk: "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
                 .to_string(),

--- a/integration-tests/src/local.rs
+++ b/integration-tests/src/local.rs
@@ -71,10 +71,9 @@ impl Node {
             behind_threshold: 120,
         };
         let indexer_eth_options = mpc_node::indexer_eth::Options {
-            eth_rpc_url: cfg.eth_rpc_url.clone(),
+            eth_rpc_ws_url: cfg.eth_rpc_ws_url.clone(),
+            eth_rpc_http_url: cfg.eth_rpc_http_url.clone(),
             eth_contract_address: cfg.eth_contract_address.clone(),
-            eth_behind_threshold: 120,
-            eth_running_threshold: 120,
         };
         let near_rpc = ctx.lake_indexer.rpc_host_address.clone();
         let mpc_contract_id = ctx.mpc_contract.id().clone();
@@ -180,10 +179,9 @@ impl Node {
             behind_threshold: 120,
         };
         let indexer_eth_options = mpc_node::indexer_eth::Options {
-            eth_rpc_url: config.cfg.eth_rpc_url.clone(),
+            eth_rpc_ws_url: config.cfg.eth_rpc_ws_url.clone(),
+            eth_rpc_http_url: config.cfg.eth_rpc_http_url.clone(),
             eth_contract_address: config.cfg.eth_contract_address.clone(),
-            eth_behind_threshold: 120,
-            eth_running_threshold: 120,
         };
         let cli = mpc_node::cli::Cli::Start {
             near_rpc: config.near_rpc.clone(),

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -22,9 +22,11 @@ enum Cli {
         nodes: usize,
         #[arg(short, long, default_value_t = 2)]
         threshold: usize,
+        #[arg(long, default_value = "ws://localhost:8545")]
+        eth_rpc_ws_url: String,
         #[arg(long, default_value = "http://localhost:8545")]
-        eth_rpc_url: String,
-        #[arg(long, default_value = "0x5FbDB2315678afecb367f032d93F642f64180aa3")]
+        eth_rpc_http_url: String,
+        #[arg(long, default_value = "99bbA657f2BbC93c02D617f8bA121cB8Fc104Acf")]
         eth_contract_address: String,
         #[arg(
             long,
@@ -50,7 +52,8 @@ async fn main() -> anyhow::Result<()> {
         Cli::SetupEnv {
             nodes,
             threshold,
-            eth_rpc_url,
+            eth_rpc_ws_url,
+            eth_rpc_http_url,
             eth_contract_address,
             eth_account_sk,
         } => {
@@ -61,7 +64,8 @@ async fn main() -> anyhow::Result<()> {
             let config = NodeConfig {
                 nodes,
                 threshold,
-                eth_rpc_url,
+                eth_rpc_ws_url,
+                eth_rpc_http_url,
                 eth_contract_address,
                 eth_account_sk,
                 ..Default::default()


### PR DESCRIPTION
This PR changes the way we get sign requests from ethereum chain. Previously, we pull for latest block every 5 seconds, if there is a request in the block, we process it. The problem with that is that there's always a delay between block becoming available and us pulling for it no matter how frequent we pull.
The approach in this PR is, we subscribe to the logs in the sign request via web socket, and those logs will be pushed to us when they become available. This will minimize delay in previous approach.
There is much less ethereum RPC calls to be made because we essentially have one web socket and that's it. 