### PR TITLE
fix: build script for zsh and fix cargo/.config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,6 +14,12 @@ rustflags = [
   "-C", "link-arg=dynamic_lookup",
 ]
 
+# This is basically a prebuild script used to build the node/contract before running
+# integration-tests.
+[target.'cfg(not(target = "wasm32-unknown-unknown"))']
+runner = "./setup.sh"
+
+
 [alias]
 build-node = "build -p mpc-node --release"
 build-test = "build -p integration-tests --tests"

--- a/integration-tests/.cargo/config.toml
+++ b/integration-tests/.cargo/config.toml
@@ -1,4 +1,0 @@
-# This is basically a prebuild script used to build the node/contract before running
-# integration-tests.
-[target.'cfg(not(target = "wasm32-unknown-unknown"))']
-runner = "./setup.sh"

--- a/setup.sh
+++ b/setup.sh
@@ -4,16 +4,18 @@
 export ROOT_DIR=$(dirname -- "$0")
 export TARGET_DIR=$ROOT_DIR/target
 
-echo "running cargo build script"
+CARGO_CMD_ARGS="$@"
+CARGO_BUILD_INDENT="            "
+echo "${CARGO_BUILD_INDENT} running MPC build script"
 
 # add additional features if we're benchmarking:
-if echo "$@" | grep -q "bench"; then
+if echo $CARGO_CMD_ARGS | grep -q "bench"; then
     FEATURES="--features bench"
 fi
 
+set --
 set -e
-cd $ROOT_DIR
 . $ROOT_DIR/build-contract.sh $FEATURES
-cargo build -p mpc-node $FEATURES
+cargo build -p mpc-node --release $FEATURES
 
-exec "$@"
+exec $CARGO_CMD_ARGS


### PR DESCRIPTION
Looks like adding the runner to a package specific config.toml doesn't work very well, so moving it back to root dir. This also fixes the `setup.sh` for zsh related environments since that env passes down script args from parent to child automatically