### PR TITLE
eth indexer: use helios to directly query for finalized blocks

### DIFF
--- a/chain-signatures/contract-eth/scripts/requestSign.js
+++ b/chain-signatures/contract-eth/scripts/requestSign.js
@@ -9,9 +9,8 @@ async function main() {
     contractAddress = deployments[Object.keys(deployments).pop()];
     console.log(contractAddress)
   } else if (network === 'sepolia') {
-    // const deployments = require('../ignition/deployments/chain-11155111/deployed_addresses.json'); 
-    // contractAddress = deployments[Object.keys(deployments).pop()];
-    contractAddress = "0x127e11636c3bDe79EDCcAF90756F8A33c96d87eB"; 
+    const deployments = require('../ignition/deployments/chain-11155111/deployed_addresses.json'); 
+    contractAddress = deployments[Object.keys(deployments).pop()];
   } else {
     throw new Error('Unsupported network specified. Use "localhost" or "sepolia"');
   }

--- a/chain-signatures/contract-eth/scripts/requestSign.js
+++ b/chain-signatures/contract-eth/scripts/requestSign.js
@@ -9,8 +9,9 @@ async function main() {
     contractAddress = deployments[Object.keys(deployments).pop()];
     console.log(contractAddress)
   } else if (network === 'sepolia') {
-    const deployments = require('../ignition/deployments/chain-11155111/deployed_addresses.json'); 
-    contractAddress = deployments[Object.keys(deployments).pop()];
+    // const deployments = require('../ignition/deployments/chain-11155111/deployed_addresses.json'); 
+    // contractAddress = deployments[Object.keys(deployments).pop()];
+    contractAddress = "0x127e11636c3bDe79EDCcAF90756F8A33c96d87eB"; 
   } else {
     throw new Error('Unsupported network specified. Use "localhost" or "sepolia"');
   }

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -885,7 +885,7 @@ async fn send_requests_when_final(
                         }
                     };
 
-                    let cur_block_hash = block.header.hash_slow();
+                    let cur_block_hash = block.header.hash;
                     if cur_block_hash == block_hash {
                         tracing::info!("Block {block_number} is finalized!");
                         send_indexed_requests(

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -3,7 +3,6 @@ use alloy::consensus::BlockHeader;
 use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::primitives::hex::{self, ToHexExt};
 use alloy::primitives::{Address, Bytes, U256};
-use alloy::providers::{Provider, ProviderBuilder, RootProvider};
 use alloy::rpc::types::Log;
 use alloy::sol_types::{sol, SolEvent};
 use anyhow::anyhow;
@@ -14,7 +13,6 @@ use mpc_crypto::{kdf::derive_epsilon_eth, ScalarExt as _};
 use mpc_primitives::{SignArgs, SignId};
 use near_account_id::AccountId;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::{fmt, path::PathBuf, str::FromStr, sync::LazyLock, time::Instant};
 use tokio::sync::mpsc;
@@ -408,37 +406,10 @@ fn failed_blocks_channel() -> (
     mpsc::channel(MAX_FAILED_BLOCKS)
 }
 
-type BlockNumberToHashMap = HashMap<u64, alloy::primitives::B256>;
-
-#[derive(Debug, Clone)]
-struct FinalizedEpoch {
-    pub start_block: u64,
-    pub end_block: u64,
-    pub blocks: BlockNumberToHashMap,
-}
-
 const MAX_FINALIZED_BLOCKS: usize = 1024;
-fn finalized_blocks_channel() -> (mpsc::Sender<FinalizedEpoch>, mpsc::Receiver<FinalizedEpoch>) {
+fn finalized_block_channel() -> (mpsc::Sender<u64>, mpsc::Receiver<u64>) {
     mpsc::channel(MAX_FINALIZED_BLOCKS)
 }
-
-// Type alias for the complex FillProvider type
-type UntrustedRpcClient = alloy::providers::fillers::FillProvider<
-    alloy::providers::fillers::JoinFill<
-        alloy::providers::Identity,
-        alloy::providers::fillers::JoinFill<
-            alloy::providers::fillers::GasFiller,
-            alloy::providers::fillers::JoinFill<
-                alloy::providers::fillers::BlobGasFiller,
-                alloy::providers::fillers::JoinFill<
-                    alloy::providers::fillers::NonceFiller,
-                    alloy::providers::fillers::ChainIdFiller,
-                >,
-            >,
-        >,
-    >,
-    RootProvider,
->;
 
 pub async fn run(
     eth: Option<EthConfig>,
@@ -468,11 +439,6 @@ pub async fn run(
 
     client.wait_synced().await;
 
-    let untrusted_rpc_client: UntrustedRpcClient = ProviderBuilder::new().connect_http(
-        url::Url::parse(&eth.execution_rpc_http_url)
-            .map_err(|err| anyhow::anyhow!("Failed to parse execution RPC URL: {:?}", err))?,
-    );
-
     tracing::info!("running ethereum indexer");
 
     let eth_contract_addr = Address::from_str(&format!("0x{}", eth.contract_address))?;
@@ -487,30 +453,31 @@ pub async fn run(
 
     let (requests_indexed_send, requests_indexed_recv) = indexed_channel();
 
-    let (finalized_epoch_send, finalized_epoch_recv) = finalized_blocks_channel();
+    let (finalized_block_send, finalized_block_recv) = finalized_block_channel();
 
     let client = Arc::new(client);
     let client_clone = Arc::clone(&client);
     tokio::spawn(async move {
-        tracing::info!("Spawned task to refresh finalized epoch's blocks");
-        refresh_finalized_epoch(
+        tracing::info!("Spawned task to refresh the latest finalized block");
+        refresh_finalized_block(
             &client_clone,
-            &untrusted_rpc_client,
-            finalized_epoch_send.clone(),
+            finalized_block_send.clone(),
             eth.refresh_finalized_interval,
         )
         .await
         .unwrap_or_else(|err| {
-            tracing::warn!("Failed to refresh finalized epoch: {:?}", err);
+            tracing::warn!("Failed to refresh latest finalized block: {:?}", err);
         });
     });
 
     let near_account_id_clone = node_near_account_id.clone();
+    let client_clone = Arc::clone(&client);
     tokio::spawn(async move {
         tracing::info!("Spawned task to send indexed requests to send queue");
         send_requests_when_final(
+            &client_clone,
             requests_indexed_recv,
-            finalized_epoch_recv,
+            finalized_block_recv,
             sign_tx.clone(),
             near_account_id_clone.clone(),
         )
@@ -638,6 +605,47 @@ async fn add_failed_block(
 }
 
 // retry getting latest finalized block from helios with exponential backoff
+async fn fetch_block_by_number(
+    helios_client: &Arc<EthereumClient>,
+    block_number: u64,
+    max_retries: u8,
+    base_delay: Duration,
+) -> anyhow::Result<alloy::rpc::types::Block> {
+    let mut retries = 0;
+    loop {
+        match helios_client
+            .get_block(
+                BlockId::Number(BlockNumberOrTag::Number(block_number)),
+                false,
+            )
+            .await
+        {
+            Ok(Some(block)) => return Ok(block),
+            Ok(None) => {
+                let err_msg = "Block number {block_number} not found from Helios client";
+                return Err(anyhow::anyhow!(err_msg));
+            }
+            Err(e) => {
+                if retries < max_retries {
+                    retries += 1;
+                    let delay = base_delay * 2u32.pow((retries - 1) as u32);
+                    tracing::warn!(
+                        "Failed to fetch block number {block_number} from Helios client: {:?}, retrying",
+                        e
+                    );
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+                return Err(anyhow::anyhow!(
+                    "Failed to fetch block number {block_number} from Helios client: {:?}, exceeded maximum retry",
+                    e
+                ));
+            }
+        }
+    }
+}
+
+// retry getting latest finalized block from helios with exponential backoff
 async fn fetch_finalized_block_from_helio(
     helios_client: &Arc<EthereumClient>,
     max_retries: u8,
@@ -674,20 +682,15 @@ async fn fetch_finalized_block_from_helio(
     }
 }
 
-/// Polls for the latest finalized block and update the latest finalized blocks.
-/// Once finalized block gets updated, we fetch the blocks in the epoch ending with the finalized block.
-/// To ensure the blocks we fetched are proven, we fetch the latest finalized block from Helios.
-/// Then using an unstrusted RPC client, we go backwards to fetch the blocks in the epoch and check that the hash of the block's header == its next block's parent_hash.
-/// This is proven because the finalized block is already proven by helios, and by checking current block hash == next block's parent hash, we prove that each block is indeed included in the chain.
-async fn refresh_finalized_epoch(
+/// Polls for the latest finalized block and update finalized block channel.
+async fn refresh_finalized_block(
     helios_client: &Arc<EthereumClient>,
-    untrusted_rpc_client: &UntrustedRpcClient,
-    finalized_epoch_send: mpsc::Sender<FinalizedEpoch>,
+    finalized_block_send: mpsc::Sender<u64>,
     refresh_finalized_interval: u64,
 ) -> anyhow::Result<()> {
     let mut interval = tokio::time::interval(Duration::from_millis(refresh_finalized_interval));
-    let mut finalized_blocks: BlockNumberToHashMap = BlockNumberToHashMap::new();
     let mut final_block_number: Option<u64> = None;
+
     loop {
         interval.tick().await;
         tracing::info!("Refreshing finalized epoch");
@@ -702,17 +705,18 @@ async fn refresh_finalized_epoch(
                     continue;
                 }
             };
-        tracing::info!(
-            "New finalized block number: {}, last finalized block number: {:?}",
-            new_finalized_block.header.number,
-            final_block_number
-        );
 
         let new_final_block_number = new_finalized_block.header.number;
+        tracing::info!(
+            "New finalized block number: {}, last finalized block number: {:?}",
+            new_final_block_number,
+            final_block_number
+        );
 
         let Some(last_final_block_number) = final_block_number else {
             tracing::info!("Last finalized block was None");
             final_block_number.replace(new_final_block_number);
+            send_finalized_block(&finalized_block_send, new_final_block_number).await?;
             continue;
         };
 
@@ -729,109 +733,20 @@ async fn refresh_finalized_epoch(
         }
 
         tracing::info!("Found new finalized block!");
-        finalized_blocks.clear();
-        finalized_blocks.insert(new_final_block_number, new_finalized_block.header.hash);
-
-        let mut parent_hash = new_finalized_block.header.inner.parent_hash;
-
-        let Some(start) = last_final_block_number.checked_add(1) else {
-            tracing::warn!("Last finalized block number + 1 overflowed range of u64!");
-            continue;
-        };
-        let Some(end) = new_final_block_number.checked_sub(1) else {
-            tracing::warn!("New finalized block number - 1 overflowed range of u64!");
-            continue;
-        };
-
-        let mut epoch_update_err = false;
-        // go backwards from latest_finalized_block_number - 1, and check that each block's hash == next block's parent hash
-        for i in (start..=end).rev() {
-            tracing::info!("Fetching block {i} from untrusted RPC client");
-
-            let cur_block = match fetch_block_from_untrusted_rpc(
-                untrusted_rpc_client,
-                i,
-                5,
-                Duration::from_millis(200),
-            )
-            .await
-            {
-                Ok(block) => block,
-                Err(e) => {
-                    tracing::warn!("Failed to fetch finalized block {i}: {:?}", e);
-                    break;
-                }
-            };
-
-            let cur_block_hash = cur_block.header.hash_slow();
-
-            if cur_block_hash == parent_hash {
-                finalized_blocks.insert(i, cur_block_hash);
-                parent_hash = cur_block.header.inner.parent_hash;
-            } else {
-                tracing::warn!(
-                    "Block {i} hash mismatch: expected {}, got {}, untrusted RPC returned invalid block",
-                    parent_hash,
-                    cur_block_hash
-                );
-                epoch_update_err = true;
-                break;
-            }
-        }
-        if epoch_update_err {
-            tracing::warn!("Finalized epoch update failed on some blocks, retrying");
-            continue;
-        }
         final_block_number.replace(new_final_block_number);
-        tracing::info!("Sending finalized blocks to finalized epoch");
-        let finalized_epoch = FinalizedEpoch {
-            start_block: start,
-            end_block: end,
-            blocks: finalized_blocks.clone(),
-        };
-        finalized_epoch_send
-            .send(finalized_epoch)
-            .await
-            .map_err(|err| anyhow!("Failed to send finalized block: {:?}", err))?;
+        send_finalized_block(&finalized_block_send, new_final_block_number).await?;
     }
 }
 
-// retry getting block by number from untrusted rpc with exponential backoff
-async fn fetch_block_from_untrusted_rpc(
-    untrusted_rpc_client: &UntrustedRpcClient,
+// Helper function to send finalized block and handle errors
+async fn send_finalized_block(
+    finalized_block_send: &mpsc::Sender<u64>,
     block_number: u64,
-    max_retries: u8,
-    base_delay: Duration,
-) -> anyhow::Result<alloy::rpc::types::Block> {
-    let mut retries = 0;
-    loop {
-        match untrusted_rpc_client
-            .get_block_by_number(alloy::eips::BlockNumberOrTag::Number(block_number))
-            .await
-        {
-            Ok(Some(block)) => return Ok(block),
-            Ok(None) => {
-                let err_msg = format!("Block {block_number} not found from untrusted RPC client");
-                return Err(anyhow::anyhow!(err_msg));
-            }
-            Err(e) => {
-                if retries < max_retries {
-                    retries += 1;
-                    let delay = base_delay * 2u32.pow((retries - 1) as u32);
-                    tracing::warn!(
-                        "Failed to get block {block_number} from untrusted RPC client: {:?}, retrying",
-                        e
-                    );
-                    tokio::time::sleep(delay).await;
-                    continue;
-                }
-                return Err(anyhow::anyhow!(
-                    "Failed to get block {block_number} from untrusted RPC client: {:?}, exceeded maximum retry",
-                    e
-                ));
-            }
-        }
-    }
+) -> anyhow::Result<()> {
+    finalized_block_send
+        .send(block_number)
+        .await
+        .map_err(|err| anyhow!("Failed to send finalized block: {:?}", err))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -923,13 +838,16 @@ async fn process_block(
 /// This assumes that the requests_indexed are mostly ordered by block number, with occasional retried blocks that can go farthest 2 finalized epochs back.
 /// Whenever there are requests in requests_indexed, function will keep polling if the block where the first request is in has finalized, if finalized, it will send this request to the sign queue.
 async fn send_requests_when_final(
+    helios_client: &Arc<EthereumClient>,
     mut requests_indexed: mpsc::Receiver<BlockAndRequests>,
-    mut finalized_epoch_rx: mpsc::Receiver<FinalizedEpoch>,
+    mut finalized_block_rx: mpsc::Receiver<u64>,
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     node_near_account_id: AccountId,
 ) -> anyhow::Result<()> {
     // We keep the last 2 finalized epochs to handle retried blocks that happen to be older
-    let mut finalized_epochs: Vec<FinalizedEpoch> = Vec::new();
+
+    let mut finalized_block_number: Option<u64> = None;
+    // the logic with 8k blocks can be: for each received indexed block, check if it's <= current finalized block. If so, check that its block hash == the block hash from helios, if so, send;else, err.
     loop {
         while let Some(BlockAndRequests {
             block_number,
@@ -939,67 +857,60 @@ async fn send_requests_when_final(
         {
             loop {
                 // Check if block is in any of the finalized epochs
-                let mut block_found = false;
-                for epoch in &finalized_epochs {
-                    if let Some(finalized_block_hash) = epoch.blocks.get(&block_number) {
-                        block_found = true;
-                        if *finalized_block_hash == block_hash {
-                            tracing::info!("Block {block_number} is finalized!");
-                            send_indexed_requests(
-                                indexed_requests.clone(),
-                                sign_tx.clone(),
-                                node_near_account_id.clone(),
-                            );
-                            break;
-                        } else {
-                            tracing::error!(
-                                "Block {block_number} hash mismatch: expected {block_hash:?}, got {finalized_block_hash:?}. Chain re-orged."
-                            );
-                            //TODO: handle the block reorg case
-                            break;
+                let Some(last_finalized_block_number) = finalized_block_number else {
+                    tracing::info!("Last finalized block was None");
+                    // Wait for new finalized block
+                    let Some(new_finalized_block) = finalized_block_rx.recv().await else {
+                        tracing::warn!("Failed to receive finalized blocks");
+                        return Err(anyhow::anyhow!("Failed to receive finalized blocks"));
+                    };
+                    finalized_block_number.replace(new_finalized_block);
+                    continue;
+                };
+
+                if block_number <= last_finalized_block_number {
+                    let block = match fetch_block_by_number(
+                        helios_client,
+                        block_number,
+                        5,
+                        Duration::from_millis(200),
+                    )
+                    .await
+                    {
+                        Ok(block) => block,
+                        Err(e) => {
+                            tracing::warn!("Failed to fetch block {block_number}: {:?}", e);
+                            tokio::time::sleep(Duration::from_millis(500)).await;
+                            continue;
                         }
-                    }
-                }
+                    };
 
-                if block_found {
+                    let cur_block_hash = block.header.hash_slow();
+                    if cur_block_hash == block_hash {
+                        tracing::info!("Block {block_number} is finalized!");
+                        send_indexed_requests(
+                            indexed_requests.clone(),
+                            sign_tx.clone(),
+                            node_near_account_id.clone(),
+                        );
+                    } else {
+                        tracing::error!(
+                            "Block {block_number} hash mismatch: expected {block_hash:?}, got {cur_block_hash:?}. Chain re-orged."
+                        );
+                    }
                     break;
+                } else {
+                    tracing::warn!(
+                        "Block number {block_number} with hash: {block_hash:?} not finalized. "
+                    );
                 }
 
-                tracing::warn!(
-                    "Block number {block_number} with hash: {block_hash:?} not in finalized epochs. "
-                );
-
-                // Check if block is in history (older than our oldest epoch)
-                if !finalized_epochs.is_empty() {
-                    let oldest_epoch = &finalized_epochs[0];
-                    if block_number < oldest_epoch.start_block {
-                        tracing::error!("Block {block_number} is in history");
-                        //TODO: handle the block in history case which happens when a block is retried
-                        break;
-                    }
-                }
-
-                // Wait for new finalized epoch
-                let Some(received_epoch) = finalized_epoch_rx.recv().await else {
+                // Wait for new finalized block
+                let Some(new_finalized_block) = finalized_block_rx.recv().await else {
                     tracing::warn!("Failed to receive finalized blocks");
                     return Err(anyhow::anyhow!("Failed to receive finalized blocks"));
                 };
-
-                let start_block = received_epoch.start_block;
-                let end_block = received_epoch.end_block;
-                let blocks = received_epoch.blocks;
-
-                let new_epoch = FinalizedEpoch {
-                    start_block,
-                    end_block,
-                    blocks,
-                };
-
-                // Update epochs list, keeping only the last 2
-                finalized_epochs.push(new_epoch);
-                if finalized_epochs.len() > 2 {
-                    finalized_epochs.remove(0);
-                }
+                finalized_block_number.replace(new_finalized_block);
             }
         }
     }


### PR DESCRIPTION
Changes involved:
1. the finalized_block_channel only save the latest finalized block number
2. in send_requests_when_final, once the request's block number <= finalized block number, and its block hash == block hash from helios, we send the request to sign queue