### PR TITLE
fix: expire eth and solana requests with different timeouts

### DIFF
--- a/chain-signatures/node/src/indexer.rs
+++ b/chain-signatures/node/src/indexer.rs
@@ -233,6 +233,7 @@ async fn handle_block(
                     chain: Chain::NEAR,
                     unix_timestamp_indexed: crate::util::current_unix_timestamp(),
                     timestamp_sign_queue: Some(Instant::now()),
+                    total_timeout: Duration::from_secs(200),
                 });
             }
         }

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -40,6 +40,8 @@ enum Cli {
         eth_helios_data_path: String,
         #[arg(long, default_value = "10000")]
         eth_refresh_finalized_interval: u64,
+        #[arg(long, default_value = "1200")]
+        eth_total_timeout: u64,
     },
     /// Spin up dependent services but not mpc nodes
     DepServices,
@@ -65,6 +67,7 @@ async fn main() -> anyhow::Result<()> {
             eth_network,
             eth_helios_data_path,
             eth_refresh_finalized_interval,
+            eth_total_timeout,
         } => {
             println!(
                 "Setting up an environment with {} nodes, {} threshold ...",
@@ -81,6 +84,7 @@ async fn main() -> anyhow::Result<()> {
                     network: eth_network,
                     helios_data_path: eth_helios_data_path,
                     refresh_finalized_interval: eth_refresh_finalized_interval,
+                    total_timeout: eth_total_timeout,
                 }),
                 ..Default::default()
             };


### PR DESCRIPTION
1. add a field total_timeout to IndexedSignRequest
2. configure different chains to have a different total timeout 
3. expire requests in sign queue according to this total timeout