### PR TITLE
eth indexer: run catchup first so last processed block is accurate

### DIFF
--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -732,7 +732,7 @@ async fn add_catchup_blocks_to_process(
     end_block_number: u64,
 ) {
     // helios can only go back maximum MAX_CATCHUP_BLOCKS blocks, so we need to adjust the start block number if it's too far behind
-    let helios_oldest_block_number = end_block_number - MAX_CATCHUP_BLOCKS;
+    let helios_oldest_block_number = end_block_number.saturating_sub(MAX_CATCHUP_BLOCKS);
     let start_block_number = if start_block_number < helios_oldest_block_number {
         tracing::warn!(
             "Start block number {start_block_number} is too far behind the latest block {end_block_number}, adjusting to {helios_oldest_block_number}"

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -1000,6 +1000,7 @@ async fn try_batch_publish_eth(
     let tx_hash =
         send_eth_transaction(&eth.contract, &params, gas, &sign_ids, near_account_id).await?;
 
+    tracing::info!(?tx_hash, "sent eth tx");
     let receipt = wait_for_transaction_receipt(
         eth.contract.provider(),
         tx_hash,
@@ -1102,6 +1103,8 @@ async fn execute_batch_publish(
             actions.clear();
             break;
         }
+
+        tracing::warn!("batch publish failed, {publish:?}");
 
         retry_count += 1;
         tokio::time::sleep(Duration::from_millis(100)).await;


### PR DESCRIPTION
We still want to run catchup first because otherwise the last processed block will be confusing.
in this pr, we send catchup blocks and the blocks from block_heads_rx to a channel to make sure they come in order. And the main loop will consume blocks to process from this channel.