### PR TITLE
fix: make retrying messages less aggressive

### DIFF
--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -875,7 +875,7 @@ impl MessageOutbox {
                                     .observe(attempt_timestamp.elapsed().as_millis() as f64);
                             }
                         }
-                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        tokio::time::sleep(Duration::from_millis(500)).await;
                     }
                 });
             }

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -271,7 +271,7 @@ async fn test_presignature_timeout() {
         .build()
         .await;
 
-    tokio::time::timeout(Duration::from_secs(10), network.wait_for_presignatures(1))
+    tokio::time::timeout(Duration::from_secs(15), network.wait_for_presignatures(1))
         .await
         .expect("should have enough presignatures eventually");
 }


### PR DESCRIPTION
Retrying messages may be a little bit aggressive, so let's bump it to 500ms