### PR TITLE
feat: add redis latency for triple/presignature storage

### DIFF
--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -98,6 +98,17 @@ pub(crate) static SIGN_QUEUE_SIZE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
     .unwrap()
 });
 
+// Redis operation metrics
+pub(crate) static REDIS_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
+    try_create_histogram_vec(
+        "multichain_redis_operation_latency_ms",
+        "Latency of Redis operations in storage layers",
+        &["protocol", "operation", "node_account_id"],
+        Some(exponential_buckets(1.0, 2.0, 15).unwrap()),
+    )
+    .unwrap()
+});
+
 pub(crate) static SIGN_QUEUE_MINE_SIZE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
     try_create_int_gauge_vec(
         "multichain_sign_queue_mine_size",

--- a/chain-signatures/node/src/storage/presignature_storage.rs
+++ b/chain-signatures/node/src/storage/presignature_storage.rs
@@ -3,6 +3,7 @@ use chrono::Duration;
 use deadpool_redis::{Connection, Pool};
 use near_sdk::AccountId;
 use redis::{AsyncCommands, FromRedisValue, RedisError, RedisWrite, ToRedisArgs};
+use std::time::Instant;
 use tokio::task::JoinHandle;
 
 use crate::protocol::presignature::{Presignature, PresignatureId};
@@ -104,6 +105,7 @@ pub fn init(pool: &Pool, account_id: &AccountId) -> PresignatureStorage {
         used_key,
         reserved_key,
         owner_keys,
+        account_id: account_id.clone(),
     }
 }
 
@@ -114,6 +116,7 @@ pub struct PresignatureStorage {
     used_key: String,
     reserved_key: String,
     owner_keys: String,
+    account_id: AccountId,
 }
 
 impl PresignatureStorage {
@@ -163,6 +166,7 @@ impl PresignatureStorage {
             end
         "#;
 
+        let start = Instant::now();
         let mut conn = self.connect().await?;
         let result: Result<(), _> = redis::Script::new(SCRIPT)
             .key(&self.presig_key)
@@ -172,6 +176,11 @@ impl PresignatureStorage {
             .invoke_async(&mut conn)
             .await;
 
+        let elapsed = start.elapsed();
+        crate::metrics::REDIS_LATENCY
+            .with_label_values(&["presignature", "reserve", self.account_id.as_str()])
+            .observe(elapsed.as_millis() as f64);
+
         match result {
             Ok(_) => Some(PresignatureSlot {
                 id,
@@ -179,7 +188,12 @@ impl PresignatureStorage {
                 stored: false,
             }),
             Err(err) => {
-                tracing::warn!(id, ?err, "failed to reserve presignature");
+                tracing::warn!(
+                    id,
+                    ?err,
+                    elapsed_ms = elapsed.as_millis(),
+                    "failed to reserve presignature"
+                );
                 None
             }
         }
@@ -239,6 +253,7 @@ impl PresignatureStorage {
             return outdated
         "#;
 
+        let start = Instant::now();
         let Some(mut conn) = self.connect().await else {
             return Vec::new();
         };
@@ -251,15 +266,28 @@ impl PresignatureStorage {
             .invoke_async(&mut conn)
             .await;
 
+        let elapsed = start.elapsed();
+        crate::metrics::REDIS_LATENCY
+            .with_label_values(&["presignature", "remove_outdated", self.account_id.as_str()])
+            .observe(elapsed.as_millis() as f64);
+
         match result {
             Ok(outdated) => {
                 if !outdated.is_empty() {
-                    tracing::info!(?outdated, "removed outdated presignatures");
+                    tracing::info!(
+                        ?outdated,
+                        elapsed_ms = elapsed.as_millis(),
+                        "removed outdated presignatures"
+                    );
                 }
                 outdated
             }
             Err(err) => {
-                tracing::warn!(?err, "failed to remove outdated presignatures");
+                tracing::warn!(
+                    ?err,
+                    elapsed_ms = elapsed.as_millis(),
+                    "failed to remove outdated presignatures"
+                );
                 Vec::new()
             }
         }
@@ -292,6 +320,7 @@ impl PresignatureStorage {
             redis.call("HSET", presig_key, presig_id, presig)
         "#;
 
+        let start = Instant::now();
         let id = presignature.id;
         let Some(mut conn) = self.connect().await else {
             tracing::warn!(id, "failed to insert presignature: connection failed");
@@ -308,10 +337,20 @@ impl PresignatureStorage {
             .invoke_async(&mut conn)
             .await;
 
+        let elapsed = start.elapsed();
+        crate::metrics::REDIS_LATENCY
+            .with_label_values(&["presignature", "insert", self.account_id.as_str()])
+            .observe(elapsed.as_millis() as f64);
+
         match outcome {
             Ok(()) => true,
             Err(err) => {
-                tracing::warn!(id, ?err, "failed to insert presignature");
+                tracing::warn!(
+                    id,
+                    ?err,
+                    elapsed_ms = elapsed.as_millis(),
+                    "failed to insert presignature"
+                );
                 false
             }
         }
@@ -399,8 +438,9 @@ impl PresignatureStorage {
             return presig
         "#;
 
+        let start = Instant::now();
         let mut conn = self.connect().await?;
-        match redis::Script::new(SCRIPT)
+        let result = redis::Script::new(SCRIPT)
             .key(&self.presig_key)
             .key(&self.used_key)
             .key(owner_key(&self.owner_keys, owner))
@@ -409,11 +449,24 @@ impl PresignatureStorage {
             .arg(id)
             .arg(USED_EXPIRE_TIME.num_seconds())
             .invoke_async(&mut conn)
-            .await
-        {
+            .await;
+
+        let elapsed = start.elapsed();
+        crate::metrics::REDIS_LATENCY
+            .with_label_values(&["presignature", "take", self.account_id.as_str()])
+            .observe(elapsed.as_millis() as f64);
+
+        match result {
             Ok(presignature) => Some(PresignatureTaken::foreigner(presignature)),
             Err(err) => {
-                tracing::warn!(id, ?owner, ?me, ?err, "failed to take presignature");
+                tracing::warn!(
+                    id,
+                    ?owner,
+                    ?me,
+                    ?err,
+                    elapsed_ms = elapsed.as_millis(),
+                    "failed to take presignature"
+                );
                 None
             }
         }
@@ -444,20 +497,32 @@ impl PresignatureStorage {
             return presig
         "#;
 
+        let start = Instant::now();
         let mut conn = self.connect().await?;
-        match redis::Script::new(SCRIPT)
+        let result = redis::Script::new(SCRIPT)
             .key(&self.presig_key)
             .key(&self.used_key)
             .key(&self.reserved_key)
             .key(owner_key(&self.owner_keys, me))
             .arg(USED_EXPIRE_TIME.num_seconds())
             .invoke_async(&mut conn)
-            .await
-        {
+            .await;
+
+        let elapsed = start.elapsed();
+        crate::metrics::REDIS_LATENCY
+            .with_label_values(&["presignature", "take_mine", self.account_id.as_str()])
+            .observe(elapsed.as_millis() as f64);
+
+        match result {
             Ok(Some(presignature)) => Some(PresignatureTaken::owner(presignature, self.clone())),
             Ok(None) => None,
             Err(err) => {
-                tracing::warn!(?me, ?err, "failed to take my presignature");
+                tracing::warn!(
+                    ?me,
+                    ?err,
+                    elapsed_ms = elapsed.as_millis(),
+                    "failed to take my presignature"
+                );
                 None
             }
         }
@@ -508,6 +573,7 @@ impl PresignatureStorage {
             redis.call("DEL", unpack(del))
         "#;
 
+        let start = Instant::now();
         let Some(mut conn) = self.connect().await else {
             return false;
         };
@@ -519,9 +585,20 @@ impl PresignatureStorage {
             .invoke_async(&mut conn)
             .await
             .inspect_err(|err| {
-                tracing::warn!(?err, "failed to clear presignature storage");
+                let elapsed = start.elapsed();
+                tracing::warn!(
+                    ?err,
+                    elapsed_ms = elapsed.as_millis(),
+                    "failed to clear presignature storage"
+                );
             })
             .ok();
+
+        let elapsed = start.elapsed();
+        crate::metrics::REDIS_LATENCY
+            .with_label_values(&["presignature", "clear", self.account_id.as_str()])
+            .observe(elapsed.as_millis() as f64);
+
         outcome.is_some()
     }
 }

--- a/chain-signatures/node/src/storage/triple_storage.rs
+++ b/chain-signatures/node/src/storage/triple_storage.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::time::Instant;
 
 use crate::protocol::triple::{Triple, TripleId};
 
@@ -135,6 +136,7 @@ pub fn init(pool: &Pool, account_id: &AccountId) -> TripleStorage {
         used_key,
         reserved_key,
         owner_keys,
+        account_id: account_id.clone(),
     }
 }
 
@@ -145,6 +147,7 @@ pub struct TripleStorage {
     used_key: String,
     reserved_key: String,
     owner_keys: String,
+    account_id: AccountId,
 }
 
 impl TripleStorage {
@@ -159,6 +162,8 @@ impl TripleStorage {
     }
 
     pub async fn reserve(&self, id: TripleId) -> Option<TripleSlot> {
+        let start = Instant::now();
+
         const SCRIPT: &str = r#"
             local triple_key = KEYS[1]
             local used_key = KEYS[2]
@@ -190,6 +195,11 @@ impl TripleStorage {
             .invoke_async(&mut conn)
             .await;
 
+        let elapsed = start.elapsed();
+        crate::metrics::REDIS_LATENCY
+            .with_label_values(&["triple", "reserve", self.account_id.as_str()])
+            .observe(elapsed.as_millis() as f64);
+
         match result {
             Ok(_) => Some(TripleSlot {
                 id,
@@ -197,7 +207,11 @@ impl TripleStorage {
                 stored: false,
             }),
             Err(err) => {
-                tracing::warn!(?err, "failed to reserve triple");
+                tracing::warn!(
+                    ?err,
+                    elapsed_ms = elapsed.as_millis(),
+                    "failed to reserve triple"
+                );
                 None
             }
         }
@@ -218,6 +232,8 @@ impl TripleStorage {
         owner: Participant,
         owner_shares: &[TripleId],
     ) -> Vec<TripleId> {
+        let start = Instant::now();
+
         const SCRIPT: &str = r#"
             local triple_key = KEYS[1]
             local reserved_key = KEYS[2]
@@ -270,15 +286,28 @@ impl TripleStorage {
             .invoke_async(&mut conn)
             .await;
 
+        let elapsed = start.elapsed();
+        crate::metrics::REDIS_LATENCY
+            .with_label_values(&["triple", "remove_outdated", self.account_id.as_str()])
+            .observe(elapsed.as_millis() as f64);
+
         match result {
             Ok(outdated) => {
                 if !outdated.is_empty() {
-                    tracing::info!(?outdated, "removed outdated triples");
+                    tracing::info!(
+                        ?outdated,
+                        elapsed_ms = elapsed.as_millis(),
+                        "removed outdated triples"
+                    );
                 }
                 outdated
             }
             Err(err) => {
-                tracing::warn!(?err, "failed to remove outdated triples");
+                tracing::warn!(
+                    ?err,
+                    elapsed_ms = elapsed.as_millis(),
+                    "failed to remove outdated triples"
+                );
                 Vec::new()
             }
         }
@@ -299,6 +328,8 @@ impl TripleStorage {
     }
 
     async fn insert(&self, triple: Triple, owner: Participant) -> bool {
+        let start = Instant::now();
+
         const SCRIPT: &str = r#"
             local triple_key = KEYS[1]
             local used_key = KEYS[2]
@@ -339,8 +370,18 @@ impl TripleStorage {
             .invoke_async(&mut conn)
             .await;
 
+        let elapsed = start.elapsed();
+        crate::metrics::REDIS_LATENCY
+            .with_label_values(&["triple", "insert", self.account_id.as_str()])
+            .observe(elapsed.as_millis() as f64);
+
         if let Err(err) = result {
-            tracing::warn!(id, ?err, "failed to insert triple into storage");
+            tracing::warn!(
+                id,
+                ?err,
+                elapsed_ms = elapsed.as_millis(),
+                "failed to insert triple into storage"
+            );
             false
         } else {
             true
@@ -456,8 +497,9 @@ impl TripleStorage {
             return triples
         "#;
 
+        let start = Instant::now();
         let mut conn = self.connect().await?;
-        match redis::Script::new(SCRIPT)
+        let result = redis::Script::new(SCRIPT)
             .key(&self.triple_key)
             .key(&self.used_key)
             .key(owner_key(&self.owner_keys, owner))
@@ -467,14 +509,31 @@ impl TripleStorage {
             .arg(id2)
             .arg(USED_EXPIRE_TIME.num_seconds())
             .invoke_async(&mut conn)
-            .await
-        {
+            .await;
+
+        let elapsed = start.elapsed();
+        crate::metrics::REDIS_LATENCY
+            .with_label_values(&["triple", "take_two", self.account_id.as_str()])
+            .observe(elapsed.as_millis() as f64);
+
+        match result {
             Ok((triple0, triple1)) => {
-                tracing::debug!(id1, id2, "took two triples");
+                tracing::debug!(
+                    id1,
+                    id2,
+                    elapsed_ms = elapsed.as_millis(),
+                    "took two triples"
+                );
                 Some(TriplesTaken::foreigner(triple0, triple1))
             }
             Err(err) => {
-                tracing::warn!(id1, id2, ?err, "failed to take two triples from storage");
+                tracing::warn!(
+                    id1,
+                    id2,
+                    ?err,
+                    elapsed_ms = elapsed.as_millis(),
+                    "failed to take two triples from storage"
+                );
                 None
             }
         }
@@ -523,28 +582,40 @@ impl TripleStorage {
             return triples
         "#;
 
+        let start = Instant::now();
         let mut conn = self.connect().await?;
-        match redis::Script::new(SCRIPT)
+        let result = redis::Script::new(SCRIPT)
             .key(&self.triple_key)
             .key(&self.used_key)
             .key(owner_key(&self.owner_keys, me))
             .key(&self.reserved_key)
             .arg(USED_EXPIRE_TIME.num_seconds())
             .invoke_async(&mut conn)
-            .await
-        {
+            .await;
+
+        let elapsed = start.elapsed();
+        crate::metrics::REDIS_LATENCY
+            .with_label_values(&["triple", "take_two_mine", self.account_id.as_str()])
+            .observe(elapsed.as_millis() as f64);
+
+        match result {
             Ok(Some((triple0, triple1))) => {
                 let taken = TriplesTaken::owner(triple0, triple1, self.clone());
                 tracing::debug!(
                     id0 = taken.triple0.id,
                     id1 = taken.triple1.id,
+                    elapsed_ms = elapsed.as_millis(),
                     "took two mine triples"
                 );
                 Some(taken)
             }
             Ok(None) => None,
             Err(err) => {
-                tracing::warn!(?err, "failed to take two mine triples from storage");
+                tracing::warn!(
+                    ?err,
+                    elapsed_ms = elapsed.as_millis(),
+                    "failed to take two mine triples from storage"
+                );
                 None
             }
         }
@@ -597,6 +668,7 @@ impl TripleStorage {
             redis.call("DEL", unpack(del))
         "#;
 
+        let start = Instant::now();
         let Some(mut conn) = self.connect().await else {
             return false;
         };
@@ -608,9 +680,19 @@ impl TripleStorage {
             .invoke_async(&mut conn)
             .await
             .inspect_err(|err| {
-                tracing::warn!(?err, "failed to clear triple storage");
+                let elapsed = start.elapsed();
+                tracing::warn!(
+                    ?err,
+                    elapsed_ms = elapsed.as_millis(),
+                    "failed to clear triple storage"
+                );
             })
             .ok();
+
+        let elapsed = start.elapsed();
+        crate::metrics::REDIS_LATENCY
+            .with_label_values(&["triple", "clear", self.account_id.as_str()])
+            .observe(elapsed.as_millis() as f64);
 
         // if the outcome is None, it means the script failed or there was an error.
         outcome.is_some()


### PR DESCRIPTION
This adds in latency metrics for all the redis operations so we can keep track of how long each operations take. This will be useful for when these operations change and we want to monitor how much of a diff they make