### PR TITLE
fix: taking foreign triple bug

### DIFF
--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -359,7 +359,12 @@ impl PresignatureManager {
             )));
         }
 
-        tracing::info!(id, "starting protocol to generate a new presignature");
+        tracing::info!(
+            id,
+            triple0 = triple0.id,
+            triple1 = triple1.id,
+            "starting protocol to generate a new presignature"
+        );
         let generator = Self::generate_internal(
             participants,
             self.me,

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -54,9 +54,13 @@ impl TripleGenerator {
         id: TripleId,
         me: Participant,
         threshold: usize,
-        participants: Vec<Participant>,
+        mut participants: Vec<Participant>,
         timeout: u64,
     ) -> Result<Self, InitializationError> {
+        // Participants can be out of order, so let's sort them before doing anything. Critical
+        // for the triple_is_mine check:
+        participants.sort();
+
         let protocol = Arc::new(RwLock::new(
             cait_sith::triples::generate_triple::<Secp256k1>(&participants, me, threshold)?,
         ));
@@ -189,26 +193,12 @@ impl TripleGenerator {
                 Action::Return(output) => {
                     let elapsed = {
                         let timestamp = self.timestamp.read().await;
-                        timestamp.map(|t| t.elapsed()).unwrap_or_default()
+                        let elapsed = timestamp.map(|t| t.elapsed()).unwrap_or_default();
+                        crate::metrics::TRIPLE_LATENCY
+                            .with_label_values(&[my_account_id.as_str()])
+                            .observe(elapsed.as_secs_f64());
+                        elapsed
                     };
-                    tracing::info!(
-                        id = self.id,
-                        ?me,
-                        big_a = ?output.1.big_a.to_base58(),
-                        big_b = ?output.1.big_b.to_base58(),
-                        big_c = ?output.1.big_c.to_base58(),
-                        ?elapsed,
-                        "completed triple generation"
-                    );
-
-                    {
-                        let timestamp = self.timestamp.read().await;
-                        if let Some(start_time) = &*timestamp {
-                            crate::metrics::TRIPLE_LATENCY
-                                .with_label_values(&[my_account_id.as_str()])
-                                .observe(start_time.elapsed().as_secs_f64());
-                        }
-                    }
 
                     crate::metrics::NUM_TOTAL_HISTORICAL_TRIPLE_GENERATORS_SUCCESS
                         .with_label_values(&[my_account_id.as_str()])
@@ -237,6 +227,18 @@ impl TripleGenerator {
 
                         triple_owner == me
                     };
+
+                    tracing::info!(
+                        id = self.id,
+                        ?me,
+                        triple_is_mine,
+                        participants = ?self.participants,
+                        big_a = ?triple.public.big_a.to_base58(),
+                        big_b = ?triple.public.big_b.to_base58(),
+                        big_c = ?triple.public.big_c.to_base58(),
+                        ?elapsed,
+                        "completed triple generation"
+                    );
 
                     if triple_is_mine {
                         crate::metrics::NUM_TOTAL_HISTORICAL_TRIPLE_GENERATIONS_MINE_SUCCESS
@@ -661,7 +663,7 @@ impl TripleManager {
             )));
         }
 
-        tracing::debug!(id, "starting protocol to generate a new triple");
+        tracing::info!(id, "starting protocol to generate a new triple");
         {
             let participants = participants.keys_vec();
             let mut tasks = self.tasks.write().await;


### PR DESCRIPTION
Sometimes, there will be an issue with taking foreign owned triples: `presignature cannot be generated id=12317391677896674303 err=TripleStoreError("failed to take two triples Redis(Triple: 8442524960860672804 cannot be taken as foreign)`. This is because the `triple_is_mine` selection had an issue where the passed in `participant` list for `TripleGenerator` was out of order. To remedy this, we have to sort the participant list at the beginning of the `TripleGenerator`.