### PR TITLE
reduce alchemy bill: getTransaction once and then match the cpi event type

### DIFF
--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -665,7 +665,7 @@ where
         let now = Instant::now();
         // Periodic cleanup of expired entries in the TTL cache
         seen.retain(|_, &mut timestamp| now.duration_since(timestamp) < ttl);
-        if seen.get(&signature).is_some() {
+        if seen.contains_key(&signature) {
             continue;
         }
         seen.insert(signature, now);

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -655,9 +655,6 @@ where
     let ttl = Duration::from_secs(30);
 
     while let Some(response) = stream.next().await {
-        // Periodic cleanup of expired entries in the TTL cache
-        let now = Instant::now();
-        seen.retain(|_, &mut timestamp| now.duration_since(timestamp) < ttl);
         if response.value.err.is_some() {
             continue;
         }
@@ -665,12 +662,11 @@ where
             tracing::warn!("Invalid signature format");
             continue;
         };
-
         let now = Instant::now();
-        if let Some(last) = seen.get(&signature) {
-            if now.duration_since(*last) < ttl {
-                continue; // Skip recently seen signatures
-            }
+        // Periodic cleanup of expired entries in the TTL cache
+        seen.retain(|_, &mut timestamp| now.duration_since(timestamp) < ttl);
+        if seen.get(&signature).is_some() {
+            continue;
         }
         seen.insert(signature, now);
 

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -162,6 +162,10 @@ trait SignatureEventTrait {
     ) -> anyhow::Result<IndexedSignRequest>;
 }
 
+trait SignatureEvent: SignatureEventTrait + std::fmt::Debug {}
+
+type SignatureEventBox = Box<dyn SignatureEvent + Send>;
+
 #[event]
 #[derive(Clone, Debug)]
 pub struct SignatureRequestedEvent {
@@ -176,6 +180,8 @@ pub struct SignatureRequestedEvent {
     pub params: String,
     pub fee_payer: Option<Pubkey>,
 }
+
+impl SignatureEvent for SignatureRequestedEvent {}
 
 impl SignatureEventTrait for SignatureRequestedEvent {
     fn generate_request_id(&self) -> [u8; 32] {
@@ -273,6 +279,8 @@ pub struct SignRespondRequestedEvent {
     pub callback_serialization_schema: Vec<u8>,
 }
 
+impl SignatureEvent for SignRespondRequestedEvent {}
+
 impl SignatureEventTrait for SignRespondRequestedEvent {
     fn generate_request_id(&self) -> [u8; 32] {
         // Match TypeScript implementation using ABI encoding
@@ -351,108 +359,6 @@ impl SignatureEventTrait for SignRespondRequestedEvent {
 
 type Result<T> = anyhow::Result<T>;
 
-async fn parse_cpi_events<T>(
-    rpc_client: &RpcClient,
-    signature: &Signature,
-    target_program_id: &Pubkey,
-) -> Result<Vec<T>>
-where
-    T: anchor_lang::Event
-        + anchor_lang::AnchorDeserialize
-        + anchor_lang::Discriminator
-        + Clone
-        + std::fmt::Debug,
-{
-    let tx = rpc_client
-        .get_transaction_with_config(
-            signature,
-            solana_client::rpc_config::RpcTransactionConfig {
-                encoding: Some(solana_transaction_status::UiTransactionEncoding::JsonParsed),
-                commitment: Some(CommitmentConfig::confirmed()),
-                max_supported_transaction_version: Some(0),
-            },
-        )
-        .await?;
-
-    let Some(meta) = tx.transaction.meta else {
-        return Ok(Vec::new());
-    };
-
-    let target_program_str = target_program_id.to_string();
-    let mut events = Vec::new();
-
-    let process_instruction_data = |data: &str| -> Result<Vec<T>> {
-        let Ok(ix_data) = solana_sdk::bs58::decode(data).into_vec() else {
-            tracing::warn!("Failed to decode instruction data for target program");
-            return Ok(Vec::new());
-        };
-
-        // Validate instruction discriminator matches emit_cpi! instruction discriminator
-        if !ix_data.starts_with(anchor_lang::event::EVENT_IX_TAG_LE) {
-            tracing::warn!("Instruction discriminator mismatch - not our instruction type");
-            return Ok(Vec::new());
-        }
-
-        // Validate event discriminator matches our target event type
-        let event_discriminator = &ix_data[8..16];
-        if event_discriminator != T::DISCRIMINATOR {
-            tracing::warn!("Event discriminator mismatch - not our event type");
-            return Ok(Vec::new());
-        }
-
-        let event_data = &ix_data[16..];
-
-        match T::deserialize(&mut &event_data[..]) {
-            Ok(event) => Ok(vec![event]),
-            Err(e) => {
-                tracing::warn!(
-                    "Failed to deserialize event data from target program: {}",
-                    e
-                );
-                Ok(Vec::new())
-            }
-        }
-    };
-
-    // Check inner instructions for CPI calls
-    let inner_ixs = match meta.inner_instructions {
-        solana_transaction_status::option_serializer::OptionSerializer::Some(ixs) => ixs,
-        _ => return Ok(Vec::new()),
-    };
-
-    for (set_idx, inner_ix_set) in inner_ixs.iter().enumerate() {
-        for (ix_idx, instruction) in inner_ix_set.instructions.iter().enumerate() {
-            // We only care about:
-            // 1. Parsed instructions (not Compiled - only used for non-JsonParsed encodings)
-            // 2. PartiallyDecoded instructions (not fully Parsed - only applies to well-known programs like System, Token, etc.)
-            if let solana_transaction_status::UiInstruction::Parsed(
-                solana_transaction_status::UiParsedInstruction::PartiallyDecoded(
-                    ui_partially_decoded_instruction,
-                ),
-            ) = instruction
-            {
-                // Check if inner instruction is from our target program
-                if ui_partially_decoded_instruction.program_id == target_program_str {
-                    match process_instruction_data(&ui_partially_decoded_instruction.data) {
-                        Ok(mut instruction_events) => {
-                            tracing::info!("instruction events: {:?}", instruction_events);
-                            events.append(&mut instruction_events);
-                        }
-                        Err(e) => tracing::warn!(
-                            "Error processing inner instruction {}.{}: {}",
-                            set_idx,
-                            ix_idx,
-                            e
-                        ),
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(events)
-}
-
 pub async fn run(
     sol: Option<SolConfig>,
     sign_tx: mpsc::Sender<IndexedSignRequest>,
@@ -487,24 +393,10 @@ pub async fn run(
     let rpc_http_url_clone = sol.rpc_http_url.clone();
     let rpc_ws_url_clone = sol.rpc_ws_url.clone();
     tokio::spawn(async move {
-        subscribe_and_process_sign_events::<SignRespondRequestedEvent>(
+        subscribe_and_process_sign_events(
             program_id,
             &rpc_http_url_clone,
             &rpc_ws_url_clone,
-            sign_tx_clone,
-            node_near_account_id_clone,
-            total_timeout,
-        )
-        .await;
-    });
-
-    let sign_tx_clone = sign_tx.clone();
-    let node_near_account_id_clone = node_near_account_id.clone();
-    tokio::spawn(async move {
-        subscribe_and_process_sign_events::<SignatureRequestedEvent>(
-            program_id,
-            &sol.rpc_http_url,
-            &sol.rpc_ws_url,
             sign_tx_clone,
             node_near_account_id_clone,
             total_timeout,
@@ -536,63 +428,6 @@ pub async fn run(
     }
 }
 
-// Reference: https://github.com/solana-foundation/anchor/blob/a5df519319ac39cff21191f2b09d54eda42c5716/client/src/lib.rs#L311
-async fn subscribe_to_program_cpi_events<T, F>(
-    program_id: Pubkey,
-    rpc_url: &str,
-    ws_url: &str,
-    mut event_handler: F,
-) -> Result<()>
-where
-    T: anchor_lang::Event
-        + anchor_lang::AnchorDeserialize
-        + anchor_lang::Discriminator
-        + Clone
-        + std::fmt::Debug,
-    F: FnMut(T, Signature, u64) + Send,
-{
-    let rpc_client = RpcClient::new(rpc_url.to_string());
-    let pubsub_client = PubsubClient::new(ws_url).await?;
-
-    let filter = RpcTransactionLogsFilter::Mentions(vec![program_id.to_string()]);
-    let config = RpcTransactionLogsConfig {
-        commitment: Some(CommitmentConfig::confirmed()),
-    };
-
-    let (mut stream, _unsubscriber) = pubsub_client.logs_subscribe(filter, config).await?;
-
-    while let Some(response) = stream.next().await {
-        // Skip failed transactions immediately
-        // Anchor's emit_cpi! performs validation of event authority:
-        // 1. Verifies event_authority is a transaction signer
-        // 2. Validates event_authority matches the expected PDA derived from program seeds
-        // 3. Ensures only the program itself can emit events via emit_cpi!
-        // Transaction fails with ConstraintSigner/ConstraintSeeds errors if validation fails.
-        // Reference: https://github.com/solana-foundation/anchor/blob/a5df519319ac39cff21191f2b09d54eda42c5716/lang/syn/src/codegen/program/handlers.rs#L208
-        if response.value.err.is_some() {
-            continue;
-        }
-
-        let Ok(signature) = Signature::from_str(&response.value.signature) else {
-            tracing::warn!("Invalid signature format received");
-            continue;
-        };
-
-        match parse_cpi_events::<T>(&rpc_client, &signature, &program_id).await {
-            Ok(events) => {
-                for event in events {
-                    event_handler(event, signature, response.context.slot);
-                }
-            }
-            Err(e) => {
-                tracing::error!("❌ Failed to parse transaction {}: {}", signature, e);
-            }
-        }
-    }
-
-    Ok(())
-}
-
 async fn subscribe_to_program_non_cpi_events<C: Deref<Target = Keypair> + Clone>(
     program: &Program<C>,
     sign_tx: mpsc::Sender<IndexedSignRequest>,
@@ -614,7 +449,7 @@ async fn subscribe_to_program_non_cpi_events<C: Deref<Target = Keypair> + Clone>
     tracing::info!("Subscribed to program events");
     while let Some((event, tx_sig)) = receiver.recv().await {
         if let Err(err) = process_anchor_sign_event(
-            event,
+            Box::new(event),
             tx_sig,
             sign_tx.clone(),
             node_near_account_id.clone(),
@@ -629,8 +464,8 @@ async fn subscribe_to_program_non_cpi_events<C: Deref<Target = Keypair> + Clone>
     Ok(event_unsubscriber)
 }
 
-async fn process_anchor_sign_event<T: SignatureEventTrait>(
-    sign_event: T,
+async fn process_anchor_sign_event(
+    sign_event: SignatureEventBox,
     tx_sig: Vec<u8>,
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     node_near_account_id: AccountId,
@@ -650,33 +485,25 @@ async fn process_anchor_sign_event<T: SignatureEventTrait>(
     Ok(())
 }
 
-async fn subscribe_and_process_sign_events<T>(
+// Reference: https://github.com/solana-foundation/anchor/blob/a5df519319ac39cff21191f2b09d54eda42c5716/client/src/lib.rs#L31
+async fn subscribe_and_process_sign_events(
     program_id: Pubkey,
     rpc_url: &str,
     ws_url: &str,
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     node_near_account_id: AccountId,
     total_timeout: Duration,
-) where
-    T: anchor_lang::Event
-        + anchor_lang::AnchorDeserialize
-        + anchor_lang::Discriminator
-        + Clone
-        + std::fmt::Debug
-        + Send
-        + SignatureEventTrait
-        + 'static,
-{
+) {
     loop {
         let sign_tx_clone = sign_tx.clone();
         let node_near_account_id_clone = node_near_account_id.clone();
 
-        let result = subscribe_to_program_cpi_events::<T, _>(
+        let result = subscribe_to_program_cpi_events(
             program_id,
             rpc_url,
             ws_url,
-            move |sign_event, signature, _slot| {
-                tracing::info!("got event: {:?}", sign_event);
+            move |event, signature, _slot| {
+                tracing::info!("got event: {:?}", event);
                 let tx_sig: Vec<u8> = signature.as_ref().to_vec();
 
                 let sign_tx_inner = sign_tx_clone.clone();
@@ -684,7 +511,7 @@ async fn subscribe_and_process_sign_events<T>(
 
                 tokio::spawn(async move {
                     if let Err(err) = process_anchor_sign_event(
-                        sign_event,
+                        event,
                         tx_sig,
                         sign_tx_inner,
                         node_near_account_id_inner,
@@ -705,4 +532,154 @@ async fn subscribe_and_process_sign_events<T>(
 
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
+}
+
+async fn parse_cpi_events(
+    rpc_client: &RpcClient,
+    signature: &Signature,
+    target_program_id: &Pubkey,
+) -> Result<Vec<SignatureEventBox>> {
+    use solana_transaction_status::{UiInstruction, UiParsedInstruction};
+
+    let tx = rpc_client
+        .get_transaction_with_config(
+            signature,
+            solana_client::rpc_config::RpcTransactionConfig {
+                encoding: Some(solana_transaction_status::UiTransactionEncoding::JsonParsed),
+                commitment: Some(CommitmentConfig::confirmed()),
+                max_supported_transaction_version: Some(0),
+            },
+        )
+        .await?;
+
+    let Some(meta) = tx.transaction.meta else {
+        return Ok(Vec::new());
+    };
+
+    let target_program_str = target_program_id.to_string();
+    let mut out = Vec::<SignatureEventBox>::new();
+
+    // Small helper closure to try decoding both event types from raw data
+    let try_parse_events = |data: &str| -> Result<Vec<SignatureEventBox>> {
+        let Ok(ix_data) = solana_sdk::bs58::decode(data).into_vec() else {
+            tracing::warn!("Failed to decode instruction data for target program");
+            return Ok(Vec::new());
+        };
+
+        // Ensure this is an Anchor emit_cpi! instruction
+        if !ix_data.starts_with(anchor_lang::event::EVENT_IX_TAG_LE) {
+            return Ok(Vec::new());
+        }
+
+        let event_discriminator = &ix_data[8..16];
+        let event_data = &ix_data[16..];
+
+        let mut acc = Vec::new();
+
+        // handle both event types
+        if event_discriminator == SignatureRequestedEvent::DISCRIMINATOR {
+            match SignatureRequestedEvent::deserialize(&mut &event_data[..]) {
+                Ok(ev) => acc.push(Box::new(ev) as SignatureEventBox),
+                Err(e) => tracing::warn!("Failed to deserialize SignatureRequestedEvent: {e}"),
+            }
+        } else if event_discriminator == SignRespondRequestedEvent::DISCRIMINATOR {
+            match SignRespondRequestedEvent::deserialize(&mut &event_data[..]) {
+                Ok(ev) => acc.push(Box::new(ev) as SignatureEventBox),
+                Err(e) => tracing::warn!("Failed to deserialize SignRespondRequestedEvent: {e}"),
+            }
+        }
+
+        Ok(acc)
+    };
+
+    // Look into inner instructions for CPI calls
+    let inner_ixs = match meta.inner_instructions {
+        solana_transaction_status::option_serializer::OptionSerializer::Some(ixs) => ixs,
+        _ => return Ok(Vec::new()),
+    };
+
+    for (set_idx, inner_ix_set) in inner_ixs.iter().enumerate() {
+        for (ix_idx, instruction) in inner_ix_set.instructions.iter().enumerate() {
+            if let UiInstruction::Parsed(UiParsedInstruction::PartiallyDecoded(ui)) = instruction {
+                if ui.program_id == target_program_str {
+                    match try_parse_events(&ui.data) {
+                        Ok(mut v) => {
+                            if !v.is_empty() {
+                                tracing::info!(
+                                    "parsed {} event(s) from {}.{}",
+                                    v.len(),
+                                    set_idx,
+                                    ix_idx
+                                );
+                            }
+                            out.append(&mut v);
+                        }
+                        Err(e) => tracing::warn!(
+                            "Error processing inner instruction {}.{}: {}",
+                            set_idx,
+                            ix_idx,
+                            e
+                        ),
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+async fn subscribe_to_program_cpi_events<F>(
+    program_id: Pubkey,
+    rpc_url: &str,
+    ws_url: &str,
+    mut event_handler: F,
+) -> Result<()>
+where
+    F: FnMut(SignatureEventBox, Signature, u64) + Send,
+{
+    use std::collections::HashMap;
+
+    let rpc_client = RpcClient::new(rpc_url.to_string());
+    let pubsub_client = PubsubClient::new(ws_url).await?;
+
+    let filter = RpcTransactionLogsFilter::Mentions(vec![program_id.to_string()]);
+    let config = RpcTransactionLogsConfig {
+        commitment: Some(CommitmentConfig::confirmed()),
+    };
+
+    let (mut stream, _unsubscriber) = pubsub_client.logs_subscribe(filter, config).await?;
+
+    // Simple TTL cache to avoid multiple getTransaction calls for the same signature
+    let mut seen: HashMap<Signature, Instant> = HashMap::new();
+    let ttl = Duration::from_secs(30);
+
+    while let Some(response) = stream.next().await {
+        if response.value.err.is_some() {
+            continue;
+        }
+        let Ok(signature) = Signature::from_str(&response.value.signature) else {
+            tracing::warn!("Invalid signature format");
+            continue;
+        };
+
+        let now = Instant::now();
+        if let Some(last) = seen.get(&signature) {
+            if now.duration_since(*last) < ttl {
+                continue; // Skip recently seen signatures
+            }
+        }
+        seen.insert(signature, now);
+
+        match parse_cpi_events(&rpc_client, &signature, &program_id).await {
+            Ok(events) => {
+                for ev in events {
+                    event_handler(ev, signature, response.context.slot);
+                }
+            }
+            Err(e) => tracing::error!("Failed to parse tx {}: {}", signature, e),
+        }
+    }
+
+    Ok(())
 }

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -629,6 +629,7 @@ async fn parse_cpi_events(
     Ok(out)
 }
 
+// Reference: https://github.com/solana-foundation/anchor/blob/a5df519319ac39cff21191f2b09d54eda42c5716/client/src/lib.rs#L311
 async fn subscribe_to_program_cpi_events<F>(
     program_id: Pubkey,
     rpc_url: &str,

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -22,6 +22,7 @@ use solana_client::{
 };
 use solana_sdk::signer::keypair::Keypair;
 use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey, signature::Signature};
+use std::collections::HashMap;
 use std::fmt;
 use std::ops::Deref;
 use std::str::FromStr;
@@ -639,8 +640,6 @@ async fn subscribe_to_program_cpi_events<F>(
 where
     F: FnMut(SignatureEventBox, Signature, u64) + Send,
 {
-    use std::collections::HashMap;
-
     let rpc_client = RpcClient::new(rpc_url.to_string());
     let pubsub_client = PubsubClient::new(ws_url).await?;
 
@@ -656,6 +655,9 @@ where
     let ttl = Duration::from_secs(30);
 
     while let Some(response) = stream.next().await {
+        // Periodic cleanup of expired entries in the TTL cache
+        let now = Instant::now();
+        seen.retain(|_, &mut timestamp| now.duration_since(timestamp) < ttl);
         if response.value.err.is_some() {
             continue;
         }


### PR DESCRIPTION
previously, we had 1 task each for sign and sign_respond cpi events. This means we are doing getTransaction twice for each event we received, and since we don't have filters to filter for the event type before calling getTransaction, we are changing the logic to calling getTransaction, then match the 2 types of cpi events.