### PR TITLE
feat: consensus no longer return error & no more cloning on protocol state changes

### DIFF
--- a/chain-signatures/node/src/protocol/consensus.rs
+++ b/chain-signatures/node/src/protocol/consensus.rs
@@ -4,7 +4,6 @@ use super::state::{
     WaitingForConsensusState,
 };
 use super::MpcSignProtocol;
-use crate::gcp::error::SecretStorageError;
 use crate::protocol::contract::primitives::Participants;
 use crate::protocol::presignature::PresignatureManager;
 use crate::protocol::signature::SignatureManager;
@@ -16,149 +15,156 @@ use crate::util::AffinePointExt;
 use std::cmp::Ordering;
 use std::sync::Arc;
 
-use cait_sith::protocol::InitializationError;
 use tokio::sync::RwLock;
 
-#[derive(thiserror::Error, Debug)]
-pub enum ConsensusError {
-    #[error("contract state has been rolled back")]
-    ContractStateRollback,
-    #[error("contract epoch has been rolled back")]
-    EpochRollback,
-    #[error("mismatched public key between contract state and local state")]
-    MismatchedPublicKey,
-    #[error("mismatched threshold between contract state and local state")]
-    MismatchedThreshold,
-    #[error("mismatched participant set between contract state and local state")]
-    MismatchedParticipants,
-    #[error("this node has been unexpectedly kicked from the participant set")]
-    HasBeenKicked,
-    #[error("this node errored out during the join process: {0}")]
-    CannotJoin(String),
-    #[error("this node errored out while trying to vote: {0}")]
-    CannotVote(String),
-    #[error("cait-sith initialization error: {0}")]
-    CaitSithInitializationError(#[from] InitializationError),
-    #[error("secret storage error: {0}")]
-    SecretStorageError(#[from] SecretStorageError),
-}
-
 pub(crate) trait ConsensusProtocol {
-    async fn advance(
-        self,
-        ctx: &mut MpcSignProtocol,
-        contract_state: ProtocolState,
-    ) -> Result<NodeState, ConsensusError>;
+    async fn advance(self, ctx: &mut MpcSignProtocol, contract_state: ProtocolState) -> NodeState;
 }
 
 impl ConsensusProtocol for StartedState {
-    async fn advance(
-        self,
-        ctx: &mut MpcSignProtocol,
-        contract_state: ProtocolState,
-    ) -> Result<NodeState, ConsensusError> {
+    async fn advance(self, ctx: &mut MpcSignProtocol, contract_state: ProtocolState) -> NodeState {
         match self.persistent_node_data {
             Some(PersistentNodeData {
                 epoch,
                 private_share,
                 public_key,
             }) => match contract_state {
-                ProtocolState::Initializing(_) => Err(ConsensusError::ContractStateRollback),
+                ProtocolState::Initializing(contract_state) => {
+                    tracing::warn!(
+                        ?contract_state,
+                        "started(initializing): contract state has not been finalized yet"
+                    );
+                    NodeState::Started(self)
+                }
                 ProtocolState::Running(contract_state) => {
                     if contract_state.public_key != public_key {
-                        return Err(ConsensusError::MismatchedPublicKey);
+                        tracing::warn!(
+                            node_pk = ?public_key,
+                            contract_pk = ?contract_state.public_key,
+                            "started(running): our public key is different from the contract, rejoining...",
+                        );
+                        return NodeState::Joining(JoiningState {
+                            participants: contract_state.participants,
+                            public_key,
+                        });
                     }
                     match contract_state.epoch.cmp(&epoch) {
                         Ordering::Greater => {
                             tracing::warn!(
-                                "started(running): our current epoch is {} while contract state's is {}, trying to rejoin as a new participant",
-                                epoch,
-                                contract_state.epoch
+                                node_epoch = epoch,
+                                contract_epoch = contract_state.epoch,
+                                "started(running): our current epoch is less than contract, rejoining...",
                             );
-                            Ok(NodeState::Joining(JoiningState {
+                            NodeState::Joining(JoiningState {
                                 participants: contract_state.participants,
                                 public_key,
-                            }))
+                            })
                         }
-                        Ordering::Less => Err(ConsensusError::EpochRollback),
+                        Ordering::Less => {
+                            tracing::error!(
+                                node_epoch = epoch,
+                                contract_epoch = contract_state.epoch,
+                                "started(running): unexpected, our current epoch is greater than contract, rejoining...",
+                            );
+                            NodeState::Joining(JoiningState {
+                                participants: contract_state.participants,
+                                public_key,
+                            })
+                        }
                         Ordering::Equal => {
-                            match contract_state
+                            let Some(&me) = contract_state
                                 .participants
                                 .find_participant(&ctx.my_account_id)
-                            {
-                                Some(me) => {
-                                    tracing::info!(
-                                        "started: contract state is running and we are already a participant"
-                                    );
-                                    let triple_manager = TripleManager::new(
-                                        *me,
-                                        contract_state.threshold,
-                                        epoch,
-                                        &ctx.my_account_id,
-                                        &ctx.triple_storage,
-                                        ctx.msg_channel.clone(),
-                                    );
-
-                                    let presignature_manager =
-                                        Arc::new(RwLock::new(PresignatureManager::new(
-                                            *me,
-                                            contract_state.threshold,
-                                            epoch,
-                                            &ctx.my_account_id,
-                                            &ctx.triple_storage,
-                                            &ctx.presignature_storage,
-                                            ctx.msg_channel.clone(),
-                                        )));
-
-                                    let signature_manager =
-                                        Arc::new(RwLock::new(SignatureManager::new(
-                                            *me,
-                                            &ctx.my_account_id,
-                                            contract_state.threshold,
-                                            public_key,
-                                            epoch,
-                                            ctx.sign_rx.clone(),
-                                            &ctx.presignature_storage,
-                                            ctx.msg_channel.clone(),
-                                        )));
-
-                                    Ok(NodeState::Running(RunningState {
-                                        epoch,
-                                        me: *me,
-                                        participants: contract_state.participants,
-                                        threshold: contract_state.threshold,
-                                        private_share,
-                                        public_key,
-                                        triple_manager,
-                                        presignature_manager,
-                                        signature_manager,
-                                    }))
-                                }
-                                None => Ok(NodeState::Joining(JoiningState {
+                            else {
+                                return NodeState::Joining(JoiningState {
                                     participants: contract_state.participants,
                                     public_key,
-                                })),
-                            }
+                                });
+                            };
+
+                            tracing::info!(
+                                "started: contract state is running and we are already a participant"
+                            );
+                            let triple_manager = TripleManager::new(
+                                me,
+                                contract_state.threshold,
+                                epoch,
+                                &ctx.my_account_id,
+                                &ctx.triple_storage,
+                                ctx.msg_channel.clone(),
+                            );
+
+                            let presignature_manager =
+                                Arc::new(RwLock::new(PresignatureManager::new(
+                                    me,
+                                    contract_state.threshold,
+                                    epoch,
+                                    &ctx.my_account_id,
+                                    &ctx.triple_storage,
+                                    &ctx.presignature_storage,
+                                    ctx.msg_channel.clone(),
+                                )));
+
+                            let signature_manager = Arc::new(RwLock::new(SignatureManager::new(
+                                me,
+                                &ctx.my_account_id,
+                                contract_state.threshold,
+                                public_key,
+                                epoch,
+                                ctx.sign_rx.clone(),
+                                &ctx.presignature_storage,
+                                ctx.msg_channel.clone(),
+                            )));
+
+                            NodeState::Running(RunningState {
+                                epoch,
+                                me,
+                                participants: contract_state.participants,
+                                threshold: contract_state.threshold,
+                                private_share,
+                                public_key,
+                                triple_manager,
+                                presignature_manager,
+                                signature_manager,
+                            })
                         }
                     }
                 }
                 ProtocolState::Resharing(contract_state) => {
                     if contract_state.public_key != public_key {
-                        return Err(ConsensusError::MismatchedPublicKey);
+                        tracing::warn!(
+                            node_pk = ?public_key,
+                            contract_pk = ?contract_state.public_key,
+                            "started(resharing): our public key is different from the contract, rejoining...",
+                        );
+                        return NodeState::Joining(JoiningState {
+                            participants: contract_state.old_participants,
+                            public_key,
+                        });
                     }
                     match contract_state.old_epoch.cmp(&epoch) {
                         Ordering::Greater => {
                             tracing::warn!(
-                                "started(resharing): our current epoch is {} while contract state's is {}, trying to rejoin as a new participant",
-                                epoch,
-                                contract_state.old_epoch
+                                node_epoch = epoch,
+                                contract_epoch = contract_state.old_epoch,
+                                "started(resharing): contract epoch is greater than node epoch, rejoining...",
                             );
-                            Ok(NodeState::Joining(JoiningState {
+                            NodeState::Joining(JoiningState {
                                 participants: contract_state.old_participants,
                                 public_key,
-                            }))
+                            })
                         }
-                        Ordering::Less => Err(ConsensusError::EpochRollback),
+                        Ordering::Less => {
+                            tracing::error!(
+                                node_epoch = epoch,
+                                contract_epoch = contract_state.old_epoch,
+                                "started(resharing): unexpected, contract epoch is less than node epoch, rejoining...",
+                            );
+                            NodeState::Joining(JoiningState {
+                                participants: contract_state.old_participants,
+                                public_key,
+                            })
+                        }
                         Ordering::Equal => {
                             tracing::info!(
                                 "started(resharing): contract state is resharing with us, joining as a participant"
@@ -171,98 +177,132 @@ impl ConsensusProtocol for StartedState {
             None => match contract_state {
                 ProtocolState::Initializing(contract_state) => {
                     let participants: Participants = contract_state.candidates.clone().into();
-                    match participants.find_participant(&ctx.my_account_id) {
-                        Some(me) => {
-                            tracing::info!(
-                                "started(initializing): starting key generation as a part of the participant set"
+                    let Some(&me) = participants.find_participant(&ctx.my_account_id) else {
+                        tracing::info!("started(initializing): we are not a part of the initial participant set, waiting for key generation to complete");
+                        return NodeState::Started(self);
+                    };
+
+                    tracing::info!(
+                        "started(initializing): starting key generation as a part of the participant set"
+                    );
+                    let protocol = match KeygenProtocol::new(
+                        &participants.keys_vec(),
+                        me,
+                        contract_state.threshold,
+                    ) {
+                        Ok(protocol) => protocol,
+                        Err(err) => {
+                            tracing::error!(
+                                ?err,
+                                "started(initializing): failed to initialize key generation"
                             );
-                            let protocol = KeygenProtocol::new(
-                                &participants.keys_vec(),
-                                *me,
-                                contract_state.threshold,
-                            )?;
-                            Ok(NodeState::Generating(GeneratingState {
-                                me: *me,
-                                participants,
-                                threshold: contract_state.threshold,
-                                protocol,
-                                failed_store: Default::default(),
-                            }))
+                            return NodeState::Started(self);
                         }
-                        None => {
-                            tracing::info!("started(initializing): we are not a part of the initial participant set, waiting for key generation to complete");
-                            Ok(NodeState::Started(self))
-                        }
-                    }
+                    };
+                    NodeState::Generating(GeneratingState {
+                        me,
+                        participants,
+                        threshold: contract_state.threshold,
+                        protocol,
+                        failed_store: Default::default(),
+                    })
                 }
-                ProtocolState::Running(contract_state) => Ok(NodeState::Joining(JoiningState {
+                ProtocolState::Running(contract_state) => NodeState::Joining(JoiningState {
                     participants: contract_state.participants,
                     public_key: contract_state.public_key,
-                })),
-                ProtocolState::Resharing(contract_state) => Ok(NodeState::Joining(JoiningState {
+                }),
+                ProtocolState::Resharing(contract_state) => NodeState::Joining(JoiningState {
                     participants: contract_state.old_participants,
                     public_key: contract_state.public_key,
-                })),
+                }),
             },
         }
     }
 }
 
 impl ConsensusProtocol for GeneratingState {
-    async fn advance(
-        self,
-        _ctx: &mut MpcSignProtocol,
-        contract_state: ProtocolState,
-    ) -> Result<NodeState, ConsensusError> {
+    async fn advance(self, _ctx: &mut MpcSignProtocol, contract_state: ProtocolState) -> NodeState {
         match contract_state {
             ProtocolState::Initializing(_) => {
                 tracing::info!("generating(initializing): continuing generation, contract state has not been finalized yet");
-                Ok(NodeState::Generating(self))
+                NodeState::Generating(self)
             }
             ProtocolState::Running(contract_state) => {
+                tracing::info!("generating(running): contract state has finished key generation, trying to catch up");
                 if contract_state.epoch > 0 {
-                    tracing::warn!("generating(running): contract has already changed epochs, trying to rejoin as a new participant");
-                    return Ok(NodeState::Joining(JoiningState {
+                    tracing::warn!(
+                        "generating(running): contract has already changed epochs, rejoining..."
+                    );
+                    return NodeState::Joining(JoiningState {
                         participants: contract_state.participants,
                         public_key: contract_state.public_key,
-                    }));
+                    });
                 }
-                tracing::info!("generating(running): contract state has finished key generation, trying to catch up");
                 if self.participants != contract_state.participants {
-                    return Err(ConsensusError::MismatchedParticipants);
+                    tracing::warn!(
+                        node_participants = ?self.participants,
+                        contract_participants = ?contract_state.participants,
+                        "generating(running): our participants do not match contract",
+                    );
+                    return NodeState::Joining(JoiningState {
+                        participants: contract_state.participants,
+                        public_key: contract_state.public_key,
+                    });
                 }
                 if self.threshold != contract_state.threshold {
-                    return Err(ConsensusError::MismatchedThreshold);
+                    tracing::warn!(
+                        node_threshold = self.threshold,
+                        contract_threshold = contract_state.threshold,
+                        "generating(running): our threshold does not match contract",
+                    );
+                    return NodeState::Joining(JoiningState {
+                        participants: contract_state.participants,
+                        public_key: contract_state.public_key,
+                    });
                 }
-                Ok(NodeState::Generating(self))
+                NodeState::Generating(self)
             }
             ProtocolState::Resharing(contract_state) => {
+                tracing::warn!("generating(resharing): contract state is resharing without us, trying to catch up");
                 if contract_state.old_epoch > 0 {
-                    tracing::warn!("generating(resharing): contract has already changed epochs, trying to rejoin as a new participant");
-                    return Ok(NodeState::Joining(JoiningState {
+                    tracing::warn!(
+                        "generating(resharing): contract has already changed epochs, rejoining..."
+                    );
+                    return NodeState::Joining(JoiningState {
                         participants: contract_state.old_participants,
                         public_key: contract_state.public_key,
-                    }));
+                    });
                 }
-                tracing::warn!("generating(resharing): contract state is resharing without us, trying to catch up");
                 if self.participants != contract_state.old_participants {
-                    return Err(ConsensusError::MismatchedParticipants);
+                    tracing::warn!(
+                        node_participants = ?self.participants,
+                        contract_participants = ?contract_state.old_participants,
+                        "generating(resharing): our participants do not match contract",
+                    );
+                    return NodeState::Joining(JoiningState {
+                        participants: contract_state.old_participants,
+                        public_key: contract_state.public_key,
+                    });
                 }
                 if self.threshold != contract_state.threshold {
-                    return Err(ConsensusError::MismatchedThreshold);
+                    tracing::warn!(
+                        node_threshold = self.threshold,
+                        contract_threshold = contract_state.threshold,
+                        "generating(resharing): our threshold does not match contract",
+                    );
+                    return NodeState::Joining(JoiningState {
+                        participants: contract_state.old_participants,
+                        public_key: contract_state.public_key,
+                    });
                 }
-                Ok(NodeState::Generating(self))
+                NodeState::Generating(self)
             }
         }
     }
 }
 
 impl ConsensusProtocol for WaitingForConsensusState {
-    async fn advance(
-        self,
-        ctx: &mut MpcSignProtocol,
-        contract_state: ProtocolState,
-    ) -> Result<NodeState, ConsensusError> {
+    async fn advance(self, ctx: &mut MpcSignProtocol, contract_state: ProtocolState) -> NodeState {
         match contract_state {
             ProtocolState::Initializing(contract_state) => {
                 tracing::info!("waiting(initializing): waiting for consensus, contract state has not been finalized yet");
@@ -274,49 +314,84 @@ impl ConsensusProtocol for WaitingForConsensusState {
                     .unwrap_or_default();
                 if !has_voted {
                     tracing::info!("waiting(initializing): we haven't voted yet, voting for the generated public key");
-                    ctx.near
-                        .vote_public_key(&public_key)
-                        .await
-                        .map_err(|err| ConsensusError::CannotVote(format!("{err:?}")))?;
+                    if let Err(err) = ctx.near.vote_public_key(&public_key).await {
+                        tracing::error!(
+                            ?err,
+                            "waiting(initializing): failed to vote for the generated public key, retrying..."
+                        );
+                    }
                 }
-                Ok(NodeState::WaitingForConsensus(self))
+                NodeState::WaitingForConsensus(self)
             }
             ProtocolState::Running(contract_state) => match contract_state.epoch.cmp(&self.epoch) {
                 Ordering::Greater => {
                     tracing::warn!(
-                        "waiting(running): our current epoch is {} while contract state's is {}, trying to rejoin as a new participant",
-                        self.epoch,
-                        contract_state.epoch
+                        node_epoch = self.epoch,
+                        contract_epoch = contract_state.epoch,
+                        "waiting(running): our current epoch is behind contract epoch, rejoining...",
                     );
-
-                    Ok(NodeState::Joining(JoiningState {
+                    NodeState::Joining(JoiningState {
                         participants: contract_state.participants,
                         public_key: contract_state.public_key,
-                    }))
+                    })
                 }
-                Ordering::Less => Err(ConsensusError::EpochRollback),
+                Ordering::Less => {
+                    tracing::error!(
+                        node_epoch = self.epoch,
+                        contract_epoch = contract_state.epoch,
+                        "waiting(running, unexpected): our current epoch is ahead of contract, rejoining...",
+                    );
+                    NodeState::Joining(JoiningState {
+                        participants: contract_state.participants,
+                        public_key: contract_state.public_key,
+                    })
+                }
                 Ordering::Equal => {
                     tracing::info!("waiting(running): contract state has reached consensus");
                     if contract_state.participants != self.participants {
-                        return Err(ConsensusError::MismatchedParticipants);
+                        tracing::warn!(
+                            node_participants = ?self.participants,
+                            contract_participants = ?contract_state.participants,
+                            "waiting(running): our participants do not match contract",
+                        );
+                        return NodeState::Joining(JoiningState {
+                            participants: contract_state.participants,
+                            public_key: contract_state.public_key,
+                        });
                     }
                     if contract_state.threshold != self.threshold {
-                        return Err(ConsensusError::MismatchedThreshold);
+                        tracing::warn!(
+                            node_threshold = self.threshold,
+                            contract_threshold = contract_state.threshold,
+                            "waiting(running): our threshold does not match contract",
+                        );
+                        return NodeState::Joining(JoiningState {
+                            participants: contract_state.participants,
+                            public_key: contract_state.public_key,
+                        });
                     }
                     if contract_state.public_key != self.public_key {
-                        return Err(ConsensusError::MismatchedPublicKey);
+                        tracing::warn!(
+                            node_pk = ?self.public_key,
+                            contract_pk = ?contract_state.public_key,
+                            "waiting(running): our public key does not match contract",
+                        );
+                        return NodeState::Joining(JoiningState {
+                            participants: contract_state.participants,
+                            public_key: contract_state.public_key,
+                        });
                     }
 
-                    let Some(me) = contract_state
+                    let Some(&me) = contract_state
                         .participants
                         .find_participant(&ctx.my_account_id)
                     else {
                         tracing::error!("waiting(running, unexpected): we do not belong to the participant set -- cannot progress!");
-                        return Ok(NodeState::WaitingForConsensus(self));
+                        return NodeState::WaitingForConsensus(self);
                     };
 
                     let triple_manager = TripleManager::new(
-                        *me,
+                        me,
                         self.threshold,
                         self.epoch,
                         &ctx.my_account_id,
@@ -325,7 +400,7 @@ impl ConsensusProtocol for WaitingForConsensusState {
                     );
 
                     let presignature_manager = Arc::new(RwLock::new(PresignatureManager::new(
-                        *me,
+                        me,
                         self.threshold,
                         self.epoch,
                         &ctx.my_account_id,
@@ -335,7 +410,7 @@ impl ConsensusProtocol for WaitingForConsensusState {
                     )));
 
                     let signature_manager = Arc::new(RwLock::new(SignatureManager::new(
-                        *me,
+                        me,
                         &ctx.my_account_id,
                         self.threshold,
                         self.public_key,
@@ -345,9 +420,9 @@ impl ConsensusProtocol for WaitingForConsensusState {
                         ctx.msg_channel.clone(),
                     )));
 
-                    Ok(NodeState::Running(RunningState {
+                    NodeState::Running(RunningState {
                         epoch: self.epoch,
-                        me: *me,
+                        me,
                         participants: self.participants,
                         threshold: self.threshold,
                         private_share: self.private_share,
@@ -355,68 +430,66 @@ impl ConsensusProtocol for WaitingForConsensusState {
                         triple_manager,
                         presignature_manager,
                         signature_manager,
-                    }))
+                    })
                 }
             },
             ProtocolState::Resharing(contract_state) => {
                 match (contract_state.old_epoch + 1).cmp(&self.epoch) {
-                    Ordering::Greater if contract_state.old_epoch + 2 == self.epoch => {
-                        tracing::info!("waiting(resharing): contract state is resharing, joining");
-                        if contract_state.old_participants != self.participants {
-                            return Err(ConsensusError::MismatchedParticipants);
-                        }
-                        if contract_state.threshold != self.threshold {
-                            return Err(ConsensusError::MismatchedThreshold);
-                        }
-                        if contract_state.public_key != self.public_key {
-                            return Err(ConsensusError::MismatchedPublicKey);
-                        }
-                        start_resharing(Some(self.private_share), ctx, contract_state).await
-                    }
                     Ordering::Greater => {
                         tracing::warn!(
-                            "waiting(resharing): our current epoch is {} while contract state's is {}, trying to rejoin as a new participant",
-                            self.epoch,
-                            contract_state.old_epoch
+                            node_epoch = self.epoch,
+                            contract_old_epoch = contract_state.old_epoch,
+                            "waiting(resharing, unexpected): our current epoch is behind contract, rejoining...",
                         );
 
-                        Ok(NodeState::Joining(JoiningState {
+                        NodeState::Joining(JoiningState {
                             participants: contract_state.old_participants,
                             public_key: contract_state.public_key,
-                        }))
+                        })
                     }
-                    Ordering::Less => Err(ConsensusError::EpochRollback),
+                    Ordering::Less => {
+                        tracing::error!(
+                            node_epoch = self.epoch,
+                            contract_old_epoch = contract_state.old_epoch,
+                            "waiting(resharing, unexpected): our current epoch is ahead of contract, trying to rejoin as a new participant",
+                        );
+                        NodeState::Joining(JoiningState {
+                            participants: contract_state.old_participants,
+                            public_key: contract_state.public_key,
+                        })
+                    }
                     Ordering::Equal => {
                         tracing::info!(
                             "waiting(resharing): waiting for resharing consensus, contract state has not been finalized yet"
                         );
                         let has_voted = contract_state.finished_votes.contains(&ctx.my_account_id);
-                        match contract_state
+                        let Some(_me) = contract_state
                             .old_participants
                             .find_participant(&ctx.my_account_id)
-                        {
-                            Some(_) => {
-                                if !has_voted {
-                                    tracing::info!(
-                                        epoch = self.epoch,
-                                        "waiting(resharing): we haven't voted yet, voting for resharing to complete"
-                                    );
-
-                                    ctx.near.vote_reshared(self.epoch).await.map_err(|err| {
-                                        ConsensusError::CannotVote(format!("{err:?}"))
-                                    })?;
-                                } else {
-                                    tracing::info!(
-                                        epoch = self.epoch,
-                                        "waiting(resharing): we have voted for resharing to complete"
-                                    );
-                                }
+                        else {
+                            tracing::info!(
+                                "waiting(resharing): we are not a part of the old participant set"
+                            );
+                            return NodeState::WaitingForConsensus(self);
+                        };
+                        if !has_voted {
+                            tracing::info!(
+                                epoch = self.epoch,
+                                "waiting(resharing): we haven't voted yet, voting for resharing to complete"
+                            );
+                            if let Err(err) = ctx.near.vote_reshared(self.epoch).await {
+                                tracing::error!(
+                                    ?err,
+                                    "waiting(resharing): failed to vote for resharing to complete, retrying..."
+                                );
                             }
-                            None => {
-                                tracing::info!("waiting(resharing): we are not a part of the old participant set");
-                            }
+                        } else {
+                            tracing::debug!(
+                                epoch = self.epoch,
+                                "waiting(resharing): we have voted for resharing to complete"
+                            );
                         }
-                        Ok(NodeState::WaitingForConsensus(self))
+                        NodeState::WaitingForConsensus(self)
                     }
                 }
             }
@@ -426,55 +499,110 @@ impl ConsensusProtocol for WaitingForConsensusState {
 
 impl ConsensusProtocol for RunningState {
     async fn advance(
-        self,
+        mut self,
         ctx: &mut MpcSignProtocol,
         contract_state: ProtocolState,
-    ) -> Result<NodeState, ConsensusError> {
+    ) -> NodeState {
         match contract_state {
-            ProtocolState::Initializing(_) => Err(ConsensusError::ContractStateRollback),
-            ProtocolState::Running(contract_state) => match contract_state.epoch.cmp(&self.epoch) {
-                Ordering::Greater => {
-                    tracing::warn!(
-                        "running(running): our current epoch is {} while contract state's is {}, trying to rejoin as a new participant",
-                        self.epoch,
-                        contract_state.epoch
-                    );
+            ProtocolState::Initializing(_) => {
+                tracing::warn!(
+                    "running(initializing): contract is initializing, staying in running"
+                );
+                NodeState::Running(self)
+            }
+            ProtocolState::Running(contract_state) => {
+                match contract_state.epoch.cmp(&self.epoch) {
+                    Ordering::Greater => {
+                        tracing::warn!(
+                            node_epoch = self.epoch,
+                            contract_epoch = contract_state.epoch,
+                            "running: running contract has epoch ahead, rejoining...",
+                        );
 
-                    Ok(NodeState::Joining(JoiningState {
-                        participants: contract_state.participants,
-                        public_key: contract_state.public_key,
-                    }))
+                        NodeState::Joining(JoiningState {
+                            participants: contract_state.participants,
+                            public_key: contract_state.public_key,
+                        })
+                    }
+                    Ordering::Less => {
+                        tracing::error!(
+                            node_epoch = self.epoch,
+                            contract_epoch = contract_state.epoch,
+                            "running(unexpected): our current epoch is ahead of contract, rejoining...",
+                        );
+                        NodeState::Joining(JoiningState {
+                            participants: contract_state.participants,
+                            public_key: contract_state.public_key,
+                        })
+                    }
+                    Ordering::Equal => {
+                        tracing::debug!("running(running): continuing to run as normal");
+                        if contract_state.public_key != self.public_key {
+                            tracing::warn!(
+                                node_pk = ?self.public_key,
+                                contract_pk = ?contract_state.public_key,
+                                "running(running): our public key does not match contract, rejoining...",
+                            );
+                            return NodeState::Joining(JoiningState {
+                                participants: contract_state.participants,
+                                public_key: contract_state.public_key,
+                            });
+                        }
+                        if contract_state.participants != self.participants {
+                            tracing::warn!(
+                                node_participants = ?self.participants,
+                                contract_participants = ?contract_state.participants,
+                                "running(running): our participants do not match contract...",
+                            );
+                            if contract_state.participants.contains_key(&self.me) {
+                                tracing::warn!("running(running): ... but we are still a participant, overriding");
+                                self.participants = contract_state.participants;
+                            } else {
+                                tracing::warn!(
+                                "running(running): ... but we are not a participant anymore, rejoining...",
+                            );
+                                return NodeState::Joining(JoiningState {
+                                    participants: contract_state.participants,
+                                    public_key: contract_state.public_key,
+                                });
+                            }
+                        }
+                        if contract_state.threshold != self.threshold {
+                            tracing::warn!(
+                            node_threshold = self.threshold,
+                            contract_threshold = contract_state.threshold,
+                            "running(running): our threshold does not match contract, overriding",
+                        );
+                            self.threshold = contract_state.threshold;
+                        }
+                        NodeState::Running(self)
+                    }
                 }
-                Ordering::Less => Err(ConsensusError::EpochRollback),
-                Ordering::Equal => {
-                    tracing::debug!("running(running): continuing to run as normal");
-                    if contract_state.participants != self.participants {
-                        return Err(ConsensusError::MismatchedParticipants);
-                    }
-                    if contract_state.threshold != self.threshold {
-                        return Err(ConsensusError::MismatchedThreshold);
-                    }
-                    if contract_state.public_key != self.public_key {
-                        return Err(ConsensusError::MismatchedPublicKey);
-                    }
-                    Ok(NodeState::Running(self))
-                }
-            },
+            }
             ProtocolState::Resharing(contract_state) => {
                 match contract_state.old_epoch.cmp(&self.epoch) {
                     Ordering::Greater => {
                         tracing::warn!(
-                            "running(resharing): our current epoch is {} while contract state's is {}, trying to rejoin as a new participant",
-                            self.epoch,
-                            contract_state.old_epoch
+                            node_epoch = self.epoch,
+                            contract_epoch = contract_state.old_epoch,
+                            "running(resharing): our current epoch is behind contract, rejoining...",
                         );
-
-                        Ok(NodeState::Joining(JoiningState {
+                        NodeState::Joining(JoiningState {
                             participants: contract_state.old_participants,
                             public_key: contract_state.public_key,
-                        }))
+                        })
                     }
-                    Ordering::Less => Err(ConsensusError::EpochRollback),
+                    Ordering::Less => {
+                        tracing::error!(
+                            node_epoch = self.epoch,
+                            contract_epoch = contract_state.old_epoch,
+                            "running(resharing, unexpected): our current epoch is ahead of contract, rejoining...",
+                        );
+                        NodeState::Joining(JoiningState {
+                            participants: contract_state.old_participants,
+                            public_key: contract_state.public_key,
+                        })
+                    }
                     Ordering::Equal => {
                         tracing::info!("running(resharing): contract is resharing");
                         let is_in_old_participant_set = contract_state
@@ -484,10 +612,24 @@ impl ConsensusProtocol for RunningState {
                             .new_participants
                             .contains_account_id(&ctx.my_account_id);
                         if !is_in_old_participant_set || !is_in_new_participant_set {
-                            return Err(ConsensusError::HasBeenKicked);
+                            tracing::error!(
+                                "running(resharing): we have been kicked, rejoining..."
+                            );
+                            return NodeState::Joining(JoiningState {
+                                participants: contract_state.old_participants,
+                                public_key: contract_state.public_key,
+                            });
                         }
                         if contract_state.public_key != self.public_key {
-                            return Err(ConsensusError::MismatchedPublicKey);
+                            tracing::warn!(
+                                node_pk = ?self.public_key,
+                                contract_pk = ?contract_state.public_key,
+                                "running(resharing): our public key does not match contract, rejoining...",
+                            );
+                            return NodeState::Joining(JoiningState {
+                                participants: contract_state.new_participants,
+                                public_key: contract_state.public_key,
+                            });
                         }
                         start_resharing(Some(self.private_share), ctx, contract_state).await
                     }
@@ -498,40 +640,74 @@ impl ConsensusProtocol for RunningState {
 }
 
 impl ConsensusProtocol for ResharingState {
-    async fn advance(
-        self,
-        _ctx: &mut MpcSignProtocol,
-        contract_state: ProtocolState,
-    ) -> Result<NodeState, ConsensusError> {
+    async fn advance(self, _ctx: &mut MpcSignProtocol, contract_state: ProtocolState) -> NodeState {
         match contract_state {
-            ProtocolState::Initializing(_) => Err(ConsensusError::ContractStateRollback),
+            ProtocolState::Initializing(_) => {
+                tracing::info!(
+                    "resharing(initializing): continue reshare, wait for contract finalization"
+                );
+                NodeState::Resharing(self)
+            }
             ProtocolState::Running(contract_state) => {
                 match contract_state.epoch.cmp(&(self.old_epoch + 1)) {
                     Ordering::Greater => {
                         tracing::warn!(
-                            "resharing(running): expected epoch {} while contract state's is {}, trying to rejoin as a new participant",
-                            self.old_epoch + 1,
-                            contract_state.epoch
+                            next_epoch = self.old_epoch + 1,
+                            contract_epoch = contract_state.epoch,
+                            "resharing(running): our next epoch is behind contract, rejoining...",
                         );
-
-                        Ok(NodeState::Joining(JoiningState {
+                        NodeState::Joining(JoiningState {
                             participants: contract_state.participants,
                             public_key: contract_state.public_key,
-                        }))
+                        })
                     }
-                    Ordering::Less => Err(ConsensusError::EpochRollback),
+                    Ordering::Less => {
+                        tracing::error!(
+                            next_epoch = self.old_epoch + 1,
+                            contract_epoch = contract_state.epoch,
+                            "resharing(running, unexpected): our next epoch is ahead of contract, rejoining...",
+                        );
+                        NodeState::Joining(JoiningState {
+                            participants: contract_state.participants,
+                            public_key: contract_state.public_key,
+                        })
+                    }
                     Ordering::Equal => {
                         tracing::info!("resharing(running): contract state has finished resharing, trying to catch up");
+                        if contract_state.public_key != self.public_key {
+                            tracing::warn!(
+                                node_pk = ?self.public_key,
+                                contract_pk = ?contract_state.public_key,
+                                "resharing(running): our public key does not match contract, rejoining...",
+                            );
+                            return NodeState::Joining(JoiningState {
+                                participants: contract_state.participants,
+                                public_key: contract_state.public_key,
+                            });
+                        }
                         if contract_state.participants != self.new_participants {
-                            return Err(ConsensusError::MismatchedParticipants);
+                            tracing::warn!(
+                                node_participants = ?self.new_participants,
+                                contract_participants = ?contract_state.participants,
+                                "resharing(running): our participants do not match contract, rejoining...",
+                            );
+                            return NodeState::Joining(JoiningState {
+                                participants: contract_state.participants,
+                                public_key: contract_state.public_key,
+                            });
                         }
                         if contract_state.threshold != self.threshold {
-                            return Err(ConsensusError::MismatchedThreshold);
+                            tracing::warn!(
+                                node_threshold = self.threshold,
+                                contract_threshold = contract_state.threshold,
+                                "resharing(running): our threshold does not match contract, rejoining...",
+                            );
+                            return NodeState::Joining(JoiningState {
+                                participants: contract_state.participants,
+                                public_key: contract_state.public_key,
+                            });
                         }
-                        if contract_state.public_key != self.public_key {
-                            return Err(ConsensusError::MismatchedPublicKey);
-                        }
-                        Ok(NodeState::Resharing(self))
+                        NodeState::Resharing(self)
                     }
                 }
             }
@@ -539,32 +715,73 @@ impl ConsensusProtocol for ResharingState {
                 match contract_state.old_epoch.cmp(&self.old_epoch) {
                     Ordering::Greater => {
                         tracing::warn!(
-                            "resharing(resharing): expected resharing from epoch {} while contract is resharing from {}, trying to rejoin as a new participant",
-                            self.old_epoch,
-                            contract_state.old_epoch
+                            old_epoch = self.old_epoch,
+                            contract_old_epoch = contract_state.old_epoch,
+                            "resharing(resharing): our epoch is different from contract, rejoining...",
                         );
-
-                        Ok(NodeState::Joining(JoiningState {
+                        NodeState::Joining(JoiningState {
                             participants: contract_state.old_participants,
                             public_key: contract_state.public_key,
-                        }))
+                        })
                     }
-                    Ordering::Less => Err(ConsensusError::EpochRollback),
+                    Ordering::Less => {
+                        tracing::error!(
+                            old_epoch = self.old_epoch,
+                            contract_old_epoch = contract_state.old_epoch,
+                            "resharing(resharing, unexpected): our epoch is ahead of contract, rejoining...",
+                        );
+                        NodeState::Joining(JoiningState {
+                            participants: contract_state.old_participants,
+                            public_key: contract_state.public_key,
+                        })
+                    }
                     Ordering::Equal => {
                         tracing::info!("resharing(resharing): continue to reshare as normal");
+                        if contract_state.public_key != self.public_key {
+                            tracing::warn!(
+                                node_pk = ?self.public_key,
+                                contract_pk = ?contract_state.public_key,
+                                "resharing(resharing): our public key does not match contract, rejoining...",
+                            );
+                            return NodeState::Joining(JoiningState {
+                                participants: contract_state.old_participants,
+                                public_key: contract_state.public_key,
+                            });
+                        }
                         if contract_state.old_participants != self.old_participants {
-                            return Err(ConsensusError::MismatchedParticipants);
+                            tracing::warn!(
+                                node_participants = ?self.old_participants,
+                                contract_participants = ?contract_state.old_participants,
+                                "resharing(resharing): our old participants do not match contract, rejoining...",
+                            );
+                            return NodeState::Joining(JoiningState {
+                                participants: contract_state.old_participants,
+                                public_key: contract_state.public_key,
+                            });
                         }
                         if contract_state.new_participants != self.new_participants {
-                            return Err(ConsensusError::MismatchedParticipants);
+                            tracing::warn!(
+                                node_participants = ?self.new_participants,
+                                contract_participants = ?contract_state.new_participants,
+                                "resharing(resharing): our new participants do not match contract, rejoining...",
+                            );
+                            return NodeState::Joining(JoiningState {
+                                participants: contract_state.old_participants,
+                                public_key: contract_state.public_key,
+                            });
                         }
                         if contract_state.threshold != self.threshold {
-                            return Err(ConsensusError::MismatchedThreshold);
+                            tracing::warn!(
+                                node_threshold = self.threshold,
+                                contract_threshold = contract_state.threshold,
+                                "resharing(resharing): our threshold does not match contract, rejoining...",
+                            );
+                            return NodeState::Joining(JoiningState {
+                                participants: contract_state.old_participants,
+                                public_key: contract_state.public_key,
+                            });
                         }
-                        if contract_state.public_key != self.public_key {
-                            return Err(ConsensusError::MismatchedPublicKey);
-                        }
-                        Ok(NodeState::Resharing(self))
+                        NodeState::Resharing(self)
                     }
                 }
             }
@@ -573,46 +790,65 @@ impl ConsensusProtocol for ResharingState {
 }
 
 impl ConsensusProtocol for JoiningState {
-    async fn advance(
-        self,
-        ctx: &mut MpcSignProtocol,
-        contract_state: ProtocolState,
-    ) -> Result<NodeState, ConsensusError> {
+    async fn advance(self, ctx: &mut MpcSignProtocol, contract_state: ProtocolState) -> NodeState {
         match contract_state {
-            ProtocolState::Initializing(_) => Err(ConsensusError::ContractStateRollback),
+            ProtocolState::Initializing(contract_state) => {
+                let participants: Participants = contract_state.candidates.clone().into();
+                let Some(&me) = participants.find_participant(&ctx.my_account_id) else {
+                    tracing::info!("joining(initializing): contract is generating key without us");
+                    return NodeState::Joining(self);
+                };
+
+                tracing::info!(
+                    "joining(initializing): contract is doing keygen with us, need to join"
+                );
+                let protocol = match KeygenProtocol::new(
+                    &participants.keys_vec(),
+                    me,
+                    contract_state.threshold,
+                ) {
+                    Ok(protocol) => protocol,
+                    Err(err) => {
+                        tracing::error!(?err, "joining(initializing): failed to initialize keygen");
+                        return NodeState::Joining(self);
+                    }
+                };
+                NodeState::Generating(GeneratingState {
+                    me,
+                    participants,
+                    threshold: contract_state.threshold,
+                    protocol,
+                    failed_store: Default::default(),
+                })
+            }
             ProtocolState::Running(contract_state) => {
-                match contract_state.candidates.find_candidate(&ctx.my_account_id) {
-                    Some(_) => {
-                        let votes = contract_state
-                            .join_votes
-                            .get(&ctx.my_account_id)
-                            .cloned()
-                            .unwrap_or_default();
-                        let participant_account_ids_to_vote = contract_state
-                            .participants
-                            .iter()
-                            .map(|(_, info)| &info.account_id)
-                            .filter(|id| !votes.contains(*id))
-                            .collect::<Vec<_>>();
-                        if !participant_account_ids_to_vote.is_empty() {
-                            tracing::info!(
-                                ?participant_account_ids_to_vote,
-                                "Some participants have not voted for you to join"
-                            );
-                        }
-                        Ok(NodeState::Joining(self))
+                let Some(_) = contract_state.candidates.find_candidate(&ctx.my_account_id) else {
+                    tracing::info!(
+                        "joining(running): sending a transaction to join the participant set"
+                    );
+                    if let Err(err) = ctx.near.propose_join().await {
+                        tracing::error!(?err, "failed to propose to join the participant set");
                     }
-                    None => {
-                        tracing::info!(
-                            "joining(running): sending a transaction to join the participant set"
-                        );
-                        ctx.near.propose_join().await.map_err(|err| {
-                            tracing::error!(?err, "failed to join the participant set");
-                            ConsensusError::CannotJoin(format!("{err:?}"))
-                        })?;
-                        Ok(NodeState::Joining(self))
-                    }
+                    return NodeState::Joining(self);
+                };
+                let votes = contract_state
+                    .join_votes
+                    .get(&ctx.my_account_id)
+                    .cloned()
+                    .unwrap_or_default();
+                let pending_votes = contract_state
+                    .participants
+                    .iter()
+                    .map(|(_, info)| &info.account_id)
+                    .filter(|id| !votes.contains(*id))
+                    .collect::<Vec<_>>();
+                if !pending_votes.is_empty() {
+                    tracing::info!(
+                        ?pending_votes,
+                        "some participants have not voted for you to join yet",
+                    );
                 }
+                NodeState::Joining(self)
             }
             ProtocolState::Resharing(contract_state) => {
                 if contract_state
@@ -623,7 +859,7 @@ impl ConsensusProtocol for JoiningState {
                     start_resharing(None, ctx, contract_state).await
                 } else {
                     tracing::info!("joining(resharing): network is resharing without us, waiting for them to finish");
-                    Ok(NodeState::Joining(self))
+                    NodeState::Joining(self)
                 }
             }
         }
@@ -631,17 +867,19 @@ impl ConsensusProtocol for JoiningState {
 }
 
 impl ConsensusProtocol for NodeState {
-    async fn advance(
-        self,
-        ctx: &mut MpcSignProtocol,
-        contract_state: ProtocolState,
-    ) -> Result<NodeState, ConsensusError> {
+    async fn advance(self, ctx: &mut MpcSignProtocol, contract_state: ProtocolState) -> NodeState {
         match self {
             NodeState::Starting => {
-                let persistent_node_data = ctx.secret_storage.load().await?;
-                Ok(NodeState::Started(StartedState {
+                let persistent_node_data = match ctx.secret_storage.load().await {
+                    Ok(data) => data,
+                    Err(err) => {
+                        tracing::error!(?err, "failed to load persistent node data, retrying...");
+                        return NodeState::Starting;
+                    }
+                };
+                NodeState::Started(StartedState {
                     persistent_node_data,
-                }))
+                })
             }
             NodeState::Started(state) => state.advance(ctx, contract_state).await,
             NodeState::Generating(state) => state.advance(ctx, contract_state).await,
@@ -657,18 +895,27 @@ async fn start_resharing(
     private_share: Option<SecretKeyShare>,
     ctx: &MpcSignProtocol,
     contract_state: ResharingContractState,
-) -> Result<NodeState, ConsensusError> {
-    let &me = contract_state
+) -> NodeState {
+    let Some(&me) = contract_state
         .new_participants
         .find_participant(&ctx.my_account_id)
-        .or_else(|| {
-            contract_state
-                .old_participants
-                .find_participant(&ctx.my_account_id)
-        })
-        .expect("unexpected: cannot find us in the participant set while starting resharing");
-    let protocol = ReshareProtocol::new(private_share, me, &contract_state)?;
-    Ok(NodeState::Resharing(ResharingState {
+    else {
+        return NodeState::Joining(JoiningState {
+            participants: contract_state.new_participants,
+            public_key: contract_state.public_key,
+        });
+    };
+    let protocol = match ReshareProtocol::new(private_share, me, &contract_state) {
+        Ok(protocol) => protocol,
+        Err(err) => {
+            tracing::error!(?err, "resharing: failed to initialize resharing protocol");
+            return NodeState::Joining(JoiningState {
+                participants: contract_state.new_participants,
+                public_key: contract_state.public_key,
+            });
+        }
+    };
+    NodeState::Resharing(ResharingState {
         me,
         old_epoch: contract_state.old_epoch,
         old_participants: contract_state.old_participants,
@@ -677,5 +924,5 @@ async fn start_resharing(
         public_key: contract_state.public_key,
         protocol,
         failed_store: Default::default(),
-    }))
+    })
 }

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -36,13 +36,9 @@ impl CryptographicProtocol for GeneratingState {
         _cfg: Config,
         mesh_state: MeshState,
     ) -> NodeState {
-        {
-            // Previous save to secret storage failed, try again until successful.
-            let failed_store = self.failed_store.lock().await;
-            if let Some((pk, sk_share)) = *failed_store {
-                drop(failed_store);
-                return self.finalize(pk, sk_share, ctx).await;
-            }
+        // Previous save to secret storage failed, try again until successful.
+        if let Some((pk, sk_share)) = self.failed_store.take() {
+            return self.finalize(pk, sk_share, ctx).await;
         }
 
         let participants = self.participants.keys_vec();
@@ -51,12 +47,10 @@ impl CryptographicProtocol for GeneratingState {
             active = ?mesh_state.active,
             "generating: progressing key generation",
         );
-        let mut protocol = self.protocol.write().await;
         loop {
-            let action = match protocol.poke() {
+            let action = match self.protocol.poke() {
                 Ok(action) => action,
                 Err(err) => {
-                    drop(protocol);
                     tracing::error!(?err, "generating failed: refreshing...");
                     if let Err(refresh_err) = self.protocol.refresh().await {
                         tracing::warn!(?refresh_err, "unable to refresh keygen protocol");
@@ -66,7 +60,6 @@ impl CryptographicProtocol for GeneratingState {
             };
             match action {
                 Action::Wait => {
-                    drop(protocol);
                     tracing::debug!("generating: waiting");
                     return NodeState::Generating(self);
                 }
@@ -108,7 +101,6 @@ impl CryptographicProtocol for GeneratingState {
                         public_key = hex::encode(r.public_key.to_bytes()),
                         "generating: successfully completed key generation"
                     );
-                    drop(protocol);
                     return self.finalize(r.public_key, r.private_share, ctx).await;
                 }
             }
@@ -118,7 +110,7 @@ impl CryptographicProtocol for GeneratingState {
 
 impl GeneratingState {
     async fn finalize(
-        self,
+        mut self,
         public_key: PublicKey,
         private_share: SecretKeyShare,
         ctx: &mut MpcSignProtocol,
@@ -133,10 +125,7 @@ impl GeneratingState {
             .await
         {
             tracing::error!(?err, "generating: failed to store secret");
-            let mut failed_store = self.failed_store.lock().await;
-            failed_store.replace((public_key, private_share));
-            drop(failed_store);
-
+            self.failed_store.replace((public_key, private_share));
             return NodeState::Generating(self);
         }
 
@@ -169,22 +158,16 @@ impl CryptographicProtocol for ResharingState {
         _cfg: Config,
         mesh_state: MeshState,
     ) -> NodeState {
-        {
-            // Previous save to secret storage failed, try again until successful.
-            let failed_store = self.failed_store.lock().await;
-            if let Some(sk_share) = *failed_store {
-                drop(failed_store);
-                return self.finalize(sk_share, ctx).await;
-            }
+        // Previous save to secret storage failed, try again until successful.
+        if let Some(sk_share) = self.failed_store.take() {
+            return self.finalize(sk_share, ctx).await;
         }
 
         tracing::info!(active = ?mesh_state.active.keys_vec(), "progressing key reshare");
-        let mut protocol = self.protocol.write().await;
         loop {
-            let action = match protocol.poke() {
+            let action = match self.protocol.poke() {
                 Ok(action) => action,
                 Err(err) => {
-                    drop(protocol);
                     tracing::warn!(?err, "resharing failed: refreshing...");
                     if let Err(refresh_err) = self.protocol.refresh().await {
                         tracing::warn!(?refresh_err, "unable to refresh reshare protocol");
@@ -194,7 +177,6 @@ impl CryptographicProtocol for ResharingState {
             };
             match action {
                 Action::Wait => {
-                    drop(protocol);
                     tracing::debug!("resharing: waiting");
                     return NodeState::Resharing(self);
                 }
@@ -238,7 +220,6 @@ impl CryptographicProtocol for ResharingState {
                 }
                 Action::Return(private_share) => {
                     tracing::info!("resharing: successfully completed key reshare");
-                    drop(protocol);
                     return self.finalize(private_share, ctx).await;
                 }
             }
@@ -247,7 +228,11 @@ impl CryptographicProtocol for ResharingState {
 }
 
 impl ResharingState {
-    async fn finalize(self, private_share: SecretKeyShare, ctx: &mut MpcSignProtocol) -> NodeState {
+    async fn finalize(
+        mut self,
+        private_share: SecretKeyShare,
+        ctx: &mut MpcSignProtocol,
+    ) -> NodeState {
         if let Err(err) = ctx
             .secret_storage
             .store(&PersistentNodeData {
@@ -258,10 +243,7 @@ impl ResharingState {
             .await
         {
             tracing::error!(?err, "resharing: failed to store secret");
-            let mut failed_stored = self.failed_store.lock().await;
-            failed_stored.replace(private_share);
-            drop(failed_stored);
-
+            self.failed_store.replace(private_share);
             return NodeState::Resharing(self);
         }
 

--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -5,6 +5,7 @@ pub use crate::protocol::message::types::{
     GeneratingMessage, Message, MessageError, MessageFilterId, PositMessage, PositProtocolId,
     PresignatureMessage, Protocols, ResharingMessage, SignatureMessage, TripleMessage,
 };
+use crate::rpc::ContractStateWatcher;
 
 use super::contract::primitives::{ParticipantMap, Participants};
 use super::error::GenerationError;
@@ -258,7 +259,7 @@ struct MessageExecutor {
     outbox: MessageOutbox,
 
     config: Arc<RwLock<Config>>,
-    protocol_state: Arc<RwLock<NodeState>>,
+    contract_watcher: ContractStateWatcher,
     mesh_state: Arc<RwLock<MeshState>>,
 }
 
@@ -276,10 +277,7 @@ impl MessageExecutor {
                 )
             };
 
-            let participants = {
-                let state = self.protocol_state.read().await;
-                state.participants()
-            };
+            let participants = self.contract_watcher.participants().await;
             {
                 let mut inbox = self.inbox.write().await;
                 let expiration = Duration::from_millis(protocol.message_timeout);
@@ -328,7 +326,7 @@ impl MessageChannel {
         client: NodeClient,
         id: &AccountId,
         config: &Arc<RwLock<Config>>,
-        protocol_state: &Arc<RwLock<NodeState>>,
+        contract_watcher: ContractStateWatcher,
         mesh_state: &Arc<RwLock<MeshState>>,
     ) -> (mpsc::Sender<Ciphered>, Self) {
         let (inbox_tx, outbox_rx, mut channel) = Self::new();
@@ -337,7 +335,7 @@ impl MessageChannel {
             outbox: MessageOutbox::new(id, client, outbox_rx),
 
             config: config.clone(),
-            protocol_state: protocol_state.clone(),
+            contract_watcher,
             mesh_state: mesh_state.clone(),
         };
         channel.task = Some(Arc::new(tokio::spawn(runner.execute())));
@@ -405,7 +403,6 @@ impl MessageReceiver for GeneratingState {
         _mesh_state: MeshState,
     ) -> Result<(), MessageError> {
         let mut inbox = channel.inbox().write().await;
-        let mut protocol = self.protocol.write().await;
         if !inbox.generating.is_empty() {
             let message_counts: HashMap<Participant, usize> =
                 inbox
@@ -418,7 +415,7 @@ impl MessageReceiver for GeneratingState {
             tracing::info!(?message_counts, "generating: handling new messages");
         }
         while let Some(msg) = inbox.generating.pop_front() {
-            protocol.message(msg.from, msg.data);
+            self.protocol.message(msg.from, msg.data);
         }
         Ok(())
     }
@@ -448,9 +445,8 @@ impl MessageReceiver for ResharingState {
             tracing::info!(?message_counts, "resharing: handling new messages");
         }
         let q = inbox.resharing.entry(self.old_epoch).or_default();
-        let mut protocol = self.protocol.write().await;
         while let Some(msg) = q.pop_front() {
-            protocol.message(msg.from, msg.data);
+            self.protocol.message(msg.from, msg.data);
         }
         Ok(())
     }

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -300,6 +300,10 @@ impl PresignatureManager {
         self.presignatures.len_by_owner(self.me).await
     }
 
+    pub async fn len_ongoing(&self) -> usize {
+        self.generators.len()
+    }
+
     /// Returns if there are unspent presignatures available in the manager.
     pub async fn is_empty(&self) -> bool {
         self.len_generated().await == 0

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -1,4 +1,4 @@
-use super::contract::primitives::{ParticipantMap, Participants};
+use super::contract::primitives::Participants;
 use super::presignature::PresignatureManager;
 use super::signature::SignatureManager;
 use super::triple::TripleManager;
@@ -10,7 +10,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
-use tokio::sync::{Mutex, RwLock};
+
+use tokio::sync::{watch, RwLock};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct PersistentNodeData {
@@ -28,12 +29,11 @@ impl fmt::Debug for PersistentNodeData {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct StartedState {
     pub persistent_node_data: Option<PersistentNodeData>,
 }
 
-#[derive(Clone)]
 pub struct GeneratingState {
     pub me: Participant,
     pub participants: Participants,
@@ -42,10 +42,9 @@ pub struct GeneratingState {
 
     /// If the generating state fails to store data after generating, it gets temporarily
     /// stored here and retried later.
-    pub failed_store: Arc<Mutex<Option<(PublicKey, SecretKeyShare)>>>,
+    pub failed_store: Option<(PublicKey, SecretKeyShare)>,
 }
 
-#[derive(Clone)]
 pub struct WaitingForConsensusState {
     pub epoch: u64,
     pub participants: Participants,
@@ -65,7 +64,6 @@ impl fmt::Debug for WaitingForConsensusState {
     }
 }
 
-#[derive(Clone)]
 pub struct RunningState {
     pub epoch: u64,
     pub me: Participant,
@@ -78,7 +76,6 @@ pub struct RunningState {
     pub signature_manager: Arc<RwLock<SignatureManager>>,
 }
 
-#[derive(Clone)]
 pub struct ResharingState {
     pub me: Participant,
     pub old_epoch: u64,
@@ -90,16 +87,40 @@ pub struct ResharingState {
 
     /// If the resharing state fails to store data after generating, it gets temporarily
     /// stored here and retried later.
-    pub failed_store: Arc<Mutex<Option<SecretKeyShare>>>,
+    pub failed_store: Option<SecretKeyShare>,
 }
 
-#[derive(Clone)]
 pub struct JoiningState {
     pub participants: Participants,
     pub public_key: PublicKey,
 }
 
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NodeStatus {
+    Starting,
+    Started,
+    Generating {
+        participants: Vec<Participant>,
+    },
+    WaitingForConsensus {
+        participants: Vec<Participant>,
+    },
+    Running {
+        me: Participant,
+        participants: Vec<Participant>,
+        ongoing_triple_gen: usize,
+        ongoing_presignature_gen: usize,
+    },
+    Resharing {
+        old_participants: Vec<Participant>,
+        new_participants: Vec<Participant>,
+    },
+    Joining {
+        participants: Vec<Participant>,
+    },
+}
+
+#[derive(Default)]
 #[allow(clippy::large_enum_variant)]
 pub enum NodeState {
     #[default]
@@ -126,20 +147,105 @@ impl Display for NodeState {
     }
 }
 
-impl NodeState {
-    pub fn participants(&self) -> ParticipantMap {
-        match self {
-            NodeState::Generating(state) => ParticipantMap::One(state.participants.clone()),
-            NodeState::WaitingForConsensus(state) => {
-                ParticipantMap::One(state.participants.clone())
+pub struct Node {
+    pub state: NodeState,
+    pub watcher_tx: watch::Sender<NodeStatus>,
+    pub watcher: NodeStateWatcher,
+}
+
+impl Default for Node {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Node {
+    pub fn new() -> Self {
+        let (watcher_tx, watcher_rx) = watch::channel(NodeStatus::Starting);
+        let watcher = NodeStateWatcher {
+            watcher: watcher_rx,
+        };
+        Self {
+            state: NodeState::Starting,
+            watcher_tx,
+            watcher,
+        }
+    }
+
+    pub async fn update_watchers(&mut self) {
+        match &self.state {
+            NodeState::Started(_) => {
+                let _ = self.watcher_tx.send(NodeStatus::Started);
             }
-            NodeState::Running(state) => ParticipantMap::One(state.participants.clone()),
-            NodeState::Resharing(state) => ParticipantMap::Two(
-                state.new_participants.clone(),
-                state.old_participants.clone(),
-            ),
-            NodeState::Joining(state) => ParticipantMap::One(state.participants.clone()),
-            _ => ParticipantMap::Zero,
+            NodeState::Starting => {
+                let _ = self.watcher_tx.send(NodeStatus::Starting);
+            }
+            NodeState::Generating(state) => {
+                let _ = self.watcher_tx.send(NodeStatus::Generating {
+                    participants: state.participants.keys_vec(),
+                });
+            }
+            NodeState::WaitingForConsensus(state) => {
+                let _ = self.watcher_tx.send(NodeStatus::WaitingForConsensus {
+                    participants: state.participants.keys_vec(),
+                });
+            }
+            NodeState::Running(state) => {
+                let _ = self.watcher_tx.send(NodeStatus::Running {
+                    me: state.me,
+                    participants: state.participants.keys_vec(),
+                    ongoing_triple_gen: state.triple_manager.len_ongoing().await,
+                    ongoing_presignature_gen: state
+                        .presignature_manager
+                        .read()
+                        .await
+                        .len_ongoing()
+                        .await,
+                });
+            }
+            NodeState::Resharing(state) => {
+                let _ = self.watcher_tx.send(NodeStatus::Resharing {
+                    old_participants: state.old_participants.keys_vec(),
+                    new_participants: state.new_participants.keys_vec(),
+                });
+            }
+            NodeState::Joining(state) => {
+                let _ = self.watcher_tx.send(NodeStatus::Joining {
+                    participants: state.participants.keys_vec(),
+                });
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct NodeStateWatcher {
+    watcher: watch::Receiver<NodeStatus>,
+}
+
+impl NodeStateWatcher {
+    pub async fn changed(&mut self) -> Result<(), watch::error::RecvError> {
+        self.watcher.changed().await
+    }
+
+    pub fn status(&self) -> NodeStatus {
+        self.watcher.borrow().clone()
+    }
+
+    pub fn status_mut(&mut self) -> NodeStatus {
+        self.watcher.borrow_and_update().clone()
+    }
+
+    pub fn participants(&self) -> Vec<Participant> {
+        match self.status() {
+            NodeStatus::Generating { participants } => participants,
+            NodeStatus::WaitingForConsensus { participants } => participants,
+            NodeStatus::Running { participants, .. } => participants,
+            NodeStatus::Resharing {
+                new_participants, ..
+            } => new_participants,
+            NodeStatus::Joining { participants } => participants,
+            _ => Vec::new(),
         }
     }
 }

--- a/chain-signatures/node/src/protocol/sync/mod.rs
+++ b/chain-signatures/node/src/protocol/sync/mod.rs
@@ -8,7 +8,7 @@ use tokio::task::{JoinHandle, JoinSet};
 
 use crate::mesh::MeshState;
 use crate::node_client::NodeClient;
-use crate::rpc::NodeStateWatcher;
+use crate::rpc::ContractStateWatcher;
 use crate::storage::{PresignatureStorage, TripleStorage};
 
 use super::contract::primitives::ParticipantInfo;
@@ -50,7 +50,7 @@ pub struct SyncTask {
     triples: TripleStorage,
     presignatures: PresignatureStorage,
     mesh_state: Arc<RwLock<MeshState>>,
-    watcher: NodeStateWatcher,
+    watcher: ContractStateWatcher,
     requests: SyncRequestReceiver,
     synced_peer_tx: mpsc::Sender<Participant>,
 }
@@ -62,7 +62,7 @@ impl SyncTask {
         triples: TripleStorage,
         presignatures: PresignatureStorage,
         mesh_state: Arc<RwLock<MeshState>>,
-        watcher: NodeStateWatcher,
+        watcher: ContractStateWatcher,
         synced_peer_tx: mpsc::Sender<Participant>,
     ) -> (SyncChannel, Self) {
         let (requests, channel) = SyncChannel::new();

--- a/chain-signatures/node/src/storage/secret_storage.rs
+++ b/chain-signatures/node/src/storage/secret_storage.rs
@@ -106,18 +106,16 @@ impl SecretNodeStorage for DiskNodeStorage {
     }
 
     async fn load(&self) -> SecretResult<Option<PersistentNodeData>> {
-        tracing::info!("loading PersistentNodeData using DiskNodeStorage");
         // Open the file asynchronously
         let file_res = File::open(self.path.as_os_str()).await;
 
         match file_res {
             Ok(mut file) => {
+                tracing::info!("loading PersistentNodeData using DiskNodeStorage");
                 let mut contents = Vec::new();
                 // Read the contents of the file into the vector
-                tracing::info!("loading PersistentNodeData using DiskNodeStorage: reading");
                 file.read_to_end(&mut contents).await?;
 
-                tracing::info!("loading PersistentNodeData using DiskNodeStorage: read done");
                 // Deserialize the JSON content to a PersistentNodeData object
                 let data: PersistentNodeData = serde_json::from_slice(&contents)?;
 

--- a/chain-signatures/node/src/web/error.rs
+++ b/chain-signatures/node/src/web/error.rs
@@ -2,7 +2,7 @@ use axum::extract::rejection::JsonRejection;
 use reqwest::StatusCode;
 
 use crate::protocol::message::MessageError;
-use crate::protocol::{ConsensusError, CryptographicError};
+use crate::protocol::CryptographicError;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -12,8 +12,6 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub enum Error {
     #[error(transparent)]
     JsonExtractorRejection(#[from] JsonRejection),
-    #[error(transparent)]
-    Protocol(#[from] ConsensusError),
     #[error(transparent)]
     Cryptography(#[from] CryptographicError),
     #[error(transparent)]
@@ -28,7 +26,6 @@ impl Error {
     pub fn status(&self) -> StatusCode {
         match self {
             Error::JsonExtractorRejection(rejection) => rejection.status(),
-            Error::Protocol(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::Cryptography(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::Message(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::Rpc(_) => StatusCode::BAD_REQUEST,

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -2,8 +2,8 @@ mod error;
 
 use self::error::Error;
 use crate::indexer::NearIndexer;
+use crate::protocol::state::{NodeStateWatcher, NodeStatus};
 use crate::protocol::sync::{SyncChannel, SyncUpdate};
-use crate::protocol::NodeState;
 use crate::storage::{PresignatureStorage, TripleStorage};
 use crate::web::error::Result;
 
@@ -18,11 +18,11 @@ use near_primitives::types::BlockHeight;
 use prometheus::{Encoder, TextEncoder};
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, sync::Arc};
-use tokio::sync::{mpsc::Sender, RwLock};
+use tokio::sync::mpsc::Sender;
 
 struct AxumState {
     sender: Sender<Ciphered>,
-    protocol_state: Arc<RwLock<NodeState>>,
+    node_watcher: NodeStateWatcher,
     indexer: Option<NearIndexer>,
     triple_storage: TripleStorage,
     presignature_storage: PresignatureStorage,
@@ -32,7 +32,7 @@ struct AxumState {
 pub async fn run(
     port: u16,
     sender: Sender<Ciphered>,
-    protocol_state: Arc<RwLock<NodeState>>,
+    node_watcher: NodeStateWatcher,
     indexer: Option<NearIndexer>,
     triple_storage: TripleStorage,
     presignature_storage: PresignatureStorage,
@@ -41,7 +41,7 @@ pub async fn run(
     tracing::info!("starting web server");
     let axum_state = AxumState {
         sender,
-        protocol_state,
+        node_watcher,
         indexer,
         triple_storage,
         presignature_storage,
@@ -130,21 +130,22 @@ async fn state(Extension(web): Extension<Arc<AxumState>>) -> Result<Json<StateVi
         0
     };
 
-    let protocol_state = web.protocol_state.read().await;
-
-    match &*protocol_state {
-        NodeState::Running(state) => {
-            let triple_potential_count = state.triple_manager.len_potential().await;
+    match web.node_watcher.status() {
+        NodeStatus::Running {
+            me,
+            participants,
+            ongoing_triple_gen,
+            ongoing_presignature_gen,
+        } => {
             let triple_count = web.triple_storage.len_generated().await;
-            let triple_mine_count = web.triple_storage.len_by_owner(state.me).await;
-            let presignature_read = state.presignature_manager.read().await;
+            let triple_mine_count = web.triple_storage.len_by_owner(me).await;
+            let triple_potential_count = triple_count + ongoing_triple_gen;
             let presignature_count = web.presignature_storage.len_generated().await;
-            let presignature_mine_count = web.presignature_storage.len_by_owner(state.me).await;
-            let presignature_potential_count = presignature_read.len_potential().await;
-            let participants = state.participants.keys_vec();
+            let presignature_mine_count = web.presignature_storage.len_by_owner(me).await;
+            let presignature_potential_count = presignature_count + ongoing_presignature_gen;
 
             Ok(Json(StateView::Running {
-                participants,
+                participants: participants.clone(),
                 triple_count,
                 triple_mine_count,
                 triple_potential_count,
@@ -154,22 +155,18 @@ async fn state(Extension(web): Extension<Arc<AxumState>>) -> Result<Json<StateVi
                 latest_block_height,
             }))
         }
-        NodeState::Resharing(state) => {
-            let old_participants = state.old_participants.keys_vec();
-            let new_participants = state.new_participants.keys_vec();
-            Ok(Json(StateView::Resharing {
-                old_participants,
-                new_participants,
-                latest_block_height,
-            }))
-        }
-        NodeState::Joining(state) => {
-            let participants = state.participants.keys_vec();
-            Ok(Json(StateView::Joining {
-                participants,
-                latest_block_height,
-            }))
-        }
+        NodeStatus::Resharing {
+            old_participants,
+            new_participants,
+        } => Ok(Json(StateView::Resharing {
+            old_participants: old_participants.clone(),
+            new_participants: new_participants.clone(),
+            latest_block_height,
+        })),
+        NodeStatus::Joining { participants } => Ok(Json(StateView::Joining {
+            participants: participants.clone(),
+            latest_block_height,
+        })),
         _ => {
             tracing::debug!("not running, state unavailable");
             Ok(Json(StateView::NotRunning))

--- a/integration-tests/benches/store.rs
+++ b/integration-tests/benches/store.rs
@@ -19,11 +19,14 @@ use mpc_node::{
         triple::Triple,
         ParticipantInfo, ProtocolState,
     },
-    rpc::NodeStateWatcher,
+    rpc::ContractStateWatcher,
     storage::{PresignatureStorage, TripleStorage},
 };
 use near_account_id::AccountId;
-use tokio::{runtime::Runtime, sync::RwLock};
+use tokio::{
+    runtime::Runtime,
+    sync::{mpsc, RwLock},
+};
 
 fn runtime() -> tokio::runtime::Runtime {
     tokio::runtime::Builder::new_current_thread()
@@ -96,11 +99,12 @@ fn env() -> (Runtime, SyncEnv) {
         let mesh_state = Arc::new(RwLock::new(MeshState {
             stable: participants.keys_vec(),
             active: participants.clone(),
+            need_sync: Participants::default(),
         }));
 
         let sk = k256::SecretKey::random(&mut rand::thread_rng());
         let pk = sk.public_key();
-        let watcher = NodeStateWatcher::mock(
+        let watcher = ContractStateWatcher::mock(
             &node_id,
             ProtocolState::Running(RunningContractState {
                 epoch: 0,
@@ -112,12 +116,15 @@ fn env() -> (Runtime, SyncEnv) {
                 threshold,
             }),
         );
+
+        let (synced_peer_tx, _synced_peer_rx) = mpsc::channel(1024);
         let (sync_channel, sync) = SyncTask::new(
             &client,
             triples.clone(),
             presignatures.clone(),
             mesh_state.clone(),
             watcher.clone(),
+            synced_peer_tx,
         );
 
         // let sync_handle = tokio::spawn(sync.run());

--- a/integration-tests/tests/cases/sync.rs
+++ b/integration-tests/tests/cases/sync.rs
@@ -16,7 +16,7 @@ use mpc_node::protocol::presignature::Presignature;
 use mpc_node::protocol::sync::{SyncTask, SyncUpdate};
 use mpc_node::protocol::triple::Triple;
 use mpc_node::protocol::{ParticipantInfo, ProtocolState};
-use mpc_node::rpc::NodeStateWatcher;
+use mpc_node::rpc::ContractStateWatcher;
 use mpc_node::storage::{PresignatureStorage, TripleStorage};
 
 #[test_log::test(tokio::test)]
@@ -41,7 +41,7 @@ async fn test_state_sync_update() -> anyhow::Result<()> {
     let node0_triples = redis.triple_storage(&node0_account_id);
     let node0_presignatures = redis.presignature_storage(&node0_account_id);
 
-    let watcher = NodeStateWatcher::mock(
+    let watcher = ContractStateWatcher::mock(
         &node0_account_id,
         ProtocolState::Running(RunningContractState {
             epoch: 0,


### PR DESCRIPTION
This continues the work started in https://github.com/sig-net/mpc/pull/374. This will make it so that we no longer do a clone on our node/protocol state when we try to make a state advancement. This means that any state machine changes that could fail or error out in some manner will need to be done explicitly and not through reversions.

We actually had a good state to transition to already when we go into a failed state. It's the `Joining` state since most of the errors are just mismatched configurations between contract and our node, it just means that the contract is ahead or behind node. If its ahead, then that means a resharing step has already completed and so we just need to rejoin.

Note `NodeStateWatcher` was renamed to `ContractStateWatcher`, since a new `NodeStateWatcher` struct was needed for actual node side changes and the previous one was really just watching contract changes.


