### PR TITLE
refactor: delete unused `is_stable` code

### DIFF
--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -14,11 +14,15 @@ use crate::web::StateView;
 
 use super::MeshState;
 
-type IsStable = bool;
-
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum NodeStatus {
-    Active(IsStable),
+    /// The connected node responds and is actively participating in the MPC
+    /// network.
+    Active,
+    /// The node responds but is in an inactive NodeState, hence it is not ready
+    /// for participating in any MPC protocols, yet.
+    Inactive,
+    /// The node can't be reached at the moment.
     Offline,
 }
 
@@ -78,11 +82,10 @@ impl NodeConnection {
             match client.state(&url).await {
                 Ok(state) => {
                     let new_status = match state {
-                        StateView::Running { is_stable, .. }
-                        | StateView::Resharing { is_stable, .. } => NodeStatus::Active(is_stable),
-                        StateView::Joining { .. } | StateView::NotRunning => {
-                            NodeStatus::Active(false)
+                        StateView::Running { .. } | StateView::Resharing { .. } => {
+                            NodeStatus::Active
                         }
+                        StateView::Joining { .. } | StateView::NotRunning => NodeStatus::Inactive,
                     };
                     let mut status = status.write().await;
                     if *status != new_status {
@@ -207,11 +210,18 @@ impl Pool {
         let mut stable = Vec::new();
         let mut active = Participants::default();
         for (participant, conn) in self.connections.iter() {
-            if let NodeStatus::Active(is_stable) = conn.status().await {
-                active.insert(participant, conn.info.clone());
-                if is_stable {
+            match conn.status().await {
+                NodeStatus::Active => {
+                    active.insert(participant, conn.info.clone());
                     stable.push(*participant);
                 }
+                NodeStatus::Inactive => {
+                    // TODO: should we really insert inactive nodes to the active list here?
+                    // For now, in the refactoring PR, I just keep the exact same behavior.
+                    // We can delete this line when in the next PR.
+                    active.insert(participant, conn.info.clone());
+                }
+                NodeStatus::Offline => (),
             }
         }
 

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -32,8 +32,7 @@ pub struct MeshState {
     /// Participants that are active in the network; as in they respond when pinged.
     pub active: Participants,
 
-    /// Participants that are stable in the network; as in they have met certain criterias such
-    /// as indexing the latest blocks.
+    /// Participants that can be selected for a new protocol invocation.
     pub stable: Vec<Participant>,
 }
 

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -98,13 +98,11 @@ pub enum StateView {
         presignature_mine_count: usize,
         presignature_potential_count: usize,
         latest_block_height: BlockHeight,
-        is_stable: bool,
     },
     Resharing {
         old_participants: Vec<Participant>,
         new_participants: Vec<Participant>,
         latest_block_height: BlockHeight,
-        is_stable: bool,
     },
     Joining {
         participants: Vec<Participant>,
@@ -118,12 +116,10 @@ async fn state(Extension(state): Extension<Arc<AxumState>>) -> Result<Json<State
     tracing::debug!("fetching state");
 
     // TODO: remove once we have integration tests built using other chains
-    let (latest_block_height, is_stable) = if let Some(indexer) = &state.indexer {
-        let latest_block_height = indexer.last_processed_block().await.unwrap_or(0);
-        let is_stable = indexer.is_stable().await;
-        (latest_block_height, is_stable)
+    let latest_block_height = if let Some(indexer) = &state.indexer {
+        indexer.last_processed_block().await.unwrap_or(0)
     } else {
-        (0, true)
+        0
     };
 
     let protocol_state = state.protocol_state.read().await;
@@ -148,7 +144,6 @@ async fn state(Extension(state): Extension<Arc<AxumState>>) -> Result<Json<State
                 presignature_mine_count,
                 presignature_potential_count,
                 latest_block_height,
-                is_stable,
             }))
         }
         NodeState::Resharing(state) => {
@@ -158,7 +153,6 @@ async fn state(Extension(state): Extension<Arc<AxumState>>) -> Result<Json<State
                 old_participants,
                 new_participants,
                 latest_block_height,
-                is_stable,
             }))
         }
         NodeState::Joining(state) => {


### PR DESCRIPTION
`is_stable` has been set to a constant of `true` since #241

The `is_stable` flag was useful when we only looked at the near indexer. It checked of the indexer data is behind.
But now with many chains integrated, we want to move away from chain-specific checks. Hence, is_stable should go away entirely.

This PR removes dead code that was still around from the old is_stable check and  renames some field to make it easier to understand what actually happens.

Specifically, replace `NodeStatus::Active(IsStable=true)` with `NodeStatus::Active`.

For the case where the peer node is online but it still is in a protocol state where it is not ready to participate, we now use `NodeStatus::Inactive`. (Before, we used `NodeStatus::Active(IsStable=false)` for that, although it doesn't really have anything to do with stability.)

These changes are in preparation for state sync to be used for deciding which nodes are indeed ready to participate in a protocol invocation. For that, we want to add a check for a node being in-sync. Which will touch the same code, so it's a good timing to refactor it a bit first.