### PR TITLE
Run the PR workflow on any file change

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches:
       - develop
-  pull_request:
     paths:
       - integration-tests/**
       - chain-signatures/**
+  pull_request:
 
 env:
   RUSTFLAGS: -D warnings

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - develop
-  pull_request:
     paths:
       - ".github/workflows/unit.yml"
       - "chain-signatures/**/*.rs"
@@ -12,6 +11,7 @@ on:
       - "integration-tests/**/*.rs"
       - "chain-signatures/contract-eth/**/*.sol"
       - "chain-signatures/contract-eth/**/*.js"
+  pull_request:
 
 env:
   RUSTFLAGS: -D warnings


### PR DESCRIPTION
Since now we require tests to pass before merging, we need to run the workflow on all PRs.
We will not do that on each commit, but it must happen at least once per PR.