### PR TITLE
patch: remove port number for an url if it's not an IP address

### DIFF
--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use url::Url;
 
+use crate::util;
 use mpc_keys::hpke;
 
 #[derive(Parser, Debug)]
@@ -231,7 +232,9 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let sign_sk = sign_sk.unwrap_or_else(|| account_sk.clone());
             let my_address = my_address
                 .map(|mut addr| {
-                    addr.set_port(Some(web_port)).unwrap();
+                    if util::is_url_host_ip(&addr) {
+                        addr.set_port(Some(web_port)).unwrap();
+                    }
                     addr
                 })
                 .unwrap_or_else(|| {

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -19,7 +19,6 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use url::Url;
 
-use crate::util;
 use mpc_keys::hpke;
 
 #[derive(Parser, Debug)]
@@ -232,9 +231,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let sign_sk = sign_sk.unwrap_or_else(|| account_sk.clone());
             let my_address = my_address
                 .map(|mut addr| {
-                    if util::is_url_host_ip(&addr) {
-                        addr.set_port(Some(web_port)).unwrap();
-                    }
+                    addr.set_port(Some(web_port)).unwrap();
                     addr
                 })
                 .unwrap_or_else(|| {

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -507,6 +507,7 @@ impl SolanaClient {
 }
 
 /// Client related to a specific chain
+#[allow(clippy::large_enum_variant)]
 pub enum ChainClient {
     Err(&'static str),
     Near(NearClient),

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -414,7 +414,7 @@ impl NearClient {
         self.client
             .call(&self.signer, &self.contract_id, "join")
             .args_json(json!({
-                "url": self.my_addr,
+                "url": crate::util::process_url(self.my_addr.to_string()),
                 "cipher_pk": self.cipher_pk.to_bytes(),
                 "sign_pk": self.sign_pk,
             }))

--- a/chain-signatures/node/src/util.rs
+++ b/chain-signatures/node/src/util.rs
@@ -97,17 +97,17 @@ pub fn is_url_host_ip(url: &Url) -> bool {
 }
 
 pub fn process_url(url_str: String) -> String {
-    let url_str = url_str.clone();
     url::Url::parse(&url_str)
         .map(|mut url| {
+            let url_str = url.to_string();
             if !is_url_host_ip(&url) {
                 if let Err(err) = url.set_port(None) {
                     tracing::warn!("Error setting participant's url {url} port to None: {err:?}");
-                    return url_str.clone();
+                    return url.to_string();
                 }
-                url.to_string()
+                url_str
             } else {
-                url_str.clone()
+                url_str
             }
         })
         .unwrap_or_else(|_| url_str)

--- a/chain-signatures/node/src/util.rs
+++ b/chain-signatures/node/src/util.rs
@@ -99,15 +99,14 @@ pub fn is_url_host_ip(url: &Url) -> bool {
 pub fn process_url(url_str: String) -> String {
     url::Url::parse(&url_str)
         .map(|mut url| {
-            let url_str = url.to_string();
             if !is_url_host_ip(&url) {
                 if let Err(err) = url.set_port(None) {
                     tracing::warn!("Error setting participant's url {url} port to None: {err:?}");
                     return url.to_string();
                 }
-                url_str
+                url.to_string()
             } else {
-                url_str
+                url.to_string()
             }
         })
         .unwrap_or_else(|_| url_str)

--- a/chain-signatures/node/src/util.rs
+++ b/chain-signatures/node/src/util.rs
@@ -95,3 +95,20 @@ pub fn is_url_host_ip(url: &Url) -> bool {
         .map(|host| host.parse::<IpAddr>().is_ok())
         .unwrap_or(false)
 }
+
+pub fn process_url(url_str: String) -> String {
+    let url_str = url_str.clone();
+    url::Url::parse(&url_str)
+        .map(|mut url| {
+            if !is_url_host_ip(&url) {
+                if let Err(err) = url.set_port(None) {
+                    tracing::warn!("Error setting participant's url {url} port to None: {err:?}");
+                    return url_str.clone();
+                }
+                url.to_string()
+            } else {
+                url_str.clone()
+            }
+        })
+        .unwrap_or_else(|_| url_str)
+}

--- a/chain-signatures/node/src/util.rs
+++ b/chain-signatures/node/src/util.rs
@@ -2,7 +2,9 @@ use chrono::{DateTime, LocalResult, TimeZone, Utc};
 use k256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use k256::{AffinePoint, EncodedPoint};
 use mpc_crypto::{near_public_key_to_affine_point, PublicKey};
+use std::net::IpAddr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use url::Url;
 
 pub trait NearPublicKeyExt {
     fn into_affine_point(self) -> PublicKey;
@@ -86,4 +88,10 @@ pub fn current_unix_timestamp() -> u64 {
         .duration_since(UNIX_EPOCH)
         .expect("Time went backwards")
         .as_secs()
+}
+
+pub fn is_url_host_ip(url: &Url) -> bool {
+    url.host_str()
+        .map(|host| host.parse::<IpAddr>().is_ok())
+        .unwrap_or(false)
 }


### PR DESCRIPTION
This change should:
1. remove the port number for an url when candidates or participants in contract state gets converted to Participants struct
2. remove the port number from my_address when joining participants set