### PR TITLE
chore: no longer need /msg for mesh liveness check

### DIFF
--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -105,50 +105,43 @@ impl NodeConnection {
                     });
                 }
                 _ = interval.tick() => {
-                    if let Err(err) = client.msg_empty(&url).await {
-                        tracing::warn!(?node, ?err, "checking /msg (empty) failed");
-                        status_tx.send_if_modified(|(status, _)| {
-                            std::mem::replace(status, NodeStatus::Offline) != NodeStatus::Offline
-                        });
-                        continue;
-                    }
-
-                    match client.status(&url).await {
-                        Ok(state) => {
-                            // note: borrowing and sending later on `status_tx` can potentially deadlock,
-                            // but since we are copying the status, this is not the case. Change this carefully.
-                            let old_status = status_tx.borrow().0;
-                            let mut new_status = match state {
-                                OtherNodeStatus::Running { .. } => NodeStatus::Active,
-                                OtherNodeStatus::Resharing { .. }
-                                | OtherNodeStatus::Generating { .. }
-                                | OtherNodeStatus::Joining { .. }
-                                | OtherNodeStatus::Starting
-                                | OtherNodeStatus::Started
-                                | OtherNodeStatus::WaitingForConsensus { .. } => NodeStatus::Inactive,
-                            };
-                            if old_status == NodeStatus::Inactive && new_status == NodeStatus::Active {
-                                // Sync when we want to enter an active state
-                                //
-                                // The peer is running. But before we can reliably
-                                // use the connected node in protocols we initiate,
-                                // we need to ensure the peer has the up-to-date
-                                // data about out owned IDs.
-                                new_status = NodeStatus::Syncing;
-                            }
-                            if old_status != new_status {
-                                tracing::info!(?node, ?new_status, "updated with new status");
-                                status_tx.send_modify(|(status, _)| {
-                                    *status = new_status;
-                                });
-                            }
-                        }
+                    let status = match client.status(&url).await {
+                        Ok(status) => status,
                         Err(err) => {
                             tracing::warn!(?node, ?err, "checking /status failed");
                             status_tx.send_if_modified(|(status, _)| {
                                 std::mem::replace(status, NodeStatus::Offline) != NodeStatus::Offline
                             });
+                            continue;
                         }
+                    };
+
+                    // note: borrowing and sending later on `status_tx` can potentially deadlock,
+                    // but since we are copying the status, this is not the case. Change this carefully.
+                    let old_status = status_tx.borrow().0;
+                    let mut new_status = match status {
+                        OtherNodeStatus::Running { .. } => NodeStatus::Active,
+                        OtherNodeStatus::Resharing { .. }
+                        | OtherNodeStatus::Generating { .. }
+                        | OtherNodeStatus::Joining { .. }
+                        | OtherNodeStatus::Starting
+                        | OtherNodeStatus::Started
+                        | OtherNodeStatus::WaitingForConsensus { .. } => NodeStatus::Inactive,
+                    };
+                    if old_status == NodeStatus::Inactive && new_status == NodeStatus::Active {
+                        // Sync when we want to enter an active state
+                        //
+                        // The peer is running. But before we can reliably
+                        // use the connected node in protocols we initiate,
+                        // we need to ensure the peer has the up-to-date
+                        // data about out owned IDs.
+                        new_status = NodeStatus::Syncing;
+                    }
+                    if old_status != new_status {
+                        tracing::info!(?node, ?new_status, "updated with new status");
+                        status_tx.send_modify(|(status, _)| {
+                            *status = new_status;
+                        });
                     }
                 }
             }

--- a/chain-signatures/node/src/node_client.rs
+++ b/chain-signatures/node/src/node_client.rs
@@ -133,10 +133,6 @@ impl NodeClient {
         self.post_msg(&url, msg).await
     }
 
-    pub async fn msg_empty(&self, base: impl IntoUrl) -> Result<(), RequestError> {
-        self.msg(base, &[]).await
-    }
-
     pub async fn state(&self, base: impl IntoUrl) -> Result<StateView, RequestError> {
         let mut url = base.into_url()?;
         url.set_path("state");

--- a/chain-signatures/node/src/web/mock.rs
+++ b/chain-signatures/node/src/web/mock.rs
@@ -19,20 +19,8 @@ impl MockServer {
         server
             .mock("GET", "/state")
             .with_status(201)
-            .with_header("content-type", "text/plain")
-            .with_body(
-                serde_json::to_vec(&StateView::Running {
-                    participants: vec![Participant::from(0)],
-                    triple_count: 0,
-                    triple_mine_count: 0,
-                    triple_potential_count: 0,
-                    presignature_count: 0,
-                    presignature_mine_count: 0,
-                    presignature_potential_count: 0,
-                    latest_block_height: 0,
-                })
-                .unwrap(),
-            )
+            .with_header("content-type", "application/json")
+            .with_body(default_state_body())
             .create_async()
             .await;
 
@@ -40,15 +28,7 @@ impl MockServer {
             .mock("GET", "/status")
             .with_status(201)
             .with_header("content-type", "application/json")
-            .with_body(
-                serde_json::to_vec(&NodeStatus::Running {
-                    me: Participant::from(id),
-                    participants: vec![Participant::from(0)],
-                    ongoing_triple_gen: 0,
-                    ongoing_presignature_gen: 0,
-                })
-                .unwrap(),
-            )
+            .with_body(default_status_body(id))
             .create_async()
             .await;
 
@@ -79,7 +59,7 @@ impl MockServer {
 
     pub async fn make_offline(&mut self) {
         self.server
-            .mock("POST", "/msg")
+            .mock("GET", "/status")
             .with_status(404)
             .create_async()
             .await;
@@ -87,10 +67,10 @@ impl MockServer {
 
     pub async fn make_online(&mut self) {
         self.server
-            .mock("POST", "/msg")
+            .mock("GET", "/status")
             .with_status(201)
             .with_header("content-type", "application/json")
-            .with_body("{}")
+            .with_body(default_status_body(self.id))
             .create_async()
             .await;
     }
@@ -158,4 +138,28 @@ impl std::ops::IndexMut<usize> for MockServers {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.servers[index]
     }
+}
+
+fn default_state_body() -> Vec<u8> {
+    serde_json::to_vec(&StateView::Running {
+        participants: vec![Participant::from(0)],
+        triple_count: 0,
+        triple_mine_count: 0,
+        triple_potential_count: 0,
+        presignature_count: 0,
+        presignature_mine_count: 0,
+        presignature_potential_count: 0,
+        latest_block_height: 0,
+    })
+    .unwrap()
+}
+
+fn default_status_body(id: u32) -> Vec<u8> {
+    serde_json::to_vec(&NodeStatus::Running {
+        me: Participant::from(id),
+        participants: vec![Participant::from(0)],
+        ongoing_triple_gen: 0,
+        ongoing_presignature_gen: 0,
+    })
+    .unwrap()
 }


### PR DESCRIPTION
since message no longer takes in active participants and blindly sends, checking `/msg` for active doesn't matter as much. It's just a wasteful check to do