### PR TITLE
fix: sync timeout due to large amounts of triples & presignatures being loaded

### DIFF
--- a/chain-signatures/node/src/protocol/sync/mod.rs
+++ b/chain-signatures/node/src/protocol/sync/mod.rs
@@ -498,7 +498,7 @@ impl SyncUpdateRequest {
 
         // NOTE: err is ignored since it actually just Err(SyncView) which is a gigantic
         // list of triples and presignatures.
-        if let Err(_) = self.resp.send(view) {
+        if self.resp.send(view).is_err() {
             tracing::warn!(
                 triple_ids = triple_ids.len(),
                 presignature_ids = presignature_ids.len(),

--- a/integration-tests/tests/cases/sync.rs
+++ b/integration-tests/tests/cases/sync.rs
@@ -95,7 +95,7 @@ async fn test_protocol_sync_take() -> anyhow::Result<()> {
     }
 
     // Give it some time for sync to process the inserts
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_secs(3)).await;
 
     let mine = true;
     // Check that the inserted triples can be taken


### PR DESCRIPTION
This fixes the timeouts on dev since devnet has a large stockpile of triples/presignatures. Loading their IDs in every 250ms isn't the best idea, especially since we load one for every participant since each participant will ping us. Each call to load foreign IDs for around ~3000 triples takes about 20ms.

To fix this, this PR moves the processing of `SyncUpdate` into a separate task and now only gets a view of triple and presignature IDs every 500ms.