### PR TITLE
chore: use at least 4 worker threads if core count is less than 4

### DIFF
--- a/chain-signatures/node/src/main.rs
+++ b/chain-signatures/node/src/main.rs
@@ -1,7 +1,18 @@
 use clap::Parser;
 use mpc_node::cli::Cli;
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    mpc_node::cli::run(Cli::parse()).await
+fn main() -> anyhow::Result<()> {
+    let num_cpus = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+
+    // Ensure at least 4 worker threads if CPU cores < 4
+    let worker_threads = std::cmp::max(num_cpus, 4);
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(worker_threads)
+        .enable_all()
+        .build()?;
+
+    rt.block_on(mpc_node::cli::run(Cli::parse()))
 }


### PR DESCRIPTION
tokio::main by default takes the number of cores as the amount of worker threads. This might cause some deficiencies in our dev env where we have approx 1 core per node.