### PR TITLE
feat: make MessageOutbox send on all participants

### DIFF
--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -298,7 +298,6 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 &account_id,
                 config_rx.clone(),
                 contract_watcher.clone(),
-                mesh_state.clone(),
             )
             .await;
             let protocol = MpcSignProtocol {

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -190,8 +190,16 @@ impl ContractStateWatcher {
         self.contract_state.mark_changed();
     }
 
+    pub fn participants(&self) -> Option<Participants> {
+        match self.borrow_state().as_ref()? {
+            ProtocolState::Initializing(state) => Some(state.candidates.clone().into()),
+            ProtocolState::Running(state) => Some(state.participants.clone()),
+            ProtocolState::Resharing(state) => Some(state.new_participants.clone()),
+        }
+    }
+
     pub async fn me(&self) -> Option<Participant> {
-        match self.state().clone()? {
+        match self.borrow_state().as_ref()? {
             ProtocolState::Initializing(_) => None,
             ProtocolState::Running(state) => state
                 .participants
@@ -226,7 +234,7 @@ impl ContractStateWatcher {
         }
     }
 
-    pub async fn participants(&self) -> ParticipantMap {
+    pub async fn participant_map(&self) -> ParticipantMap {
         let Some(state) = self.state().clone() else {
             return ParticipantMap::Zero;
         };


### PR DESCRIPTION
This makes it so that the message outbox no longer looks for active participants but looks for all participants. This is because only the protocols should be saying whether they want active/stable or what other metric. The job of the outbox is to just send, so we should use all participants.

This also makes it so that each message send is its own task, so we don't block the outbox from continuing. This supercedes https://github.com/sig-net/mpc/pull/171 since I cannot be bothered to resolve merge conflicts there