### PR TITLE
eth contract: replace error with other var names

### DIFF
--- a/chain-signatures/contract-eth/contracts/ChainSignatures.sol
+++ b/chain-signatures/contract-eth/contracts/ChainSignatures.sol
@@ -35,7 +35,7 @@ contract ChainSignatures is AccessControl {
 
     struct ErrorResponse {
         bytes32 requestId;
-        string error;
+        string errorMessage;
     }
 
     uint256 signatureDeposit;
@@ -148,7 +148,7 @@ contract ChainSignatures is AccessControl {
             emit SignatureError(
                 _errors[i].requestId,
                 msg.sender,
-                _errors[i].error
+                _errors[i].errorMessage
             );
         }
     }

--- a/chain-signatures/contract-eth/test/ChainSignatures.test.js
+++ b/chain-signatures/contract-eth/test/ChainSignatures.test.js
@@ -150,7 +150,7 @@ describe("ChainSignatures", function () {
       const requestId = ethers.keccak256(encoded);
 
       const errorMessage = "sorry";
-      const tx2 = await chainSignatures.connect(addr2).respondError([{ requestId: requestId, error: errorMessage }]);
+      const tx2 = await chainSignatures.connect(addr2).respondError([{ requestId: requestId, errorMessage: errorMessage }]);
       const receipt2 = await tx2.wait();
       const responseEvent = receipt2.logs.find(log => 
         chainSignatures.interface.parseLog(log)?.name === "SignatureError"


### PR DESCRIPTION
error (Special Solidity Feature)

Introduced in Solidity 0.8.4.
Allows defining custom errors that can be used with revert, making reverts more gas-efficient compared to require with string messages.
Example:
```
error Unauthorized(address user);

function restrictedFunction() public {
    if (msg.sender != owner) {
        revert Unauthorized(msg.sender);
    }
}
```
Using error is cheaper than reverting with a string message because it avoids storing large strings in transaction logs.

We should not use `error` as variable name