### PR TITLE
fix: gcp logs not showing custom target

### DIFF
--- a/chain-signatures/node/src/protocol/message/filter.rs
+++ b/chain-signatures/node/src/protocol/message/filter.rs
@@ -39,10 +39,7 @@ impl MessageFilter {
                     break;
                 }
                 Err(TryRecvError::Disconnected) => {
-                    tracing::warn!(
-                        target: "msg[filter]",
-                        "channel disconnected, no more messages will be received"
-                    );
+                    tracing::warn!("channel disconnected, no more messages will be received");
                     break;
                 }
             };


### PR DESCRIPTION
Remove custom tracing targets for now, since they aren't showing at all in our GCP logs.