### PR TITLE
chore: add sign_id/presignature_id to erroring out signatures

### DIFF
--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -648,7 +648,13 @@ impl MessageReceiver for RunningState {
                 }
                 Err(err @ GenerationError::WaitingForIndexer(_)) => {
                     // We will revisit this this signature request later when we have the request indexed.
-                    tracing::warn!(?sign_id, ?proposer, ?err, "waiting for indexer");
+                    tracing::warn!(
+                        ?sign_id,
+                        ?presignature_id,
+                        ?proposer,
+                        ?err,
+                        "waiting for indexer"
+                    );
                     continue;
                 }
                 Err(err @ GenerationError::InvalidProposer(_, _)) => {

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -444,14 +444,21 @@ impl SignatureManager {
 
                         if generator.request.indexed.timestamp.elapsed() < generator.timeout_total {
                             failed.push(sign_id.clone());
-                            tracing::warn!(?err, "signature failed to be produced; pushing request back into failed queue");
+                            tracing::error!(
+                                ?sign_id,
+                                presignature_id = generator.presignature_id,
+                                ?err,
+                                "signature failed to be produced; pushing request back into failed queue",
+                            );
                             if generator.request.proposer == self.me {
                                 signature_generator_failures_metric.inc();
                             }
                         } else {
-                            tracing::warn!(
+                            tracing::error!(
+                                ?sign_id,
+                                presignature_id = generator.presignature_id,
                                 ?err,
-                                "signature failed to be produced; trashing request"
+                                "signature failed to be produced; full timeout, trashing request",
                             );
                             if generator.request.proposer == self.me {
                                 signature_generator_failures_metric.inc();
@@ -463,7 +470,6 @@ impl SignatureManager {
                 };
                 match action {
                     Action::Wait => {
-                        tracing::debug!("signature: waiting");
                         // Retain protocol until we are finished
                         break;
                     }


### PR DESCRIPTION
We need to have this info so that we identify correctly which specific sign request is erroring out in logs