### PR TITLE
fix solana re subscribe

### DIFF
--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -225,8 +225,8 @@ pub async fn run(
     let client =
         Client::new_with_options(cluster, Arc::new(keypair), CommitmentConfig::confirmed());
     tracing::info!("rpc url: {}, program id: {}", sol.rpc_url, program_id);
-    let program = client.program(program_id)?;
     loop {
+        let program = client.program(program_id)?;
         let unsub =
             subscribe_to_program_events(&program, sign_tx.clone(), node_near_account_id.clone())
                 .await;
@@ -236,7 +236,7 @@ pub async fn run(
             unsub.unwrap().unsubscribe().await;
             tracing::info!("unsubscribing to solana events");
         }
-        tokio::time::sleep(Duration::from_secs(10)).await;
+        tokio::time::sleep(Duration::from_secs(1)).await;
     }
 }
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -65,7 +65,7 @@ impl Default for NodeConfig {
                 account_sk: "fS5jS6X5qvaquBV1bg2YWBdYeCiRSUwNAdNpgNkjS72oNxUJcZJZduaq2oCcXJb8erTbtqqq4wxriUmRJk7bMDw"
                     .to_string(),
                 rpc_url: "https://api.devnet.solana.com".to_string(),
-                program_address: "BtGZEs9ZJX3hAQuY5er8iyWrGsrPRZYupEtVSS129XKo".to_string(),
+                program_address: "CMGYAEsqXw5z52R8fmMZwPYQARHPEkGbefJA2FmeHLMh".to_string(),
             }),
         }
     }

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -70,14 +70,14 @@ async fn main() -> anyhow::Result<()> {
             let config = NodeConfig {
                 nodes,
                 threshold,
-                eth: Some(EthConfig {
-                    account_sk: eth_account_sk,
-                    consensus_rpc_http_url: eth_consensus_rpc_http_url,
-                    execution_rpc_http_url: eth_execution_rpc_http_url,
-                    contract_address: eth_contract_address,
-                    network: eth_network,
-                    helios_data_path: eth_helios_data_path,
-                }),
+                // eth: Some(EthConfig {
+                //     account_sk: eth_account_sk,
+                //     consensus_rpc_http_url: eth_consensus_rpc_http_url,
+                //     execution_rpc_http_url: eth_execution_rpc_http_url,
+                //     contract_address: eth_contract_address,
+                //     network: eth_network,
+                //     helios_data_path: eth_helios_data_path,
+                // }),
                 ..Default::default()
             };
             println!("Full config: {:?}", config);


### PR DESCRIPTION
re subscribe is currently always fail due to: (anchor client) program keeps a reference to the websocket socket that is in a bad state, and resubscribe from there always immediately disconnect. By creating a new anchor client program instance, it also create a new websocket and resub is successful. Tested locally.