### PR TITLE
fix: generation should be on all participants not active

### DIFF
--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -54,7 +54,12 @@ impl CryptographicProtocol for GeneratingState {
         _cfg: Config,
         mesh_state: MeshState,
     ) -> Result<NodeState, CryptographicError> {
-        tracing::info!(active = ?mesh_state.active.keys_vec(), "generating: progressing key generation");
+        let participants = self.participants.keys_vec();
+        tracing::info!(
+            ?participants,
+            active = ?mesh_state.active.keys_vec(),
+            "generating: progressing key generation",
+        );
         let mut protocol = self.protocol.write().await;
         loop {
             let action = match protocol.poke() {
@@ -75,7 +80,7 @@ impl CryptographicProtocol for GeneratingState {
                 }
                 Action::SendMany(data) => {
                     tracing::debug!("generating: sending a message to many participants");
-                    for p in mesh_state.active.keys() {
+                    for p in &participants {
                         if p == &self.me {
                             // Skip yourself, cait-sith never sends messages to oneself
                             continue;


### PR DESCRIPTION
Nodes don't necessarily hop online instantly for generation, that means they can restart or be in offline state when generation has just occurred. In this case, an active node may send a message way too earlier, leading it to be binned or missed by nodes that have not started yet. They would never receive these messages due to the retrying mechanism for this being inside the message channel.

We need to try and send it to all participants instead, and let the message channel retry where possible.