### PR TITLE
chore: remove ctx traits

### DIFF
--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -275,22 +275,19 @@ pub fn run(cmd: Cli) -> anyhow::Result<()> {
             })));
             rt.block_on(async {
                 let state = Arc::new(RwLock::new(crate::protocol::NodeState::Starting));
-                let (sender, channel) =
+                let (sender, msg_channel) =
                     MessageChannel::spawn(client, &account_id, &config, &state, &mesh_state).await;
-                let protocol = MpcSignProtocol::init(
-                    my_address,
-                    mpc_contract_id,
-                    account_id.clone(),
-                    state.clone(),
-                    near_client,
+                let protocol = MpcSignProtocol {
+                    my_account_id: account_id.clone(),
+                    state: state.clone(),
+                    near: near_client,
                     rpc_channel,
-                    channel,
-                    sync_channel.clone(),
-                    sign_rx,
-                    key_storage,
+                    msg_channel,
+                    sign_rx: Arc::new(RwLock::new(sign_rx)),
+                    secret_storage: key_storage,
                     triple_storage,
                     presignature_storage,
-                );
+                };
 
                 tracing::info!("protocol initialized");
                 let sync_handle = tokio::spawn(sync.run());

--- a/chain-signatures/node/src/protocol/consensus.rs
+++ b/chain-signatures/node/src/protocol/consensus.rs
@@ -16,7 +16,6 @@ use crate::util::AffinePointExt;
 use std::cmp::Ordering;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use cait_sith::protocol::InitializationError;
 use tokio::sync::RwLock;
 
@@ -44,8 +43,7 @@ pub enum ConsensusError {
     SecretStorageError(#[from] SecretStorageError),
 }
 
-#[async_trait]
-pub trait ConsensusProtocol {
+pub(crate) trait ConsensusProtocol {
     async fn advance(
         self,
         ctx: &mut MpcSignProtocol,
@@ -53,7 +51,6 @@ pub trait ConsensusProtocol {
     ) -> Result<NodeState, ConsensusError>;
 }
 
-#[async_trait]
 impl ConsensusProtocol for StartedState {
     async fn advance(
         self,
@@ -209,7 +206,6 @@ impl ConsensusProtocol for StartedState {
     }
 }
 
-#[async_trait]
 impl ConsensusProtocol for GeneratingState {
     async fn advance(
         self,
@@ -259,7 +255,6 @@ impl ConsensusProtocol for GeneratingState {
     }
 }
 
-#[async_trait]
 impl ConsensusProtocol for WaitingForConsensusState {
     async fn advance(
         self,
@@ -426,7 +421,6 @@ impl ConsensusProtocol for WaitingForConsensusState {
     }
 }
 
-#[async_trait]
 impl ConsensusProtocol for RunningState {
     async fn advance(
         self,
@@ -500,7 +494,6 @@ impl ConsensusProtocol for RunningState {
     }
 }
 
-#[async_trait]
 impl ConsensusProtocol for ResharingState {
     async fn advance(
         self,
@@ -576,7 +569,6 @@ impl ConsensusProtocol for ResharingState {
     }
 }
 
-#[async_trait]
 impl ConsensusProtocol for JoiningState {
     async fn advance(
         self,
@@ -635,7 +627,6 @@ impl ConsensusProtocol for JoiningState {
     }
 }
 
-#[async_trait]
 impl ConsensusProtocol for NodeState {
     async fn advance(
         self,

--- a/chain-signatures/node/src/protocol/consensus.rs
+++ b/chain-signatures/node/src/protocol/consensus.rs
@@ -3,19 +3,13 @@ use super::state::{
     JoiningState, NodeState, PersistentNodeData, RunningState, StartedState,
     WaitingForConsensusState,
 };
-use super::sync::SyncChannel;
-use super::MessageChannel;
+use super::MpcSignProtocol;
 use crate::gcp::error::SecretStorageError;
 use crate::protocol::contract::primitives::Participants;
 use crate::protocol::presignature::PresignatureManager;
 use crate::protocol::signature::SignatureManager;
 use crate::protocol::state::{GeneratingState, ResharingState};
 use crate::protocol::triple::TripleManager;
-use crate::protocol::IndexedSignRequest;
-use crate::rpc::NearClient;
-use crate::storage::presignature_storage::PresignatureStorage;
-use crate::storage::secret_storage::SecretNodeStorageBox;
-use crate::storage::triple_storage::TripleStorage;
 use crate::types::{KeygenProtocol, ReshareProtocol, SecretKeyShare};
 use crate::util::AffinePointExt;
 
@@ -24,23 +18,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use cait_sith::protocol::InitializationError;
-use tokio::sync::{mpsc, RwLock};
-use url::Url;
-
-use near_account_id::AccountId;
-
-pub trait ConsensusCtx {
-    fn my_account_id(&self) -> &AccountId;
-    fn near_client(&self) -> &NearClient;
-    fn mpc_contract_id(&self) -> &AccountId;
-    fn my_address(&self) -> &Url;
-    fn sign_rx(&self) -> Arc<RwLock<mpsc::Receiver<IndexedSignRequest>>>;
-    fn secret_storage(&self) -> &SecretNodeStorageBox;
-    fn triple_storage(&self) -> &TripleStorage;
-    fn presignature_storage(&self) -> &PresignatureStorage;
-    fn msg_channel(&self) -> &MessageChannel;
-    fn sync_channel(&self) -> &SyncChannel;
-}
+use tokio::sync::RwLock;
 
 #[derive(thiserror::Error, Debug)]
 pub enum ConsensusError {
@@ -68,18 +46,18 @@ pub enum ConsensusError {
 
 #[async_trait]
 pub trait ConsensusProtocol {
-    async fn advance<C: ConsensusCtx + Send + Sync>(
+    async fn advance(
         self,
-        ctx: C,
+        ctx: &mut MpcSignProtocol,
         contract_state: ProtocolState,
     ) -> Result<NodeState, ConsensusError>;
 }
 
 #[async_trait]
 impl ConsensusProtocol for StartedState {
-    async fn advance<C: ConsensusCtx + Send + Sync>(
+    async fn advance(
         self,
-        ctx: C,
+        ctx: &mut MpcSignProtocol,
         contract_state: ProtocolState,
     ) -> Result<NodeState, ConsensusError> {
         match self.persistent_node_data {
@@ -109,7 +87,7 @@ impl ConsensusProtocol for StartedState {
                         Ordering::Equal => {
                             match contract_state
                                 .participants
-                                .find_participant(ctx.my_account_id())
+                                .find_participant(&ctx.my_account_id)
                             {
                                 Some(me) => {
                                     tracing::info!(
@@ -119,9 +97,9 @@ impl ConsensusProtocol for StartedState {
                                         *me,
                                         contract_state.threshold,
                                         epoch,
-                                        ctx.my_account_id(),
-                                        ctx.triple_storage(),
-                                        ctx.msg_channel().clone(),
+                                        &ctx.my_account_id,
+                                        &ctx.triple_storage,
+                                        ctx.msg_channel.clone(),
                                     );
 
                                     let presignature_manager =
@@ -129,22 +107,22 @@ impl ConsensusProtocol for StartedState {
                                             *me,
                                             contract_state.threshold,
                                             epoch,
-                                            ctx.my_account_id(),
-                                            ctx.triple_storage(),
-                                            ctx.presignature_storage(),
-                                            ctx.msg_channel().clone(),
+                                            &ctx.my_account_id,
+                                            &ctx.triple_storage,
+                                            &ctx.presignature_storage,
+                                            ctx.msg_channel.clone(),
                                         )));
 
                                     let signature_manager =
                                         Arc::new(RwLock::new(SignatureManager::new(
                                             *me,
-                                            ctx.my_account_id(),
+                                            &ctx.my_account_id,
                                             contract_state.threshold,
                                             public_key,
                                             epoch,
-                                            ctx.sign_rx(),
-                                            ctx.presignature_storage(),
-                                            ctx.msg_channel().clone(),
+                                            ctx.sign_rx.clone(),
+                                            &ctx.presignature_storage,
+                                            ctx.msg_channel.clone(),
                                         )));
 
                                     Ok(NodeState::Running(RunningState {
@@ -195,7 +173,7 @@ impl ConsensusProtocol for StartedState {
             None => match contract_state {
                 ProtocolState::Initializing(contract_state) => {
                     let participants: Participants = contract_state.candidates.clone().into();
-                    match participants.find_participant(ctx.my_account_id()) {
+                    match participants.find_participant(&ctx.my_account_id) {
                         Some(me) => {
                             tracing::info!(
                                 "started(initializing): starting key generation as a part of the participant set"
@@ -233,9 +211,9 @@ impl ConsensusProtocol for StartedState {
 
 #[async_trait]
 impl ConsensusProtocol for GeneratingState {
-    async fn advance<C: ConsensusCtx + Send + Sync>(
+    async fn advance(
         self,
-        _ctx: C,
+        _ctx: &mut MpcSignProtocol,
         contract_state: ProtocolState,
     ) -> Result<NodeState, ConsensusError> {
         match contract_state {
@@ -283,9 +261,9 @@ impl ConsensusProtocol for GeneratingState {
 
 #[async_trait]
 impl ConsensusProtocol for WaitingForConsensusState {
-    async fn advance<C: ConsensusCtx + Send + Sync>(
+    async fn advance(
         self,
-        ctx: C,
+        ctx: &mut MpcSignProtocol,
         contract_state: ProtocolState,
     ) -> Result<NodeState, ConsensusError> {
         match contract_state {
@@ -295,11 +273,11 @@ impl ConsensusProtocol for WaitingForConsensusState {
                 let has_voted = contract_state
                     .pk_votes
                     .get(&public_key)
-                    .map(|ps| ps.contains(ctx.my_account_id()))
+                    .map(|ps| ps.contains(&ctx.my_account_id))
                     .unwrap_or_default();
                 if !has_voted {
                     tracing::info!("waiting(initializing): we haven't voted yet, voting for the generated public key");
-                    ctx.near_client()
+                    ctx.near
                         .vote_public_key(&public_key)
                         .await
                         .map_err(|err| ConsensusError::CannotVote(format!("{err:?}")))?;
@@ -334,7 +312,7 @@ impl ConsensusProtocol for WaitingForConsensusState {
 
                     let Some(me) = contract_state
                         .participants
-                        .find_participant(ctx.my_account_id())
+                        .find_participant(&ctx.my_account_id)
                     else {
                         tracing::error!("waiting(running, unexpected): we do not belong to the participant set -- cannot progress!");
                         return Ok(NodeState::WaitingForConsensus(self));
@@ -344,30 +322,30 @@ impl ConsensusProtocol for WaitingForConsensusState {
                         *me,
                         self.threshold,
                         self.epoch,
-                        ctx.my_account_id(),
-                        ctx.triple_storage(),
-                        ctx.msg_channel().clone(),
+                        &ctx.my_account_id,
+                        &ctx.triple_storage,
+                        ctx.msg_channel.clone(),
                     );
 
                     let presignature_manager = Arc::new(RwLock::new(PresignatureManager::new(
                         *me,
                         self.threshold,
                         self.epoch,
-                        ctx.my_account_id(),
-                        ctx.triple_storage(),
-                        ctx.presignature_storage(),
-                        ctx.msg_channel().clone(),
+                        &ctx.my_account_id,
+                        &ctx.triple_storage,
+                        &ctx.presignature_storage,
+                        ctx.msg_channel.clone(),
                     )));
 
                     let signature_manager = Arc::new(RwLock::new(SignatureManager::new(
                         *me,
-                        ctx.my_account_id(),
+                        &ctx.my_account_id,
                         self.threshold,
                         self.public_key,
                         self.epoch,
-                        ctx.sign_rx(),
-                        ctx.presignature_storage(),
-                        ctx.msg_channel().clone(),
+                        ctx.sign_rx.clone(),
+                        &ctx.presignature_storage,
+                        ctx.msg_channel.clone(),
                     )));
 
                     Ok(NodeState::Running(RunningState {
@@ -414,10 +392,10 @@ impl ConsensusProtocol for WaitingForConsensusState {
                         tracing::info!(
                             "waiting(resharing): waiting for resharing consensus, contract state has not been finalized yet"
                         );
-                        let has_voted = contract_state.finished_votes.contains(ctx.my_account_id());
+                        let has_voted = contract_state.finished_votes.contains(&ctx.my_account_id);
                         match contract_state
                             .old_participants
-                            .find_participant(ctx.my_account_id())
+                            .find_participant(&ctx.my_account_id)
                         {
                             Some(_) => {
                                 if !has_voted {
@@ -426,9 +404,9 @@ impl ConsensusProtocol for WaitingForConsensusState {
                                         "waiting(resharing): we haven't voted yet, voting for resharing to complete"
                                     );
 
-                                    ctx.near_client().vote_reshared(self.epoch).await.map_err(
-                                        |err| ConsensusError::CannotVote(format!("{err:?}")),
-                                    )?;
+                                    ctx.near.vote_reshared(self.epoch).await.map_err(|err| {
+                                        ConsensusError::CannotVote(format!("{err:?}"))
+                                    })?;
                                 } else {
                                     tracing::info!(
                                         epoch = self.epoch,
@@ -450,9 +428,9 @@ impl ConsensusProtocol for WaitingForConsensusState {
 
 #[async_trait]
 impl ConsensusProtocol for RunningState {
-    async fn advance<C: ConsensusCtx + Send + Sync>(
+    async fn advance(
         self,
-        ctx: C,
+        ctx: &mut MpcSignProtocol,
         contract_state: ProtocolState,
     ) -> Result<NodeState, ConsensusError> {
         match contract_state {
@@ -504,10 +482,10 @@ impl ConsensusProtocol for RunningState {
                         tracing::info!("running(resharing): contract is resharing");
                         let is_in_old_participant_set = contract_state
                             .old_participants
-                            .contains_account_id(ctx.my_account_id());
+                            .contains_account_id(&ctx.my_account_id);
                         let is_in_new_participant_set = contract_state
                             .new_participants
-                            .contains_account_id(ctx.my_account_id());
+                            .contains_account_id(&ctx.my_account_id);
                         if !is_in_old_participant_set || !is_in_new_participant_set {
                             return Err(ConsensusError::HasBeenKicked);
                         }
@@ -524,9 +502,9 @@ impl ConsensusProtocol for RunningState {
 
 #[async_trait]
 impl ConsensusProtocol for ResharingState {
-    async fn advance<C: ConsensusCtx + Send + Sync>(
+    async fn advance(
         self,
-        _ctx: C,
+        _ctx: &mut MpcSignProtocol,
         contract_state: ProtocolState,
     ) -> Result<NodeState, ConsensusError> {
         match contract_state {
@@ -600,22 +578,19 @@ impl ConsensusProtocol for ResharingState {
 
 #[async_trait]
 impl ConsensusProtocol for JoiningState {
-    async fn advance<C: ConsensusCtx + Send + Sync>(
+    async fn advance(
         self,
-        ctx: C,
+        ctx: &mut MpcSignProtocol,
         contract_state: ProtocolState,
     ) -> Result<NodeState, ConsensusError> {
         match contract_state {
             ProtocolState::Initializing(_) => Err(ConsensusError::ContractStateRollback),
             ProtocolState::Running(contract_state) => {
-                match contract_state
-                    .candidates
-                    .find_candidate(ctx.my_account_id())
-                {
+                match contract_state.candidates.find_candidate(&ctx.my_account_id) {
                     Some(_) => {
                         let votes = contract_state
                             .join_votes
-                            .get(ctx.my_account_id())
+                            .get(&ctx.my_account_id)
                             .cloned()
                             .unwrap_or_default();
                         let participant_account_ids_to_vote = contract_state
@@ -636,7 +611,7 @@ impl ConsensusProtocol for JoiningState {
                         tracing::info!(
                             "joining(running): sending a transaction to join the participant set"
                         );
-                        ctx.near_client().propose_join().await.map_err(|err| {
+                        ctx.near.propose_join().await.map_err(|err| {
                             tracing::error!(?err, "failed to join the participant set");
                             ConsensusError::CannotJoin(format!("{err:?}"))
                         })?;
@@ -647,7 +622,7 @@ impl ConsensusProtocol for JoiningState {
             ProtocolState::Resharing(contract_state) => {
                 if contract_state
                     .new_participants
-                    .contains_account_id(ctx.my_account_id())
+                    .contains_account_id(&ctx.my_account_id)
                 {
                     tracing::info!("joining(resharing): joining as a new participant");
                     start_resharing(None, ctx, contract_state).await
@@ -662,14 +637,14 @@ impl ConsensusProtocol for JoiningState {
 
 #[async_trait]
 impl ConsensusProtocol for NodeState {
-    async fn advance<C: ConsensusCtx + Send + Sync>(
+    async fn advance(
         self,
-        ctx: C,
+        ctx: &mut MpcSignProtocol,
         contract_state: ProtocolState,
     ) -> Result<NodeState, ConsensusError> {
         match self {
             NodeState::Starting => {
-                let persistent_node_data = ctx.secret_storage().load().await?;
+                let persistent_node_data = ctx.secret_storage.load().await?;
                 Ok(NodeState::Started(StartedState {
                     persistent_node_data,
                 }))
@@ -684,18 +659,18 @@ impl ConsensusProtocol for NodeState {
     }
 }
 
-async fn start_resharing<C: ConsensusCtx>(
+async fn start_resharing(
     private_share: Option<SecretKeyShare>,
-    ctx: C,
+    ctx: &MpcSignProtocol,
     contract_state: ResharingContractState,
 ) -> Result<NodeState, ConsensusError> {
     let me = contract_state
         .new_participants
-        .find_participant(ctx.my_account_id())
+        .find_participant(&ctx.my_account_id)
         .or_else(|| {
             contract_state
                 .old_participants
-                .find_participant(ctx.my_account_id())
+                .find_participant(&ctx.my_account_id)
         })
         .expect("unexpected: cannot find us in the participant set while starting resharing");
     let protocol = ReshareProtocol::new(private_share, *me, &contract_state)?;

--- a/chain-signatures/node/src/protocol/consensus.rs
+++ b/chain-signatures/node/src/protocol/consensus.rs
@@ -5,7 +5,6 @@ use super::state::{
 };
 use super::sync::SyncChannel;
 use super::MessageChannel;
-use crate::config::Config;
 use crate::gcp::error::SecretStorageError;
 use crate::protocol::contract::primitives::Participants;
 use crate::protocol::presignature::PresignatureManager;
@@ -73,7 +72,6 @@ pub trait ConsensusProtocol {
         self,
         ctx: C,
         contract_state: ProtocolState,
-        cfg: Config,
     ) -> Result<NodeState, ConsensusError>;
 }
 
@@ -83,7 +81,6 @@ impl ConsensusProtocol for StartedState {
         self,
         ctx: C,
         contract_state: ProtocolState,
-        _cfg: Config,
     ) -> Result<NodeState, ConsensusError> {
         match self.persistent_node_data {
             Some(PersistentNodeData {
@@ -240,7 +237,6 @@ impl ConsensusProtocol for GeneratingState {
         self,
         _ctx: C,
         contract_state: ProtocolState,
-        _cfg: Config,
     ) -> Result<NodeState, ConsensusError> {
         match contract_state {
             ProtocolState::Initializing(_) => {
@@ -291,7 +287,6 @@ impl ConsensusProtocol for WaitingForConsensusState {
         self,
         ctx: C,
         contract_state: ProtocolState,
-        _cfg: Config,
     ) -> Result<NodeState, ConsensusError> {
         match contract_state {
             ProtocolState::Initializing(contract_state) => {
@@ -459,7 +454,6 @@ impl ConsensusProtocol for RunningState {
         self,
         ctx: C,
         contract_state: ProtocolState,
-        _cfg: Config,
     ) -> Result<NodeState, ConsensusError> {
         match contract_state {
             ProtocolState::Initializing(_) => Err(ConsensusError::ContractStateRollback),
@@ -534,7 +528,6 @@ impl ConsensusProtocol for ResharingState {
         self,
         _ctx: C,
         contract_state: ProtocolState,
-        _cfg: Config,
     ) -> Result<NodeState, ConsensusError> {
         match contract_state {
             ProtocolState::Initializing(_) => Err(ConsensusError::ContractStateRollback),
@@ -611,7 +604,6 @@ impl ConsensusProtocol for JoiningState {
         self,
         ctx: C,
         contract_state: ProtocolState,
-        _cfg: Config,
     ) -> Result<NodeState, ConsensusError> {
         match contract_state {
             ProtocolState::Initializing(_) => Err(ConsensusError::ContractStateRollback),
@@ -674,7 +666,6 @@ impl ConsensusProtocol for NodeState {
         self,
         ctx: C,
         contract_state: ProtocolState,
-        cfg: Config,
     ) -> Result<NodeState, ConsensusError> {
         match self {
             NodeState::Starting => {
@@ -683,12 +674,12 @@ impl ConsensusProtocol for NodeState {
                     persistent_node_data,
                 }))
             }
-            NodeState::Started(state) => state.advance(ctx, contract_state, cfg).await,
-            NodeState::Generating(state) => state.advance(ctx, contract_state, cfg).await,
-            NodeState::WaitingForConsensus(state) => state.advance(ctx, contract_state, cfg).await,
-            NodeState::Running(state) => state.advance(ctx, contract_state, cfg).await,
-            NodeState::Resharing(state) => state.advance(ctx, contract_state, cfg).await,
-            NodeState::Joining(state) => state.advance(ctx, contract_state, cfg).await,
+            NodeState::Started(state) => state.advance(ctx, contract_state).await,
+            NodeState::Generating(state) => state.advance(ctx, contract_state).await,
+            NodeState::WaitingForConsensus(state) => state.advance(ctx, contract_state).await,
+            NodeState::Running(state) => state.advance(ctx, contract_state).await,
+            NodeState::Resharing(state) => state.advance(ctx, contract_state).await,
+            NodeState::Joining(state) => state.advance(ctx, contract_state).await,
         }
     }
 }

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -1,4 +1,3 @@
-use super::message::MessageChannel;
 use super::signature::SignatureManager;
 use super::state::{GeneratingState, NodeState, ResharingState, RunningState};
 use super::MpcSignProtocol;
@@ -8,24 +7,9 @@ use crate::protocol::message::{GeneratingMessage, ResharingMessage};
 use crate::protocol::presignature::PresignatureManager;
 use crate::protocol::state::{PersistentNodeData, WaitingForConsensusState};
 use crate::protocol::MeshState;
-use crate::rpc::RpcChannel;
-use crate::storage::secret_storage::SecretNodeStorageBox;
-use crate::storage::{PresignatureStorage, TripleStorage};
 
-use async_trait::async_trait;
 use cait_sith::protocol::{Action, InitializationError, ProtocolError};
 use k256::elliptic_curve::group::GroupEncoding;
-use near_account_id::AccountId;
-
-pub trait CryptographicCtx {
-    fn mpc_contract_id(&self) -> &AccountId;
-    fn secret_storage(&mut self) -> &mut SecretNodeStorageBox;
-    fn triple_storage(&self) -> &TripleStorage;
-    fn presignature_storage(&self) -> &PresignatureStorage;
-    fn my_account_id(&self) -> &AccountId;
-    fn channel(&self) -> &MessageChannel;
-    fn rpc_channel(&self) -> &RpcChannel;
-}
 
 #[derive(thiserror::Error, Debug)]
 pub enum CryptographicError {
@@ -37,8 +21,7 @@ pub enum CryptographicError {
     SecretStorageError(#[from] SecretStorageError),
 }
 
-#[async_trait]
-pub trait CryptographicProtocol {
+pub(crate) trait CryptographicProtocol {
     async fn progress(
         self,
         ctx: &mut MpcSignProtocol,
@@ -47,7 +30,6 @@ pub trait CryptographicProtocol {
     ) -> Result<NodeState, CryptographicError>;
 }
 
-#[async_trait]
 impl CryptographicProtocol for GeneratingState {
     async fn progress(
         mut self,
@@ -138,10 +120,9 @@ impl CryptographicProtocol for GeneratingState {
     }
 }
 
-#[async_trait]
 impl CryptographicProtocol for WaitingForConsensusState {
     async fn progress(
-        mut self,
+        self,
         _ctx: &mut MpcSignProtocol,
         _cfg: Config,
         _mesh_state: MeshState,
@@ -151,7 +132,6 @@ impl CryptographicProtocol for WaitingForConsensusState {
     }
 }
 
-#[async_trait]
 impl CryptographicProtocol for ResharingState {
     async fn progress(
         mut self,
@@ -252,10 +232,9 @@ impl CryptographicProtocol for ResharingState {
     }
 }
 
-#[async_trait]
 impl CryptographicProtocol for RunningState {
     async fn progress(
-        mut self,
+        self,
         ctx: &mut MpcSignProtocol,
         cfg: Config,
         mesh_state: MeshState,
@@ -284,7 +263,6 @@ impl CryptographicProtocol for RunningState {
     }
 }
 
-#[async_trait]
 impl CryptographicProtocol for NodeState {
     async fn progress(
         self,

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -250,7 +250,7 @@ impl CryptographicProtocol for RunningState {
 
         let stable = mesh_state.stable;
         tracing::debug!(?stable, "stable participants");
-        let sig_task = SignatureManager::execute(&self, &stable, &cfg.protocol, &ctx);
+        let sig_task = SignatureManager::execute(&self, &stable, &cfg.protocol, ctx);
 
         match tokio::try_join!(triple_task, presig_task, sig_task) {
             Ok(_result) => (),

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -23,14 +23,12 @@ use crate::mesh::MeshState;
 use crate::protocol::consensus::ConsensusProtocol;
 use crate::protocol::cryptography::CryptographicProtocol;
 use crate::protocol::message::MessageReceiver as _;
-use crate::protocol::sync::SyncChannel;
 use crate::rpc::{NearClient, RpcChannel};
 use crate::storage::presignature_storage::PresignatureStorage;
 use crate::storage::secret_storage::SecretNodeStorageBox;
 use crate::storage::triple_storage::TripleStorage;
 
 use near_account_id::AccountId;
-use reqwest::IntoUrl;
 use semver::Version;
 use std::fmt;
 use std::path::Path;
@@ -39,58 +37,20 @@ use std::time::{Duration, Instant};
 use sysinfo::{CpuRefreshKind, Disks, RefreshKind, System};
 use tokio::sync::mpsc;
 use tokio::sync::RwLock;
-use url::Url;
 
 pub struct MpcSignProtocol {
-    my_address: Url,
-    my_account_id: AccountId,
-    mpc_contract_id: AccountId,
-    near: NearClient,
-    secret_storage: SecretNodeStorageBox,
-    triple_storage: TripleStorage,
-    presignature_storage: PresignatureStorage,
-    sign_rx: Arc<RwLock<mpsc::Receiver<IndexedSignRequest>>>,
-    state: Arc<RwLock<NodeState>>,
-
-    msg_channel: MessageChannel,
-    sync_channel: SyncChannel,
-    rpc_channel: RpcChannel,
+    pub(crate) my_account_id: AccountId,
+    pub(crate) near: NearClient,
+    pub(crate) secret_storage: SecretNodeStorageBox,
+    pub(crate) triple_storage: TripleStorage,
+    pub(crate) presignature_storage: PresignatureStorage,
+    pub(crate) sign_rx: Arc<RwLock<mpsc::Receiver<IndexedSignRequest>>>,
+    pub(crate) state: Arc<RwLock<NodeState>>,
+    pub(crate) msg_channel: MessageChannel,
+    pub(crate) rpc_channel: RpcChannel,
 }
 
 impl MpcSignProtocol {
-    #![allow(clippy::too_many_arguments)]
-    pub fn init<U: IntoUrl>(
-        my_address: U,
-        mpc_contract_id: AccountId,
-        account_id: AccountId,
-        state: Arc<RwLock<NodeState>>,
-        near: NearClient,
-        rpc_channel: RpcChannel,
-        channel: MessageChannel,
-        sync_channel: SyncChannel,
-        sign_rx: mpsc::Receiver<IndexedSignRequest>,
-        secret_storage: SecretNodeStorageBox,
-        triple_storage: TripleStorage,
-        presignature_storage: PresignatureStorage,
-    ) -> Self {
-        let my_address = my_address.into_url().unwrap();
-        MpcSignProtocol {
-            my_address,
-            my_account_id: account_id,
-            mpc_contract_id,
-            near,
-            sign_rx: Arc::new(RwLock::new(sign_rx)),
-            secret_storage,
-            triple_storage,
-            presignature_storage,
-            state,
-
-            rpc_channel,
-            msg_channel: channel,
-            sync_channel,
-        }
-    }
-
     pub async fn run(
         mut self,
         contract_state: Arc<RwLock<Option<ProtocolState>>>,

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -15,10 +15,8 @@ pub use contract::primitives::ParticipantInfo;
 pub use contract::ProtocolState;
 pub use cryptography::CryptographicError;
 pub use message::{Message, MessageChannel};
-use semver::Version;
 pub use signature::{IndexedSignRequest, SignQueue};
 pub use state::NodeState;
-pub use sysinfo::{Components, CpuRefreshKind, Disks, RefreshKind, System};
 
 use self::consensus::ConsensusCtx;
 use self::cryptography::CryptographicCtx;
@@ -35,10 +33,12 @@ use crate::storage::triple_storage::TripleStorage;
 
 use near_account_id::AccountId;
 use reqwest::IntoUrl;
+use semver::Version;
 use std::fmt;
 use std::path::Path;
-use std::time::Instant;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use sysinfo::{CpuRefreshKind, Disks, RefreshKind, System};
 use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 use url::Url;
@@ -235,7 +235,7 @@ impl MpcSignProtocol {
             if let Some(contract_state) = contract_state {
                 let consensus_time = Instant::now();
                 let from_state = format!("{state}");
-                state = match state.advance(&mut self, contract_state, cfg.clone()).await {
+                state = match state.advance(&mut self, contract_state).await {
                     Ok(state) => {
                         tracing::debug!("advance ok: {from_state} => {state}");
                         state

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -1,5 +1,6 @@
 use super::contract::primitives::intersect_vec;
 use super::state::RunningState;
+use super::MpcSignProtocol;
 use crate::kdf::derive_delta;
 use crate::protocol::error::GenerationError;
 use crate::protocol::message::{MessageChannel, SignatureMessage};
@@ -757,13 +758,13 @@ impl SignatureManager {
         state: &RunningState,
         stable: &[Participant],
         protocol_cfg: &ProtocolConfig,
-        ctx: &impl super::cryptography::CryptographicCtx,
+        ctx: &MpcSignProtocol,
     ) -> tokio::task::JoinHandle<()> {
         let signature_manager = state.signature_manager.clone();
         let stable = stable.to_vec();
         let protocol_cfg = protocol_cfg.clone();
-        let rpc_channel = ctx.rpc_channel().clone();
-        let channel = ctx.channel().clone();
+        let rpc_channel = ctx.rpc_channel.clone();
+        let channel = ctx.msg_channel.clone();
 
         // NOTE: signatures should only use stable and not active participants. The difference here is that
         // stable participants utilizes more than the online status of a node, such as whether or not their


### PR DESCRIPTION
This removes the `ConsensusCtx` and `CryptographicCtx` traits and `Ctx` struct since they don't add much value. Instead, we will use `MpcSignProtocol` struct directly. This cuts down the boilerplate and anytime we want to add in new fields, we would have to modify those traits.

This also removes `async_trait` since rust 1.75 stabilized async fn in traits. The only caveat is that these traits can no longer be `pub`lic, but `pub(crate)` due to bounds limitations. We don't really care about that case since we're not writing a public facing library with the `mpc-node` crate anyways.