### PR TITLE
chore: add separate metrics for sign respond and sign generation

### DIFF
--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -41,7 +41,7 @@ pub(crate) static NUM_SIGN_SUCCESS: Lazy<CounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub(crate) static SIGN_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+pub(crate) static SIGN_TOTAL_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     try_create_histogram_vec(
         "multichain_sign_latency_sec",
         "Latency of multichain signing, start from indexing sign request, end when publish() called.",
@@ -54,7 +54,7 @@ pub(crate) static SIGN_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
 pub(crate) static SIGN_GENERATION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     try_create_histogram_vec(
         "multichain_sign_gen_latency_sec",
-        "Latency of multichain signing, from received sign request to signature generation complete.",
+        "Latency of multichain signing, from start signature generation to completion.",
         &["node_account_id"],
         Some(exponential_buckets(0.001, 2.0, 20).unwrap()),
     )
@@ -64,7 +64,7 @@ pub(crate) static SIGN_GENERATION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
 pub(crate) static SIGN_RESPOND_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     try_create_histogram_vec(
         "multichain_sign_respond_latency_sec",
-        "Latency of multichain signing, from received publish request to publish complete",
+        "Latency of multichain signing, from received publish request to publish complete.",
         &["node_account_id"],
         Some(exponential_buckets(0.001, 2.0, 20).unwrap()),
     )

--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -51,6 +51,26 @@ pub(crate) static SIGN_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub(crate) static SIGN_GENERATION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "multichain_sign_gen_latency_sec",
+        "Latency of multichain signing, from received sign request to signature generation complete.",
+        &["node_account_id"],
+        Some(exponential_buckets(0.001, 2.0, 20).unwrap()),
+    )
+    .unwrap()
+});
+
+pub(crate) static SIGN_RESPOND_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "multichain_sign_respond_latency_sec",
+        "Latency of multichain signing, from received publish request to publish complete",
+        &["node_account_id"],
+        Some(exponential_buckets(0.001, 2.0, 20).unwrap()),
+    )
+    .unwrap()
+});
+
 pub(crate) static LATEST_BLOCK_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {
     try_create_int_gauge_vec(
         "multichain_latest_block_height",

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -599,6 +599,10 @@ impl SignatureManager {
                             elapsed = ?generator.generator_timestamp.elapsed(),
                             "completed signature generation"
                         );
+                        crate::metrics::SIGN_GENERATION_LATENCY
+                            .with_label_values(&[self.my_account_id.as_str()])
+                            .observe(generator.generator_timestamp.elapsed().as_secs_f64());
+
                         self.completed
                             .insert(sign_request_id.clone(), Instant::now());
                         let request = SignatureRequest {

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -596,6 +596,7 @@ impl SignatureManager {
                             presignature_id = generator.presignature_id,
                             big_r = ?output.big_r.to_base58(),
                             s = ?output.s,
+                            elapsed = ?generator.generator_timestamp.elapsed(),
                             "completed signature generation"
                         );
                         self.completed

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -447,6 +447,9 @@ async fn try_publish_near(
     crate::metrics::SIGN_LATENCY
         .with_label_values(&[near.my_account_id.as_str()])
         .observe(time_added.elapsed().as_secs_f64());
+    crate::metrics::SIGN_RESPOND_LATENCY
+        .with_label_values(&[near.my_account_id.as_str()])
+        .observe(timestamp.elapsed().as_secs_f64());
     if time_added.elapsed().as_secs() <= 30 {
         crate::metrics::NUM_SIGN_SUCCESS_30S
             .with_label_values(&[near.my_account_id.as_str()])

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -444,7 +444,7 @@ async fn try_publish_near(
     crate::metrics::NUM_SIGN_SUCCESS
         .with_label_values(&[near.my_account_id.as_str()])
         .inc();
-    crate::metrics::SIGN_LATENCY
+    crate::metrics::SIGN_TOTAL_LATENCY
         .with_label_values(&[near.my_account_id.as_str()])
         .observe(time_added.elapsed().as_secs_f64());
     crate::metrics::SIGN_RESPOND_LATENCY


### PR DESCRIPTION
Add additional metrics for signing:
- signature generation latency: time taken between request received and signature generation completed.
- respond latency: time it takes to publish the signature. 
- logging now has the elapsed times as well for signatures.

We can see how long signature generation takes a bit more precisely with this