### PR TITLE
fix: resubscribe to eth logs if no eth events in 60s

### DIFF
--- a/chain-signatures/node/src/indexer.rs
+++ b/chain-signatures/node/src/indexer.rs
@@ -282,7 +282,7 @@ async fn handle_block(
             tracing::error!(?err, "failed to send the sign request into sign queue");
         }
         crate::metrics::NUM_SIGN_REQUESTS
-            .with_label_values(&[ctx.node_account_id.as_str()])
+            .with_label_values(&[Chain::NEAR.as_str(), ctx.node_account_id.as_str()])
             .inc();
     }
 

--- a/chain-signatures/node/src/indexer.rs
+++ b/chain-signatures/node/src/indexer.rs
@@ -263,8 +263,8 @@ async fn handle_block(
         .update_block_height_and_timestamp(block.block_height(), block.header().timestamp_nanosec())
         .await;
 
-    crate::metrics::LATEST_BLOCK_HEIGHT
-        .with_label_values(&[ctx.node_account_id.as_str()])
+    crate::metrics::LATEST_BLOCK_NUMBER
+        .with_label_values(&[Chain::NEAR.as_str(), ctx.node_account_id.as_str()])
         .set(block.block_height() as i64);
 
     // Add the requests after going through the whole block to avoid partial processing if indexer fails somewhere.

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -416,7 +416,15 @@ async fn catchup(
 
     let logs = ws.eth().logs(filter).await?;
     for log in logs {
-        process_filtered_log(log, sign_tx.clone(), node_near_account_id.clone())?;
+        if let Err(err) =
+            process_filtered_log(log.clone(), sign_tx.clone(), node_near_account_id.clone())
+        {
+            tracing::warn!(
+                "Failed to process ethereum log: {:?} because of {:?}",
+                log,
+                err
+            );
+        }
     }
     Ok(())
 }

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -324,7 +324,8 @@ pub async fn run(
                                     }
                                     _ = heartbeat_interval.tick() => {
                                         if latest_sign_request_time.elapsed() > heartbeat_interval.period() {
-                                            tracing::warn!("No sign request received in the last 60 seconds");
+                                            tracing::warn!("No sign request received in the last 60 seconds, unsubscribing...");
+                                            filtered_logs_sub.unsubscribe().await?;
                                             break;
                                         }
                                     }

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -393,8 +393,8 @@ fn process_filtered_log(
     node_near_account_id: AccountId,
 ) -> anyhow::Result<()> {
     tracing::info!("Received new Ethereum sign request: {:?}", log);
-    crate::metrics::NUM_SIGN_REQUESTS_ETH
-        .with_label_values(&[node_near_account_id.as_str()])
+    crate::metrics::NUM_SIGN_REQUESTS
+        .with_label_values(&[Chain::NEAR.as_str(), node_near_account_id.as_str()])
         .inc();
     let sign_request = sign_request_from_filtered_log(log)?;
     let sign_tx = sign_tx.clone();

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -278,7 +278,7 @@ pub async fn run(
                         let last_block = latest_block_number;
                         if last_block < end_block {
                             if let Err(err) = catchup(
-                                last_block,
+                                last_block + 1,
                                 end_block,
                                 web3_ws.clone(),
                                 sign_tx.clone(),

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -280,8 +280,11 @@ pub async fn run(
                             if latest_block_number == 0 {
                                 latest_block_number = block_number.as_u64();
                                 tracing::info!("Latest eth block number: {latest_block_number}");
-                                crate::metrics::LATEST_BLOCK_NUMBER_ETH
-                                    .with_label_values(&[node_near_account_id.as_str()])
+                                crate::metrics::LATEST_BLOCK_NUMBER
+                                    .with_label_values(&[
+                                        Chain::Ethereum.as_str(),
+                                        node_near_account_id.as_str(),
+                                    ])
                                     .set(latest_block_number as i64);
                             } else if latest_block_number < end_block {
                                 if let Err(err) = catchup(
@@ -300,8 +303,11 @@ pub async fn run(
                                     tracing::info!(
                                         "Latest eth block number: {latest_block_number}"
                                     );
-                                    crate::metrics::LATEST_BLOCK_NUMBER_ETH
-                                        .with_label_values(&[node_near_account_id.as_str()])
+                                    crate::metrics::LATEST_BLOCK_NUMBER
+                                        .with_label_values(&[
+                                            Chain::Ethereum.as_str(),
+                                            node_near_account_id.as_str(),
+                                        ])
                                         .set(latest_block_number as i64);
                                 }
                             } else {
@@ -347,8 +353,8 @@ pub async fn run(
                                             latest_sign_request_time = Instant::now();
                                             latest_block_number = log.block_number.unwrap().as_u64();
                                             tracing::info!("Latest eth sign request block number: {latest_block_number}");
-                                            crate::metrics::LATEST_BLOCK_NUMBER_ETH
-                                                .with_label_values(&[node_near_account_id.as_str()])
+                                            crate::metrics::LATEST_BLOCK_NUMBER
+                                                .with_label_values(&[Chain::Ethereum.as_str(),node_near_account_id.as_str()])
                                                 .set(latest_block_number as i64);
                                         }
                                     }

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -298,6 +298,7 @@ pub async fn run(
                                 .await
                                 {
                                     tracing::warn!("Failed to catch up: {:?}", err);
+                                    tokio::time::sleep(Duration::from_secs(5)).await;
                                     continue;
                                 } else {
                                     latest_block_number = end_block;
@@ -335,7 +336,7 @@ pub async fn run(
                             tracing::info!("Ethereum indexer subscribed and listening for logs");
 
                             let mut heartbeat_interval =
-                                tokio::time::interval(Duration::from_secs(60));
+                                tokio::time::interval(Duration::from_secs(180));
                             heartbeat_interval.tick().await;
                             let mut latest_sign_request_time = Instant::now();
 
@@ -361,7 +362,7 @@ pub async fn run(
                                     }
                                     _ = heartbeat_interval.tick() => {
                                         if latest_sign_request_time.elapsed() > heartbeat_interval.period() {
-                                            tracing::warn!("No sign request received in the last 60 seconds, unsubscribing...");
+                                            tracing::warn!("No sign request received in the last 180 seconds, unsubscribing...");
                                             break;
                                         }
                                     }

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -379,9 +379,21 @@ pub async fn run(
                         }
                     };
                     if let Ok(filtered_logs_sub) = subscribe_end_result {
-                        if let Err(err) = filtered_logs_sub.unsubscribe().await {
-                            tracing::warn!("Failed to unsubscribe from logs: {:?}, will reconnect to websocket", err);
-                            break;
+                        match filtered_logs_sub.unsubscribe().await {
+                            Ok(true) => {
+                                tracing::info!("Unsubscribed from logs");
+                            }
+                            Ok(false) => {
+                                tracing::warn!(
+                                    "Failed to unsubscribe from logs, will reconnect to websocket"
+                                );
+                            }
+                            Err(err) => {
+                                tracing::warn!(
+                                    "Failed to unsubscribe from logs: {:?}, will reconnect to websocket",
+                                    err
+                                );
+                            }
                         }
                     } else {
                         break;

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -400,8 +400,9 @@ fn process_filtered_log(
 ) -> anyhow::Result<()> {
     tracing::info!("Received new Ethereum sign request: {:?}", log);
     crate::metrics::NUM_SIGN_REQUESTS
-        .with_label_values(&[Chain::NEAR.as_str(), node_near_account_id.as_str()])
+        .with_label_values(&[Chain::Ethereum.as_str(), node_near_account_id.as_str()])
         .inc();
+
     let sign_request = sign_request_from_filtered_log(log)?;
     let sign_tx = sign_tx.clone();
     tokio::spawn(async move {

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -290,12 +290,12 @@ pub async fn run(
                                 tracing::warn!("Failed to catch up: {:?}", err);
                             } else {
                                 latest_block_number = end_block;
+                                tracing::info!("Latest eth block number: {latest_block_number}");
+                                crate::metrics::LATEST_BLOCK_NUMBER_ETH
+                                    .with_label_values(&[node_near_account_id.as_str()])
+                                    .set(latest_block_number as i64);
                             }
                         }
-                        tracing::info!("Latest eth block number: {latest_block_number}");
-                        crate::metrics::LATEST_BLOCK_NUMBER_ETH
-                            .with_label_values(&[node_near_account_id.as_str()])
-                            .set(latest_block_number as i64);
                     }
                     match web3_ws.eth_subscribe().subscribe_logs(filter.clone()).await {
                         Ok(mut filtered_logs_sub) => {

--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -489,7 +489,7 @@ pub(crate) static NUM_UNIQUE_SIGN_REQUESTS: LazyLock<CounterVec> = LazyLock::new
     try_create_counter_vec(
         "multichain_sign_requests_count_unique",
         "number of multichain sign requests, marked by sign requests indexed and deduped",
-        &["node_account_id"],
+        &["chain", "node_account_id"],
     )
     .unwrap()
 });

--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -394,7 +394,7 @@ pub(crate) static SIGNATURE_PUBLISH_FAILURES: LazyLock<CounterVec> = LazyLock::n
     try_create_counter_vec(
         "multichain_signature_publish_failures",
         "number of failed signature publish",
-        &["node_account_id"],
+        &["chain", "node_account_id"],
     )
     .unwrap()
 });

--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -27,7 +27,7 @@ pub(crate) static NUM_SIGN_REQUESTS_MINE: LazyLock<CounterVec> = LazyLock::new(|
     try_create_counter_vec(
         "multichain_sign_requests_count_mine",
         "number of multichain sign requests, marked by sign requests indexed",
-        &["chain", "node_account_id"],
+        &["node_account_id"],
     )
     .unwrap()
 });
@@ -481,6 +481,15 @@ pub(crate) static LATEST_BLOCK_NUMBER: LazyLock<IntGaugeVec> = LazyLock::new(|| 
         "multichain_latest_block_number",
         "Latest block number seen by the node",
         &["chain", "node_account_id"],
+    )
+    .unwrap()
+});
+
+pub(crate) static NUM_UNIQUE_SIGN_REQUESTS: LazyLock<CounterVec> = LazyLock::new(|| {
+    try_create_counter_vec(
+        "multichain_sign_requests_count_unique",
+        "number of multichain sign requests, marked by sign requests indexed and deduped",
+        &["node_account_id"],
     )
     .unwrap()
 });

--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -69,15 +69,6 @@ pub(crate) static SIGN_RESPOND_LATENCY: LazyLock<Histogram> = LazyLock::new(|| {
     )
 });
 
-pub(crate) static LATEST_BLOCK_HEIGHT: LazyLock<IntGaugeVec> = LazyLock::new(|| {
-    try_create_int_gauge_vec(
-        "multichain_latest_block_height",
-        "Latest block height seen by the node",
-        &["node_account_id"],
-    )
-    .unwrap()
-});
-
 pub(crate) static TRIPLE_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
         "multichain_triple_latency_sec",
@@ -485,11 +476,11 @@ pub(crate) static CONFIGURATION_DIGEST: LazyLock<IntGaugeVec> = LazyLock::new(||
     .unwrap()
 });
 
-pub(crate) static LATEST_BLOCK_NUMBER_ETH: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+pub(crate) static LATEST_BLOCK_NUMBER: LazyLock<IntGaugeVec> = LazyLock::new(|| {
     try_create_int_gauge_vec(
-        "multichain_latest_block_number_eth",
-        "Latest eth block number seen by the node",
-        &["node_account_id"],
+        "multichain_latest_block_number",
+        "Latest block number seen by the node",
+        &["chain", "node_account_id"],
     )
     .unwrap()
 });

--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -18,7 +18,7 @@ pub(crate) static NUM_SIGN_REQUESTS: LazyLock<CounterVec> = LazyLock::new(|| {
     try_create_counter_vec(
         "multichain_sign_requests_count",
         "number of multichain sign requests, marked by sign requests indexed",
-        &["node_account_id"],
+        &["chain", "node_account_id"],
     )
     .unwrap()
 });
@@ -27,7 +27,7 @@ pub(crate) static NUM_SIGN_REQUESTS_MINE: LazyLock<CounterVec> = LazyLock::new(|
     try_create_counter_vec(
         "multichain_sign_requests_count_mine",
         "number of multichain sign requests, marked by sign requests indexed",
-        &["node_account_id"],
+        &["chain", "node_account_id"],
     )
     .unwrap()
 });
@@ -36,7 +36,7 @@ pub(crate) static NUM_SIGN_SUCCESS: LazyLock<CounterVec> = LazyLock::new(|| {
     try_create_counter_vec(
         "multichain_sign_requests_success",
         "number of successful multichain sign requests, marked by publish()",
-        &["node_account_id"],
+        &["chain", "node_account_id"],
     )
     .unwrap()
 });
@@ -45,7 +45,7 @@ pub(crate) static SIGN_TOTAL_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| 
     try_create_histogram_vec(
         "multichain_sign_latency_sec",
         "Latency of multichain signing, start from indexing sign request, end when publish() called.",
-        &["node_account_id"],
+        &["chain", "node_account_id"],
         Some(exponential_buckets(0.001, 2.0, 20).unwrap()),
     )
     .unwrap()
@@ -64,7 +64,7 @@ pub(crate) static SIGN_RESPOND_LATENCY: LazyLock<Histogram> = LazyLock::new(|| {
     Histogram::new(
         "multichain_sign_respond_latency_sec",
         "Latency of multichain signing, from received publish request to publish complete.",
-        &["node_account_id"],
+        &["chain", "node_account_id"],
         Some(exponential_buckets(0.001, 2.0, 20).unwrap()),
     )
 });
@@ -270,7 +270,7 @@ pub(crate) static NUM_SIGN_SUCCESS_30S: LazyLock<CounterVec> = LazyLock::new(|| 
     try_create_counter_vec(
             "multichain_sign_requests_success_30s",
             "number of successful multichain sign requests that finished within 30s, marked by publish()",
-            &["node_account_id"],
+            &["chain", "node_account_id"],
         )
         .unwrap()
 });
@@ -471,15 +471,6 @@ pub(crate) static PROTOCOL_ITER_CNT: LazyLock<CounterVec> = LazyLock::new(|| {
     try_create_counter_vec(
         "multichain_protocol_iter_count",
         "Count of multichain protocol iter",
-        &["node_account_id"],
-    )
-    .unwrap()
-});
-
-pub(crate) static NUM_SIGN_REQUESTS_ETH: LazyLock<CounterVec> = LazyLock::new(|| {
-    try_create_counter_vec(
-        "multichain_sign_requests_count_eth",
-        "number of multichain sign requests from ethereum chain, marked by sign requests indexed",
         &["node_account_id"],
     )
     .unwrap()

--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -494,6 +494,15 @@ pub(crate) static CONFIGURATION_DIGEST: LazyLock<IntGaugeVec> = LazyLock::new(||
     .unwrap()
 });
 
+pub(crate) static LATEST_BLOCK_NUMBER_ETH: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    try_create_int_gauge_vec(
+        "multichain_latest_block_number_eth",
+        "Latest eth block number seen by the node",
+        &["node_account_id"],
+    )
+    .unwrap()
+});
+
 pub fn try_create_int_gauge_vec(name: &str, help: &str, labels: &[&str]) -> Result<IntGaugeVec> {
     check_metric_multichain_prefix(name)?;
     let opts = Opts::new(name, help);

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -33,6 +33,7 @@ use crate::storage::triple_storage::TripleStorage;
 
 use near_account_id::AccountId;
 use reqwest::IntoUrl;
+use std::fmt;
 use std::path::Path;
 use std::time::Instant;
 use std::{sync::Arc, time::Duration};
@@ -354,6 +355,21 @@ pub async fn spawn_system_metrics(node_account_id: &str) -> tokio::task::JoinHan
 pub enum Chain {
     NEAR,
     Ethereum,
+}
+
+impl Chain {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Chain::NEAR => "NEAR",
+            Chain::Ethereum => "Ethereum",
+        }
+    }
+}
+
+impl fmt::Display for Chain {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
 }
 
 #[cfg(test)]

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -358,7 +358,7 @@ pub enum Chain {
 }
 
 impl Chain {
-    pub fn as_str(&self) -> &'static str {
+    pub const fn as_str(&self) -> &'static str {
         match self {
             Chain::NEAR => "NEAR",
             Chain::Ethereum => "Ethereum",

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -114,7 +114,7 @@ impl SignQueue {
                 continue;
             }
             crate::metrics::NUM_UNIQUE_SIGN_REQUESTS
-                .with_label_values(&[my_account_id.as_str()])
+                .with_label_values(&[indexed.chain.as_str(), my_account_id.as_str()])
                 .inc();
             let mut rng = StdRng::from_seed(indexed.args.entropy);
             let subset = stable.keys().cloned().choose_multiple(&mut rng, threshold);

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -591,6 +591,7 @@ impl SignatureManager {
                 // TODO: do not insert back presignature when we have a clear model for data consistency
                 // between nodes and utilizing only presignatures that meet threshold requirements.
                 presignature_manager.insert(presignature, true, true).await;
+                self.sign_queue.push_failed(my_request);
                 continue;
             }
 
@@ -605,6 +606,7 @@ impl SignatureManager {
                     ?err,
                     "failed to start signature generation: trashing presignature"
                 );
+                self.sign_queue.push_failed(my_request);
                 continue;
             }
         }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -113,6 +113,9 @@ impl SignQueue {
                 tracing::info!(?sign_id, "skipping sign request: already in the sign queue");
                 continue;
             }
+            crate::metrics::NUM_UNIQUE_SIGN_REQUESTS
+                .with_label_values(&[my_account_id.as_str()])
+                .inc();
             let mut rng = StdRng::from_seed(indexed.args.entropy);
             let subset = stable.keys().cloned().choose_multiple(&mut rng, threshold);
             let in_subset = subset.contains(&self.me);

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -106,12 +106,18 @@ impl SignQueue {
                 other => other,
             }
         } {
+            let sign_id = indexed.id.clone();
+            if self.my_requests.iter().any(|req| req.indexed.id == sign_id)
+                || self.other_requests.contains_key(&sign_id)
+            {
+                tracing::info!(?sign_id, "skipping sign request: already in the sign queue");
+                continue;
+            }
             let mut rng = StdRng::from_seed(indexed.args.entropy);
             let subset = stable.keys().cloned().choose_multiple(&mut rng, threshold);
             let in_subset = subset.contains(&self.me);
             let proposer = *subset.choose(&mut rng).unwrap();
             let is_mine = proposer == self.me;
-            let sign_id = indexed.id.clone();
 
             tracing::info!(
                 ?sign_id,

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -598,7 +598,7 @@ impl SignatureManager {
             let sign_id = my_request.indexed.id.clone();
             let presignature_id = presignature.id;
             if let Err(InitializationError::BadParameters(err)) =
-                self.generate(presignature, my_request, cfg)
+                self.generate(presignature, my_request.clone(), cfg)
             {
                 tracing::warn!(
                     ?sign_id,

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -456,7 +456,7 @@ async fn try_publish_near(
             "smart contract threw error",
         );
         crate::metrics::SIGNATURE_PUBLISH_RESPONSE_ERRORS
-            .with_label_values(&[chain.as_str(), near.my_account_id.as_str()])
+            .with_label_values(&[near.my_account_id.as_str()])
             .inc();
     })?;
     tracing::info!(


### PR DESCRIPTION
We observed that some nodes will stop receiving eth requests after running for a while.
I investigated online for a bit, seems like it's related to infura dropping the websocket while we are subscribed: https://github.com/INFURA/infura/issues/117

This PR basically unscuscribe and resubscribe when there has been no sign events in the past 60s. Choosing this solution because Infura has not committed to emitting any events to indicate they have dropped our connection. 

I tried requesting block number using websocket to keep the subscription alive as suggested by one comment in the infura issue, but while the web socket is alive and block number call keeps succeeding, subscription still won't receive new events. So I changed to unsubscribe and resubscribing. 
Also added catchup logic whenever we resubscribe so that we process all logs from last attempt.
I checked locally this will solve the previous problem of subscription not working after a while locally. 

$wise will be more expensive because we have block_number(), logs(), unsubscribe() and subscribe() call every 60s of inactivity.

