### PR TITLE
chore: added tmp_dir for proper key cleanup

### DIFF
--- a/integration-tests/src/cluster/mod.rs
+++ b/integration-tests/src/cluster/mod.rs
@@ -13,7 +13,7 @@ use crate::cluster::spawner::ClusterSpawner;
 use crate::containers::DockerClient;
 use crate::local::NodeEnvConfig;
 use crate::utils::{vote_join, vote_leave};
-use crate::{utils, NodeConfig, Nodes};
+use crate::{NodeConfig, Nodes};
 use mpc_contract::update::{ProposeUpdateArgs, UpdateId};
 use mpc_contract::{ProtocolContractState, RunningContractState};
 use mpc_node::web::StateView;
@@ -134,16 +134,7 @@ impl Cluster {
     pub async fn restart_node(&mut self, config: NodeEnvConfig) -> anyhow::Result<()> {
         self.nodes.restart_node(config).await
     }
-}
 
-impl Drop for Cluster {
-    fn drop(&mut self) {
-        let sk_local_path = self.nodes.ctx().storage_options.sk_share_local_path.clone();
-        let _task = tokio::task::spawn(utils::clear_local_sk_shares(sk_local_path));
-    }
-}
-
-impl Cluster {
     /// Starts a node and waits for the cluster to be in running. This does not have the node join the network,
     /// but it does appear as a candidate in the contract.
     pub async fn start(&mut self, node: Option<NodeEnvConfig>) -> anyhow::Result<Account> {

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -5,7 +5,7 @@ use std::vec;
 
 use clap::Parser;
 use integration_tests::cluster::spawner::ClusterSpawner;
-use integration_tests::{utils, NodeConfig};
+use integration_tests::NodeConfig;
 use near_account_id::AccountId;
 use near_crypto::PublicKey;
 use serde_json::json;
@@ -79,7 +79,6 @@ async fn main() -> anyhow::Result<()> {
             let ctx = nodes.ctx();
             let urls: Vec<_> = (0..spawner.cfg.nodes).map(|i| nodes.url(i)).collect();
             let near_accounts = nodes.near_accounts();
-            let sk_local_path = nodes.ctx().storage_options.sk_share_local_path.clone();
 
             println!("\nEnvironment is ready:");
             println!("  docker-network: {}", ctx.docker_network);
@@ -103,7 +102,6 @@ async fn main() -> anyhow::Result<()> {
 
             signal::ctrl_c().await.expect("Failed to listen for event");
             println!("Received Ctrl-C");
-            utils::clear_local_sk_shares(sk_local_path).await?;
             println!("Clean up finished");
         }
         Cli::DepServices => {

--- a/integration-tests/src/utils.rs
+++ b/integration-tests/src/utils.rs
@@ -2,9 +2,6 @@ use anyhow::Context;
 use hyper::{Body, Client, Method, Request, StatusCode, Uri};
 use near_workspaces::{Account, AccountId};
 
-use std::path::Path;
-use std::{fs, io};
-
 pub async fn vote_join(
     accounts: &[&Account],
     mpc_contract: &AccountId,
@@ -142,19 +139,5 @@ pub async fn ping_until_ok(addr: &str, timeout: u64) -> anyhow::Result<()> {
         }
     })
     .await?;
-    Ok(())
-}
-
-pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
-    fs::create_dir_all(&dst)?;
-    for entry in fs::read_dir(src)? {
-        let entry = entry?;
-        let ty = entry.file_type()?;
-        if ty.is_dir() {
-            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
-        } else {
-            fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
-        }
-    }
     Ok(())
 }

--- a/integration-tests/src/utils.rs
+++ b/integration-tests/src/utils.rs
@@ -1,7 +1,9 @@
 use anyhow::Context;
 use hyper::{Body, Client, Method, Request, StatusCode, Uri};
 use near_workspaces::{Account, AccountId};
-use std::fs;
+
+use std::path::Path;
+use std::{fs, io};
 
 pub async fn vote_join(
     accounts: &[&Account],
@@ -143,20 +145,15 @@ pub async fn ping_until_ok(addr: &str, timeout: u64) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn clear_local_sk_shares(sk_local_path: Option<String>) -> anyhow::Result<()> {
-    if let Some(sk_share_local_path) = sk_local_path {
-        let pattern = format!("{sk_share_local_path}*");
-        for entry in glob::glob(&pattern).expect("Failed to read glob pattern") {
-            match entry {
-                Ok(path) => {
-                    if path.is_file() {
-                        if let Err(e) = fs::remove_file(&path) {
-                            eprintln!("Failed to delete file {:?}: {}", path.display(), e);
-                        }
-                    }
-                }
-                Err(e) => eprintln!("{:?}", e),
-            }
+pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+    fs::create_dir_all(&dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        } else {
+            fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
         }
     }
     Ok(())


### PR DESCRIPTION
was getting annoyed by all the misc integration keys appearing in the `integration-tests` folder. So now they'll be populated under `target/tmp` folder.

Also made a few things parameterizable like GCP project id and env if that matters for anybody.