### PR TITLE
chore: bump /state and /msg timeout to 5s and mesh interval to 10s

### DIFF
--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -15,8 +15,8 @@ pub mod connection;
 #[group(id = "mesh_options")]
 pub struct Options {
     /// The interval in milliseconds between pings to participants to check their aliveness
-    /// within the MPC network. 1s is normally good enough.
-    #[clap(long, env("MPC_MESH_PING_INTERVAL"), default_value = "1000")]
+    /// within the MPC network. 10s is normally good enough.
+    #[clap(long, env("MPC_MESH_PING_INTERVAL"), default_value = "10000")]
     pub ping_interval: u64,
 }
 

--- a/chain-signatures/node/src/node_client.rs
+++ b/chain-signatures/node/src/node_client.rs
@@ -14,11 +14,11 @@ use url::Url;
 #[group(id = "message_options")]
 pub struct Options {
     /// Default timeout used for all outbound requests to other nodes.
-    #[clap(long, env("MPC_NODE_TIMEOUT"), default_value = "1000")]
+    #[clap(long, env("MPC_NODE_TIMEOUT"), default_value = "5000")]
     pub timeout: u64,
 
     /// Timeout used for fetching the state of a node.
-    #[clap(long, env("MPC_NODE_STATE_TIMEOUT"), default_value = "1000")]
+    #[clap(long, env("MPC_NODE_STATE_TIMEOUT"), default_value = "5000")]
     pub state_timeout: u64,
 }
 
@@ -36,8 +36,8 @@ impl Options {
 impl Default for Options {
     fn default() -> Self {
         Self {
-            timeout: 1000,
-            state_timeout: 1000,
+            timeout: 5000,
+            state_timeout: 5000,
         }
     }
 }


### PR DESCRIPTION
Our default timeouts for mesh ping interval and /state and /msg calls might be a bit too fast. This will have the timeouts be 5s and the pinging interval be 10s