### PR TITLE
feat: proposing new protocols through posits

### DIFF
--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -473,20 +473,14 @@ impl MessageReceiver for RunningState {
                 PositProtocolId::Triple(_) => {}
                 PositProtocolId::Presignature(id) => {
                     let mut presignature_manager = self.presignature_manager.write().await;
-                    let (should_start, triples) = presignature_manager
-                        .handle_posit(id, posit.from, posit.action, &active)
+                    let start_protocol = presignature_manager
+                        .process_posit(id, posit.from, posit.action, &active)
                         .await;
-                    if let Some(participants) = should_start {
-                        let proposer = if triples.is_some() {
-                            presignature_manager.me
-                        } else {
-                            posit.from
-                        };
+                    if let Some((participants, positor)) = start_protocol {
                         if let Err(err) = presignature_manager
                             .generate(
                                 id,
-                                triples,
-                                proposer,
+                                positor,
                                 &participants,
                                 &self.triple_manager,
                                 &self.public_key,

--- a/chain-signatures/node/src/protocol/message/types.rs
+++ b/chain-signatures/node/src/protocol/message/types.rs
@@ -4,7 +4,7 @@ use std::hash::{DefaultHasher, Hash as _};
 use cait_sith::protocol::{MessageData, Participant};
 use serde::{Deserialize, Serialize};
 
-use crate::protocol::presignature::PresignatureId;
+use crate::protocol::presignature::{FullPresignatureId, PresignatureId};
 use crate::protocol::triple::TripleId;
 use crate::protocol::PositAction;
 use crate::types::Epoch;
@@ -23,7 +23,7 @@ pub enum Protocols {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum PositProtocolId {
     Triple(TripleId),
-    Presignature(PresignatureId, TripleId, TripleId),
+    Presignature(FullPresignatureId),
     Signature(SignId, PresignatureId),
 }
 

--- a/chain-signatures/node/src/protocol/message/types.rs
+++ b/chain-signatures/node/src/protocol/message/types.rs
@@ -43,6 +43,7 @@ impl PositMessage {
             }
             PositAction::Accept => 0,
             PositAction::Reject => 0,
+            PositAction::Abort => 0,
         }
     }
 }

--- a/chain-signatures/node/src/protocol/message/types.rs
+++ b/chain-signatures/node/src/protocol/message/types.rs
@@ -19,6 +19,41 @@ pub enum Protocols {
     Signature,
 }
 
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum ProtocolId {
+    Triple(TripleId),
+    Presignature(PresignatureId),
+    Signature(SignId, PresignatureId),
+}
+
+/// All actions that can be taken when a new posit is introduced for a protocol.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum PositAction {
+    Propose(Vec<Participant>),
+    Accept,
+    Reject,
+}
+
+/// The message associated with positing a new protocol.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct PositMessage {
+    pub id: ProtocolId,
+    pub from: Participant,
+    pub action: PositAction,
+}
+
+impl PositMessage {
+    pub fn data_len(&self) -> usize {
+        match &self.action {
+            PositAction::Propose(participants) => {
+                participants.len() * std::mem::size_of::<Participant>()
+            }
+            PositAction::Accept => 0,
+            PositAction::Reject => 0,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct GeneratingMessage {
     pub from: Participant,
@@ -103,6 +138,7 @@ impl From<SignatureMessage> for Message {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub enum Message {
+    Proposal(PositMessage),
     Generating(GeneratingMessage),
     Resharing(ResharingMessage),
     Triple(TripleMessage),
@@ -118,6 +154,7 @@ pub enum Message {
 impl Message {
     pub const fn typename(&self) -> &'static str {
         match self {
+            Message::Proposal(_) => "Proposal",
             Message::Generating(_) => "Generating",
             Message::Resharing(_) => "Resharing",
             Message::Triple(_) => "Triple",
@@ -130,6 +167,9 @@ impl Message {
     /// The size of the message in bytes.
     pub fn size(&self) -> usize {
         match self {
+            Message::Proposal(proposal) => {
+                std::mem::size_of::<PositMessage>() + proposal.data_len()
+            }
             Message::Generating(msg) => std::mem::size_of::<GeneratingMessage>() + msg.data.len(),
             Message::Resharing(msg) => std::mem::size_of::<ResharingMessage>() + msg.data.len(),
             Message::Triple(msg) => std::mem::size_of::<TripleMessage>() + msg.data.len(),

--- a/chain-signatures/node/src/protocol/message/types.rs
+++ b/chain-signatures/node/src/protocol/message/types.rs
@@ -4,9 +4,9 @@ use std::hash::{DefaultHasher, Hash as _};
 use cait_sith::protocol::{MessageData, Participant};
 use serde::{Deserialize, Serialize};
 
+use crate::protocol::posit::PositAction;
 use crate::protocol::presignature::{FullPresignatureId, PresignatureId};
 use crate::protocol::triple::TripleId;
-use crate::protocol::PositAction;
 use crate::types::Epoch;
 use mpc_keys::hpke;
 use mpc_primitives::SignId;

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -298,12 +298,20 @@ impl<T: Hash + Eq + fmt::Debug, Store> Posits<T, Store> {
         }
     }
 
-    pub fn propose(&mut self, id: T, store: Store, participants: &[Participant]) -> PositAction {
+    pub fn propose(
+        &mut self,
+        me: Participant,
+        id: T,
+        store: Store,
+        participants: &[Participant],
+    ) -> PositAction {
+        let mut accepts = HashSet::new();
+        accepts.insert(me);
         self.posits.insert(
             id,
             PositCounter {
                 participants: participants.iter().copied().collect(),
-                accepts: HashSet::new(),
+                accepts,
                 store: Some(store),
             },
         );
@@ -325,8 +333,7 @@ impl<T: Hash + Eq + fmt::Debug, Store> Posits<T, Store> {
             PositAction::Accept => {
                 let (should_start, reply) = if let Some(counter) = self.posits.get_mut(&id) {
                     counter.accepts.insert(from);
-                    // `- 1` to not include us
-                    let should_start = counter.accepts.len() == counter.participants.len() - 1;
+                    let should_start = counter.accepts.len() == counter.participants.len();
                     let should_start =
                         should_start.then(|| counter.participants.iter().copied().collect());
 

--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -1,0 +1,147 @@
+use cait_sith::protocol::Participant;
+use serde::{Deserialize, Serialize};
+
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::hash::Hash;
+
+/// All actions that can be taken when a new posit is introduced for a protocol.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum PositAction {
+    Propose(Vec<Participant>),
+    Accept,
+    // TODO: Reject can also have a reason
+    Reject,
+    /// Aborts the protocol. Only the proposer can send this.
+    Abort,
+}
+
+/// A counter for a posit. This is used to track the participants that have
+/// accepted the posit alongside storing an intermediary state for the protocol
+/// that the proposer needs to keep track of.
+pub struct PositCounter<Store> {
+    pub participants: HashSet<Participant>,
+    accepts: HashSet<Participant>,
+    store: Store,
+}
+
+/// A collection of posits that are being proposed. This is used to track
+/// the posits that are being proposed and the participants that have
+/// accepted them.
+#[derive(Default)]
+pub struct Posits<Id, Store> {
+    posits: HashMap<Id, PositCounter<Store>>,
+}
+
+impl<T: Hash + Eq + fmt::Debug, Store> Posits<T, Store> {
+    pub fn new() -> Self {
+        Self {
+            posits: HashMap::new(),
+        }
+    }
+
+    pub fn propose(
+        &mut self,
+        me: Participant,
+        id: T,
+        store: Store,
+        participants: &[Participant],
+    ) -> PositAction {
+        let mut accepts = HashSet::new();
+        accepts.insert(me);
+        self.posits.insert(
+            id,
+            PositCounter {
+                participants: participants.iter().copied().collect(),
+                accepts,
+                store,
+            },
+        );
+
+        PositAction::Propose(participants.to_vec())
+    }
+
+    // TODO: make the resp of this synchronous when each of the protocol
+    // managers are their own individual tasks such that they can respond
+    // without the need of the main consensus loop.
+    /// Act on the posit action. This will map the action received to a corresponding
+    /// action to be sent back to the proposer. This will return
+    ///     (ShouldStartProtocol, TemporaryStorageItem, ReplyAction).
+    pub fn act(
+        &mut self,
+        id: T,
+        from: Participant,
+        action: &PositAction,
+        active: &[Participant],
+    ) -> (Option<Vec<Participant>>, Option<Store>, Option<PositAction>) {
+        match action {
+            PositAction::Accept => {
+                let Some(counter) = self.posits.get_mut(&id) else {
+                    tracing::warn!(?id, "received an Accept for a protocol we did NOT propose");
+                    return (None, None, None);
+                };
+
+                counter.accepts.insert(from);
+                let should_start = counter.accepts.len() == counter.participants.len();
+                let should_start =
+                    should_start.then(|| counter.participants.iter().copied().collect());
+
+                let store = if should_start.is_some() {
+                    tracing::info!(?id, "received all Accepts, starting protocol");
+                    self.posits.remove(&id).map(|counter| counter.store)
+                } else {
+                    None
+                };
+
+                (should_start, store, None)
+            }
+            PositAction::Reject => {
+                // TODO: On the first reject, we should abort the protocol for now.
+                // We should be able to narrow down the list of participants
+                // that are rejecting the protocol up until the threshold amount.
+                let reply = if self.posits.contains_key(&id) {
+                    Some(PositAction::Abort)
+                } else {
+                    tracing::warn!(?id, "received a Reject for a protocol we did NOT propose");
+                    None
+                };
+                (None, None, reply)
+            }
+            // There's no action to be done here for Abort. Abort should be handled one level above.
+            PositAction::Abort => (None, None, None),
+            PositAction::Propose(participants) => {
+                if self.posits.contains_key(&id) {
+                    tracing::warn!(
+                        ?id,
+                        ?participants,
+                        "received a protocol posit for an id that we already proposed"
+                    );
+                    return (None, None, Some(PositAction::Reject));
+                }
+
+                // Check that the participants are all active
+                for p in participants.iter() {
+                    if !active.contains(p) {
+                        tracing::warn!(?id, ?active, ?participants, "rejecting protocol posit");
+                        return (None, None, Some(PositAction::Reject));
+                    }
+                }
+
+                // Automatically join the protocol if we're accepting here.
+                (Some(participants.to_vec()), None, Some(PositAction::Accept))
+            }
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.posits.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.posits.is_empty()
+    }
+
+    pub fn remove(&mut self, id: &T) -> Option<PositCounter<Store>> {
+        self.posits.remove(id)
+    }
+}

--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -5,6 +5,19 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::hash::Hash;
 
+pub type ProposerId = Participant;
+
+pub enum Positor<Store> {
+    Proposer(ProposerId, Store),
+    Deliberator(ProposerId),
+}
+
+impl<T> Positor<T> {
+    pub fn is_proposer(&self) -> bool {
+        matches!(self, Positor::Proposer(_, _))
+    }
+}
+
 /// All actions that can be taken when a new posit is introduced for a protocol.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum PositAction {
@@ -14,6 +27,12 @@ pub enum PositAction {
     Reject,
     /// Aborts the protocol. Only the proposer can send this.
     Abort,
+}
+
+pub enum PositInternalAction<Store> {
+    StartProtocol(Vec<Participant>, Positor<Store>),
+    AbortAllNodes(Vec<Participant>),
+    Reply(PositAction),
 }
 
 /// A counter for a posit. This is used to track the participants that have
@@ -28,14 +47,15 @@ pub struct PositCounter<Store> {
 /// A collection of posits that are being proposed. This is used to track
 /// the posits that are being proposed and the participants that have
 /// accepted them.
-#[derive(Default)]
 pub struct Posits<Id, Store> {
+    me: Participant,
     posits: HashMap<Id, PositCounter<Store>>,
 }
 
 impl<T: Hash + Eq + fmt::Debug, Store> Posits<T, Store> {
-    pub fn new() -> Self {
+    pub fn new(me: Participant) -> Self {
         Self {
+            me,
             posits: HashMap::new(),
         }
     }
@@ -61,54 +81,20 @@ impl<T: Hash + Eq + fmt::Debug, Store> Posits<T, Store> {
         PositAction::Propose(participants.to_vec())
     }
 
-    // TODO: make the resp of this synchronous when each of the protocol
-    // managers are their own individual tasks such that they can respond
-    // without the need of the main consensus loop.
+    // TODO: make the resp of this synchronous when each of the protocol managers
+    // are their own individual tasks such that they can respond without the need
+    // of the main consensus loop.
     /// Act on the posit action. This will map the action received to a corresponding
-    /// action to be sent back to the proposer. This will return
-    ///     (ShouldStartProtocol, TemporaryStorageItem, ReplyAction).
+    /// action to be sent back to the proposer. This will return a series of internal
+    /// actions the node should take.
     pub fn act(
         &mut self,
         id: T,
         from: Participant,
         action: &PositAction,
         active: &[Participant],
-    ) -> (Option<Vec<Participant>>, Option<Store>, Option<PositAction>) {
+    ) -> Vec<PositInternalAction<Store>> {
         match action {
-            PositAction::Accept => {
-                let Some(counter) = self.posits.get_mut(&id) else {
-                    tracing::warn!(?id, "received an Accept for a protocol we did NOT propose");
-                    return (None, None, None);
-                };
-
-                counter.accepts.insert(from);
-                let should_start = counter.accepts.len() == counter.participants.len();
-                let should_start =
-                    should_start.then(|| counter.participants.iter().copied().collect());
-
-                let store = if should_start.is_some() {
-                    tracing::info!(?id, "received all Accepts, starting protocol");
-                    self.posits.remove(&id).map(|counter| counter.store)
-                } else {
-                    None
-                };
-
-                (should_start, store, None)
-            }
-            PositAction::Reject => {
-                // TODO: On the first reject, we should abort the protocol for now.
-                // We should be able to narrow down the list of participants
-                // that are rejecting the protocol up until the threshold amount.
-                let reply = if self.posits.contains_key(&id) {
-                    Some(PositAction::Abort)
-                } else {
-                    tracing::warn!(?id, "received a Reject for a protocol we did NOT propose");
-                    None
-                };
-                (None, None, reply)
-            }
-            // There's no action to be done here for Abort. Abort should be handled one level above.
-            PositAction::Abort => (None, None, None),
             PositAction::Propose(participants) => {
                 if self.posits.contains_key(&id) {
                     tracing::warn!(
@@ -116,19 +102,67 @@ impl<T: Hash + Eq + fmt::Debug, Store> Posits<T, Store> {
                         ?participants,
                         "received a protocol posit for an id that we already proposed"
                     );
-                    return (None, None, Some(PositAction::Reject));
+                    return vec![PositInternalAction::Reply(PositAction::Reject)];
                 }
 
                 // Check that the participants are all active
                 for p in participants.iter() {
                     if !active.contains(p) {
                         tracing::warn!(?id, ?active, ?participants, "rejecting protocol posit");
-                        return (None, None, Some(PositAction::Reject));
+                        return vec![PositInternalAction::Reply(PositAction::Reject)];
                     }
                 }
 
                 // Automatically join the protocol if we're accepting here.
-                (Some(participants.to_vec()), None, Some(PositAction::Accept))
+                vec![
+                    PositInternalAction::StartProtocol(
+                        participants.clone(),
+                        Positor::Deliberator(from),
+                    ),
+                    PositInternalAction::Reply(PositAction::Accept),
+                ]
+            }
+            // There's no action to be done here for Abort. Abort should be handled one level above.
+            PositAction::Abort => Vec::new(),
+            PositAction::Accept => {
+                let Some(counter) = self.posits.get_mut(&id) else {
+                    tracing::warn!(?id, "received an Accept for a protocol we did NOT propose");
+                    return Vec::new();
+                };
+
+                counter.accepts.insert(from);
+                let should_start = counter.accepts.len() == counter.participants.len();
+
+                let mut actions = Vec::new();
+                if should_start {
+                    tracing::info!(?id, "received all Accepts, starting protocol");
+                    let Some(counter) = self.posits.remove(&id) else {
+                        tracing::warn!(
+                            ?id,
+                            "invalid state, we should have been able to remove this posit"
+                        );
+                        return Vec::new();
+                    };
+                    let participants = counter.participants.iter().copied().collect();
+                    actions.push(PositInternalAction::StartProtocol(
+                        participants,
+                        Positor::Proposer(self.me, counter.store),
+                    ));
+                }
+                actions
+            }
+            PositAction::Reject => {
+                // TODO: On the first reject, we should abort the protocol for now.
+                // We should be able to narrow down the list of participants eventually
+                // such that we can go up until the threshold amount.
+                if let Some(counter) = self.posits.remove(&id) {
+                    vec![PositInternalAction::AbortAllNodes(
+                        counter.participants.iter().copied().collect(),
+                    )]
+                } else {
+                    tracing::warn!(?id, "received a Reject for a protocol we did NOT propose");
+                    Vec::new()
+                }
             }
         }
     }

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -1,7 +1,7 @@
 use super::message::{MessageChannel, PositMessage, PositProtocolId, PresignatureMessage};
+use super::posit::{PositAction, Posits};
 use super::state::RunningState;
 use super::triple::{TripleId, TripleManager};
-use super::{PositAction, Posits};
 use crate::protocol::contract::primitives::intersect_vec;
 use crate::protocol::error::GenerationError;
 use crate::storage::presignature_storage::{

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -609,10 +609,8 @@ impl TripleManager {
         {
             let tasks = self.tasks.read().await;
             if tasks.generators.contains_key(&id0) {
-                tracing::warn!(id0, "triple is generating");
                 return Err(GenerationError::TripleIsGenerating(id0));
             } else if tasks.generators.contains_key(&id1) {
-                tracing::warn!(id1, "triple is generating");
                 return Err(GenerationError::TripleIsGenerating(id1));
             }
         }


### PR DESCRIPTION
This PR adds posits where a node must first propose a Posit before an equivalent protocol can be generated. For the most part, the actions that we can taken for new protocol posits are `Propose, Accept, Reject, Abort`. Only the proposer can issue out aborts. Only deliberators can send out `Accept` or `Reject`.

The flow is as follows on the happy path:
- node A proposes a posit.
- node B,C sees the posit.
- node B,C accepts the post & immediately starts the protocol (did the immediate part for now for simplicity).
- node A receives all `Accept`, and start their protocol.

The path where something went wrong:
- node A proposes a posit.
- node B,C sees the posit.
- node B accepts, but node C sees that their view of participants is invalid with node A and thus sends a `Reject`.
- node A sees a singular `Reject`, and immediately broadcasts out `Abort` (due to the immediate starting of the protocol by other nodes).

Note that this PR only adds these `Posits` to presignatures since triple needs to be refactored a bit and signature also has its own deal of work.

So before handling Presignature messages, presignature manager will first see any new posits and handle those, and thus initiating protocols if necessary. Some additional changes were made for presignatures:
- no separate functions for generating an owned presignature vs foreign presignature. They are now all united under `generate`. This means that reserve will only be called after proposition is done and we start. Before, the owner would try to reserve first, then send out the presignature generation request.
- added `FullPresignatureId` to encompass both the `PresignatureId` and the two `TripleId` that it uses.

The thing missing is to wait on all accepts before starting the protocol. I avoided this for now just to get this reviewed. I also imagine us being able to narrow down the list of participants in the case where someone were to reject or not reply. Timeouts also need to be handled eventually for this