### PR TITLE
fix: stockpiling not working due introduction

### DIFF
--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -380,7 +380,9 @@ impl PresignatureSpawner {
 
         match internal_action {
             PositInternalAction::None => {}
-            PositInternalAction::Abort => {}
+            PositInternalAction::Abort => {
+                self.introduced.remove(&id.id);
+            }
             PositInternalAction::Reply(action) => {
                 self.msg
                     .send(

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -346,7 +346,9 @@ impl TripleSpawner {
 
         match internal_action {
             PositInternalAction::None => {}
-            PositInternalAction::Abort => {}
+            PositInternalAction::Abort => {
+                self.introduced.remove(&id);
+            }
             PositInternalAction::Reply(action) => {
                 self.msg
                     .send(


### PR DESCRIPTION
This should fix the issue with no mine presignatures. This is because when we abort a protocol, the `introduced` counter never gets resetted and so we end up with no presignatures being generated by that particular node if they've failed enough over time. 