### PR TITLE
feat: use /status over /state for checking liveness

### DIFF
--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -11,7 +11,7 @@ use tokio_stream::{StreamExt, StreamMap};
 use crate::node_client::NodeClient;
 use crate::protocol::contract::primitives::Participants;
 use crate::protocol::{ParticipantInfo, ProtocolState};
-use crate::web::StateView;
+use crate::web::StateStatus;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum NodeStatus {
@@ -113,16 +113,18 @@ impl NodeConnection {
                         continue;
                     }
 
-                    match client.state(&url).await {
+                    match client.status(&url).await {
                         Ok(state) => {
                             // note: borrowing and sending later on `status_tx` can potentially deadlock,
                             // but since we are copying the status, this is not the case. Change this carefully.
                             let old_status = status_tx.borrow().0;
                             let mut new_status = match state {
-                                StateView::Running { .. } => NodeStatus::Active,
-                                StateView::Resharing { .. }
-                                | StateView::Joining { .. }
-                                | StateView::NotRunning => NodeStatus::Inactive,
+                                StateStatus::Running => NodeStatus::Active,
+                                StateStatus::Resharing
+                                | StateStatus::Joining
+                                | StateStatus::NotRunning
+                                | StateStatus::Generating
+                                | StateStatus::WaitingForConsensus => NodeStatus::Inactive,
                             };
                             if old_status == NodeStatus::Inactive && new_status == NodeStatus::Active {
                                 // Sync when we want to enter an active state

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -10,8 +10,8 @@ use tokio_stream::{StreamExt, StreamMap};
 
 use crate::node_client::NodeClient;
 use crate::protocol::contract::primitives::Participants;
+use crate::protocol::state::NodeStatus as OtherNodeStatus;
 use crate::protocol::{ParticipantInfo, ProtocolState};
-use crate::web::StateStatus;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum NodeStatus {
@@ -119,12 +119,13 @@ impl NodeConnection {
                             // but since we are copying the status, this is not the case. Change this carefully.
                             let old_status = status_tx.borrow().0;
                             let mut new_status = match state {
-                                StateStatus::Running => NodeStatus::Active,
-                                StateStatus::Resharing
-                                | StateStatus::Joining
-                                | StateStatus::NotRunning
-                                | StateStatus::Generating
-                                | StateStatus::WaitingForConsensus => NodeStatus::Inactive,
+                                OtherNodeStatus::Running { .. } => NodeStatus::Active,
+                                OtherNodeStatus::Resharing { .. }
+                                | OtherNodeStatus::Generating { .. }
+                                | OtherNodeStatus::Joining { .. }
+                                | OtherNodeStatus::Starting
+                                | OtherNodeStatus::Started
+                                | OtherNodeStatus::WaitingForConsensus { .. } => NodeStatus::Inactive,
                             };
                             if old_status == NodeStatus::Inactive && new_status == NodeStatus::Active {
                                 // Sync when we want to enter an active state

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -144,7 +144,7 @@ impl NodeConnection {
                             }
                         }
                         Err(err) => {
-                            tracing::warn!(?node, ?err, "checking /state failed");
+                            tracing::warn!(?node, ?err, "checking /status failed");
                             status_tx.send_if_modified(|(status, _)| {
                                 std::mem::replace(status, NodeStatus::Offline) != NodeStatus::Offline
                             });

--- a/chain-signatures/node/src/node_client.rs
+++ b/chain-signatures/node/src/node_client.rs
@@ -1,6 +1,6 @@
 use crate::protocol::message::cbor_to_bytes;
 use crate::protocol::sync::SyncUpdate;
-use crate::web::StateView;
+use crate::web::{StateStatus, StateView};
 use hyper::StatusCode;
 use mpc_keys::hpke::Ciphered;
 use reqwest::IntoUrl;
@@ -148,6 +148,20 @@ impl NodeClient {
             .await?;
 
         Ok(resp.json::<StateView>().await?)
+    }
+
+    pub async fn status(&self, base: impl IntoUrl) -> Result<StateStatus, RequestError> {
+        let mut url = base.into_url()?;
+        url.set_path("status");
+
+        let resp = self
+            .http
+            .get(url)
+            .timeout(Duration::from_millis(self.options.state_timeout))
+            .send()
+            .await?;
+
+        Ok(resp.json().await?)
     }
 
     pub async fn sync(&self, base: impl IntoUrl, update: &SyncUpdate) -> Result<(), RequestError> {

--- a/chain-signatures/node/src/node_client.rs
+++ b/chain-signatures/node/src/node_client.rs
@@ -1,6 +1,7 @@
 use crate::protocol::message::cbor_to_bytes;
+use crate::protocol::state::NodeStatus;
 use crate::protocol::sync::SyncUpdate;
-use crate::web::{StateStatus, StateView};
+use crate::web::StateView;
 use hyper::StatusCode;
 use mpc_keys::hpke::Ciphered;
 use reqwest::IntoUrl;
@@ -150,7 +151,7 @@ impl NodeClient {
         Ok(resp.json::<StateView>().await?)
     }
 
-    pub async fn status(&self, base: impl IntoUrl) -> Result<StateStatus, RequestError> {
+    pub async fn status(&self, base: impl IntoUrl) -> Result<NodeStatus, RequestError> {
         let mut url = base.into_url()?;
         url.set_path("status");
 

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -94,7 +94,10 @@ pub struct JoiningState {
     pub public_key: PublicKey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum NodeStatus {
     Starting,
     Started,

--- a/chain-signatures/node/src/web/mock.rs
+++ b/chain-signatures/node/src/web/mock.rs
@@ -3,7 +3,7 @@ use mockito::ServerGuard;
 
 use crate::{
     node_client::NodeClient,
-    protocol::{contract::primitives::Participants, ParticipantInfo},
+    protocol::{contract::primitives::Participants, state::NodeStatus, ParticipantInfo},
 };
 
 use super::StateView;
@@ -30,6 +30,22 @@ impl MockServer {
                     presignature_mine_count: 0,
                     presignature_potential_count: 0,
                     latest_block_height: 0,
+                })
+                .unwrap(),
+            )
+            .create_async()
+            .await;
+
+        server
+            .mock("GET", "/status")
+            .with_status(201)
+            .with_header("content-type", "text/plain")
+            .with_body(
+                serde_json::to_vec(&NodeStatus::Running {
+                    me: Participant::from(id),
+                    participants: vec![Participant::from(0)],
+                    ongoing_triple_gen: 0,
+                    ongoing_presignature_gen: 0,
                 })
                 .unwrap(),
             )

--- a/chain-signatures/node/src/web/mock.rs
+++ b/chain-signatures/node/src/web/mock.rs
@@ -39,7 +39,7 @@ impl MockServer {
         server
             .mock("GET", "/status")
             .with_status(201)
-            .with_header("content-type", "text/plain")
+            .with_header("content-type", "application/json")
             .with_body(
                 serde_json::to_vec(&NodeStatus::Running {
                     me: Participant::from(id),

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -69,6 +69,7 @@ pub async fn run(
         )
         .route("/msg", post(msg))
         .route("/state", get(state))
+        .route("/status", get(status))
         .route("/metrics", get(metrics))
         .merge(sync);
 
@@ -182,6 +183,32 @@ async fn state(Extension(web): Extension<Arc<AxumState>>) -> Result<Json<StateVi
             Ok(Json(StateView::NotRunning))
         }
     }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum StateStatus {
+    NotRunning,
+    Generating,
+    Resharing,
+    WaitingForConsensus,
+    Running,
+    Joining,
+}
+
+#[tracing::instrument(level = "debug", skip_all)]
+async fn status(Extension(web): Extension<Arc<AxumState>>) -> Json<StateStatus> {
+    let status = match web.node.status() {
+        NodeStatus::Started | NodeStatus::Starting => StateStatus::NotRunning,
+        NodeStatus::Generating { .. } => StateStatus::Generating,
+        NodeStatus::WaitingForConsensus { .. } => StateStatus::WaitingForConsensus,
+        NodeStatus::Running { .. } => StateStatus::Running,
+        NodeStatus::Resharing { .. } => StateStatus::Resharing,
+        NodeStatus::Joining { .. } => StateStatus::Joining,
+    };
+    Json(status)
 }
 
 #[tracing::instrument(level = "debug", skip_all)]

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -185,30 +185,9 @@ async fn state(Extension(web): Extension<Arc<AxumState>>) -> Result<Json<StateVi
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "type")]
-#[serde(rename_all = "snake_case")]
-#[non_exhaustive]
-pub enum StateStatus {
-    NotRunning,
-    Generating,
-    Resharing,
-    WaitingForConsensus,
-    Running,
-    Joining,
-}
-
 #[tracing::instrument(level = "debug", skip_all)]
-async fn status(Extension(web): Extension<Arc<AxumState>>) -> Json<StateStatus> {
-    let status = match web.node.status() {
-        NodeStatus::Started | NodeStatus::Starting => StateStatus::NotRunning,
-        NodeStatus::Generating { .. } => StateStatus::Generating,
-        NodeStatus::WaitingForConsensus { .. } => StateStatus::WaitingForConsensus,
-        NodeStatus::Running { .. } => StateStatus::Running,
-        NodeStatus::Resharing { .. } => StateStatus::Resharing,
-        NodeStatus::Joining { .. } => StateStatus::Joining,
-    };
-    Json(status)
+async fn status(Extension(web): Extension<Arc<AxumState>>) -> Json<NodeStatus> {
+    Json(web.node.status())
 }
 
 #[tracing::instrument(level = "debug", skip_all)]


### PR DESCRIPTION
This utilizes a new endpoint called `/status` to check for liveness. `/state` makes use of 4 different calls to redis which can be slow if we have too many calls to redis at the same time. This could be the case when we're generating a ton of triples and presignatures and there's many writes to it, with congestion to the redis connection pool.

`/status` does none of these redis calls and purely checks the current protocol state (i.e. `Running`, `Resharing`, `Generating`, ...).

Should wait until https://github.com/sig-net/mpc/pull/532 gets merged first to see an improvement in our web endpoint metrics