### PR TITLE
Bidirectional communication diagram

### DIFF
--- a/doc/bidirectional_communication.plantuml
+++ b/doc/bidirectional_communication.plantuml
@@ -1,0 +1,29 @@
+@startuml Sig.Network Bidirectional Communication (Solana <-> Ethereum)
+!theme amiga
+actor Browser
+participant "USDT Contract\non Ethereum" as USDT
+participant "DEX Program\non Solana" as DEX
+participant "Signing Contract\non Solana" as SignContract
+participant "MPC Network" as MPC
+
+Browser -> Browser: Derive user Ethereum DEX USDT \ndeposit address from main address
+Browser -> USDT: Deposit 10 USDT on user address
+
+Browser -> Browser: Build and save Ethereum tx to transfer USDT \nfrom user to main DEX address
+Browser -> DEX: Call **claim_fund(offchain_parameters)**
+
+DEX -> SignContract: Build same tx and call **sign_respond(tx_hash)**
+
+SignContract -> MPC: Request signature
+MPC -> MPC: Sign tx hash with User key \n(sender is DEX, path is user address) \nStore tx ID (hash + signature)
+MPC -> SignContract: Return signature
+SignContract -> Browser: Return signature
+Browser -> USDT: Execute saved transaction
+USDT --> MPC: Notify tx executed (using MPC Ethereum indexer)
+
+MPC -> MPC: Buld DEX.read_respond() transaction
+MPC -> MPC: Request signature for DEX.read_respond() \nwith DEX key (sender is DEX, path is "")
+MPC -> DEX: Call **read_respond(tx_output)**
+
+DEX -> Browser: Success
+@enduml


### PR DESCRIPTION
<img width="1245" height="739" alt="image" src="https://github.com/user-attachments/assets/0abf2a75-2845-4c47-b3db-1d3770ce3af4" />



Updates/proposals:
- Now we are not moving the deposit transaction on-chain, since it can be created on both the Client and Contract sides
- Now `DEX's read_respond()` only accepts calls from MPC DEX address, no need to sign the payload itself
- DEX.read_respond(`tx_output`) can be DEX.read_respond(`tx_output_hash`), but it will require DEX to run their indexer and provide the output, which will use even more gas. cc @DavidM-D

Questions:
- Why do we store both hash and signature? What is the vector of attack here?

Note:
- @DavidM-D actually, we have 3 options, `DEX.read_responce()` can be called by MPC admin, MPC DEX key, or MPC DEX User key. But I still think that the MPC DEX key is the best option since handling cases where the user is out of funds would be harder.

@Pessina @esaminu , please check these updates. I still need to compare this to our latest POC .