### PR TITLE
refactor(test): concise component test setup

### DIFF
--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -322,6 +322,37 @@ impl MpcFixtureBuilder {
         self.prepared_nodes[node_idx].messaging.filter = filter;
         self
     }
+
+    /// Short-hand for creating an MPC setup that's prepared to produce triples.
+    ///
+    /// This setup will not attempt to stockpile presignatures.
+    pub fn only_generate_triples(self) -> Self {
+        self.with_preshared_key()
+            .with_min_presignatures_stockpile(0)
+            .with_max_presignatures_stockpile(0)
+    }
+
+    /// Short-hand for creating an MPC setup that's prepared to produce presignatures.
+    ///
+    /// This setup will not attempt to stockpile triples.
+    pub fn only_generate_presignatures(self) -> Self {
+        self.with_preshared_key()
+            .with_preshared_triples()
+            .with_min_triples_stockpile(0)
+            .with_max_triples_stockpile(0)
+    }
+
+    /// Short-hand for creating an MPC setup that's prepared to produce signatures.
+    ///
+    /// This setup will not attempt to stockpile triples or presignatures.
+    pub fn only_generate_signatures(self) -> Self {
+        self.with_preshared_key()
+            .with_presignature_stockpile()
+            .with_min_triples_stockpile(0)
+            .with_max_triples_stockpile(0)
+            .with_min_presignatures_stockpile(0)
+            .with_max_presignatures_stockpile(0)
+    }
 }
 
 impl MpcFixtureNodeBuilder {

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -11,6 +11,7 @@ use mpc_node::protocol::{IndexedSignRequest, ProtocolState};
 use mpc_node::storage::{PresignatureStorage, TripleStorage};
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{watch, Mutex};
 
@@ -51,6 +52,21 @@ impl MpcFixture {
     pub async fn wait_for_presignatures(&self, threshold_per_node: usize) {
         for node in &self.nodes {
             node.wait_for_presignatures(threshold_per_node).await;
+        }
+    }
+
+    pub async fn wait_for_actions(&self, threshold: usize) -> HashSet<String> {
+        let interval = Duration::from_millis(100);
+
+        loop {
+            let actions = self.output.rpc_actions.lock().await;
+
+            if actions.len() >= threshold {
+                return actions.clone();
+            }
+
+            drop(actions);
+            tokio::time::sleep(interval).await;
         }
     }
 }

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -8,7 +8,7 @@ use mpc_node::protocol::{Chain, IndexedSignRequest, ProtocolState};
 use mpc_primitives::{SignArgs, SignId, LATEST_MPC_KEY_VERSION};
 use std::collections::BTreeMap;
 use std::fs;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 /// Use this toggle locally to regenerate hard-coded inputs such as key shares,
 /// triples, and presignatures.
@@ -68,9 +68,7 @@ async fn test_basic_generate_keys() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_basic_generate_triples() {
     let network = MpcFixtureBuilder::default()
-        .with_preshared_key()
-        .with_min_presignatures_stockpile(0)
-        .with_max_presignatures_stockpile(0)
+        .only_generate_triples()
         .build()
         .await;
 
@@ -111,10 +109,7 @@ async fn test_basic_generate_triples() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_basic_generate_presignature() {
     let network = MpcFixtureBuilder::default()
-        .with_preshared_key()
-        .with_preshared_triples()
-        .with_min_triples_stockpile(0)
-        .with_max_triples_stockpile(0)
+        .only_generate_presignatures()
         .build()
         .await;
 
@@ -158,12 +153,7 @@ async fn test_basic_generate_presignature() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_basic_sign() {
     let network = MpcFixtureBuilder::default()
-        .with_preshared_key()
-        .with_presignature_stockpile()
-        .with_min_triples_stockpile(0)
-        .with_max_triples_stockpile(0)
-        .with_min_presignatures_stockpile(0)
-        .with_max_presignatures_stockpile(0)
+        .only_generate_signatures()
         .build()
         .await;
 
@@ -181,36 +171,17 @@ async fn test_basic_sign() {
     network[2].sign_tx.send(request.clone()).await.unwrap();
 
     let timeout = Duration::from_secs(10);
-    let interval = Duration::from_millis(100);
-    let deadline = Instant::now() + timeout;
 
-    loop {
-        let actions = network.output.rpc_actions.lock().await;
+    let actions = tokio::time::timeout(timeout, network.wait_for_actions(1))
+        .await
+        .expect("should publish RPC action eventually");
 
-        if !actions.is_empty() {
-            assert_eq!(actions.len(), 1);
-            let action_str = actions.iter().next().unwrap();
-            assert!(
-                action_str.contains("RpcAction::Publish"),
-                "unexpected rpc action {action_str}"
-            );
-            break;
-        }
-
-        if Instant::now() >= deadline {
-            panic!("Timeout: expected 1 rpc_action but got {}", actions.len());
-        }
-
-        drop(actions);
-        tokio::time::sleep(interval).await;
-    }
-
-    // tracing::info!("printing all messages between nodes");
-    // let out = &mut std::fs::File::create("network_msg.txt").unwrap();
-    // for line in network.msg_log.lock().await.iter() {
-    //     tracing::info!("{line}");
-    //     writeln!(out, "{line}").unwrap();
-    // }
+    assert_eq!(actions.len(), 1);
+    let action_str = actions.iter().next().unwrap();
+    assert!(
+        action_str.contains("RpcAction::Publish"),
+        "unexpected rpc action {action_str}"
+    );
 }
 
 fn sign_request(seed: u8) -> IndexedSignRequest {
@@ -259,12 +230,10 @@ async fn test_presignature_timeout() {
 
     let network = MpcFixtureBuilder::default()
         // configure network ready to generate presignatures immediately
-        .with_preshared_key()
-        .with_preshared_triples()
+        .only_generate_presignatures()
+        // set exact presignature count target
         .with_min_presignatures_stockpile(5)
         .with_max_presignatures_stockpile(5)
-        .with_min_triples_stockpile(0)
-        .with_max_triples_stockpile(0)
         // apply message filter to all nodes
         .with_outgoing_message_filter(0, create_filter())
         .with_outgoing_message_filter(1, create_filter())
@@ -274,7 +243,7 @@ async fn test_presignature_timeout() {
         .build()
         .await;
 
-    tokio::time::timeout(Duration::from_secs(15), network.wait_for_presignatures(1))
+    tokio::time::timeout(Duration::from_secs(300), network.wait_for_presignatures(1))
         .await
         .expect("should have enough presignatures eventually");
 }


### PR DESCRIPTION
The goal of this refactor is to make the intention of tests clearer and making future tests easier to implement.

Most tests using the mpc component testing framework will focus on one specific protocol. It is useful to have that configuration summarized as

```rust
only_generate_triples()
```

instead of copy-pasting the setup to disable key sharing and presignature generation:

```rust
.with_preshared_key()
.with_min_presignatures_stockpile(0)
.with_max_presignatures_stockpile(0)
```

The second refactor in this commit moves the waiting for RPC actions to a reusable function.