### PR TITLE
feat: added signature proposer election by rounds

### DIFF
--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -311,6 +311,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 secret_storage: key_storage,
                 triple_storage: triple_storage.clone(),
                 presignature_storage: presignature_storage.clone(),
+                contract: contract_watcher.clone(),
                 config: config_rx.clone(),
                 mesh_state: mesh_state.clone(),
             };

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -49,6 +49,7 @@ pub struct MpcSignProtocol {
     pub(crate) resharing: mpsc::Receiver<ResharingMessage>,
     pub(crate) msg_channel: MessageChannel,
     pub(crate) rpc_channel: RpcChannel,
+    pub(crate) contract: ContractStateWatcher,
     pub(crate) config: watch::Receiver<Config>,
     pub(crate) mesh_state: watch::Receiver<MeshState>,
 }


### PR DESCRIPTION
This adds the signature proposer election based on rounds by @jakmeier previously with https://github.com/sig-net/mpc/pull/410.

This is a bit different since the rounds are stored in the `SignRequest` struct. So the newly organized request will start from there on reorganization of proposer.