### PR TITLE
FIX: Added an increase high rate load test for constant LTs

### DIFF
--- a/.github/workflows/k6-ci-loadtest.yml
+++ b/.github/workflows/k6-ci-loadtest.yml
@@ -65,7 +65,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             echo "lt_chain=${CHAIN:-Solana}" >> "$GITHUB_OUTPUT"
             echo "lt_env=${ENV:-dev}" >> "$GITHUB_OUTPUT"
-            echo "lt_strategy=${STRATEGY:-constant_high_rate_1h}" >> "$GITHUB_OUTPUT"
+            echo "lt_strategy=${STRATEGY:-constant_low_rate_1h}" >> "$GITHUB_OUTPUT"
             echo "lt_check_signature=${CHECK_SIGNATURE:-true}" >> "$GITHUB_OUTPUT"
           else
             echo "lt_chain=${CHAIN:-Solana}" >> "$GITHUB_OUTPUT"

--- a/infra/loadtests/k6-load-test.js
+++ b/infra/loadtests/k6-load-test.js
@@ -34,8 +34,8 @@ const strategies = {
         maxVUs: 10,
         stages: [
           { duration: '1m', target: 1 },
-          { duration: '58m', target: 1 },
-          { duration: '1m', target: 0 },
+          { duration: '58m', target: 3 },
+          { duration: '1m', target: 1 },
         ],
       },
     },
@@ -54,7 +54,7 @@ const strategies = {
         maxVUs: 20,
         stages: [
           { duration: '1m', target: 2 },
-          { duration: '58m', target: 8 },
+          { duration: '58m', target: 5 },
           { duration: '1m', target: 2 },
         ],
       },


### PR DESCRIPTION
This may be a little optimistic for constant rate, 8 rps for 58 mins. We can reduce this amount if it's too crazy, but ideally we can see where we are at with a higher rate like this and adjust as needed. This may be at the upper end of the limit for RPC services, but with Alchemy we just pay for increased usage I believe.


closes #437 