### PR TITLE
hotfix: do not infinitely loop signature request & do trash presignature/triples 

### DIFF
--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -421,13 +421,12 @@ impl PresignatureManager {
                 ]);
                 if presig_participants.len() < self.threshold {
                     tracing::warn!(
+                        target: "presign[stockpile]",
+                        triple0 = triple0.id,
+                        triple1 = triple1.id,
                         participants = ?presig_participants,
-                        "running: the intersection of participants is less than the threshold"
+                        "intersection < threshold, trashing two triples"
                     );
-                    // TODO: do not insert back triples when we have a clear model for data consistency
-                    // between nodes and utilizing only triples that meet threshold requirements.
-                    triple_manager.insert(triple0, true, true).await;
-                    triple_manager.insert(triple1, true, true).await;
                 } else {
                     self.generate(
                         &presig_participants,


### PR DESCRIPTION
- fixes infinitely looping over sign requests when retrying.
- trash presignatures and triples that do not meet threshold requirements for now until we implement github.com/sig-net/mpc/issues/130 