### PR TITLE
feat: lower message loop sleep interval

### DIFF
--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -338,7 +338,7 @@ struct MessageExecutor {
 
 impl MessageExecutor {
     pub async fn execute(mut self) {
-        let mut interval = tokio::time::interval(Duration::from_millis(100));
+        let mut interval = tokio::time::interval(Duration::from_millis(10));
         loop {
             interval.tick().await;
             let config = self.config.borrow().clone();

--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -45,7 +45,7 @@ impl PositAction {
 pub enum PositInternalAction<S> {
     StartProtocol(Vec<Participant>, Positor<S>),
     Reply(PositAction),
-    Rejected,
+    Abort,
     None,
 }
 
@@ -234,7 +234,7 @@ impl<T: Copy + Hash + Eq + fmt::Debug, S> Posits<T, S> {
                 if enough_rejections {
                     tracing::info!(?id, rejects = ?counter.rejects, "received enough REJECTs, aborting protocol");
                     entry.remove();
-                    return PositInternalAction::Rejected;
+                    return PositInternalAction::Abort;
                 }
 
                 // TODO: have a timeout on waiting for votes. The moment we have enough threshold accepts,
@@ -378,6 +378,6 @@ mod tests {
         let action = posits0.act(id, Participant::from(1), threshold, &PositAction::Reject);
         assert!(matches!(action, PositInternalAction::None));
         let action = posits0.act(id, Participant::from(2), threshold, &PositAction::Reject);
-        assert!(matches!(action, PositInternalAction::Rejected));
+        assert!(matches!(action, PositInternalAction::Abort));
     }
 }

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -380,7 +380,7 @@ impl PresignatureSpawner {
 
         match internal_action {
             PositInternalAction::None => {}
-            PositInternalAction::Rejected => {}
+            PositInternalAction::Abort => {}
             PositInternalAction::Reply(action) => {
                 self.msg
                     .send(

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -733,7 +733,7 @@ impl SignatureSpawner {
 
         match internal_action {
             PositInternalAction::None => {}
-            PositInternalAction::Rejected => {
+            PositInternalAction::Abort => {
                 tracing::warn!(
                     ?sign_id,
                     presignature_id,

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -346,7 +346,7 @@ impl TripleSpawner {
 
         match internal_action {
             PositInternalAction::None => {}
-            PositInternalAction::Rejected => {}
+            PositInternalAction::Abort => {}
             PositInternalAction::Reply(action) => {
                 self.msg
                     .send(


### PR DESCRIPTION
Testing this to see how much better our messaging is. In the future, sending messages out should be a bit smarter and more reactive by reaching the payload limit or timeout.

With this, I've noticed a slight performance increase in our `test_signature_basic` test by about 5-10s