### PR TITLE
fix: expire and start signatures w/ enough participants

### DIFF
--- a/chain-signatures/node/src/protocol/consensus.rs
+++ b/chain-signatures/node/src/protocol/consensus.rs
@@ -531,7 +531,6 @@ impl<G: Governance> ConsensusProtocol<G> for RunningState {
                         })
                     }
                     Ordering::Equal => {
-                        tracing::debug!("running(running): continuing to run as normal");
                         if contract_state.public_key != self.public_key {
                             tracing::warn!(
                                 node_pk = ?self.public_key,

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -98,8 +98,6 @@ impl MpcSignProtocol {
 
         loop {
             let protocol_time = Instant::now();
-            tracing::debug!("trying to advance chain signatures protocol");
-
             crate::metrics::PROTOCOL_ITER_CNT
                 .with_label_values(&[my_account_id.as_str()])
                 .inc();

--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -333,6 +333,9 @@ impl<Id: Copy + Hash + Eq + fmt::Debug, S> Posits<Id, S> {
                 ?expired_deliberators,
                 ?expired_proposers,
                 ?expired_and_accepted,
+                total_expired = expired_proposers.len()
+                    + expired_deliberators.len()
+                    + expired_and_accepted.len(),
                 "expiring posits"
             );
         }

--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -287,6 +287,8 @@ impl<Id: Copy + Hash + Eq + fmt::Debug, S> Posits<Id, S> {
         self.posits.is_empty()
     }
 
+    /// Expire and start protocols on enough accepted votes. Abort protocols action will be returned
+    /// if the posit has expired.
     pub fn expire_and_start(
         &mut self,
         threshold: usize,
@@ -322,6 +324,7 @@ impl<Id: Copy + Hash + Eq + fmt::Debug, S> Posits<Id, S> {
                 ));
             } else {
                 expired_proposers.push(*id);
+                actions.push((*id, PositInternalAction::Abort));
             }
         }
 

--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -478,9 +478,11 @@ mod tests {
         std::thread::sleep(Duration::from_millis(1100));
         // add a posit that will not expire yet
         posits0.propose(303, (), &participants);
-        let actions = posits0.expire_and_start(threshold, Duration::from_secs(1));
+        let mut actions = posits0.expire_and_start(threshold, Duration::from_secs(1));
+        actions.sort_by_key(|(id, _)| *id);
         assert_eq!(posits0.len(), 1);
-        assert_eq!(actions.len(), 1);
+        assert_eq!(actions.len(), 2);
+        println!("actions: {actions:?}");
         assert!(matches!(
             actions[0],
             (
@@ -488,6 +490,7 @@ mod tests {
                 PositInternalAction::StartProtocol(_, Positor::Proposer(_, _))
             ),
         ));
+        assert!(matches!(actions[1], (202, PositInternalAction::Abort)));
 
         // the posit for id101 should have expired after not receiving a start action.
         let mut posits1 = Posits::<Id, ()>::new(Participant::from(1));

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -404,6 +404,12 @@ impl PresignatureSpawner {
                 "presignature id does not match the expected hash"
             );
             PositInternalAction::Reply(PositAction::Reject)
+        } else if self.contains_ongoing(id.id) {
+            tracing::warn!(?id, ?from, ?action, "presignature already generating");
+            PositInternalAction::Reply(PositAction::Reject)
+        } else if self.contains(id.id).await {
+            tracing::warn!(?id, ?from, ?action, "presignature already generated");
+            PositInternalAction::Reply(PositAction::Reject)
         } else if !{
             // TODO: we can potentially wait for the triples to exist first to then be able to accept.
             // whereas we just blatantly reject here. The problem with waiting is that the other side
@@ -418,12 +424,6 @@ impl PresignatureSpawner {
                 ?action,
                 "presignature required triples are not known"
             );
-            PositInternalAction::Reply(PositAction::Reject)
-        } else if self.contains_ongoing(id.id) {
-            tracing::warn!(?id, ?from, ?action, "presignature already generating");
-            PositInternalAction::Reply(PositAction::Reject)
-        } else if self.contains(id.id).await {
-            tracing::warn!(?id, ?from, ?action, "presignature already generated");
             PositInternalAction::Reply(PositAction::Reject)
         } else {
             self.posits.act(id, from, self.threshold, &action)

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -431,7 +431,9 @@ impl PresignatureSpawner {
 
         match internal_action {
             PositInternalAction::None => {}
-            PositInternalAction::Abort => {}
+            PositInternalAction::Abort => {
+                tracing::warn!(?id, "presignature posit aborted due to too many rejections");
+            }
             PositInternalAction::Reply(action) => {
                 self.msg
                     .send(
@@ -682,6 +684,10 @@ impl PresignatureSpawner {
                 _ = expiration_interval.tick() => {
                     for (id, action) in self.posits.expire_and_start(self.threshold, Duration::from_secs(60)) {
                         let PositInternalAction::StartProtocol(participants, positor) = action else {
+                            tracing::warn!(
+                                ?id,
+                                "presignature posit expired: insufficient accepts"
+                            );
                             continue;
                         };
                         let timeout = config.borrow().protocol.presignature.generation_timeout;

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -814,42 +814,8 @@ impl SignatureSpawner {
                     .await;
             }
             PositInternalAction::StartProtocol(participants, positor) => {
-                if positor.is_proposer() {
-                    for &p in &participants {
-                        if p == self.me {
-                            continue;
-                        }
-                        self.msg
-                            .send(
-                                self.me,
-                                p,
-                                PositMessage {
-                                    id: PositProtocolId::Signature(sign_id, presignature_id),
-                                    from: self.me,
-                                    action: PositAction::Start(participants.clone()),
-                                },
-                            )
-                            .await;
-                    }
-                }
-
-                let request = self.sign_queue.get_or_pending(&sign_id);
-                let presignature = match positor {
-                    Positor::Proposer(_proposer, taken) => PendingPresignature::Available(taken),
-                    Positor::Deliberator(proposer) => PendingPresignature::InStorage(
-                        presignature_id,
-                        proposer,
-                        self.presignatures.clone(),
-                    ),
-                };
-                self.generate(
-                    request,
-                    presignature,
-                    participants,
-                    cfg,
-                    self.sign_respond_signature_channel.clone(),
-                )
-                .await;
+                self.start_generation(positor, sign_id, presignature_id, participants, cfg)
+                    .await;
             }
         }
     }
@@ -905,6 +871,52 @@ impl SignatureSpawner {
         };
 
         self.ongoing.spawn((sign_id, presignature_id), task);
+    }
+
+    async fn start_generation(
+        &mut self,
+        positor: Positor<PresignatureTaken>,
+        sign_id: SignId,
+        presignature_id: PresignatureId,
+        participants: Vec<Participant>,
+        cfg: ProtocolConfig,
+    ) {
+        if positor.is_proposer() {
+            for &p in &participants {
+                if p == self.me {
+                    continue;
+                }
+                self.msg
+                    .send(
+                        self.me,
+                        p,
+                        PositMessage {
+                            id: PositProtocolId::Signature(sign_id, presignature_id),
+                            from: self.me,
+                            action: PositAction::Start(participants.clone()),
+                        },
+                    )
+                    .await;
+            }
+        }
+
+        let request = self.sign_queue.get_or_pending(&sign_id);
+        let presignature = match positor {
+            Positor::Proposer(_proposer, taken) => PendingPresignature::Available(taken),
+            Positor::Deliberator(proposer) => PendingPresignature::InStorage(
+                presignature_id,
+                proposer,
+                self.presignatures.clone(),
+            ),
+        };
+        self.generate(
+            request,
+            presignature,
+            participants,
+            cfg,
+            self.sign_respond_signature_channel.clone(),
+        )
+        .await;
     }
 
     async fn handle_requests(
@@ -1003,23 +1015,8 @@ impl SignatureSpawner {
                             },
                             _ => continue,
                         };
-                        let request = self.sign_queue.get_or_pending(&sign_id);
-                        let presignature = match positor {
-                            Positor::Proposer(_proposer, taken) => PendingPresignature::Available(taken),
-                            Positor::Deliberator(proposer) => PendingPresignature::InStorage(
-                                presignature_id,
-                                proposer,
-                                self.presignatures.clone(),
-                            ),
-                        };
-                        let cfg = cfg.borrow().protocol.clone();
-                        self.generate(
-                            request,
-                            presignature,
-                            participants,
-                            cfg,
-                            self.sign_respond_signature_channel.clone(),
-                        ).await;
+                        let protocol = cfg.borrow().protocol.clone();
+                        self.start_generation(positor, sign_id, presignature_id, participants, protocol).await;
                     }
                 }
                 Some((sign_id, presignature_id, from, action)) = posits.recv() => {

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -982,11 +982,46 @@ impl SignatureSpawner {
         // then they are considered unstable and should not be a part of signature generation this round.
 
         let mut check_requests_interval = tokio::time::interval(Duration::from_millis(100));
+        let mut expiration_interval = tokio::time::interval(Duration::from_secs(20));
         let mut posits = self.msg.subscribe_signature_posit().await;
         let mut pending_posits = JoinSet::new();
 
         loop {
             tokio::select! {
+                _ = expiration_interval.tick() => {
+                    for ((sign_id, presignature_id), action) in self.posits.expire_and_start(self.threshold, Duration::from_secs(60)) {
+                        let (participants, positor) = match action {
+                            PositInternalAction::StartProtocol(participants, positor) => (participants, positor),
+                            PositInternalAction::Abort => {
+                                tracing::warn!(
+                                    ?sign_id,
+                                    presignature_id,
+                                    "signature posit aborting on expiration, retrying..."
+                                );
+                                self.sign_queue.push_failed(sign_id);
+                                continue;
+                            },
+                            _ => continue,
+                        };
+                        let request = self.sign_queue.get_or_pending(&sign_id);
+                        let presignature = match positor {
+                            Positor::Proposer(_proposer, taken) => PendingPresignature::Available(taken),
+                            Positor::Deliberator(proposer) => PendingPresignature::InStorage(
+                                presignature_id,
+                                proposer,
+                                self.presignatures.clone(),
+                            ),
+                        };
+                        let cfg = cfg.borrow().protocol.clone();
+                        self.generate(
+                            request,
+                            presignature,
+                            participants,
+                            cfg,
+                            self.sign_respond_signature_channel.clone(),
+                        ).await;
+                    }
+                }
                 Some((sign_id, presignature_id, from, action)) = posits.recv() => {
                     let request = self.sign_queue.get_or_pending(&sign_id);
                     let timeout = Duration::from_millis(cfg.borrow().protocol.signature.generation_timeout);


### PR DESCRIPTION
we weren't kickstarting signature generation on posit expiry, so this expire posits and restart them if needed. This is causing retrys to not happen if it gets hung up on posits