### PR TITLE
Check deposit with `=`

### DIFF
--- a/chain-signatures/contract-eth/contracts/ChainSignatures.sol
+++ b/chain-signatures/contract-eth/contracts/ChainSignatures.sol
@@ -110,7 +110,7 @@ contract ChainSignatures is AccessControl {
      * @param _request The signature request details.
      */
     function sign(SignRequest memory _request) external payable {
-        require(msg.value >= signatureDeposit, "Insufficient deposit");
+        require(msg.value == signatureDeposit, "Insufficient deposit");
 
         emit SignatureRequested(
             msg.sender,


### PR DESCRIPTION
Auditors:
```
There's no refund for overpayments. To enforce an exact deposit, update the check to:
require(msg.value == signatureDeposit, "Insufficient deposit");
```
Overall, it makes sense, but it disallows us to accept flexible payments, such as prioritizing signatures in the queue.