### PR TITLE
bug: correct the block hash for eth finalized block

### DIFF
--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -646,10 +646,7 @@ async fn refresh_finalized_epoch(
             continue;
         }
 
-        finalized_epoch.insert(
-            new_final_block_number,
-            new_finalized_bock.header.inner.parent_hash,
-        );
+        finalized_epoch.insert(new_final_block_number, new_finalized_bock.header.hash);
 
         let mut parent_hash = new_finalized_bock.header.inner.parent_hash;
 


### PR DESCRIPTION
the block hash for the finalized block was wrongly set to its parent hash. Correcting it.