### PR TITLE
feat: use watch::{Receiver, Sender} for Config, MeshState, ContractState

### DIFF
--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -254,7 +254,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let signer = InMemorySigner::from_secret_key(account_id.clone(), account_sk);
             let (synced_peer_tx, synced_peer_rx) = SyncTask::synced_nodes_channel();
             let mesh = Mesh::new(&client, mesh_options, synced_peer_rx);
-            let mesh_state = mesh.state().clone();
+            let mesh_state = mesh.state();
             let watcher = ContractStateWatcher::new(&account_id);
             let contract_state = watcher.state().clone();
 
@@ -294,9 +294,14 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let state = Node::new();
             let state_watcher = state.watcher.clone();
 
-            let (sender, msg_channel) =
-                MessageChannel::spawn(client, &account_id, config_rx.clone(), watcher, &mesh_state)
-                    .await;
+            let (sender, msg_channel) = MessageChannel::spawn(
+                client,
+                &account_id,
+                config_rx.clone(),
+                watcher,
+                mesh_state.clone(),
+            )
+            .await;
             let protocol = MpcSignProtocol {
                 my_account_id: account_id.clone(),
                 near: near_client,

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -254,9 +254,8 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let signer = InMemorySigner::from_secret_key(account_id.clone(), account_sk);
             let (synced_peer_tx, synced_peer_rx) = SyncTask::synced_nodes_channel();
             let mesh = Mesh::new(&client, mesh_options, synced_peer_rx);
-            let mesh_state = mesh.state();
-            let watcher = ContractStateWatcher::new(&account_id);
-            let contract_state = watcher.state().clone();
+            let mesh_state = mesh.watch();
+            let (contract_watcher, contract_state_tx) = ContractStateWatcher::new(&account_id);
 
             let eth = eth.into_config();
             let sol = sol.into_config();
@@ -269,7 +268,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 triple_storage.clone(),
                 presignature_storage.clone(),
                 mesh_state.clone(),
-                watcher.clone(),
+                contract_watcher.clone(),
                 synced_peer_tx,
             );
 
@@ -291,14 +290,14 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             });
             let (config_tx, config_rx) = watch::channel(config);
 
-            let state = Node::new();
-            let state_watcher = state.watcher.clone();
+            let node = Node::new();
+            let node_watcher = node.watch();
 
             let (sender, msg_channel) = MessageChannel::spawn(
                 client,
                 &account_id,
                 config_rx.clone(),
-                watcher,
+                contract_watcher.clone(),
                 mesh_state.clone(),
             )
             .await;
@@ -317,16 +316,16 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
 
             tracing::info!("protocol initialized");
             tokio::spawn(sync.run());
-            tokio::spawn(rpc.run(contract_state.clone(), config_tx.clone()));
-            tokio::spawn(mesh.run(contract_state.clone()));
+            tokio::spawn(rpc.run(contract_state_tx, config_tx.clone()));
+            tokio::spawn(mesh.run(contract_watcher.clone()));
             let system_handle = spawn_system_metrics(account_id.as_str()).await;
             let protocol_handle =
-                tokio::spawn(protocol.run(state, contract_state, config_rx, mesh_state));
+                tokio::spawn(protocol.run(node, contract_watcher, config_rx, mesh_state));
             tracing::info!("protocol thread spawned");
             let web_handle = tokio::spawn(web::run(
                 web_port,
                 sender,
-                state_watcher,
+                node_watcher,
                 indexer,
                 triple_storage,
                 presignature_storage,

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -160,11 +160,11 @@ impl Pool {
         }
     }
 
-    pub async fn connect(&mut self, contract: &ProtocolState) {
+    pub async fn connect(&mut self, contract: ProtocolState) {
         let mut seen = HashSet::new();
         match contract {
             ProtocolState::Initializing(init) => {
-                let participants: Participants = init.candidates.clone().into();
+                let participants: Participants = init.candidates.into();
                 self.connect_nodes(&participants, &mut seen).await;
             }
             ProtocolState::Running(running) => {

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -5,7 +5,7 @@ use crate::protocol::contract::primitives::Participants;
 use crate::protocol::ProtocolState;
 use cait_sith::protocol::Participant;
 use std::sync::Arc;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{mpsc, watch, RwLock};
 
 pub mod connection;
 
@@ -45,7 +45,8 @@ pub struct MeshState {
 pub struct Mesh {
     /// Pool of connections to participants. Used to check who is alive in the network.
     connections: connection::Pool,
-    state: Arc<RwLock<MeshState>>,
+    state_tx: watch::Sender<MeshState>,
+    state_rx: watch::Receiver<MeshState>,
     ping_interval: Duration,
     synced_peer_rx: mpsc::Receiver<Participant>,
 }
@@ -57,16 +58,18 @@ impl Mesh {
         synced_peer_rx: mpsc::Receiver<Participant>,
     ) -> Self {
         let ping_interval = Duration::from_millis(options.ping_interval);
+        let (state_tx, state_rx) = watch::channel(MeshState::default());
         Self {
             connections: connection::Pool::new(client, ping_interval),
-            state: Arc::new(RwLock::new(MeshState::default())),
+            state_tx,
+            state_rx,
             ping_interval,
             synced_peer_rx,
         }
     }
 
-    pub fn state(&self) -> &Arc<RwLock<MeshState>> {
-        &self.state
+    pub fn state(&self) -> watch::Receiver<MeshState> {
+        self.state_rx.clone()
     }
 
     pub async fn run(mut self, contract_state: Arc<RwLock<Option<ProtocolState>>>) {
@@ -74,22 +77,23 @@ impl Mesh {
         loop {
             tokio::select! {
                 _ = interval.tick() => {
-
                     if let Some(contract) = &*contract_state.read().await {
                         self.connections.connect(contract).await;
                         let new_state = self.connections.status().await;
-                        let mut state = self.state.write().await;
-                        *state = new_state;
+                        let _ = self.state_tx.send(new_state);
                     }
                 }
                 Some(participant) = self.synced_peer_rx.recv() => {
                     self.connections.report_node_synced(participant).await;
-                    let mut state = self.state.write().await;
-
-                    if let Some(info) = state.need_sync.remove(&participant) {
-                        state.active.insert(&participant, info);
-                        state.stable.push(participant);
-                    }
+                    self.state_tx.send_if_modified(|state| {
+                        if let Some(info) = state.need_sync.remove(&participant) {
+                            state.active.insert(&participant, info);
+                            state.stable.push(participant);
+                            true
+                        } else {
+                            false
+                        }
+                    });
                 }
             }
         }

--- a/chain-signatures/node/src/protocol/contract/mod.rs
+++ b/chain-signatures/node/src/protocol/contract/mod.rs
@@ -9,7 +9,7 @@ use std::{collections::HashSet, str::FromStr};
 
 use self::primitives::{Candidates, Participants, PkVotes, Votes};
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct InitializingContractState {
     pub candidates: Candidates,
     pub threshold: usize,
@@ -26,7 +26,7 @@ impl From<mpc_contract::InitializingContractState> for InitializingContractState
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct RunningContractState {
     pub epoch: u64,
     pub participants: Participants,
@@ -51,7 +51,7 @@ impl From<mpc_contract::RunningContractState> for RunningContractState {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct ResharingContractState {
     pub old_epoch: u64,
     pub old_participants: Participants,
@@ -78,7 +78,7 @@ impl From<mpc_contract::ResharingContractState> for ResharingContractState {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ProtocolState {
     Initializing(InitializingContractState),
     Running(RunningContractState),

--- a/chain-signatures/node/src/protocol/contract/primitives.rs
+++ b/chain-signatures/node/src/protocol/contract/primitives.rs
@@ -229,7 +229,7 @@ pub struct CandidateInfo {
     pub sign_pk: near_crypto::PublicKey,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct Candidates {
     pub candidates: BTreeMap<AccountId, CandidateInfo>,
 }
@@ -282,7 +282,7 @@ impl From<mpc_contract::primitives::Candidates> for Candidates {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct PkVotes {
     pub pk_votes: BTreeMap<near_crypto::PublicKey, HashSet<AccountId>>,
 }
@@ -317,7 +317,7 @@ impl From<mpc_contract::primitives::PkVotes> for PkVotes {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct Votes {
     pub votes: BTreeMap<AccountId, HashSet<AccountId>>,
 }

--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -32,7 +32,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::error::TryRecvError;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{mpsc, watch, RwLock};
 
 pub const MAX_MESSAGE_INCOMING: usize = 1024 * 1024;
 pub const MAX_MESSAGE_OUTGOING: usize = 1024 * 1024;
@@ -331,7 +331,7 @@ struct MessageExecutor {
     inbox: Arc<RwLock<MessageInbox>>,
     outbox: MessageOutbox,
 
-    config: Arc<RwLock<Config>>,
+    config: watch::Receiver<Config>,
     contract_watcher: ContractStateWatcher,
     mesh_state: Arc<RwLock<MeshState>>,
 }
@@ -341,30 +341,27 @@ impl MessageExecutor {
         let mut interval = tokio::time::interval(Duration::from_millis(100));
         loop {
             interval.tick().await;
-            let (sign_sk, cipher_sk, protocol) = {
-                let config = self.config.read().await;
-                (
-                    config.local.network.sign_sk.clone(),
-                    config.local.network.cipher_sk.clone(),
-                    config.protocol.clone(),
-                )
-            };
+            let config = self.config.borrow().clone();
 
             let participants = self.contract_watcher.participants().await;
             {
                 let mut inbox = self.inbox.write().await;
-                let expiration = Duration::from_millis(protocol.message_timeout);
-                inbox.update(expiration, &cipher_sk, &participants).await;
+                let expiration = Duration::from_millis(config.protocol.message_timeout);
+                inbox
+                    .update(expiration, &config.local.network.cipher_sk, &participants)
+                    .await;
             }
 
             let active = {
                 let mesh_state = self.mesh_state.read().await;
                 mesh_state.active.clone()
             };
-            self.outbox.expire(&protocol);
+            self.outbox.expire(&config.protocol);
             self.outbox.recv_updates();
             let compacted = self.outbox.compact();
-            let encrypted = self.outbox.encrypt(&sign_sk, &active, compacted);
+            let encrypted = self
+                .outbox
+                .encrypt(&config.local.network.sign_sk, &active, compacted);
             self.outbox.send(&active, encrypted).await;
         }
     }
@@ -375,7 +372,6 @@ pub struct MessageChannel {
     outgoing: mpsc::Sender<SendMessage>,
     inbox: Arc<RwLock<MessageInbox>>,
     filter: mpsc::Sender<(Protocols, u64)>,
-    task: Option<Arc<tokio::task::JoinHandle<()>>>,
 }
 
 impl MessageChannel {
@@ -389,7 +385,6 @@ impl MessageChannel {
             inbox,
             outgoing: outbox_tx,
             filter: filter_tx,
-            task: None,
         };
 
         (inbox_tx, outbox_rx, channel)
@@ -398,20 +393,20 @@ impl MessageChannel {
     pub async fn spawn(
         client: NodeClient,
         id: &AccountId,
-        config: &Arc<RwLock<Config>>,
+        config: watch::Receiver<Config>,
         contract_watcher: ContractStateWatcher,
         mesh_state: &Arc<RwLock<MeshState>>,
     ) -> (mpsc::Sender<Ciphered>, Self) {
-        let (inbox_tx, outbox_rx, mut channel) = Self::new();
+        let (inbox_tx, outbox_rx, channel) = Self::new();
         let runner = MessageExecutor {
             inbox: channel.inbox.clone(),
             outbox: MessageOutbox::new(id, client, outbox_rx),
 
-            config: config.clone(),
+            config,
             contract_watcher,
             mesh_state: mesh_state.clone(),
         };
-        channel.task = Some(Arc::new(tokio::spawn(runner.execute())));
+        tokio::spawn(runner.execute());
 
         (inbox_tx, channel)
     }

--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -332,7 +332,7 @@ struct MessageExecutor {
     outbox: MessageOutbox,
 
     config: watch::Receiver<Config>,
-    contract_watcher: ContractStateWatcher,
+    contract: ContractStateWatcher,
     mesh_state: watch::Receiver<MeshState>,
 }
 
@@ -343,7 +343,7 @@ impl MessageExecutor {
             interval.tick().await;
             let config = self.config.borrow().clone();
 
-            let participants = self.contract_watcher.participants().await;
+            let participants = self.contract.participants().await;
             {
                 let mut inbox = self.inbox.write().await;
                 let expiration = Duration::from_millis(config.protocol.message_timeout);
@@ -391,7 +391,7 @@ impl MessageChannel {
         client: NodeClient,
         id: &AccountId,
         config: watch::Receiver<Config>,
-        contract_watcher: ContractStateWatcher,
+        contract: ContractStateWatcher,
         mesh_state: watch::Receiver<MeshState>,
     ) -> (mpsc::Sender<Ciphered>, Self) {
         let (inbox_tx, outbox_rx, channel) = Self::new();
@@ -400,7 +400,7 @@ impl MessageChannel {
             outbox: MessageOutbox::new(id, client, outbox_rx),
 
             config,
-            contract_watcher,
+            contract,
             mesh_state,
         };
         tokio::spawn(runner.execute());

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -48,7 +48,7 @@ pub struct MpcSignProtocol {
     pub(crate) msg_channel: MessageChannel,
     pub(crate) rpc_channel: RpcChannel,
     pub(crate) config: watch::Receiver<Config>,
-    pub(crate) mesh_state: Arc<RwLock<MeshState>>,
+    pub(crate) mesh_state: watch::Receiver<MeshState>,
 }
 
 impl MpcSignProtocol {
@@ -57,7 +57,7 @@ impl MpcSignProtocol {
         mut node: Node,
         contract_state: Arc<RwLock<Option<ProtocolState>>>,
         config: watch::Receiver<Config>,
-        mesh_state: Arc<RwLock<MeshState>>,
+        mesh_state: watch::Receiver<MeshState>,
     ) {
         let my_account_id = self.my_account_id.as_str();
         let _span = tracing::info_span!("running", my_account_id);
@@ -83,10 +83,7 @@ impl MpcSignProtocol {
                 state.clone()
             };
             let cfg = config.borrow().clone();
-            let mesh_state = {
-                let state = mesh_state.read().await;
-                state.clone()
-            };
+            let mesh_state = mesh_state.borrow().clone();
 
             let crypto_time = Instant::now();
             node.state = node

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -23,9 +23,8 @@ use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
 use std::collections::HashSet;
 use std::fmt;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::{mpsc, watch, RwLock};
+use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 use tokio::time;
 
@@ -605,7 +604,7 @@ impl PresignatureSpawner {
 
     async fn run(
         mut self,
-        mesh_state: Arc<RwLock<MeshState>>,
+        mesh_state: watch::Receiver<MeshState>,
         config: watch::Receiver<Config>,
         ongoing_gen_tx: watch::Sender<usize>,
     ) {
@@ -631,10 +630,7 @@ impl PresignatureSpawner {
                     let _ = ongoing_gen_tx.send(self.ongoing.len());
                 }
                 _ = stockpile_interval.tick() => {
-                    let active = {
-                        let mesh_state = mesh_state.read().await;
-                        mesh_state.active.keys_vec()
-                    };
+                    let active = mesh_state.borrow().active.keys_vec();
                     let protocol_cfg = config.borrow().protocol.clone();
                     self.stockpile(&active, &protocol_cfg).await;
                     let _ = ongoing_gen_tx.send(self.ongoing.len());

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -606,7 +606,7 @@ impl PresignatureSpawner {
     async fn run(
         mut self,
         mesh_state: Arc<RwLock<MeshState>>,
-        config: Arc<RwLock<Config>>,
+        config: watch::Receiver<Config>,
         ongoing_gen_tx: watch::Sender<usize>,
     ) {
         let mut stockpile_interval = time::interval(Duration::from_millis(100));
@@ -615,7 +615,7 @@ impl PresignatureSpawner {
         loop {
             tokio::select! {
                 Some((id, from, action)) = posits.recv() => {
-                    let timeout = config.read().await.protocol.presignature.generation_timeout;
+                    let timeout = config.borrow().protocol.presignature.generation_timeout;
                     self.process_posit(id, from, action, Duration::from_millis(timeout)).await;
                 }
                 // `join_next` returns None on the set being empty, so don't handle that case
@@ -635,10 +635,7 @@ impl PresignatureSpawner {
                         let mesh_state = mesh_state.read().await;
                         mesh_state.active.keys_vec()
                     };
-                    let protocol_cfg = {
-                        let config = config.read().await;
-                        config.protocol.clone()
-                    };
+                    let protocol_cfg = config.borrow().protocol.clone();
                     self.stockpile(&active, &protocol_cfg).await;
                     let _ = ongoing_gen_tx.send(self.ongoing.len());
 

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -27,7 +27,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::error::TryRecvError;
-use tokio::sync::{mpsc, oneshot, RwLock};
+use tokio::sync::{mpsc, oneshot, watch, RwLock};
 use tokio::task::{JoinHandle, JoinSet};
 
 use near_account_id::AccountId;
@@ -907,7 +907,7 @@ impl SignatureSpawner {
         }
     }
 
-    async fn run(mut self, mesh_state: Arc<RwLock<MeshState>>, cfg: Arc<RwLock<Config>>) {
+    async fn run(mut self, mesh_state: watch::Receiver<MeshState>, cfg: watch::Receiver<Config>) {
         // NOTE: signatures should only use stable and not active participants. The difference here is that
         // stable participants utilizes more than the online status of a node, such as whether or not their
         // block height is up to date, such that they too can process signature requests. If they cannot
@@ -920,13 +920,8 @@ impl SignatureSpawner {
         loop {
             tokio::select! {
                 Some((sign_id, presignature_id, from, action)) = posits.recv() => {
-                    let cfg = {
-                        let cfg = cfg.read().await;
-                        cfg.protocol.clone()
-                    };
-
                     let request = self.sign_queue.get_or_pending(&sign_id);
-                    let timeout = Duration::from_millis(cfg.signature.generation_timeout);
+                    let timeout = Duration::from_millis(cfg.borrow().protocol.signature.generation_timeout);
                     pending_posits.spawn(async move {
                         let request = request.fetch(timeout).await;
                         (sign_id, presignature_id, request, from, action)
@@ -941,11 +936,8 @@ impl SignatureSpawner {
                         },
                     };
 
-                    let cfg = {
-                        let cfg = cfg.read().await;
-                        cfg.protocol.clone()
-                    };
-                    self.process_posit(sign_id, presignature_id, request, from, action, cfg).await;
+                    let protocol = cfg.borrow().protocol.clone();
+                    self.process_posit(sign_id, presignature_id, request, from, action, protocol).await;
                 }
                 // `join_next` returns None on the set being empty, so don't handle that case
                 Some(result) = self.ongoing.join_next(), if !self.ongoing.is_empty() => {
@@ -967,15 +959,9 @@ impl SignatureSpawner {
                     }
                 }
                 _ = check_requests_interval.tick() => {
-                    let stable = {
-                        let state = mesh_state.read().await;
-                        state.stable.clone()
-                    };
-                    let protocol_cfg = {
-                        let config = cfg.read().await;
-                        config.protocol.clone()
-                    };
-                    self.handle_requests(&stable, &protocol_cfg).await;
+                    let stable = mesh_state.borrow().stable.clone();
+                    let protocol = cfg.borrow().protocol.clone();
+                    self.handle_requests(&stable, &protocol).await;
                 }
             }
         }

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -171,6 +171,10 @@ impl Node {
         }
     }
 
+    pub fn watch(&self) -> NodeStateWatcher {
+        self.watcher.clone()
+    }
+
     pub async fn update_watchers(&mut self) {
         match &self.state {
             NodeState::Started(_) => {

--- a/chain-signatures/node/src/protocol/sync/mod.rs
+++ b/chain-signatures/node/src/protocol/sync/mod.rs
@@ -50,7 +50,7 @@ pub struct SyncTask {
     triples: TripleStorage,
     presignatures: PresignatureStorage,
     mesh_state: watch::Receiver<MeshState>,
-    watcher: ContractStateWatcher,
+    contract: ContractStateWatcher,
     requests: SyncRequestReceiver,
     synced_peer_tx: mpsc::Sender<Participant>,
 }
@@ -62,7 +62,7 @@ impl SyncTask {
         triples: TripleStorage,
         presignatures: PresignatureStorage,
         mesh_state: watch::Receiver<MeshState>,
-        watcher: ContractStateWatcher,
+        contract: ContractStateWatcher,
         synced_peer_tx: mpsc::Sender<Participant>,
     ) -> (SyncChannel, Self) {
         let (requests, channel) = SyncChannel::new();
@@ -71,7 +71,7 @@ impl SyncTask {
             triples,
             presignatures,
             mesh_state,
-            watcher,
+            contract,
             requests,
             synced_peer_tx,
         };
@@ -90,7 +90,7 @@ impl SyncTask {
         // TODO: constantly watch for changes on node state after this initial one so we can start/stop sync running.
         let (_threshold, me) = loop {
             watcher_interval.tick().await;
-            if let Some(info) = self.watcher.info().await {
+            if let Some(info) = self.contract.info().await {
                 break info;
             }
         };

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -17,12 +17,11 @@ use k256::elliptic_curve::group::GroupEncoding;
 use k256::Secp256k1;
 use near_account_id::AccountId;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{mpsc, watch, RwLock};
+use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 
 use std::collections::HashSet;
 use std::fmt;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 /// Unique number used to identify a specific ongoing triple generation protocol.
@@ -486,7 +485,7 @@ impl TripleSpawner {
 
     async fn run(
         mut self,
-        mesh_state: Arc<RwLock<MeshState>>,
+        mesh_state: watch::Receiver<MeshState>,
         config: watch::Receiver<Config>,
         ongoing_gen_tx: watch::Sender<usize>,
     ) {
@@ -515,7 +514,7 @@ impl TripleSpawner {
                     // TODO: eventually we should use all participants, and let nodes replying with
                     // accept/reject determine who is a participant. The messaging layer should
                     // rely more on active.
-                    let active = mesh_state.read().await.active.keys_vec();
+                    let active = mesh_state.borrow().active.keys_vec();
                     let protocol = config.borrow().protocol.clone();
                     self.stockpile(&active, &protocol).await;
                     let _ = ongoing_gen_tx.send(self.ongoing.len());

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -37,7 +37,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::{mpsc, watch, RwLock};
+use tokio::sync::{mpsc, watch};
 use url::Url;
 
 /// The maximum amount of times to retry publishing a signature.
@@ -124,36 +124,58 @@ impl RpcChannel {
 #[derive(Clone)]
 pub struct ContractStateWatcher {
     account_id: AccountId,
-    // TODO: use tokio::watch channel in the future.
-    contract_state: Arc<RwLock<Option<ProtocolState>>>,
+    contract_state: watch::Receiver<Option<ProtocolState>>,
 }
 
 impl ContractStateWatcher {
-    pub fn new(id: &AccountId) -> Self {
-        Self {
-            account_id: id.clone(),
-            contract_state: Arc::new(RwLock::new(None)),
-        }
+    pub fn new(id: &AccountId) -> (Self, watch::Sender<Option<ProtocolState>>) {
+        let (tx, rx) = watch::channel(None);
+        (
+            Self {
+                account_id: id.clone(),
+                contract_state: rx,
+            },
+            tx,
+        )
     }
 
-    pub fn mock(id: &AccountId, state: ProtocolState) -> Self {
-        Self {
-            account_id: id.clone(),
-            contract_state: Arc::new(RwLock::new(Some(state))),
-        }
+    pub fn with(
+        id: &AccountId,
+        state: ProtocolState,
+    ) -> (Self, watch::Sender<Option<ProtocolState>>) {
+        let (tx, rx) = watch::channel(Some(state));
+        (
+            Self {
+                account_id: id.clone(),
+                contract_state: rx,
+            },
+            tx,
+        )
     }
 
     pub fn account_id(&self) -> &AccountId {
         &self.account_id
     }
 
-    pub fn state(&self) -> &Arc<RwLock<Option<ProtocolState>>> {
-        &self.contract_state
+    pub fn borrow_state(&self) -> watch::Ref<'_, Option<ProtocolState>> {
+        self.contract_state.borrow()
+    }
+
+    pub fn state(&self) -> Option<ProtocolState> {
+        self.borrow_state().clone()
+    }
+
+    pub async fn next_state(&mut self) -> Option<ProtocolState> {
+        let _ = self.contract_state.changed().await;
+        self.contract_state.borrow_and_update().clone()
+    }
+
+    pub fn mark_changed(&mut self) {
+        self.contract_state.mark_changed();
     }
 
     pub async fn me(&self) -> Option<Participant> {
-        let state = self.contract_state.read().await;
-        match state.as_ref()? {
+        match self.state().clone()? {
             ProtocolState::Initializing(_) => None,
             ProtocolState::Running(state) => state
                 .participants
@@ -167,8 +189,7 @@ impl ContractStateWatcher {
     }
 
     pub async fn threshold(&self) -> Option<usize> {
-        let state = self.contract_state.read().await;
-        match state.as_ref()? {
+        match self.state().clone()? {
             ProtocolState::Initializing(_) => None,
             ProtocolState::Running(state) => Some(state.threshold),
             ProtocolState::Resharing(state) => Some(state.threshold),
@@ -176,8 +197,7 @@ impl ContractStateWatcher {
     }
 
     pub async fn info(&self) -> Option<(usize, Participant)> {
-        let state = self.contract_state.read().await;
-        match state.as_ref()? {
+        match self.state().clone()? {
             ProtocolState::Initializing(_) => None,
             ProtocolState::Running(state) => Some((
                 state.threshold,
@@ -191,8 +211,7 @@ impl ContractStateWatcher {
     }
 
     pub async fn participants(&self) -> ParticipantMap {
-        let contract_state = self.contract_state.read().await;
-        let Some(state) = contract_state.as_ref() else {
+        let Some(state) = self.state().clone() else {
             return ParticipantMap::Zero;
         };
 
@@ -238,7 +257,7 @@ impl RpcExecutor {
 
     pub async fn run(
         mut self,
-        contract_state: Arc<RwLock<Option<ProtocolState>>>,
+        contract: watch::Sender<Option<ProtocolState>>,
         config: watch::Sender<Config>,
     ) {
         // spin up update task for updating contract state and config
@@ -247,7 +266,7 @@ impl RpcExecutor {
             let mut interval = tokio::time::interval(UPDATE_INTERVAL);
             loop {
                 interval.tick().await;
-                tokio::spawn(update_contract(near.clone(), contract_state.clone()));
+                tokio::spawn(update_contract(near.clone(), contract.clone()));
                 tokio::spawn(update_config(near.clone(), config.clone()));
             }
         });
@@ -536,15 +555,24 @@ pub enum ChainClient {
     Solana(SolanaClient),
 }
 
-async fn update_contract(near: NearClient, contract_state: Arc<RwLock<Option<ProtocolState>>>) {
-    match near.fetch_state().await {
-        Ok(state) => {
-            *contract_state.write().await = Some(state);
-        }
+async fn update_contract(near: NearClient, contract: watch::Sender<Option<ProtocolState>>) {
+    let new_state = match near.fetch_state().await {
+        Ok(state) => state,
         Err(error) => {
             tracing::error!(?error, "could not fetch contract state");
+            return;
         }
-    }
+    };
+
+    contract.send_if_modified(|old_state| {
+        if let Some(old_state) = old_state {
+            if *old_state == new_state {
+                return false;
+            }
+        }
+        *old_state = Some(new_state);
+        true
+    });
 }
 
 async fn update_config(near: NearClient, config: watch::Sender<Config>) {

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -22,7 +22,7 @@ use tokio::sync::mpsc::Sender;
 
 struct AxumState {
     sender: Sender<Ciphered>,
-    node_watcher: NodeStateWatcher,
+    node: NodeStateWatcher,
     indexer: Option<NearIndexer>,
     triple_storage: TripleStorage,
     presignature_storage: PresignatureStorage,
@@ -32,7 +32,7 @@ struct AxumState {
 pub async fn run(
     port: u16,
     sender: Sender<Ciphered>,
-    node_watcher: NodeStateWatcher,
+    node: NodeStateWatcher,
     indexer: Option<NearIndexer>,
     triple_storage: TripleStorage,
     presignature_storage: PresignatureStorage,
@@ -41,7 +41,7 @@ pub async fn run(
     tracing::info!("starting web server");
     let axum_state = AxumState {
         sender,
-        node_watcher,
+        node,
         indexer,
         triple_storage,
         presignature_storage,
@@ -130,7 +130,7 @@ async fn state(Extension(web): Extension<Arc<AxumState>>) -> Result<Json<StateVi
         0
     };
 
-    match web.node_watcher.status() {
+    match web.node.status() {
         NodeStatus::Running {
             me,
             participants,

--- a/integration-tests/tests/cases/sync.rs
+++ b/integration-tests/tests/cases/sync.rs
@@ -41,7 +41,7 @@ async fn test_state_sync_update() -> anyhow::Result<()> {
     let node0_triples = redis.triple_storage(&node0_account_id);
     let node0_presignatures = redis.presignature_storage(&node0_account_id);
 
-    let watcher = ContractStateWatcher::mock(
+    let (contract_watcher, _contract_tx) = ContractStateWatcher::with(
         &node0_account_id,
         ProtocolState::Running(RunningContractState {
             epoch: 0,
@@ -66,8 +66,8 @@ async fn test_state_sync_update() -> anyhow::Result<()> {
         &client,
         node0_triples.clone(),
         node0_presignatures.clone(),
-        mesh.state().clone(),
-        watcher,
+        mesh.watch(),
+        contract_watcher,
         synced_peer_tx,
     );
     tokio::spawn(sync.run());


### PR DESCRIPTION
This removes all the `Arc<RwLock<T>>` for Config, MeshState and ContractState. Instead we will use `watch::{Sender, Receiver}` to be more reactive and listen for changes made to them. This requires less cycles as we no longer need to poll in certain scenarios and merely just listen for changes once woken by the runtime.