### PR TITLE
separate solana websocket and http rpc url to use alchemy for http respond()

### DIFF
--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -42,8 +42,10 @@ pub(crate) static MAX_SECP256K1_SCALAR: LazyLock<Scalar> = LazyLock::new(|| {
 pub struct SolConfig {
     /// The solana account secret key used to sign solana respond txn.
     pub account_sk: String,
-    /// Solana RPC URL
-    pub rpc_url: String,
+    /// Solana RPC http URL
+    pub rpc_http_url: String,
+    /// Solana RPC websocket URL
+    pub rpc_ws_url: String,
     /// The program address to watch
     pub program_address: String,
 }
@@ -52,7 +54,8 @@ impl fmt::Debug for SolConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SolConfig")
             .field("account_sk", &"<hidden>")
-            .field("rpc_url", &self.rpc_url)
+            .field("rpc_http_url", &self.rpc_http_url)
+            .field("rpc_ws_url", &self.rpc_ws_url)
             .field("program_address", &self.program_address)
             .finish()
     }
@@ -65,9 +68,12 @@ pub struct SolArgs {
     /// The solana account secret key used to sign solana respond txn.
     #[arg(long, env("MPC_SOL_ACCOUNT_SK"))]
     pub sol_account_sk: Option<String>,
-    /// Solana RPC URL
-    #[clap(long, env("MPC_SOL_RPC_URL"), requires = "sol_account_sk")]
-    pub sol_rpc_url: Option<String>,
+    /// Solana RPC HTTP URL
+    #[clap(long, env("MPC_SOL_RPC_HTTP_URL"), requires = "sol_account_sk")]
+    pub sol_rpc_http_url: Option<String>,
+    /// Solana RPC WS URL
+    #[clap(long, env("MPC_SOL_RPC_WS_URL"), requires = "sol_account_sk")]
+    pub sol_rpc_ws_url: Option<String>,
     /// The program address to watch
     #[clap(long, env("MPC_SOL_PROGRAM_ADDRESS"), requires = "sol_account_sk")]
     pub sol_program_address: Option<String>,
@@ -79,8 +85,11 @@ impl SolArgs {
         if let Some(sol_account_sk) = self.sol_account_sk {
             args.extend(["--sol-account-sk".to_string(), sol_account_sk]);
         }
-        if let Some(sol_rpc_url) = self.sol_rpc_url {
-            args.extend(["--sol-rpc-url".to_string(), sol_rpc_url]);
+        if let Some(sol_rpc_http_url) = self.sol_rpc_http_url {
+            args.extend(["--sol-rpc-http-url".to_string(), sol_rpc_http_url]);
+        }
+        if let Some(sol_rpc_ws_url) = self.sol_rpc_ws_url {
+            args.extend(["--sol-rpc-ws-url".to_string(), sol_rpc_ws_url]);
         }
         if let Some(sol_program_address) = self.sol_program_address {
             args.extend(["--sol-program-address".to_string(), sol_program_address]);
@@ -91,7 +100,8 @@ impl SolArgs {
     pub fn into_config(self) -> Option<SolConfig> {
         Some(SolConfig {
             account_sk: self.sol_account_sk?,
-            rpc_url: self.sol_rpc_url?,
+            rpc_http_url: self.sol_rpc_http_url?,
+            rpc_ws_url: self.sol_rpc_ws_url?,
             program_address: self.sol_program_address?,
         })
     }
@@ -100,12 +110,14 @@ impl SolArgs {
         match config {
             Some(config) => SolArgs {
                 sol_account_sk: Some(config.account_sk),
-                sol_rpc_url: Some(config.rpc_url),
+                sol_rpc_http_url: Some(config.rpc_http_url),
+                sol_rpc_ws_url: Some(config.rpc_ws_url),
                 sol_program_address: Some(config.program_address),
             },
             None => SolArgs {
                 sol_account_sk: None,
-                sol_rpc_url: None,
+                sol_rpc_http_url: None,
+                sol_rpc_ws_url: None,
                 sol_program_address: None,
             },
         }
@@ -221,10 +233,15 @@ pub async fn run(
     let program_id = Pubkey::from_str(&sol.program_address)?;
     let keypair = Keypair::from_base58_string(&sol.account_sk);
 
-    let cluster = Cluster::Custom(sol.rpc_url.clone(), sol.rpc_url.replace("http", "ws"));
+    let cluster = Cluster::Custom(sol.rpc_http_url.clone(), sol.rpc_ws_url.clone());
     let client =
         Client::new_with_options(cluster, Arc::new(keypair), CommitmentConfig::confirmed());
-    tracing::info!("rpc url: {}, program id: {}", sol.rpc_url, program_id);
+    tracing::info!(
+        "rpc http url: {}, rpc websocket url: {}, program id: {}",
+        sol.rpc_http_url,
+        sol.rpc_ws_url,
+        program_id
+    );
     loop {
         let program = client.program(program_id)?;
         let unsub =

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -491,7 +491,7 @@ impl SolanaClient {
         let keypair = Keypair::from_base58_string(&sol.account_sk);
         let payer = Arc::new(keypair);
         let cluster =
-            anchor_client::Cluster::Custom(sol.rpc_url.clone(), sol.rpc_url.replace("http", "ws"));
+            anchor_client::Cluster::Custom(sol.rpc_http_url.clone(), sol.rpc_ws_url.clone());
         let client = anchor_client::Client::new_with_options(
             cluster,
             payer.clone(),

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -64,7 +64,8 @@ impl Default for NodeConfig {
             sol: Some(SolConfig {
                 account_sk: "fS5jS6X5qvaquBV1bg2YWBdYeCiRSUwNAdNpgNkjS72oNxUJcZJZduaq2oCcXJb8erTbtqqq4wxriUmRJk7bMDw"
                     .to_string(),
-                rpc_url: "https://api.devnet.solana.com".to_string(),
+                rpc_http_url: "https://api.devnet.solana.com".to_string(),
+                rpc_ws_url: "wss://api.devnet.solana.com/".to_string(),
                 program_address: "BtGZEs9ZJX3hAQuY5er8iyWrGsrPRZYupEtVSS129XKo".to_string(),
             }),
         }


### PR DESCRIPTION
Separating solana websocket and http rpc url so that we could use alchemy http url for respond() calls and would be able to respond when traffic is high