### PR TITLE
feat: make MessageInbox/Outbox fully async

### DIFF
--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -293,7 +293,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let node = Node::new();
             let node_watcher = node.watch();
 
-            let (sender, msg_channel) = MessageChannel::spawn(
+            let msg_channel = MessageChannel::spawn(
                 client,
                 &account_id,
                 config_rx.clone(),
@@ -305,7 +305,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 my_account_id: account_id.clone(),
                 near: near_client,
                 rpc_channel,
-                msg_channel,
+                msg_channel: msg_channel.clone(),
                 sign_rx: Arc::new(RwLock::new(sign_rx)),
                 secret_storage: key_storage,
                 triple_storage: triple_storage.clone(),
@@ -324,7 +324,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             tracing::info!("protocol thread spawned");
             let web_handle = tokio::spawn(web::run(
                 web_port,
-                sender,
+                msg_channel,
                 node_watcher,
                 indexer,
                 triple_storage,

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -306,6 +306,8 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 near: near_client,
                 rpc_channel,
                 msg_channel: msg_channel.clone(),
+                generating: msg_channel.subscribe_generation().await,
+                resharing: msg_channel.subscribe_resharing().await,
                 sign_rx: Arc::new(RwLock::new(sign_rx)),
                 secret_storage: key_storage,
                 triple_storage: triple_storage.clone(),

--- a/chain-signatures/node/src/config.rs
+++ b/chain-signatures/node/src/config.rs
@@ -5,6 +5,7 @@ use mpc_contract::config::ProtocolConfig;
 use mpc_keys::hpke;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tokio::sync::watch;
 
 /// The contract's config is a dynamic representation of all configurations possible.
 pub type ContractConfig = HashMap<String, Value>;
@@ -16,6 +17,15 @@ pub struct Config {
 }
 
 impl Config {
+    pub fn channel(local: LocalConfig) -> (watch::Sender<Self>, watch::Receiver<Self>) {
+        let config = Self::new(local);
+        watch::channel(config)
+    }
+
+    pub fn channel_default() -> (watch::Sender<Self>, watch::Receiver<Self>) {
+        Self::channel(LocalConfig::default())
+    }
+
     pub fn new(local: LocalConfig) -> Self {
         let mut protocol = ProtocolConfig::default();
 

--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -170,15 +170,6 @@ pub(crate) static NUM_PRESIGNATURE_GENERATORS_TOTAL: LazyLock<IntGaugeVec> = Laz
     .unwrap()
 });
 
-pub(crate) static MESSAGE_QUEUE_SIZE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
-    try_create_int_gauge_vec(
-        "multichain_message_queue_size",
-        "size of message queue of the node",
-        &["node_account_id"],
-    )
-    .unwrap()
-});
-
 pub(crate) static NODE_VERSION: LazyLock<IntGaugeVec> = LazyLock::new(|| {
     try_create_int_gauge_vec(
         "multichain_node_version",

--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -297,16 +297,6 @@ pub(crate) static PROTOCOL_LATENCY_ITER_CONSENSUS: LazyLock<HistogramVec> = Lazy
     .unwrap()
 });
 
-pub(crate) static PROTOCOL_LATENCY_ITER_MESSAGE: LazyLock<HistogramVec> = LazyLock::new(|| {
-    try_create_histogram_vec(
-        "multichain_protocol_iter_message",
-        "Latency of multichain protocol iter, start of message iter till end",
-        &["node_account_id"],
-        Some(exponential_buckets(0.001, 2.0, 20).unwrap()),
-    )
-    .unwrap()
-});
-
 pub(crate) static NUM_SEND_ENCRYPTED_FAILURE: LazyLock<CounterVec> = LazyLock::new(|| {
     try_create_counter_vec(
         "multichain_send_encrypted_failure",

--- a/chain-signatures/node/src/node_client.rs
+++ b/chain-signatures/node/src/node_client.rs
@@ -7,8 +7,6 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::str::Utf8Error;
 use std::time::Duration;
-use tokio_retry::strategy::{jitter, ExponentialBackoff};
-use tokio_retry::Retry;
 use url::Url;
 
 #[derive(Debug, Clone, clap::Parser)]
@@ -121,9 +119,7 @@ impl NodeClient {
     pub async fn msg(&self, base: impl IntoUrl, msg: &[&Ciphered]) -> Result<(), RequestError> {
         let mut url = base.into_url()?;
         url.set_path("msg");
-
-        let strategy = ExponentialBackoff::from_millis(10).map(jitter).take(3);
-        Retry::spawn(strategy, || self.post_msg(&url, msg)).await
+        self.post_msg(&url, msg).await
     }
 
     pub async fn msg_empty(&self, base: impl IntoUrl) -> Result<(), RequestError> {

--- a/chain-signatures/node/src/protocol/message/filter.rs
+++ b/chain-signatures/node/src/protocol/message/filter.rs
@@ -31,12 +31,6 @@ impl MessageFilter {
         self.filter.get(&(M::PROTOCOL, msg.id())).is_some()
     }
 
-    pub fn contains_id(&mut self, id: u64, protocol: Protocols) -> bool {
-        // Check if the message is already in the filter. Doing `get` here will also
-        // update the LRU cache and promote the rank of this id to be most recent.
-        self.filter.get(&(protocol, id)).is_some()
-    }
-
     pub async fn update(&mut self) {
         let Some((msg_type, id)) = self.filter_rx.recv().await else {
             return;

--- a/chain-signatures/node/src/protocol/message/sub.rs
+++ b/chain-signatures/node/src/protocol/message/sub.rs
@@ -1,0 +1,120 @@
+use cait_sith::protocol::Participant;
+use mpc_primitives::SignId;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::protocol::message::{
+    GeneratingMessage, PresignatureMessage, ResharingMessage, SignatureMessage, TripleMessage,
+};
+use crate::protocol::posit::PositAction;
+use crate::protocol::presignature::{FullPresignatureId, PresignatureId};
+use crate::protocol::triple::TripleId;
+
+/// This should be enough to hold a few messages in the inbox.
+pub const MAX_MESSAGE_SUB_CHANNEL_SIZE: usize = 4 * 1024;
+
+pub enum SubscribeId {
+    Generating,
+    Resharing,
+    Triples,
+    Presignatures,
+    Signatures,
+    Triple(TripleId),
+    Presignature(PresignatureId),
+    Signature(SignId, PresignatureId),
+}
+
+pub enum SubscribeResponse {
+    Generating(mpsc::Receiver<GeneratingMessage>),
+    Resharing(mpsc::Receiver<ResharingMessage>),
+    Triple(mpsc::Receiver<TripleMessage>),
+    TriplePosit(mpsc::Receiver<(TripleId, Participant, PositAction)>),
+    Presignature(mpsc::Receiver<PresignatureMessage>),
+    PresignaturePosit(mpsc::Receiver<(FullPresignatureId, Participant, PositAction)>),
+    Signature(mpsc::Receiver<SignatureMessage>),
+    SignaturePosit(mpsc::Receiver<(SignId, PresignatureId, Participant, PositAction)>),
+}
+
+pub enum SubscribeRequestAction {
+    Subscribe(oneshot::Sender<SubscribeResponse>),
+    Unsubscribe,
+}
+
+pub struct SubscribeRequest {
+    pub id: SubscribeId,
+    pub action: SubscribeRequestAction,
+}
+
+impl SubscribeRequest {
+    pub fn subscribe(id: SubscribeId) -> (Self, oneshot::Receiver<SubscribeResponse>) {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        (
+            Self {
+                id,
+                action: SubscribeRequestAction::Subscribe(resp_tx),
+            },
+            resp_rx,
+        )
+    }
+
+    pub fn unsubscribe(id: SubscribeId) -> Self {
+        Self {
+            id,
+            action: SubscribeRequestAction::Unsubscribe,
+        }
+    }
+}
+
+pub enum Subscriber<T> {
+    /// Temporary/replaceable value, and will never be used. Only here so we can have a
+    /// way to convert from an Unsubscribed to a Subscribed subscription.
+    Unknown,
+    /// A subscribed channel where the subscriber has a handle to the receiver.
+    Subscribed(mpsc::Sender<T>),
+    /// An unsubscribed channel where there's potentially messages that have yet to be sent.
+    Unsubscribed(mpsc::Sender<T>, mpsc::Receiver<T>),
+}
+
+impl<T> Subscriber<T> {
+    pub fn subscribed() -> (Self, mpsc::Receiver<T>) {
+        let (tx, rx) = mpsc::channel(MAX_MESSAGE_SUB_CHANNEL_SIZE);
+        (Self::Subscribed(tx), rx)
+    }
+
+    pub fn unsubscribed() -> Self {
+        let (tx, rx) = mpsc::channel(MAX_MESSAGE_SUB_CHANNEL_SIZE);
+        Self::Unsubscribed(tx, rx)
+    }
+
+    /// Convert this subscriber into a subscribed one, returning the receiver.
+    /// If the subscriber is already subscribed, it overrides the existing subscription.
+    pub fn subscribe(&mut self) -> mpsc::Receiver<T> {
+        let sub = std::mem::replace(self, Self::Unknown);
+        let (sub, rx) = match sub {
+            Self::Subscribed(_) | Self::Unknown => Self::subscribed(),
+            Self::Unsubscribed(tx, rx) => (Self::Subscribed(tx), rx),
+        };
+        *self = sub;
+        rx
+    }
+
+    /// Unsubscribe from the subscriber, converting it into an unsubscribed one.
+    pub fn unsubscribe(&mut self) {
+        if matches!(self, Self::Subscribed(_) | Self::Unknown) {
+            *self = Self::unsubscribed();
+        }
+    }
+
+    pub async fn send(&self, msg: T) -> Result<(), mpsc::error::SendError<T>> {
+        match self {
+            Self::Subscribed(tx) => tx.send(msg).await,
+            Self::Unsubscribed(tx, _) => tx.send(msg).await,
+            Self::Unknown => Ok(()),
+        }
+    }
+}
+
+impl<T> Default for Subscriber<T> {
+    fn default() -> Self {
+        Self::unsubscribed()
+    }
+}

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -22,7 +22,7 @@ use crate::config::Config;
 use crate::mesh::MeshState;
 use crate::protocol::consensus::ConsensusProtocol;
 use crate::protocol::cryptography::CryptographicProtocol;
-use crate::protocol::message::MessageReceiver as _;
+use crate::protocol::message::{GeneratingMessage, MessageReceiver as _, ResharingMessage};
 use crate::rpc::{ContractStateWatcher, NearClient, RpcChannel};
 use crate::storage::presignature_storage::PresignatureStorage;
 use crate::storage::secret_storage::SecretNodeStorageBox;
@@ -45,6 +45,8 @@ pub struct MpcSignProtocol {
     pub(crate) triple_storage: TripleStorage,
     pub(crate) presignature_storage: PresignatureStorage,
     pub(crate) sign_rx: Arc<RwLock<mpsc::Receiver<IndexedSignRequest>>>,
+    // pub(crate) generating: mpsc::Receiver<GeneratingMessage>,
+    // pub(crate) resharing: mpsc::Receiver<ResharingMessage>,
     pub(crate) msg_channel: MessageChannel,
     pub(crate) rpc_channel: RpcChannel,
     pub(crate) config: watch::Receiver<Config>,

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -1,7 +1,8 @@
 use crate::config::{Config, ContractConfig, NetworkConfig};
 use crate::indexer_eth::EthConfig;
 use crate::indexer_sol::SolConfig;
-use crate::protocol::contract::primitives::ParticipantMap;
+use crate::protocol::contract::primitives::{ParticipantMap, Participants};
+use crate::protocol::contract::RunningContractState;
 use crate::protocol::signature::SignRequest;
 use crate::protocol::{Chain, ProtocolState};
 use crate::util::AffinePointExt as _;
@@ -15,7 +16,7 @@ use alloy::providers::{Provider, RootProvider};
 use alloy::rpc::types::TransactionReceipt;
 use cait_sith::protocol::Participant;
 use cait_sith::FullSignature;
-use k256::Secp256k1;
+use k256::{AffinePoint, Secp256k1};
 use mpc_keys::hpke;
 use mpc_primitives::SignId;
 use mpc_primitives::Signature;
@@ -145,6 +146,26 @@ impl ContractStateWatcher {
                 contract_state: rx,
             },
             tx,
+        )
+    }
+
+    pub fn with_running(
+        node_id: &AccountId,
+        public_key: AffinePoint,
+        threshold: usize,
+        participants: Participants,
+    ) -> (Self, watch::Sender<Option<ProtocolState>>) {
+        Self::with(
+            node_id,
+            ProtocolState::Running(RunningContractState {
+                epoch: 0,
+                public_key,
+                participants,
+                candidates: Default::default(),
+                join_votes: Default::default(),
+                leave_votes: Default::default(),
+                threshold,
+            }),
         )
     }
 

--- a/chain-signatures/node/src/web/error.rs
+++ b/chain-signatures/node/src/web/error.rs
@@ -18,8 +18,6 @@ pub enum Error {
     Message(#[from] MessageError),
     #[error(transparent)]
     Rpc(#[from] near_fetch::Error),
-    #[error("internal error: {0}")]
-    Internal(&'static str),
 }
 
 impl Error {
@@ -29,7 +27,6 @@ impl Error {
             Error::Cryptography(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::Message(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::Rpc(_) => StatusCode::BAD_REQUEST,
-            Error::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -4,6 +4,7 @@ use self::error::Error;
 use crate::indexer::NearIndexer;
 use crate::protocol::state::{NodeStateWatcher, NodeStatus};
 use crate::protocol::sync::{SyncChannel, SyncUpdate};
+use crate::protocol::MessageChannel;
 use crate::storage::{PresignatureStorage, TripleStorage};
 use crate::web::error::Result;
 
@@ -18,20 +19,19 @@ use near_primitives::types::BlockHeight;
 use prometheus::{Encoder, TextEncoder};
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, sync::Arc};
-use tokio::sync::mpsc::Sender;
 
 struct AxumState {
-    sender: Sender<Ciphered>,
     node: NodeStateWatcher,
     indexer: Option<NearIndexer>,
     triple_storage: TripleStorage,
     presignature_storage: PresignatureStorage,
     sync_channel: SyncChannel,
+    msg_channel: MessageChannel,
 }
 
 pub async fn run(
     port: u16,
-    sender: Sender<Ciphered>,
+    msg_channel: MessageChannel,
     node: NodeStateWatcher,
     indexer: Option<NearIndexer>,
     triple_storage: TripleStorage,
@@ -40,7 +40,7 @@ pub async fn run(
 ) {
     tracing::info!("starting web server");
     let axum_state = AxumState {
-        sender,
+        msg_channel,
         node,
         indexer,
         triple_storage,
@@ -82,7 +82,7 @@ async fn msg(
     WithRejection(Json(encrypted), _): WithRejection<Json<Vec<Ciphered>>, Error>,
 ) -> Result<()> {
     for encrypted in encrypted.into_iter() {
-        if let Err(err) = state.sender.send(encrypted).await {
+        if let Err(err) = state.msg_channel.inbox_tx.send(encrypted).await {
             tracing::error!(?err, "failed to forward an encrypted protocol message");
             return Err(Error::Internal(
                 "failed to forward an encrypted protocol message",

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -82,7 +82,7 @@ async fn msg(
     WithRejection(Json(encrypted), _): WithRejection<Json<Vec<Ciphered>>, Error>,
 ) -> Result<()> {
     for encrypted in encrypted.into_iter() {
-        if let Err(err) = state.msg_channel.inbox_tx.send(encrypted).await {
+        if let Err(err) = state.msg_channel.inbox.send(encrypted).await {
             tracing::error!(?err, "failed to forward an encrypted protocol message");
             return Err(Error::Internal(
                 "failed to forward an encrypted protocol message",

--- a/integration-tests/tests/cases/store.rs
+++ b/integration-tests/tests/cases/store.rs
@@ -21,7 +21,7 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
 
     let node0 = Participant::from(0);
     let node1 = Participant::from(1);
-    let (_, msg, _inbox) = MessageChannel::new();
+    let (_, _, msg) = MessageChannel::new();
     let node0_id = "party0.near".parse().unwrap();
     let redis = containers::Redis::run(&spawner).await;
     let triple_storage = redis.triple_storage(&node0_id);
@@ -170,7 +170,7 @@ async fn test_presignature_persistence() -> anyhow::Result<()> {
 
     let node0 = Participant::from(0);
     let node1 = Participant::from(1);
-    let (_, msg, _inbox) = MessageChannel::new();
+    let (_, _, msg) = MessageChannel::new();
     let node0_id = "party0.near".parse().unwrap();
     let redis = containers::Redis::run(&spawner).await;
     let triple_storage = redis.triple_storage(&node0_id);

--- a/integration-tests/tests/cases/store.rs
+++ b/integration-tests/tests/cases/store.rs
@@ -21,7 +21,7 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
 
     let node0 = Participant::from(0);
     let node1 = Participant::from(1);
-    let (_, _, msg) = MessageChannel::new();
+    let (_, msg, _inbox) = MessageChannel::new();
     let node0_id = "party0.near".parse().unwrap();
     let redis = containers::Redis::run(&spawner).await;
     let triple_storage = redis.triple_storage(&node0_id);
@@ -170,7 +170,7 @@ async fn test_presignature_persistence() -> anyhow::Result<()> {
 
     let node0 = Participant::from(0);
     let node1 = Participant::from(1);
-    let (_, _, msg) = MessageChannel::new();
+    let (_, msg, _inbox) = MessageChannel::new();
     let node0_id = "party0.near".parse().unwrap();
     let redis = containers::Redis::run(&spawner).await;
     let triple_storage = redis.triple_storage(&node0_id);


### PR DESCRIPTION
This change makes it so that the message inbox and outbox are completely async. Triples, Presignatures, and Signature when subscribing for messages stays the same. Generating and Resharing states now get their messages within their `Action::Wait` step, where there's a global subscriber/receiver for generating and resharing messages in the `MpcSignProtocol`. When we make generating and resharing more async (as in their own task), then we can move these subscribers there. Until then, they'll stay in the global context of the node.

- No more `MessageReceiver` interface.
- No more `MessageExecutor` (replaced by `MessageInbox` and `MessageOutbox` individual tasks).
- PROTOCOL_LATENCY_ITER_MESSAGE is no longer used since message is now no longer a part of state machine.
- MESSAGE_QUEUE_SIZE was also removed since there's no more outgoing message queue.

Overall this PR makes messaging more robust, with no lock on the inbox. The inbox and outbox will not interfere with each other when receiving and sending messages, since there are no dependencies on each other. Our protocols should see a slight speed up