### PR TITLE
fix: make integration tests disable gcp logging

### DIFF
--- a/chain-signatures/node/src/logs.rs
+++ b/chain-signatures/node/src/logs.rs
@@ -63,6 +63,13 @@ impl Options {
         }
         opts
     }
+
+    pub fn test() -> Self {
+        Self {
+            disable_gcp_logs: true,
+            ..Default::default()
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Default, clap::ValueEnum, serde::Serialize, serde::Deserialize)]

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -305,7 +305,7 @@ pub async fn setup(spawner: &mut ClusterSpawner) -> anyhow::Result<Context> {
         redis_url: redis.internal_address.clone(),
     };
 
-    let log_options = logs::Options::default();
+    let log_options = logs::Options::test();
 
     let mesh_options = mpc_node::mesh::Options {
         ping_interval: 1000,


### PR DESCRIPTION
this didn't get explicitly disabled for integration tests before