### PR TITLE
feat: poc of a request queue in redis

### DIFF
--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -34,7 +34,6 @@ use reqwest::IntoUrl;
 use std::path::Path;
 use std::time::Instant;
 use std::{sync::Arc, time::Duration};
-use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 use url::Url;
 
@@ -44,7 +43,7 @@ struct Ctx {
     mpc_contract_id: AccountId,
     near: NearClient,
     rpc_channel: RpcChannel,
-    sign_rx: Arc<RwLock<mpsc::Receiver<SignRequest>>>,
+    redis_pool: deadpool_redis::Pool,
     secret_storage: SecretNodeStorageBox,
     triple_storage: TripleStorage,
     presignature_storage: PresignatureStorage,
@@ -67,8 +66,8 @@ impl ConsensusCtx for &mut MpcSignProtocol {
         &self.ctx.my_address
     }
 
-    fn sign_rx(&self) -> Arc<RwLock<mpsc::Receiver<SignRequest>>> {
-        self.ctx.sign_rx.clone()
+    fn redis_pool(&self) -> &deadpool_redis::Pool {
+        &self.ctx.redis_pool
     }
 
     fn secret_storage(&self) -> &SecretNodeStorageBox {
@@ -130,7 +129,7 @@ impl MpcSignProtocol {
         near: NearClient,
         rpc_channel: RpcChannel,
         channel: MessageChannel,
-        sign_rx: mpsc::Receiver<SignRequest>,
+        redis_pool: deadpool_redis::Pool,
         secret_storage: SecretNodeStorageBox,
         triple_storage: TripleStorage,
         presignature_storage: PresignatureStorage,
@@ -142,7 +141,7 @@ impl MpcSignProtocol {
             mpc_contract_id,
             near,
             rpc_channel,
-            sign_rx: Arc::new(RwLock::new(sign_rx)),
+            redis_pool,
             secret_storage,
             triple_storage,
             presignature_storage,

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -459,11 +459,11 @@ async fn try_publish_near(
         .inc();
     crate::metrics::SIGN_TOTAL_LATENCY
         .with_label_values(&[near.my_account_id.as_str()])
-        .observe(time_added.elapsed().as_secs_f64());
+        .observe(time_added.elapsed().unwrap_or_default().as_secs_f64());
     crate::metrics::SIGN_RESPOND_LATENCY
         .with_label_values(&[near.my_account_id.as_str()])
         .observe(timestamp.elapsed().as_secs_f64());
-    if time_added.elapsed().as_secs() <= 30 {
+    if time_added.elapsed().unwrap_or_default().as_secs() <= 30 {
         crate::metrics::NUM_SIGN_SUCCESS_30S
             .with_label_values(&[near.my_account_id.as_str()])
             .inc();

--- a/chain-signatures/node/src/storage/mod.rs
+++ b/chain-signatures/node/src/storage/mod.rs
@@ -1,6 +1,7 @@
 pub mod app_data_storage;
 pub mod error;
 pub mod presignature_storage;
+pub mod request_queue;
 pub mod secret_storage;
 pub mod triple_storage;
 

--- a/chain-signatures/node/src/storage/request_queue.rs
+++ b/chain-signatures/node/src/storage/request_queue.rs
@@ -1,0 +1,52 @@
+//! A FIFO queue for signature requests between many chain indexers (producers)
+//! and one MPC node (consumer).
+//!
+//! Under the "sign_request_queue" key on redis, we store signature requests
+//! that have been validated by a chain indexer. The MPC node is picking them up
+//! as the sole consumer on the queue.
+//!
+//! The redis type is a list, therefore, use `lpush` and `brpop` to modify the
+//! queue.
+
+use crate::protocol::SignRequest;
+use redis::AsyncCommands;
+
+const QUEUE_KEY: &str = "sign_request_queue";
+
+/// Take a validated sign request from a chain and hand it off to the MPC node
+/// for processing.
+pub async fn push_sign_request(
+    redis_pool: &deadpool_redis::Pool,
+    request: SignRequest,
+) -> anyhow::Result<()> {
+    let mut request_cbor = Vec::new();
+    ciborium::ser::into_writer(&request, &mut request_cbor)?;
+
+    let mut conn = redis_pool.get().await?;
+    // Using a redis list as a FIFO queue, pushing on the left and popping on the right.
+    let _len: usize = conn.lpush(QUEUE_KEY, request_cbor).await?;
+
+    Ok(())
+}
+
+/// Take a signature request from the head of the FIFO queue.
+///
+/// Blocks until a request is available, asynchronously waiting for a
+/// notification by redis.
+pub async fn pop_sign_request(redis_pool: &deadpool_redis::Pool) -> anyhow::Result<SignRequest> {
+    let mut conn = redis_pool.get().await?;
+    // Using a redis list as a FIFO queue, pushing on the left and popping on the right.
+    // timeout = 0.0 will block indefinitely
+    let maybe_request_cbor: Option<Vec<u8>> = conn.brpop(QUEUE_KEY, 0.0).await?;
+
+    if let Some(request_cbor) = maybe_request_cbor {
+        let cursor = std::io::Cursor::new(request_cbor);
+
+        let request = ciborium::de::from_reader(cursor)?;
+        Ok(request)
+    } else {
+        // this is against the redis documentation
+        // https://redis.io/docs/latest/commands/blpop/
+        anyhow::bail!("redis BRPOP with timeout=0.0 returned nil value");
+    }
+}


### PR DESCRIPTION
This commit shows how a redis list can be used to decouple the sign request
producers (indexers) from the rest of the MPC node.

This is essentially just ripping out a mpsc::channel() with a redis FIFO queue.
Most code changes are just replacing the corresponding sender / receiver to a
redis pool.

The biggest change in this is that we have to serialize `SignRequest` to queue
it. This caused a conflict with the time_added field on the request. Using
`Instant` only works for relative timing within a single process and it is
therefore not designed to be serialized. Replacing it with `SystemTime` works
opens up problems with system time changes, in which case the `.elapsed()` time
could fail to work or return invalid data. I think this is fine, as we only use
the time for metrics. Thus, I use `unwrap_or_default` to convert failures in
time measuring to 0 ms duration.