### PR TITLE
Remove "Finish sending msg" logs

### DIFF
--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -863,7 +863,6 @@ impl MessageOutbox {
                             result = client.msg(&url, payload) => {
                                 let Err(err) = result else {
                                     send_encrypted_latency_metric.observe(start.elapsed().as_millis() as f64);
-                                    tracing::debug!(?to, ?url, elapsed = ?instant.elapsed(), "finished sending messages");
                                     break;
                                 };
 


### PR DESCRIPTION
About 60% of what I see in logs is this message. It increases our GCP bill and not providing much informatin. In case of an error - we have another log. In case of success - we have counter that sends data to Grafana.