### PR TITLE
fix CI cargo audit checks

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -81,5 +81,8 @@ jobs:
         # RUSTSEC-2022-0054 wee-alloc is unmaintained, it's fine for now because we barely use an allocator and the contracts are short lived, but we should find a replacement/use the default allocator
         # RUSTSEC-2021-0145 atty can do an unallocated read with a custom allocator in windows. We don't run this in windows and we don't use a custom allocator.
         # RUSTSEC-2024-0399 according to the description, this is not affecting us since we are not using Acceptor
+        # RUSTSEC-2024-0421 temporarily ignored to make CI green [https://github.com/sig-net/mpc/issues/414]
+        # RUSTSEC-2025-0009 temporarily ignored to make CI green [https://github.com/sig-net/mpc/issues/415]
+        # RUSTSEC-2024-0336 temporarily ignored to make CI green [https://github.com/sig-net/mpc/issues/415]
         run: |
-          cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2022-0054 --ignore RUSTSEC-2021-0145 --ignore RUSTSEC-2024-0399
+          cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2022-0054 --ignore RUSTSEC-2021-0145 --ignore RUSTSEC-2024-0399 --ignore RUSTSEC-2024-0421 --ignore RUSTSEC-2025-0009 --ignore RUSTSEC-2024-0336

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3607,7 +3607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.101",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -9794,9 +9794,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if 1.0.0",
  "fnv",
@@ -9804,7 +9804,7 @@ dependencies = [
  "memchr",
  "parking_lot 0.12.3",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9875,9 +9875,23 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "qstring"

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -23,7 +23,7 @@ http = "1.1.0"
 hyper-rustls = { version = "=0.24", features = ["http2"] }
 local-ip-address = "0.5.4"
 lru = "0.13.0"
-prometheus = "0.13.3"
+prometheus = "0.14.0"
 redis = "0.27.2"
 semver = "1.0.23"
 sysinfo = "0.32.0"


### PR DESCRIPTION
## Fixed

RUSTSEC-2024-0437 solved by bumping prometheus from 0.13.4 to 0.14.0

changelog: https://github.com/tikv/rust-prometheus/blob/master/CHANGELOG.md#0140

## Ignored

We need to ignore some checks temporarily to make the `cargo audit` check meaningful again. Otherwise, we don't even notice when we are affected by new CVEs.

RUSTSEC-2024-0421 -> see #414
RUSTSEC-2025-0009 -> see #415
RUSTSEC-2024-0336 -> see #415