### PR TITLE
fix: wait should timeout instead of checking at beginning of protocol

### DIFF
--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -255,9 +255,6 @@ impl<Id: Copy + Hash + Eq + fmt::Debug, S> Posits<Id, S> {
                     return PositInternalAction::Abort;
                 }
 
-                // TODO: have a timeout on waiting for votes. The moment we have enough threshold accepts,
-                // we can start the protocol after a timeout, such that we don't wait for slow responders.
-                // This will be our way to cleanup the posits that are nowhere to be found.
                 if !counter.meets_totality() {
                     return PositInternalAction::None;
                 }

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -132,7 +132,12 @@ impl PresignatureGenerator {
     /// Receive the next message for the presignature protocol; error out on the timeout being reached
     /// or the channel having been closed (aborted).
     async fn recv(&mut self) -> Option<PresignatureMessage> {
-        match tokio::time::timeout(self.timeout - self.created.elapsed(), self.inbox.recv()).await {
+        match tokio::time::timeout(
+            self.timeout.saturating_sub(self.created.elapsed()),
+            self.inbox.recv(),
+        )
+        .await
+        {
             Ok(Some(msg)) => Some(msg),
             Ok(None) => {
                 tracing::warn!(

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -129,6 +129,30 @@ pub struct PresignatureGenerator {
 }
 
 impl PresignatureGenerator {
+    /// Receive the next message for the presignature protocol; error out on the timeout being reached
+    /// or the channel having been closed (aborted).
+    async fn recv(&mut self) -> Option<PresignatureMessage> {
+        match tokio::time::timeout(self.timeout - self.created.elapsed(), self.inbox.recv()).await {
+            Ok(Some(msg)) => Some(msg),
+            Ok(None) => {
+                tracing::warn!(
+                    id = self.id,
+                    owner = ?self.owner,
+                    "presignature generation aborted",
+                );
+                None
+            }
+            Err(_err) => {
+                tracing::warn!(
+                    id = self.id,
+                    owner = ?self.owner,
+                    "presignature generation timeout",
+                );
+                None
+            }
+        }
+    }
+
     pub async fn run(mut self, my_account_id: &AccountId, me: Participant, epoch: u64) {
         let failure_counts = crate::metrics::PRESIGNATURE_GENERATOR_FAILURES
             .with_label_values(&[my_account_id.as_str()]);
@@ -156,13 +180,6 @@ impl PresignatureGenerator {
         before_first_poke_delay.observe(self.created.elapsed().as_millis() as f64);
 
         loop {
-            let elapsed = self.created.elapsed();
-            if elapsed > self.timeout {
-                failure_counts.inc();
-                tracing::warn!(id = self.id, ?elapsed, "presignature generation timeout");
-                break;
-            }
-
             let poke_start_time = Instant::now();
             let action = match self.protocol.poke() {
                 Ok(action) => action,
@@ -186,7 +203,8 @@ impl PresignatureGenerator {
             match action {
                 Action::Wait => {
                     // Wait for the next set of messages to arrive.
-                    let Some(msg) = self.inbox.recv().await else {
+                    let Some(msg) = self.recv().await else {
+                        failure_counts.inc();
                         break;
                     };
                     self.protocol.message(msg.from, msg.data);
@@ -239,6 +257,7 @@ impl PresignatureGenerator {
                     tracing::info!(
                         id = self.id,
                         ?me,
+                        owner = ?self.owner,
                         big_r = ?output.big_r.to_base58(),
                         elapsed = ?self.created.elapsed(),
                         "completed presignature generation"

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -452,7 +452,12 @@ impl SignatureGenerator {
     async fn recv(&mut self) -> Result<SignatureMessage, SignError> {
         let sign_id = self.request.indexed.id;
         let presignature_id = self.dropper.id;
-        match tokio::time::timeout(self.timeout - self.created.elapsed(), self.inbox.recv()).await {
+        match tokio::time::timeout(
+            self.timeout.saturating_sub(self.created.elapsed()),
+            self.inbox.recv(),
+        )
+        .await
+        {
             Ok(Some(msg)) => Ok(msg),
             Ok(None) => {
                 tracing::warn!(?sign_id, presignature_id, "signature generation aborted");

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -437,10 +437,6 @@ impl SignatureGenerator {
         })
     }
 
-    fn timeout(&self) -> bool {
-        self.created.elapsed() >= self.timeout
-    }
-
     fn timeout_total(&self) -> bool {
         let timestamp = self
             .request
@@ -449,6 +445,28 @@ impl SignatureGenerator {
             .as_ref()
             .unwrap_or(&self.created);
         timestamp.elapsed() >= self.timeout_total
+    }
+
+    /// Receive the next message for the signature protocol; error out on the timeout being reached
+    /// or the channel having been closed (aborted).
+    async fn recv(&mut self) -> Result<SignatureMessage, SignError> {
+        let sign_id = self.request.indexed.id;
+        let presignature_id = self.dropper.id;
+        match tokio::time::timeout(self.timeout - self.created.elapsed(), self.inbox.recv()).await {
+            Ok(Some(msg)) => Ok(msg),
+            Ok(None) => {
+                tracing::warn!(?sign_id, presignature_id, "signature generation aborted");
+                Err(SignError::Aborted)
+            }
+            Err(_err) => {
+                tracing::warn!(
+                    ?sign_id,
+                    presignature_id,
+                    "signature generation timeout, retrying..."
+                );
+                Err(SignError::Retry)
+            }
+        }
     }
 
     async fn run(
@@ -492,18 +510,6 @@ impl SignatureGenerator {
                 break Err(SignError::TotalTimeout);
             }
 
-            if self.timeout() {
-                tracing::warn!(
-                    ?sign_id,
-                    presignature_id,
-                    "signature generation timeout, retrying..."
-                );
-                if self.request.proposer == me {
-                    signature_generator_failures_metric.inc();
-                }
-                break Err(SignError::Retry);
-            }
-
             let poke_start_time = Instant::now();
             let action = match self.protocol.poke() {
                 Ok(action) => action,
@@ -525,9 +531,11 @@ impl SignatureGenerator {
             match action {
                 Action::Wait => {
                     // Wait for the next set of messages to arrive.
-                    let Some(msg) = self.inbox.recv().await else {
-                        break Err(SignError::Aborted);
-                    };
+                    let msg = self.recv().await.inspect_err(|_| {
+                        if self.request.proposer == me {
+                            signature_generator_failures_metric.inc();
+                        }
+                    })?;
                     self.protocol.message(msg.from, msg.data);
                 }
                 Action::SendMany(data) => {

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -85,7 +85,12 @@ impl TripleGenerator {
     /// Receive the next message for the triple protocol; error out on the timeout being reached
     /// or the channel having been closed (aborted).
     async fn recv(&mut self) -> Option<TripleMessage> {
-        match tokio::time::timeout(self.timeout - self.created.elapsed(), self.inbox.recv()).await {
+        match tokio::time::timeout(
+            self.timeout.saturating_sub(self.created.elapsed()),
+            self.inbox.recv(),
+        )
+        .await
+        {
             Ok(Some(msg)) => Some(msg),
             Ok(None) => {
                 tracing::warn!(id = self.id, "triple generation aborted");

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -82,6 +82,22 @@ impl TripleGenerator {
         })
     }
 
+    /// Receive the next message for the triple protocol; error out on the timeout being reached
+    /// or the channel having been closed (aborted).
+    async fn recv(&mut self) -> Option<TripleMessage> {
+        match tokio::time::timeout(self.timeout - self.created.elapsed(), self.inbox.recv()).await {
+            Ok(Some(msg)) => Some(msg),
+            Ok(None) => {
+                tracing::warn!(id = self.id, "triple generation aborted");
+                None
+            }
+            Err(_err) => {
+                tracing::warn!(id = self.id, "triple generation timeout");
+                None
+            }
+        }
+    }
+
     async fn run(mut self, my_account_id: AccountId, epoch: u64) {
         let before_first_poke_delay =
             crate::metrics::TRIPLE_BEFORE_POKE_DELAY.with_label_values(&[my_account_id.as_str()]);
@@ -110,13 +126,6 @@ impl TripleGenerator {
         before_first_poke_delay.observe(self.created.elapsed().as_millis() as f64);
 
         loop {
-            let elapsed = self.created.elapsed();
-            if elapsed > self.timeout {
-                failure_counts.inc();
-                tracing::warn!(id = self.id, ?elapsed, "triple protocol timed out");
-                break;
-            }
-
             let poke_start_time = Instant::now();
             let action = match self.protocol.poke() {
                 Ok(action) => action,
@@ -140,7 +149,8 @@ impl TripleGenerator {
             match action {
                 Action::Wait => {
                     // Wait for the next set of messages to arrive.
-                    let Some(msg) = self.inbox.recv().await else {
+                    let Some(msg) = self.recv().await else {
+                        failure_counts.inc();
                         break;
                     };
                     self.protocol.message(msg.from, msg.data);
@@ -211,7 +221,7 @@ impl TripleGenerator {
                         big_a = ?triple.public.big_a.to_base58(),
                         big_b = ?triple.public.big_b.to_base58(),
                         big_c = ?triple.public.big_c.to_base58(),
-                        ?elapsed,
+                        elapsed = ?self.created.elapsed(),
                         "completed triple generation"
                     );
 


### PR DESCRIPTION
This is most likely what was causing our introduction issue. We should timeout not at the beginning of the protocol loop, but when trying to receive messages. This is because when awaiting for a message, it will stall till the next message, meaning we don't check the timeout until we get a new message if ever. This means that there will be a set of owned ongoing generators that will never wake up given that they receive no messages, which means our introduced "counter" never gets decremented since there will be live generators that never expire that contribute to this count.

