### PR TITLE
Respect CARGO_TARGET_DIR in build script

### DIFF
--- a/integration-tests/src/execute.rs
+++ b/integration-tests/src/execute.rs
@@ -4,6 +4,14 @@ use async_process::Child;
 pub(crate) const PACKAGE_MULTICHAIN: &str = "mpc-node";
 
 pub fn target_dir() -> Option<std::path::PathBuf> {
+    // CARGO_TARGET_DIR can be set explicitly.
+    // https://doc.rust-lang.org/cargo/reference/environment-variables.html
+    if let Ok(out_dir) = std::env::var("CARGO_TARGET_DIR") {
+        return Some(out_dir.into());
+    };
+
+    // If CARGO_TARGET_DIR is not set, search for the default the target
+    // directory in the parents of the build artifact output directory.
     let mut out_dir = std::path::Path::new(std::env!("OUT_DIR"));
     loop {
         if out_dir.ends_with("target") {

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,8 @@
 
 # expects this script to be at the root of the project:
 export ROOT_DIR=$(dirname -- "$0")
-export TARGET_DIR=$ROOT_DIR/target
+# Use CARGO_TARGET_DIR if it is set, or the default ./target location otherwise
+export TARGET_DIR=${CARGO_TARGET_DIR:-$ROOT_DIR/target}
 
 CARGO_CMD_ARGS="$@"
 CARGO_BUILD_INDENT="            "


### PR DESCRIPTION
Some devs (like myself) like placing the target dir for multiple projects in a common shared place to keep the size of all locals builds smaller. `CARGO_TARGET_DIR` exists for this.

The integration tests and the setup script should ideally check this env variable rather than assuming the directory is named exactly "target".