### PR TITLE
performance metrics: fix triple metrics

### DIFF
--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -2,7 +2,8 @@ use std::sync::LazyLock;
 use std::sync::Mutex;
 
 use prometheus::{
-    self, exponential_buckets, CounterVec, HistogramOpts, HistogramVec, IntGaugeVec, Opts, Result,
+    self, exponential_buckets, linear_buckets, CounterVec, HistogramOpts, HistogramVec,
+    IntGaugeVec, Opts, Result,
 };
 
 pub(crate) static NODE_RUNNING: LazyLock<IntGaugeVec> = LazyLock::new(|| {
@@ -529,7 +530,7 @@ pub(crate) static TRIPLE_BEFORE_POKE_DELAY: LazyLock<HistogramVec> = LazyLock::n
         "multichain_triple_before_poke_delay_ms",
         "per triple protocol, delay between generator creation and first poke that returns SendMany/SendPrivate",
         &["node_account_id"],
-        Some(exponential_buckets(1.0, 1.5, 25).unwrap()),
+        Some(exponential_buckets(1.0, 1.5, 30).unwrap()),
     )
     .unwrap()
 });
@@ -599,7 +600,7 @@ pub(crate) static TRIPLE_POKES_CNT: LazyLock<HistogramVec> = LazyLock::new(|| {
         "multichain_triple_pokes_cnt",
         "total pokes per triple protocol",
         &["node_account_id"],
-        None,
+        Some(linear_buckets(0.0, 1.0, 30).unwrap()),
     )
     .unwrap()
 });
@@ -609,7 +610,7 @@ pub(crate) static PRESIGNATURE_POKES_CNT: LazyLock<HistogramVec> = LazyLock::new
         "multichain_presignature_pokes_cnt",
         "total pokes per presignature protocol",
         &["node_account_id"],
-        None,
+        Some(linear_buckets(0.0, 1.0, 30).unwrap()),
     )
     .unwrap()
 });
@@ -619,7 +620,7 @@ pub(crate) static SIGNATURE_POKES_CNT: LazyLock<HistogramVec> = LazyLock::new(||
         "multichain_signature_pokes_cnt",
         "total pokes per signature protocol",
         &["node_account_id"],
-        None,
+        Some(linear_buckets(0.0, 1.0, 30).unwrap()),
     )
     .unwrap()
 });

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -287,7 +287,7 @@ impl TripleGenerator {
                         triple_owner == me
                     };
 
-                    tracing::error!(
+                    tracing::info!(
                         id = self.id,
                         ?me,
                         triple_is_mine,
@@ -312,10 +312,6 @@ impl TripleGenerator {
                             let total_pokes = total_pokes + 1;
                             triple_accrued_wait_delay_metric.observe(total_wait.as_millis() as f64);
                             triple_pokes_cnt_metric.observe(total_pokes as f64);
-                            tracing::error!(
-                                "triple total pokes is {total_pokes}, total wait is {:?}",
-                                total_wait
-                            );
                         }
                     }
                     triple_poke_cpu_time_metric

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -46,7 +46,7 @@ pub struct TripleGenerator {
     pub protocol: Arc<TripleProtocol>,
     pub timestamp: Arc<RwLock<Option<Instant>>>,
     pub timeout: Duration,
-    poked_latest: Option<(Instant, Duration, u64)>,
+    poked_latest: Arc<RwLock<Option<(Instant, Duration, u64)>>>,
     generator_created: Instant,
 }
 
@@ -74,7 +74,7 @@ impl TripleGenerator {
             protocol,
             timestamp: Arc::new(RwLock::new(None)),
             timeout: Duration::from_millis(timeout),
-            poked_latest: None,
+            poked_latest: Arc::new(RwLock::new(None)),
             generator_created: Instant::now(),
         })
     }
@@ -197,19 +197,22 @@ impl TripleGenerator {
                         )
                         .await;
                     }
-                    let (total_wait, total_pokes) =
-                        if let Some((last_poked, total_wait, total_pokes)) = self.poked_latest {
-                            (
-                                total_wait + (generator_poke_time - last_poked),
-                                total_pokes + 1,
-                            )
-                        } else {
-                            let start_time = self.generator_created;
-                            triple_before_poke_delay_metric
-                                .observe((generator_poke_time - start_time).as_millis() as f64);
-                            (Duration::from_millis(0), 1)
-                        };
-                    self.poked_latest = Some((Instant::now(), total_wait, total_pokes));
+                    {
+                        let mut poked_latest = self.poked_latest.write().await;
+                        let (total_wait, total_pokes) =
+                            if let Some((last_poked, total_wait, total_pokes)) = *poked_latest {
+                                (
+                                    total_wait + (generator_poke_time - last_poked),
+                                    total_pokes + 1,
+                                )
+                            } else {
+                                let start_time = self.generator_created;
+                                triple_before_poke_delay_metric
+                                    .observe((generator_poke_time - start_time).as_millis() as f64);
+                                (Duration::from_millis(0), 1)
+                            };
+                        *poked_latest = Some((Instant::now(), total_wait, total_pokes));
+                    }
                     triple_poke_cpu_time_metric
                         .observe(generator_poke_time.elapsed().as_millis() as f64);
                 }
@@ -226,19 +229,22 @@ impl TripleGenerator {
                         },
                     )
                     .await;
-                    let (total_wait, total_pokes) =
-                        if let Some((last_poked, total_wait, total_pokes)) = self.poked_latest {
-                            (
-                                total_wait + (generator_poke_time - last_poked),
-                                total_pokes + 1,
-                            )
-                        } else {
-                            let start_time = self.generator_created;
-                            triple_before_poke_delay_metric
-                                .observe((generator_poke_time - start_time).as_millis() as f64);
-                            (Duration::from_millis(0), 1)
-                        };
-                    self.poked_latest = Some((Instant::now(), total_wait, total_pokes));
+                    {
+                        let mut poked_latest = self.poked_latest.write().await;
+                        let (total_wait, total_pokes) =
+                            if let Some((last_poked, total_wait, total_pokes)) = *poked_latest {
+                                (
+                                    total_wait + (generator_poke_time - last_poked),
+                                    total_pokes + 1,
+                                )
+                            } else {
+                                let start_time = self.generator_created;
+                                triple_before_poke_delay_metric
+                                    .observe((generator_poke_time - start_time).as_millis() as f64);
+                                (Duration::from_millis(0), 1)
+                            };
+                        *poked_latest = Some((Instant::now(), total_wait, total_pokes));
+                    }
                     triple_poke_cpu_time_metric
                         .observe(generator_poke_time.elapsed().as_millis() as f64);
                 }
@@ -248,15 +254,6 @@ impl TripleGenerator {
                         let timestamp = self.timestamp.read().await;
                         timestamp.map(|t| now - t).unwrap_or_default()
                     };
-                    tracing::info!(
-                        id = self.id,
-                        ?me,
-                        big_a = ?output.1.big_a.to_base58(),
-                        big_b = ?output.1.big_b.to_base58(),
-                        big_c = ?output.1.big_c.to_base58(),
-                        ?elapsed,
-                        "completed triple generation"
-                    );
 
                     triple_latency_metric.observe(elapsed.as_secs_f64());
 
@@ -290,7 +287,7 @@ impl TripleGenerator {
                         triple_owner == me
                     };
 
-                    tracing::info!(
+                    tracing::error!(
                         id = self.id,
                         ?me,
                         triple_is_mine,
@@ -307,12 +304,19 @@ impl TripleGenerator {
                     }
 
                     msg.filter_triple(self.id).await;
-                    if let Some((last_poked, total_wait, total_pokes)) = self.poked_latest {
-                        let elapsed = generator_poke_time - last_poked;
-                        let total_wait = total_wait + elapsed;
-                        let total_pokes = total_pokes + 1;
-                        triple_accrued_wait_delay_metric.observe(total_wait.as_millis() as f64);
-                        triple_pokes_cnt_metric.observe(total_pokes as f64);
+                    {
+                        let poked_latest = self.poked_latest.read().await;
+                        if let Some((last_poked, total_wait, total_pokes)) = *poked_latest {
+                            let elapsed = generator_poke_time - last_poked;
+                            let total_wait = total_wait + elapsed;
+                            let total_pokes = total_pokes + 1;
+                            triple_accrued_wait_delay_metric.observe(total_wait.as_millis() as f64);
+                            triple_pokes_cnt_metric.observe(total_pokes as f64);
+                            tracing::error!(
+                                "triple total pokes is {total_pokes}, total wait is {:?}",
+                                total_wait
+                            );
+                        }
                     }
                     triple_poke_cpu_time_metric
                         .observe(generator_poke_time.elapsed().as_millis() as f64);


### PR DESCRIPTION
Problems:
1. triple before poke delay showing constant value all the time
2. triple accrued delay p95 is too low (<10ms)

Changes:
1. modify the buckets for the triple metrics
This is important because these metrics are histogram metrics, and the values in the bucket is used as the upper bound of each value interval. And the metric counts how many observed values fall in each interval.
Previously the triple before poke delay metric's bucket has the largest upper bound set too low, which explains why the metric shows a constant value for p20, p50, p95, because the observed values are mostly greater than the biggest upper bound.

3. Lock the poked_latest field of triple generator.
This is necessary because in the current code, the triple generator can be poked by multiple tasks at the same time. Thus not locking it up will lead to the values being inconsistent. I checked our triple_acccrued_delay and triple_pokes_cnt, they are not set most of the time because the poked_latest field was not locked, and modifications was not saved properly hence in the last poke somehow the field is still None.
