### PR TITLE
set fake aws credentials in integration tests

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -10,13 +10,6 @@ docker pull redis:7.4.2
 
 In case of authorization issues make sure you have logged into docker using your [access token](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic).
 
-Set dummy AWS credentials and the correct region
-
-```bash
-aws configure set region us-east-1
-aws --profile default configure set aws_access_key_id "123"
-aws --profile default configure set aws_secret_access_key "456"
-```
 
 Then run the integration tests:
 

--- a/integration-tests/src/cluster/spawner.rs
+++ b/integration-tests/src/cluster/spawner.rs
@@ -160,6 +160,13 @@ impl ClusterSpawner {
     pub async fn dry_run(&mut self) -> anyhow::Result<crate::Context> {
         crate::dry_run(self).await
     }
+
+    /// Integration tests rely on a fake AWS configuration for LocalStack
+    pub fn fake_aws_credentials(&self) {
+        std::env::set_var("AWS_ACCESS_KEY_ID", "123");
+        std::env::set_var("AWS_SECRET_ACCESS_KEY", "456");
+        std::env::set_var("AWS_DEFAULT_REGION", "us-east-1");
+    }
 }
 
 impl IntoFuture for ClusterSpawner {
@@ -169,6 +176,7 @@ impl IntoFuture for ClusterSpawner {
     fn into_future(mut self) -> Self::IntoFuture {
         Box::pin(async move {
             self = self.init_network().await?;
+            self.fake_aws_credentials();
 
             let nodes = self.run().await?;
             let connector = near_jsonrpc_client::JsonRpcClient::new_client();


### PR DESCRIPTION
Rather than requiring a manual step for everyone to run before integration tests, we can set the fake credentials as a setup step for integration tests.

Using environment variables instead of the aws cli also avoids means devs have to install one less tool. Plus, this won't pollute the local home directory with fake credentials.