### PR TITLE
fix: push failed signature request into sign queue for non-proposers

### DIFF
--- a/chain-signatures/node/src/protocol/message.rs
+++ b/chain-signatures/node/src/protocol/message.rs
@@ -612,7 +612,7 @@ impl MessageReceiver for RunningState {
 
             queue.retain(|msg| active.contains(&msg.presignature_id));
 
-            queue.is_empty()
+            !queue.is_empty()
         });
 
         for (sign_id, queue) in signature_messages {


### PR DESCRIPTION
discovered that eth requests fail when it did not succeed on 1st generator, and need to retry.
Poking the logs, I find that the non-proposer nodes were warning `waiting for indexer`. This means that the request has been removed from sign_queue, and not added back.
This should affect near requests as well, but likely near block time is fast thus less delay on indexer side, thus most requests finish in first attempt.