### PR TITLE
Update protocol default configs

### DIFF
--- a/chain-signatures/contract/src/config/impls.rs
+++ b/chain-signatures/contract/src/config/impls.rs
@@ -29,8 +29,8 @@ impl Default for ProtocolConfig {
         Self {
             message_timeout: min_to_ms(5),
             garbage_timeout: hours_to_ms(2),
-            max_concurrent_introduction: 2,
-            max_concurrent_generation: 2 * MAX_EXPECTED_PARTICIPANTS,
+            max_concurrent_introduction: 512,
+            max_concurrent_generation: 512 * MAX_EXPECTED_PARTICIPANTS,
             triple: TripleConfig::default(),
             presignature: PresignatureConfig::default(),
             signature: Default::default(),

--- a/chain-signatures/contract/src/config/impls.rs
+++ b/chain-signatures/contract/src/config/impls.rs
@@ -29,8 +29,8 @@ impl Default for ProtocolConfig {
         Self {
             message_timeout: min_to_ms(5),
             garbage_timeout: hours_to_ms(2),
-            max_concurrent_introduction: 512,
-            max_concurrent_generation: 512 * MAX_EXPECTED_PARTICIPANTS,
+            max_concurrent_introduction: 16,
+            max_concurrent_generation: 16 * MAX_EXPECTED_PARTICIPANTS,
             triple: TripleConfig::default(),
             presignature: PresignatureConfig::default(),
             signature: Default::default(),

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -235,7 +235,7 @@ impl VersionedMpcContract {
         let load = pending_requests as f64 / MAX_CONCURRENT_REQUESTS as f64;
 
         match load {
-            0.0..=0.25 => U128(1),
+            0.0..=0.25 => U128(2),
             0.25..=0.5 => U128(NearToken::from_millinear(50).as_yoctonear()),
             0.5..=0.75 => U128(NearToken::from_millinear(500).as_yoctonear()),
             0.75..=1.0 => U128(NearToken::from_near(1).as_yoctonear()),

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -50,7 +50,7 @@ const RETURN_SIGNATURE_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(10);
 const UPDATE_CONFIG_GAS: Gas = Gas::from_tgas(5);
 
 // Maximum number of concurrent requests
-const MAX_CONCURRENT_REQUESTS: u32 = 2048;
+const MAX_CONCURRENT_REQUESTS: u32 = 128;
 
 #[near_bindgen]
 #[derive(BorshDeserialize, BorshSerialize, Debug)]

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -235,7 +235,7 @@ impl VersionedMpcContract {
         let load = pending_requests as f64 / MAX_CONCURRENT_REQUESTS as f64;
 
         match load {
-            0.0..=0.25 => U128(2),
+            0.0..=0.25 => U128(1),
             0.25..=0.5 => U128(NearToken::from_millinear(50).as_yoctonear()),
             0.5..=0.75 => U128(NearToken::from_millinear(500).as_yoctonear()),
             0.75..=1.0 => U128(NearToken::from_near(1).as_yoctonear()),

--- a/chain-signatures/contract/tests/user_views.rs
+++ b/chain-signatures/contract/tests/user_views.rs
@@ -67,7 +67,7 @@ async fn test_experimental_signature_deposit() -> anyhow::Result<()> {
     let alice = worker.dev_create_account().await?;
     let path = "test";
 
-    for i in 1..700 {
+    for i in 1..8 {
         let msg = format!("hello world {}", i);
         println!("submitting: {msg}");
         let (payload_hash, _, _) = create_response(alice.id(), &msg, path, &sk).await;
@@ -97,6 +97,6 @@ async fn test_experimental_signature_deposit() -> anyhow::Result<()> {
         .json::<String>()
         .unwrap()
         .parse()?;
-    assert_eq!(deposit, NearToken::from_millinear(50).as_yoctonear());
+    assert_eq!(deposit, NearToken::from_yoctonear(1).as_yoctonear());
     Ok(())
 }

--- a/chain-signatures/contract/tests/user_views.rs
+++ b/chain-signatures/contract/tests/user_views.rs
@@ -67,7 +67,7 @@ async fn test_experimental_signature_deposit() -> anyhow::Result<()> {
     let alice = worker.dev_create_account().await?;
     let path = "test";
 
-    for i in 1..5 {
+    for i in 1..700 {
         let msg = format!("hello world {}", i);
         println!("submitting: {msg}");
         let (payload_hash, _, _) = create_response(alice.id(), &msg, path, &sk).await;

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -425,6 +425,7 @@ impl PresignatureManager {
                 // We will always try to generate a new triple if we have less than the minimum
                 self.len_mine().await < cfg.presignature.min_presignatures as usize
                     && self.introduced.len() < cfg.max_concurrent_introduction as usize
+                    && self.generators.len() < cfg.max_concurrent_generation as usize
             }
         };
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -44,6 +44,8 @@ impl Default for NodeConfig {
             nodes: 3,
             threshold: 2,
             protocol: ProtocolConfig {
+                max_concurrent_generation: 16,
+                max_concurrent_introduction: 2,
                 triple: TripleConfig {
                     min_triples: 8,
                     max_triples: 80,


### PR DESCRIPTION
Let's set the default number of concurrent protocols to a higher number. This should stress test our multithreading design and messaging layer.
At first, I wanted to separate the T and P parameters, but this made little sense while introducing the breaking change.

The number of signature protocols remains unconstrained. Limits for T and P protocols are separate (each node can introduce 512 T and 512 P protocols and as a result process 1024*12(number of nodes in the system) parallel protocols)
cc @auto-mausx 

@ChaoticTempest ~12,000 Tokyo tasks seem reasonable since they are mostly IO-bound. We can adjust these numbers after we have more metrics. For now higher number will give us better data.