### PR TITLE
fix: remove dedupping the sign requests based on signId

### DIFF
--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -496,15 +496,6 @@ pub(crate) static PRESIGNATURE_BEFORE_POKE_DELAY: LazyLock<HistogramVec> = LazyL
     .unwrap()
 });
 
-pub(crate) static NUM_UNIQUE_SIGN_REQUESTS: LazyLock<CounterVec> = LazyLock::new(|| {
-    try_create_counter_vec(
-        "multichain_sign_requests_count_unique",
-        "number of multichain sign requests, marked by sign requests indexed and deduped",
-        &["chain", "node_account_id"],
-    )
-    .unwrap()
-});
-
 pub(crate) static PRESIGNATURE_ACCRUED_WAIT_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
         "multichain_presignature_accrued_wait_delay_ms",

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -101,13 +101,6 @@ impl SignQueue {
         self.len() == 0
     }
 
-    fn contains(&self, sign_id: &SignId) -> bool {
-        self.my_requests
-            .iter()
-            .any(|req| req.indexed.id == *sign_id)
-            || self.other_requests.contains_key(sign_id)
-    }
-
     fn organize_request(
         &self,
         threshold: usize,
@@ -183,14 +176,6 @@ impl SignQueue {
                 other => other,
             }
         } {
-            if self.contains(&indexed.id) {
-                tracing::info!(sign_id = ?indexed.id, "skipping sign request: already in the sign queue");
-                continue;
-            }
-            crate::metrics::NUM_UNIQUE_SIGN_REQUESTS
-                .with_label_values(&[indexed.chain.as_str(), my_account_id.as_str()])
-                .inc();
-
             let request = self.organize_request(threshold, &stable, indexed, false);
             let is_mine = request.proposer == self.me;
             if is_mine {


### PR DESCRIPTION
We used to dedup sign requests based on signIds because our eth indexer used to have to go back to the last processed block and resubscribe. Since we do not have resubscribe logic any more, we do not need to dedup