### PR TITLE
feat: initial checkpoints 

### DIFF
--- a/chain-signatures/node/src/backlog.rs
+++ b/chain-signatures/node/src/backlog.rs
@@ -1,0 +1,416 @@
+use crate::protocol::Chain;
+use crate::sign_bidirectional::{BidirectionalTx, PendingRequestStatus};
+use mpc_primitives::SignId;
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+#[derive(Debug, Clone)]
+pub struct PendingRequests {
+    requests: HashMap<SignId, BidirectionalTx>,
+    /// Queue of transaction IDs waiting to be published
+    pending_publish: VecDeque<SignId>,
+    /// The highest block height that has been processed for this chain
+    processed_block_height: Option<u64>,
+}
+
+impl Default for PendingRequests {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PendingRequests {
+    /// Creates a new empty PendingRequests container
+    pub fn new() -> Self {
+        Self {
+            requests: HashMap::new(),
+            pending_publish: VecDeque::new(),
+            processed_block_height: None,
+        }
+    }
+
+    /// Inserts a sign-respond transaction into the pending requests map
+    /// Returns Some(old_value) if the key was already present
+    fn insert(&mut self, id: SignId, tx: BidirectionalTx) -> Option<BidirectionalTx> {
+        self.requests.insert(id, tx)
+    }
+
+    /// Removes a sign-respond transaction from the pending requests map
+    /// Returns Some(value) if the key was present
+    fn remove(&mut self, id: &SignId) -> Option<BidirectionalTx> {
+        self.requests.remove(id)
+    }
+
+    /// Gets a clone of a sign-respond transaction from the pending requests map
+    /// Returns Some(value) if the key is present
+    fn get(&self, id: &SignId) -> Option<BidirectionalTx> {
+        self.requests.get(id).cloned()
+    }
+
+    /// Returns the number of pending requests
+    fn len(&self) -> usize {
+        self.requests.len()
+    }
+
+    /// Returns all sign-respond transactions with a specific status
+    pub fn get_by_status(&self, status: PendingRequestStatus) -> HashMap<SignId, BidirectionalTx> {
+        self.requests
+            .iter()
+            .filter(|(_, tx)| tx.status == status)
+            .map(|(id, tx)| (*id, tx.clone()))
+            .collect()
+    }
+
+    /// Add a transaction ID to the pending publish queue
+    pub fn push_pending_publish(&mut self, id: SignId) {
+        self.pending_publish.push_back(id);
+    }
+
+    /// Pop the next transaction ID from the pending publish queue
+    /// Returns the transaction if found
+    pub fn pop_pending_publish(&mut self) -> Option<(SignId, BidirectionalTx)> {
+        let id = self.pending_publish.pop_front()?;
+        let tx = self.get(&id)?;
+        Some((id, tx))
+    }
+
+    /// Get the number of transactions waiting to be published
+    fn pending_publish_count(&self) -> usize {
+        self.pending_publish.len()
+    }
+
+    /// Get all pending transaction IDs and their transactions
+    fn pending_execution(&self) -> Vec<(SignId, BidirectionalTx)> {
+        self.pending_publish
+            .iter()
+            .filter_map(|id| self.get(id).map(|tx| (*id, tx)))
+            .collect()
+    }
+
+    /// Get the processed block height for this chain
+    fn processed_block_height(&self) -> Option<u64> {
+        self.processed_block_height
+    }
+
+    /// Set the processed block height for this chain
+    fn set_processed_block(&mut self, height: u64) {
+        self.processed_block_height = Some(height);
+    }
+}
+
+/// Backlog manages pending sign-respond requests across multiple chains.
+/// Each chain has its own isolated set of pending requests with their own
+/// publish queues.
+#[derive(Debug, Clone)]
+pub struct Backlog {
+    requests: Arc<RwLock<HashMap<Chain, PendingRequests>>>,
+}
+
+impl Default for Backlog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Backlog {
+    pub fn new() -> Self {
+        Self {
+            requests: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub async fn insert(
+        &self,
+        chain: Chain,
+        id: SignId,
+        tx: BidirectionalTx,
+    ) -> Option<BidirectionalTx> {
+        self.requests
+            .write()
+            .await
+            .entry(chain)
+            .or_insert_with(PendingRequests::new)
+            .insert(id, tx)
+    }
+
+    pub async fn remove(&self, chain: Chain, id: &SignId) -> Option<BidirectionalTx> {
+        self.requests
+            .write()
+            .await
+            .entry(chain)
+            .or_insert_with(PendingRequests::new)
+            .remove(id)
+    }
+
+    pub async fn get(&self, chain: Chain, id: &SignId) -> Option<BidirectionalTx> {
+        self.requests
+            .read()
+            .await
+            .get(&chain)
+            .and_then(|pending_requests| pending_requests.get(id))
+    }
+
+    /// Returns the number of pending requests in total
+    pub async fn len(&self) -> usize {
+        self.requests
+            .read()
+            .await
+            .values()
+            .map(|requests| requests.len())
+            .sum()
+    }
+
+    /// Returns true if there are no pending requests
+    pub async fn is_empty(&self) -> bool {
+        self.requests.read().await.is_empty()
+    }
+
+    /// Returns all sign-respond transactions with a specific status
+    pub async fn get_by_status(
+        &self,
+        chain: Chain,
+        status: PendingRequestStatus,
+    ) -> HashMap<SignId, BidirectionalTx> {
+        self.requests
+            .read()
+            .await
+            .get(&chain)
+            .map(|requests| requests.get_by_status(status))
+            .unwrap_or_default()
+    }
+
+    pub async fn len_by_chain(&self, chain: Chain) -> usize {
+        self.requests
+            .read()
+            .await
+            .get(&chain)
+            .map(|requests| requests.len())
+            .unwrap_or(0)
+    }
+
+    /// Mark a request as published (success or failure)
+    pub async fn mark_published(
+        &self,
+        _chain: Chain,
+        _id: &SignId,
+        _success: bool,
+    ) -> Result<(), BacklogError> {
+        // TODO: implement
+        Ok(())
+    }
+
+    /// Get the number of transactions waiting to be published for a specific chain
+    pub async fn pending_publish_count(&self, chain: Chain) -> usize {
+        self.requests
+            .read()
+            .await
+            .get(&chain)
+            .map(|pr| pr.pending_publish_count())
+            .unwrap_or(0)
+    }
+
+    /// Get all pending transactions for a specific chain
+    pub async fn pending_execution(&self, chain: Chain) -> Vec<(SignId, BidirectionalTx)> {
+        self.requests
+            .read()
+            .await
+            .get(&chain)
+            .map(|pr| pr.pending_execution())
+            .unwrap_or_default()
+    }
+
+    /// Get the processed block height for a specific chain
+    pub async fn processed_block(&self, chain: Chain) -> Option<u64> {
+        self.requests
+            .read()
+            .await
+            .get(&chain)
+            .and_then(|pr| pr.processed_block_height())
+    }
+
+    /// Set the processed block height for a specific chain
+    pub async fn set_processed_block(&self, chain: Chain, height: u64) {
+        let mut map = self.requests.write().await;
+        let pending_requests = map.entry(chain).or_default();
+        pending_requests.set_processed_block(height);
+        tracing::debug!(?chain, height, "updated processed block height");
+    }
+}
+
+/// Errors that can occur when working with Backlog
+#[derive(Debug, thiserror::Error)]
+pub enum BacklogError {
+    #[error("request not found for chain {chain:?} with id {id:?}")]
+    NotFound { chain: Chain, id: SignId },
+    #[error("chain not initialized: {chain:?}")]
+    ChainNotInitialized { chain: Chain },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sign_bidirectional::{BidirectionalTx, BidirectionalTxId, PendingRequestStatus};
+    use alloy::primitives::{Address, B256};
+    use anchor_lang::prelude::Pubkey;
+    use mpc_primitives::SignId;
+
+    fn create_test_tx(id: u8, status: PendingRequestStatus) -> BidirectionalTx {
+        BidirectionalTx {
+            id: BidirectionalTxId(B256::from([id; 32])),
+            sender: Pubkey::new_unique(),
+            transaction_data: vec![1, 2, 3],
+            caip2_id: "test_caip2_id".to_string(),
+            key_version: 1,
+            deposit: 1000,
+            path: "test_path".to_string(),
+            algo: "ECDSA".to_string(),
+            dest: "0x1234567890123456789012345678901234567890".to_string(),
+            params: "{}".to_string(),
+            output_deserialization_schema: vec![],
+            respond_serialization_schema: vec![],
+            request_id: [id; 32],
+            from_address: Address::ZERO,
+            nonce: 0,
+            participants: vec![],
+            status,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_backlog_chain_isolation() {
+        let backlog = Backlog::new();
+
+        let tx_eth = create_test_tx(1, PendingRequestStatus::PendingExecution);
+        let tx_sol = create_test_tx(2, PendingRequestStatus::PendingExecution);
+        let tx_near = create_test_tx(3, PendingRequestStatus::PendingExecution);
+
+        let sign_id_eth = SignId::new(tx_eth.request_id);
+        let sign_id_sol = SignId::new(tx_sol.request_id);
+        let sign_id_near = SignId::new(tx_near.request_id);
+
+        // Insert into different chains
+        backlog
+            .insert(Chain::Ethereum, sign_id_eth, tx_eth.clone())
+            .await;
+        backlog
+            .insert(Chain::Solana, sign_id_sol, tx_sol.clone())
+            .await;
+        backlog
+            .insert(Chain::NEAR, sign_id_near, tx_near.clone())
+            .await;
+
+        // Verify correct transactions in each chain
+        assert!(backlog.get(Chain::Ethereum, &sign_id_eth).await.is_some());
+        assert!(backlog.get(Chain::Ethereum, &sign_id_sol).await.is_none());
+        assert!(backlog.get(Chain::Solana, &sign_id_sol).await.is_some());
+        assert!(backlog.get(Chain::Solana, &sign_id_eth).await.is_none());
+        assert!(backlog.get(Chain::NEAR, &sign_id_near).await.is_some());
+        assert!(backlog.get(Chain::NEAR, &sign_id_eth).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_backlog_filter_by_status() {
+        let backlog = Backlog::new();
+
+        // Add transactions with different statuses to Ethereum
+        let tx1 = create_test_tx(1, PendingRequestStatus::PendingExecution);
+        let tx2 = create_test_tx(2, PendingRequestStatus::Success);
+        let tx3 = create_test_tx(3, PendingRequestStatus::PendingExecution);
+
+        backlog
+            .insert(Chain::Ethereum, SignId::new(tx1.request_id), tx1)
+            .await;
+        backlog
+            .insert(Chain::Ethereum, SignId::new(tx2.request_id), tx2)
+            .await;
+        backlog
+            .insert(Chain::Ethereum, SignId::new(tx3.request_id), tx3)
+            .await;
+
+        // Add transactions to Solana
+        let tx4 = create_test_tx(4, PendingRequestStatus::PendingExecution);
+        backlog
+            .insert(Chain::Solana, SignId::new(tx4.request_id), tx4)
+            .await;
+
+        // Filter Ethereum by Pending
+        let eth_pending = backlog
+            .get_by_status(Chain::Ethereum, PendingRequestStatus::PendingExecution)
+            .await;
+        assert_eq!(eth_pending.len(), 2);
+
+        // Filter Ethereum by Success
+        let eth_success = backlog
+            .get_by_status(Chain::Ethereum, PendingRequestStatus::Success)
+            .await;
+        assert_eq!(eth_success.len(), 1);
+
+        // Filter Solana by Pending
+        let sol_pending = backlog
+            .get_by_status(Chain::Solana, PendingRequestStatus::PendingExecution)
+            .await;
+        assert_eq!(sol_pending.len(), 1);
+
+        // Filter non-existent chain returns empty
+        let near_pending = backlog
+            .get_by_status(Chain::NEAR, PendingRequestStatus::PendingExecution)
+            .await;
+        assert_eq!(near_pending.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_backlog_concurrent_access() {
+        let backlog = Backlog::new();
+        let mut handles = vec![];
+
+        // Spawn multiple tasks that insert concurrently to different chains
+        for i in 0..5 {
+            let backlog = backlog.clone();
+            let handle = tokio::spawn(async move {
+                let tx = create_test_tx(i, PendingRequestStatus::PendingExecution);
+                let sign_id = SignId::new(tx.request_id);
+                backlog.insert(Chain::Ethereum, sign_id, tx).await;
+            });
+            handles.push(handle);
+        }
+
+        for i in 5..10 {
+            let backlog = backlog.clone();
+            let handle = tokio::spawn(async move {
+                let tx = create_test_tx(i, PendingRequestStatus::PendingExecution);
+                let sign_id = SignId::new(tx.request_id);
+                backlog.insert(Chain::Solana, sign_id, tx).await;
+            });
+            handles.push(handle);
+        }
+
+        // Wait for all insertions and verify all were inserted
+        for handle in handles {
+            handle.await.unwrap();
+        }
+        assert_eq!(backlog.len_by_chain(Chain::Ethereum).await, 5);
+        assert_eq!(backlog.len_by_chain(Chain::Solana).await, 5);
+
+        // Spawn multiple tasks that remove concurrently
+        let mut handles = vec![];
+        for i in 0..5 {
+            let backlog = backlog.clone();
+            let handle = tokio::spawn(async move {
+                let id = SignId::new([i; 32]);
+                backlog.remove(Chain::Ethereum, &id).await
+            });
+            handles.push(handle);
+        }
+
+        // Wait for all removals
+        for handle in handles {
+            let removed = handle.await.unwrap();
+            assert!(removed.is_some());
+        }
+
+        // Verify Ethereum chain is now empty, but Solana still has data
+        assert_eq!(backlog.len_by_chain(Chain::Ethereum).await, 0);
+        assert_eq!(backlog.len_by_chain(Chain::Solana).await, 5);
+    }
+}

--- a/chain-signatures/node/src/backlog.rs
+++ b/chain-signatures/node/src/backlog.rs
@@ -260,6 +260,8 @@ mod tests {
             id: BidirectionalTxId(B256::from([id; 32])),
             sender: Pubkey::new_unique(),
             transaction_data: vec![1, 2, 3],
+            source_chain: Chain::Solana,
+            target_chain: Chain::Ethereum,
             caip2_id: "test_caip2_id".to_string(),
             key_version: 1,
             deposit: 1000,

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::backlog::Backlog;
 use crate::config::{Config, LocalConfig, NetworkConfig, OverrideConfig};
 use crate::gcp::GcpService;
 use crate::mesh::Mesh;
@@ -8,7 +9,6 @@ use crate::protocol::sync::SyncTask;
 use crate::protocol::{spawn_system_metrics, MpcSignProtocol, SignQueue};
 use crate::respond_bidirectional::RespondBidirectionalTxProcessor;
 use crate::rpc::{ContractStateWatcher, NearClient, RpcExecutor};
-use crate::sign_bidirectional::SignBidirectionalSignatureProcessor;
 use crate::storage::app_data_storage;
 use crate::{indexer, indexer_eth, indexer_sol, logs, mesh, storage, web};
 use clap::Parser;
@@ -18,7 +18,6 @@ use local_ip_address::local_ip;
 use near_account_id::AccountId;
 use near_crypto::{InMemorySigner, PublicKey, SecretKey};
 use sha3::Digest;
-use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{watch, RwLock};
 use url::Url;
@@ -225,6 +224,8 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             }
             tracing::info!(rpc_addr = rpc_client.rpc_addr(), "rpc client initialized");
 
+            let backlog = Backlog::new();
+
             // NEAR Indexer is only used for integration tests
             // TODO: Remove this once we have integration tests built on other chains
             let indexer = if storage_options.env == "integration-tests" {
@@ -234,6 +235,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                     &account_id,
                     sign_tx.clone(),
                     rpc_client.clone(),
+                    backlog.clone(),
                 )?;
                 Some(indexer)
             } else {
@@ -264,9 +266,8 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let network = NetworkConfig { cipher_sk, sign_sk };
             let near_client =
                 NearClient::new(&near_rpc, &my_address, &network, &mpc_contract_id, signer);
-            let (rpc_channel, rpc) = RpcExecutor::new(&near_client, &eth, &sol);
-            let (sign_bidirectional_signature_channel, sign_bidirectional_signature_processor) =
-                SignBidirectionalSignatureProcessor::new();
+
+            let (rpc_channel, rpc) = RpcExecutor::new(&near_client, &eth, &sol, backlog.clone());
             let (respond_bidirectional_tx_channel, respond_bidirectional_tx_processor) =
                 RespondBidirectionalTxProcessor::new();
             let (sync_channel, sync) = SyncTask::new(
@@ -277,11 +278,6 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 contract_watcher.clone(),
                 synced_peer_tx,
             );
-
-            let bidirectional_tx_map = Arc::new(RwLock::new(HashMap::<
-                crate::sign_bidirectional::BidirectionalTxId,
-                crate::sign_bidirectional::BidirectionalTx,
-            >::new()));
 
             tracing::info!(
                 %digest,
@@ -325,7 +321,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 contract: contract_watcher.clone(),
                 config: config_rx,
                 mesh_state: mesh_state.clone(),
-                sign_bidirectional_signature_channel: sign_bidirectional_signature_channel.clone(),
+                backlog: backlog.clone(),
             };
 
             tracing::info!("protocol initialized");
@@ -333,14 +329,10 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             tokio::spawn(rpc.run(
                 contract_state_tx,
                 config_tx.clone(),
-                sign_bidirectional_signature_channel.clone(),
                 respond_bidirectional_tx_channel.clone(),
             ));
 
-            let bidirectional_tx_map_clone = bidirectional_tx_map.clone();
-            tokio::spawn(sign_bidirectional_signature_processor.run(bidirectional_tx_map_clone, 5));
-            let bidirectional_tx_map_clone = bidirectional_tx_map.clone();
-            tokio::spawn(respond_bidirectional_tx_processor.run(bidirectional_tx_map_clone, 5));
+            tokio::spawn(respond_bidirectional_tx_processor.run(backlog.clone(), 5));
             tokio::spawn(mesh.run(contract_watcher.clone()));
             let system_handle = spawn_system_metrics(account_id.as_str()).await;
             let protocol_handle =
@@ -361,9 +353,9 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 sign_tx.clone(),
                 app_data_storage.clone(),
                 account_id.clone(),
-                bidirectional_tx_map,
+                backlog.clone(),
             ));
-            tokio::spawn(indexer_sol::run(sol, sign_tx, account_id));
+            tokio::spawn(indexer_sol::run(sol, sign_tx, account_id, backlog));
             tracing::info!("protocol http server spawned");
             protocol_handle.await?;
             web_handle.await?;

--- a/chain-signatures/node/src/indexer.rs
+++ b/chain-signatures/node/src/indexer.rs
@@ -1,3 +1,4 @@
+use crate::backlog::Backlog;
 use crate::protocol::Chain;
 use crate::protocol::IndexedSignRequest;
 use mpc_contract::primitives::PendingRequest;
@@ -141,9 +142,13 @@ struct Context {
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     indexer: NearIndexer,
     rpc_client: near_fetch::Client,
+    backlog: Backlog,
 }
 
 async fn poll_pending_requests(ctx: &Context) -> anyhow::Result<()> {
+    let latest_block = ctx.rpc_client.view_block().await?;
+    let latest_height = latest_block.header.height;
+
     // Fetch pending requests from the contract
     let pending_requests = ctx
         .indexer
@@ -179,7 +184,7 @@ async fn poll_pending_requests(ctx: &Context) -> anyhow::Result<()> {
     // Update metrics
     crate::metrics::LATEST_BLOCK_NUMBER
         .with_label_values(&[Chain::NEAR.as_str(), ctx.node_account_id.as_str()])
-        .set(crate::util::current_unix_timestamp() as i64);
+        .set(latest_height as i64);
 
     // Send all new requests
     for request in new_requests {
@@ -196,6 +201,10 @@ async fn poll_pending_requests(ctx: &Context) -> anyhow::Result<()> {
         }
     }
 
+    ctx.backlog
+        .set_processed_block(Chain::NEAR, latest_height)
+        .await;
+
     // Cleanup old processed requests periodically
     ctx.indexer.cleanup_old_requests().await;
 
@@ -208,6 +217,7 @@ pub fn run(
     node_account_id: &AccountId,
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     rpc_client: near_fetch::Client,
+    backlog: Backlog,
 ) -> anyhow::Result<(JoinHandle<anyhow::Result<()>>, NearIndexer)> {
     tracing::info!(
         %mpc_contract_id,
@@ -222,6 +232,7 @@ pub fn run(
         sign_tx,
         indexer: indexer.clone(),
         rpc_client,
+        backlog,
     };
 
     let join_handle = tokio::spawn(run_polling_loop(context));

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -1423,11 +1423,12 @@ async fn process_bidirectional_requests(
         };
 
         let completed_tx = CompletedTx::new(updated_tx.clone(), block_number);
+        let source_chain = updated_tx.source_chain;
         if status {
             match extract_success_output_with_rpc(client, &updated_tx, block_number).await {
                 Ok(serialized_output) => {
                     match completed_tx.create_sign_request_from_serialized_output(
-                        Chain::Ethereum,
+                        source_chain,
                         serialized_output,
                         total_timeout,
                     ) {
@@ -1449,7 +1450,7 @@ async fn process_bidirectional_requests(
             }
         } else {
             match completed_tx
-                .create_failed_sign_request_without_light_client(Chain::Ethereum, total_timeout)
+                .create_failed_sign_request_without_light_client(source_chain, total_timeout)
                 .await
             {
                 Ok(sign_request) => respond_requests.push(sign_request),
@@ -1490,7 +1491,7 @@ async fn process_bidirectional_requests(
             tx.status = PendingRequestStatus::Failed;
             let completed_tx = CompletedTx::new(tx.clone(), block_number);
             match completed_tx
-                .create_failed_sign_request_without_light_client(Chain::Ethereum, total_timeout)
+                .create_failed_sign_request_without_light_client(tx.source_chain, total_timeout)
                 .await
             {
                 Ok(sign_request) => respond_requests.push(sign_request),

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -1,7 +1,18 @@
+use std::fmt;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::sync::LazyLock;
+use std::time::Instant;
+
+use crate::backlog::Backlog;
 use crate::protocol::{Chain, IndexedSignRequest, SignRequestType};
+#[cfg(not(feature = "light_client"))]
 use crate::sign_bidirectional::BidirectionalTx;
+#[cfg(not(feature = "light_client"))]
 use crate::sign_bidirectional::BidirectionalTxId;
+use crate::sign_bidirectional::PendingRequestStatus;
 use crate::storage::app_data_storage::AppDataStorage;
+
 use alloy::consensus::BlockHeader;
 #[cfg(not(feature = "light_client"))]
 use alloy::consensus::Transaction as _;
@@ -20,7 +31,6 @@ use crate::respond_bidirectional::{
     CompletedTx, RespondBidirectionalSerializedOutput, SerDeserFormat,
     OUTPUT_DESERIALIZATION_FORMAT, RESPOND_SERIALIZATION_FORMAT,
 };
-use crate::sign_bidirectional::BidirectionalTxStatus;
 #[cfg(not(feature = "light_client"))]
 use crate::sign_bidirectional::TransactionOutput;
 use alloy::sol_types::{sol, SolEvent};
@@ -34,16 +44,12 @@ use mpc_primitives::{SignArgs, SignId, LATEST_MPC_KEY_VERSION};
 use near_account_id::AccountId;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::json;
-use std::collections::HashMap;
 #[cfg(feature = "light_client")]
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-use std::{fmt, str::FromStr, sync::LazyLock, time::Instant};
 #[cfg(feature = "light_client")]
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::mpsc;
-use tokio::sync::RwLock;
 use tokio::time::{sleep, Duration};
 
 pub(crate) static MAX_SECP256K1_SCALAR: LazyLock<Scalar> = LazyLock::new(|| {
@@ -457,7 +463,7 @@ pub async fn run(
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     app_data_storage: AppDataStorage,
     node_near_account_id: AccountId,
-    bidirectional_tx_map: Arc<RwLock<HashMap<BidirectionalTxId, BidirectionalTx>>>,
+    backlog: Backlog,
 ) {
     let Some(eth) = eth else {
         tracing::warn!("ethereum indexer is disabled");
@@ -551,40 +557,26 @@ pub async fn run(
         .await;
     });
 
-    let near_account_id_clone = node_near_account_id.clone();
-    let client_clone = Arc::clone(&client);
-    tokio::spawn(async move {
-        tracing::info!("Spawned task to send indexed requests to send queue");
-        send_requests_when_final(
-            &client_clone,
-            requests_indexed_recv,
-            finalized_block_recv,
-            sign_tx.clone(),
-            app_data_storage.clone(),
-            near_account_id_clone.clone(),
-        )
-        .await;
-    });
+    tokio::spawn(send_requests_when_final(
+        Arc::clone(&client),
+        requests_indexed_recv,
+        finalized_block_recv,
+        sign_tx.clone(),
+        app_data_storage.clone(),
+        node_near_account_id.clone(),
+        backlog.clone(),
+    ));
 
-    let near_account_id_clone = node_near_account_id.clone();
-    let requests_indexed_send_clone = requests_indexed_send.clone();
-    let blocks_failed_send_clone = blocks_failed_send.clone();
-    let client_clone = Arc::clone(&client);
-    let bidirectional_tx_map_clone = bidirectional_tx_map.clone();
-    tokio::spawn(async move {
-        tracing::info!("Spawned task to retry failed blocks");
-        retry_failed_blocks(
-            blocks_failed_recv,
-            blocks_failed_send_clone,
-            &client_clone,
-            eth_contract_addr,
-            near_account_id_clone,
-            requests_indexed_send_clone,
-            total_timeout,
-            bidirectional_tx_map_clone,
-        )
-        .await;
-    });
+    tokio::spawn(retry_failed_blocks(
+        blocks_failed_recv,
+        blocks_failed_send.clone(),
+        Arc::clone(&client),
+        eth_contract_addr,
+        node_near_account_id.clone(),
+        requests_indexed_send.clone(),
+        total_timeout,
+        backlog.clone(),
+    ));
 
     let blocks_to_process_send_clone = blocks_to_process_send.clone();
     if let Some(last_processed_block) = last_processed_block {
@@ -633,7 +625,6 @@ pub async fn run(
                 (block_number, block_hash, false)
             }
         };
-        let bidirectional_tx_map_clone = bidirectional_tx_map.clone();
         if let Err(err) = process_block(
             block_number,
             block_hash,
@@ -642,7 +633,7 @@ pub async fn run(
             node_near_account_id.clone(),
             requests_indexed_send_clone.clone(),
             total_timeout,
-            bidirectional_tx_map_clone,
+            backlog.clone(),
         )
         .await
         {
@@ -668,12 +659,12 @@ pub async fn run(
 async fn retry_failed_blocks(
     mut blocks_failed_rx: mpsc::Receiver<BlockNumberAndHash>,
     blocks_failed_tx: mpsc::Sender<BlockNumberAndHash>,
-    client: &Arc<EthereumClient>,
+    client: Arc<EthereumClient>,
     eth_contract_addr: Address,
     node_near_account_id: AccountId,
     requests_indexed: mpsc::Sender<BlockAndRequests>,
     total_timeout: Duration,
-    bidirectional_tx_map: Arc<RwLock<HashMap<BidirectionalTxId, BidirectionalTx>>>,
+    backlog: Backlog,
 ) {
     loop {
         let Some((block_number, block_hash)) = blocks_failed_rx.recv().await else {
@@ -683,12 +674,12 @@ async fn retry_failed_blocks(
         if let Err(err) = process_block(
             block_number,
             block_hash,
-            client,
+            &client,
             eth_contract_addr,
             node_near_account_id.clone(),
             requests_indexed.clone(),
             total_timeout,
-            bidirectional_tx_map.clone(),
+            backlog.clone(),
         )
         .await
         {
@@ -896,7 +887,7 @@ async fn process_block(
     node_near_account_id: AccountId,
     requests_indexed: mpsc::Sender<BlockAndRequests>,
     total_timeout: Duration,
-    bidirectional_tx_map: Arc<RwLock<HashMap<BidirectionalTxId, BidirectionalTx>>>,
+    backlog: Backlog,
 ) -> anyhow::Result<()> {
     tracing::info!(
         "Processing block number {} with hash {:?}",
@@ -921,112 +912,79 @@ async fn process_block(
         return Ok(());
     };
 
-    let pending_txs: HashMap<BidirectionalTxId, BidirectionalTx> = {
-        bidirectional_tx_map
-            .read()
-            .await
-            .iter()
-            .filter(|(_, tx)| tx.status == BidirectionalTxStatus::Pending)
-            .map(|(id, tx)| (*id, tx.clone()))
-            .collect()
+    let pending_txs = backlog
+        .get_by_status(Chain::Ethereum, PendingRequestStatus::PendingExecution)
+        .await;
+
+    let Some((sign_id, pending_tx)) = pending_entry else {
+        continue;
     };
-    let mut respond_bidirectional_requests: Vec<IndexedSignRequest> = Vec::new();
-    for receipt in &block_receipts {
-        let Some(pending_tx) = pending_txs.get(&receipt.transaction_hash.into()) else {
-            continue;
-        };
-        let status = receipt.status();
-        tracing::info!(
-            "Tx {} found in block {block_number}: {}",
-            receipt.transaction_hash,
-            if status { "success" } else { "failed" }
+    let status = receipt.status();
+    tracing::info!(
+        "Tx {} found in block {block_number}: {}",
+        receipt.transaction_hash,
+        if status { "success" } else { "failed" }
+    );
+    let mut pending_tx = pending_tx.clone();
+    pending_tx.status = if status {
+        PendingRequestStatus::Success
+    } else {
+        PendingRequestStatus::Failed
+    };
+
+    let pending_tx_clone = pending_tx.clone();
+    let completed_tx =
+        crate::respond_bidirectional::CompletedTx::new(pending_tx_clone, block_number);
+
+    let respond_bidirectional_sign_request: Option<IndexedSignRequest> = completed_tx
+        .create_sign_request_from_completed_tx(client, Chain::Ethereum, 6, total_timeout)
+        .await;
+    if let Some(request) = respond_bidirectional_sign_request {
+        respond_bidirectional_requests.push(request);
+        backlog.insert(Chain::Ethereum, *sign_id, pending_tx).await;
+    } else {
+        // failed to create sign request from completed tx, remove the tx from the map
+        // TODO: we need to implement a better solution for not finding such txs in helios. possible: https://github.com/sig-net/mpc/issues/499
+        tracing::warn!(
+            "Failed to create sign request from completed tx, removing tx from map: {:?}",
+            receipt.transaction_hash
         );
-        let client_clone = client.clone();
-        let mut pending_tx = pending_tx.clone();
-        pending_tx.status = if status {
-            BidirectionalTxStatus::Success
-        } else {
-            BidirectionalTxStatus::Failed
-        };
-
-        let pending_tx_clone = pending_tx.clone();
-        let completed_tx =
-            crate::respond_bidirectional::CompletedTx::new(pending_tx_clone, block_number);
-
-        let respond_bidirectional_sign_request: Option<IndexedSignRequest> = completed_tx
-            .create_sign_request_from_completed_tx(&client_clone, 6, total_timeout)
-            .await;
-        if let Some(respond_bidirectional_sign_request) = respond_bidirectional_sign_request {
-            respond_bidirectional_requests.push(respond_bidirectional_sign_request);
-            bidirectional_tx_map
-                .write()
-                .await
-                .insert(receipt.transaction_hash.into(), pending_tx);
-        } else {
-            // failed to create sign request from completed tx, remove the tx from the map
-            // TODO: we need to implement a better solution for not finding such txs in helios. possible: https://github.com/sig-net/mpc/issues/499
-            tracing::warn!(
-                "Failed to create sign request from completed tx, removing tx from map: {:?}",
-                receipt.transaction_hash
-            );
-            bidirectional_tx_map
-                .write()
-                .await
-                .remove(&receipt.transaction_hash.into());
-        }
+        backlog.remove(Chain::Ethereum, sign_id).await;
     }
 
-    let remaining_pending_txs: HashMap<BidirectionalTxId, BidirectionalTx> = {
-        bidirectional_tx_map
-            .read()
-            .await
-            .iter()
-            .filter(|(_, tx)| tx.status == BidirectionalTxStatus::Pending)
-            .map(|(id, tx)| (*id, tx.clone()))
-            .collect()
-    };
+    let remaining_pending_txs = backlog
+        .get_by_status(Chain::Ethereum, PendingRequestStatus::PendingExecution)
+        .await;
+    if current_nonce.is_err() {
+        tracing::warn!("Failed to get current nonce: {:?}", current_nonce.err());
+        continue;
+    }
+    let current_nonce = current_nonce.unwrap();
+    if tx.nonce < current_nonce {
+        tracing::warn!(
+            ?sign_id,
+            expected_nonce = tx.nonce,
+            actual_nonce = current_nonce,
+            "nonce too low for tx",
+        );
+        tx.status = PendingRequestStatus::Failed;
+        let pending_tx = tx.clone();
 
-    for (tx_id, mut tx) in remaining_pending_txs {
-        let current_nonce = client
-            .get_nonce(
-                tx.from_address,
-                BlockId::Number(BlockNumberOrTag::Number(block_number)),
-            )
+        let completed_tx = crate::respond_bidirectional::CompletedTx::new(pending_tx, block_number);
+
+        let respond_bidirectional_sign_request: Option<IndexedSignRequest> = completed_tx
+            .create_sign_request_from_completed_tx(client, Chain::Ethereum, 6, total_timeout)
             .await;
-        if current_nonce.is_err() {
-            tracing::warn!("Failed to get current nonce: {:?}", current_nonce.err());
-            continue;
-        }
-        let current_nonce = current_nonce.unwrap();
-        if tx.nonce < current_nonce {
+        if let Some(request) = respond_bidirectional_sign_request {
+            respond_bidirectional_requests.push(request);
+            backlog.insert(Chain::Ethereum, sign_id, tx).await;
+        } else {
+            // failed to create sign request from completed tx, remove the tx from the map
             tracing::warn!(
-                "Nonce too low for tx {:?}: expected {}, got {}",
-                tx_id,
-                tx.nonce,
-                current_nonce
+                ?sign_id,
+                "failed to create sign request from completed tx, removing tx from map",
             );
-            tx.status = BidirectionalTxStatus::Failed;
-            let client_clone = client.clone();
-
-            let pending_tx = tx.clone();
-
-            let completed_tx =
-                crate::respond_bidirectional::CompletedTx::new(pending_tx, block_number);
-
-            let respond_bidirectional_sign_request: Option<IndexedSignRequest> = completed_tx
-                .create_sign_request_from_completed_tx(&client_clone, 6, total_timeout)
-                .await;
-            if let Some(respond_bidirectional_sign_request) = respond_bidirectional_sign_request {
-                respond_bidirectional_requests.push(respond_bidirectional_sign_request);
-                bidirectional_tx_map.write().await.insert(tx_id, tx);
-            } else {
-                // failed to create sign request from completed tx, remove the tx from the map
-                tracing::warn!(
-                    "Failed to create sign request from completed tx, removing tx from map: {:?}",
-                    tx_id
-                );
-                bidirectional_tx_map.write().await.remove(&tx_id);
-            }
+            backlog.remove(Chain::Ethereum, &sign_id).await;
         }
     }
 
@@ -1093,12 +1051,13 @@ async fn process_block(
 /// Sends a request to the sign queue when the block where the request is in is finalized.
 #[cfg(feature = "light_client")]
 async fn send_requests_when_final(
-    helios_client: &Arc<EthereumClient>,
+    helios_client: Arc<EthereumClient>,
     mut requests_indexed: mpsc::Receiver<BlockAndRequests>,
     mut finalized_block_rx: mpsc::Receiver<BlockNumber>,
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     app_data_storage: AppDataStorage,
     node_near_account_id: AccountId,
+    backlog: Backlog,
 ) {
     let mut finalized_block_number: Option<BlockNumber> = None;
     let mut last_processed_block: Option<BlockNumber> = app_data_storage
@@ -1131,7 +1090,7 @@ async fn send_requests_when_final(
 
         // Verify block hash and send requests
         let block = fetch_block(
-            helios_client,
+            &helios_client,
             block_number.into(),
             5,
             Duration::from_millis(200),
@@ -1159,6 +1118,9 @@ async fn send_requests_when_final(
                 }
                 last_processed_block.replace(block_number);
             }
+            backlog
+                .set_processed_block(Chain::Ethereum, block_number)
+                .await;
         } else {
             // no special handling for chain reorg, just log the error
             // This is because when such chain reorg happens, the new canonical chain will have already been emitted by helios's block header stream, and we can safely skip this block here.
@@ -1263,7 +1225,7 @@ pub async fn run(
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     app_data_storage: AppDataStorage,
     node_near_account_id: AccountId,
-    bidirectional_tx_map: Arc<RwLock<HashMap<BidirectionalTxId, BidirectionalTx>>>,
+    backlog: Backlog,
 ) {
     let Some(eth) = eth else {
         tracing::warn!("ethereum indexer is disabled");
@@ -1328,7 +1290,7 @@ pub async fn run(
                 node_near_account_id.clone(),
                 sign_tx.clone(),
                 total_timeout,
-                &bidirectional_tx_map,
+                &backlog,
             )
             .await
             {
@@ -1366,7 +1328,7 @@ async fn process_block(
     node_near_account_id: AccountId,
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     total_timeout: Duration,
-    bidirectional_tx_map: &Arc<RwLock<HashMap<BidirectionalTxId, BidirectionalTx>>>,
+    backlog: &Backlog,
 ) -> anyhow::Result<()> {
     tracing::info!("Processing block number {}", block_number);
 
@@ -1392,7 +1354,7 @@ async fn process_block(
         client,
         block_number,
         total_timeout,
-        bidirectional_tx_map,
+        backlog,
         &node_near_account_id,
     )
     .await?;
@@ -1426,24 +1388,18 @@ async fn process_bidirectional_requests(
     client: &RpcEthereumClient,
     block_number: u64,
     total_timeout: Duration,
-    bidirectional_tx_map: &Arc<RwLock<HashMap<BidirectionalTxId, BidirectionalTx>>>,
+    backlog: &Backlog,
     node_near_account_id: &AccountId,
 ) -> anyhow::Result<Vec<IndexedSignRequest>> {
-    let pending_txs: HashMap<BidirectionalTxId, BidirectionalTx> = {
-        bidirectional_tx_map
-            .read()
-            .await
-            .iter()
-            .filter(|(_, tx)| tx.status == BidirectionalTxStatus::Pending)
-            .map(|(id, tx)| (*id, tx.clone()))
-            .collect()
-    };
+    let pending_txs = backlog
+        .get_by_status(Chain::Ethereum, PendingRequestStatus::PendingExecution)
+        .await;
 
     let mut respond_requests = Vec::new();
 
     for (tx_id, pending_tx) in pending_txs {
         let start = Instant::now();
-        let receipt = client.transaction_receipt(tx_id).await;
+        let receipt = client.transaction_receipt(pending_tx.id).await;
         crate::metrics::ETH_BLOCK_RECEIPT_LATENCY
             .with_label_values(&[node_near_account_id.as_str()])
             .observe(start.elapsed().as_millis() as f64);
@@ -1461,9 +1417,9 @@ async fn process_bidirectional_requests(
 
         let mut updated_tx = pending_tx.clone();
         updated_tx.status = if status {
-            BidirectionalTxStatus::Success
+            PendingRequestStatus::Success
         } else {
-            BidirectionalTxStatus::Failed
+            PendingRequestStatus::Failed
         };
 
         let completed_tx = CompletedTx::new(updated_tx.clone(), block_number);
@@ -1471,6 +1427,7 @@ async fn process_bidirectional_requests(
             match extract_success_output_with_rpc(client, &updated_tx, block_number).await {
                 Ok(serialized_output) => {
                     match completed_tx.create_sign_request_from_serialized_output(
+                        Chain::Ethereum,
                         serialized_output,
                         total_timeout,
                     ) {
@@ -1492,7 +1449,7 @@ async fn process_bidirectional_requests(
             }
         } else {
             match completed_tx
-                .create_failed_sign_request_without_light_client(total_timeout)
+                .create_failed_sign_request_without_light_client(Chain::Ethereum, total_timeout)
                 .await
             {
                 Ok(sign_request) => respond_requests.push(sign_request),
@@ -1504,18 +1461,12 @@ async fn process_bidirectional_requests(
             }
         }
 
-        bidirectional_tx_map.write().await.insert(tx_id, updated_tx);
+        backlog.insert(Chain::Ethereum, tx_id, updated_tx).await;
     }
 
-    let remaining_pending: HashMap<BidirectionalTxId, BidirectionalTx> = {
-        bidirectional_tx_map
-            .read()
-            .await
-            .iter()
-            .filter(|(_, tx)| tx.status == BidirectionalTxStatus::Pending)
-            .map(|(id, tx)| (*id, tx.clone()))
-            .collect()
-    };
+    let remaining_pending = backlog
+        .get_by_status(Chain::Ethereum, PendingRequestStatus::PendingExecution)
+        .await;
 
     for (tx_id, mut tx) in remaining_pending {
         let current_nonce = match client
@@ -1536,10 +1487,10 @@ async fn process_bidirectional_requests(
                 tx.nonce,
                 current_nonce
             );
-            tx.status = BidirectionalTxStatus::Failed;
+            tx.status = PendingRequestStatus::Failed;
             let completed_tx = CompletedTx::new(tx.clone(), block_number);
             match completed_tx
-                .create_failed_sign_request_without_light_client(total_timeout)
+                .create_failed_sign_request_without_light_client(Chain::Ethereum, total_timeout)
                 .await
             {
                 Ok(sign_request) => respond_requests.push(sign_request),
@@ -1547,7 +1498,7 @@ async fn process_bidirectional_requests(
                     tracing::warn!(?tx_id, ?err, "Failed to build sign request for stale nonce")
                 }
             }
-            bidirectional_tx_map.write().await.insert(tx_id, tx);
+            backlog.insert(Chain::Ethereum, tx_id, tx).await;
         }
     }
 

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -1,3 +1,4 @@
+use crate::backlog::Backlog;
 use crate::protocol::SignRequestType;
 use crate::protocol::{Chain, IndexedSignRequest};
 use crate::sign_bidirectional::hash_rlp_data;
@@ -367,6 +368,7 @@ pub async fn run(
     sol: Option<SolConfig>,
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     node_near_account_id: AccountId,
+    backlog: Backlog,
 ) {
     let Some(sol) = sol else {
         tracing::warn!("solana indexer is disabled");
@@ -392,21 +394,15 @@ pub async fn run(
     );
 
     let total_timeout = Duration::from_secs(sol.total_timeout);
-    let sign_tx_clone = sign_tx.clone();
-    let node_near_account_id_clone = node_near_account_id.clone();
-    let rpc_http_url_clone = sol.rpc_http_url.clone();
-    let rpc_ws_url_clone = sol.rpc_ws_url.clone();
-    tokio::spawn(async move {
-        subscribe_and_process_sign_events(
-            program_id,
-            &rpc_http_url_clone,
-            &rpc_ws_url_clone,
-            sign_tx_clone,
-            node_near_account_id_clone,
-            total_timeout,
-        )
-        .await;
-    });
+    tokio::spawn(subscribe_and_process_sign_events(
+        program_id,
+        sol.rpc_http_url.clone(),
+        sol.rpc_ws_url.clone(),
+        sign_tx.clone(),
+        node_near_account_id.clone(),
+        total_timeout,
+        backlog,
+    ));
 
     // Subscribe to non-CPI sign events
     loop {
@@ -492,11 +488,12 @@ async fn process_anchor_sign_event(
 // Reference: https://github.com/solana-foundation/anchor/blob/a5df519319ac39cff21191f2b09d54eda42c5716/client/src/lib.rs#L31
 async fn subscribe_and_process_sign_events(
     program_id: Pubkey,
-    rpc_url: &str,
-    ws_url: &str,
+    rpc_url: String,
+    ws_url: String,
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     node_near_account_id: AccountId,
     total_timeout: Duration,
+    backlog: Backlog,
 ) {
     loop {
         let sign_tx_clone = sign_tx.clone();
@@ -504,8 +501,9 @@ async fn subscribe_and_process_sign_events(
 
         let result = subscribe_to_program_cpi_events(
             program_id,
-            rpc_url,
-            ws_url,
+            &rpc_url,
+            &ws_url,
+            backlog.clone(),
             move |event, signature, _slot| {
                 tracing::info!("got event: {:?}", event);
                 let tx_sig: Vec<u8> = signature.as_ref().to_vec();
@@ -640,6 +638,7 @@ async fn subscribe_to_program_cpi_events<F>(
     program_id: Pubkey,
     rpc_url: &str,
     ws_url: &str,
+    backlog: Backlog,
     mut event_handler: F,
 ) -> Result<()>
 where
@@ -691,6 +690,10 @@ where
             }
             Err(e) => tracing::error!("Failed to parse tx {}: {}", signature, e),
         }
+
+        backlog
+            .set_processed_block(Chain::Solana, response.context.slot)
+            .await;
     }
 
     Ok(())

--- a/chain-signatures/node/src/lib.rs
+++ b/chain-signatures/node/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod backlog;
 pub mod cli;
 pub mod config;
 pub mod gcp;

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -35,6 +35,7 @@ use crate::storage::triple_storage::TripleStorage;
 
 use near_account_id::AccountId;
 use semver::Version;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::path::Path;
 use std::sync::Arc;
@@ -226,7 +227,7 @@ pub async fn spawn_system_metrics(node_account_id: &str) -> tokio::task::JoinHan
     })
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Copy, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Chain {
     NEAR,
     Ethereum,

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -20,6 +20,7 @@ pub use message::{Message, MessageChannel};
 pub use signature::{IndexedSignRequest, SignQueue};
 pub use state::{Node, NodeState};
 
+use crate::backlog::Backlog;
 use crate::config::Config;
 use crate::indexer_sol::SignBidirectionalEvent;
 use crate::mesh::MeshState;
@@ -28,7 +29,6 @@ use crate::protocol::cryptography::CryptographicProtocol;
 use crate::protocol::message::{GeneratingMessage, ReadyMessage, ResharingMessage};
 use crate::respond_bidirectional::RespondBidirectionalTx;
 use crate::rpc::{ContractStateWatcher, RpcChannel};
-use crate::sign_bidirectional::SignBidirectionalSignatureChannel;
 use crate::storage::presignature_storage::PresignatureStorage;
 use crate::storage::secret_storage::SecretNodeStorageBox;
 use crate::storage::triple_storage::TripleStorage;
@@ -57,7 +57,7 @@ pub struct MpcSignProtocol {
     pub(crate) contract: ContractStateWatcher,
     pub(crate) config: watch::Receiver<Config>,
     pub(crate) mesh_state: watch::Receiver<MeshState>,
-    pub(crate) sign_bidirectional_signature_channel: SignBidirectionalSignatureChannel,
+    pub(crate) backlog: Backlog,
 }
 
 /// Interface required by the [`MpcSignProtocol`] to participate in the
@@ -246,6 +246,19 @@ impl Chain {
             Chain::NEAR => "NEAR",
             Chain::Ethereum => "Ethereum",
             Chain::Solana => "Solana",
+        }
+    }
+}
+
+impl std::str::FromStr for Chain {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "NEAR" | "Near" | "near" => Ok(Chain::NEAR),
+            "Ethereum" | "ethereum" | "eth" => Ok(Chain::Ethereum),
+            "Solana" | "solana" | "sol" => Ok(Chain::Solana),
+            _ => Err(format!("unknown or unsupported chain {s}")),
         }
     }
 }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -1,5 +1,6 @@
 use super::contract::primitives::intersect_vec;
 use super::MpcSignProtocol;
+use crate::backlog::Backlog;
 use crate::config::Config;
 use crate::kdf::derive_delta;
 use crate::mesh::MeshState;
@@ -9,7 +10,7 @@ use crate::protocol::posit::{PositAction, PositInternalAction, Positor, Posits};
 use crate::protocol::presignature::PresignatureId;
 use crate::protocol::Chain;
 use crate::rpc::{ContractStateWatcher, RpcChannel};
-use crate::sign_bidirectional::SignBidirectionalSignatureChannel;
+use crate::sign_bidirectional::{BidirectionalTx, SignBidirectionalSignature};
 use crate::storage::presignature_storage::{PresignatureTaken, PresignatureTakenDropper};
 use crate::storage::PresignatureStorage;
 use crate::types::SignatureProtocol;
@@ -27,6 +28,7 @@ use rand::rngs::StdRng;
 use rand::seq::IteratorRandom;
 use rand::SeedableRng;
 use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::str::FromStr as _;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::error::TryRecvError;
@@ -388,8 +390,8 @@ struct SignatureGenerator {
     inbox: mpsc::Receiver<SignatureMessage>,
     msg: MessageChannel,
     rpc: RpcChannel,
+    backlog: Backlog,
 
-    sign_bidirectional_signature_channel: SignBidirectionalSignatureChannel,
     #[cfg(feature = "debug-page")]
     debug_view: crate::web::debug::DebugPageTaskHandle,
 }
@@ -405,7 +407,7 @@ impl SignatureGenerator {
         cfg: ProtocolConfig,
         msg: MessageChannel,
         rpc: RpcChannel,
-        sign_bidirectional_signature_channel: SignBidirectionalSignatureChannel,
+        backlog: Backlog,
         _my_account_id: &AccountId,
     ) -> Result<Self, InitializationError> {
         let sign_id = request.id();
@@ -465,7 +467,7 @@ impl SignatureGenerator {
             inbox,
             msg,
             rpc,
-            sign_bidirectional_signature_channel,
+            backlog,
             #[cfg(feature = "debug-page")]
             debug_view: crate::web::debug::register_task(
                 _my_account_id.to_string(),
@@ -622,12 +624,14 @@ impl SignatureGenerator {
                         .await;
                 }
                 Action::Return(output) => {
+                    let big_r = output.big_r;
+                    let s = output.s;
                     tracing::info!(
                         ?sign_id,
                         ?me,
                         presignature_id,
-                        big_r = ?output.big_r.to_base58(),
-                        s = ?output.s,
+                        big_r = ?big_r.to_base58(),
+                        ?s,
                         elapsed = ?self.created.elapsed(),
                         "completed signature generation"
                     );
@@ -645,15 +649,75 @@ impl SignatureGenerator {
                             output,
                             self.participants.clone(),
                         );
-                    } else if let SignRequestType::SignBidirectional(_) =
-                        self.request.indexed.sign_request_type
+                    }
+
+                    if let SignRequestType::SignBidirectional(event) =
+                        &self.request.indexed.sign_request_type
                     {
-                        self.sign_bidirectional_signature_channel.send(
+                        let source_chain = self.request.indexed.chain;
+                        let target_chain = match Chain::from_str(&event.dest) {
+                            Ok(chain) => chain,
+                            Err(err) => {
+                                tracing::error!(
+                                    ?sign_id,
+                                    ?source_chain,
+                                    ?err,
+                                    "invalid target chain: unable to proceed w/ SignRespond"
+                                );
+                                break Ok(());
+                            }
+                        };
+                        let expected_public_key = mpc_crypto::derive_key(
                             self.public_key,
-                            self.request.clone(),
-                            output,
-                            self.participants.clone(),
+                            self.request.indexed.args.epsilon,
                         );
+
+                        let signature = match crate::kdf::into_eth_sig(
+                            &expected_public_key,
+                            &big_r,
+                            &s,
+                            self.request.indexed.args.payload,
+                        ) {
+                            Ok(sig) => sig,
+                            Err(err) => {
+                                tracing::error!(
+                                    ?sign_id,
+                                    ?source_chain,
+                                    ?target_chain,
+                                    ?err,
+                                    "failed to generate a valid signature"
+                                );
+                                break Ok(());
+                            }
+                        };
+
+                        let signature = SignBidirectionalSignature {
+                            public_key: self.public_key,
+                            request: self.request.clone(),
+                            signature,
+                            participants: self.participants.clone(),
+                        };
+
+                        match BidirectionalTx::new(signature) {
+                            Ok(tx) => {
+                                self.backlog.insert(target_chain, sign_id, tx).await;
+                                tracing::info!(
+                                    ?sign_id,
+                                    ?source_chain,
+                                    ?target_chain,
+                                    "inserted SignRespond tx into backlog with Pending status"
+                                );
+                            }
+                            Err(err) => {
+                                tracing::error!(
+                                    ?sign_id,
+                                    ?source_chain,
+                                    ?target_chain,
+                                    ?err,
+                                    "failed to create SignRespondTx",
+                                );
+                            }
+                        }
                     }
 
                     break Ok(());
@@ -700,7 +764,7 @@ pub struct SignatureSpawner {
     epoch: u64,
     msg: MessageChannel,
     rpc: RpcChannel,
-    sign_bidirectional_signature_channel: SignBidirectionalSignatureChannel,
+    backlog: Backlog,
 }
 
 impl SignatureSpawner {
@@ -715,7 +779,7 @@ impl SignatureSpawner {
         presignatures: &PresignatureStorage,
         msg: MessageChannel,
         rpc: RpcChannel,
-        sign_bidirectional_signature_channel: SignBidirectionalSignatureChannel,
+        backlog: Backlog,
     ) -> Self {
         Self {
             presignatures: presignatures.clone(),
@@ -729,7 +793,7 @@ impl SignatureSpawner {
             epoch,
             msg,
             rpc,
-            sign_bidirectional_signature_channel,
+            backlog,
         }
     }
 
@@ -863,7 +927,6 @@ impl SignatureSpawner {
         presignature: PendingPresignature,
         participants: Vec<Participant>,
         cfg: ProtocolConfig,
-        sign_bidirectional_signature_channel: SignBidirectionalSignatureChannel,
     ) {
         let me = self.me;
         let epoch = self.epoch;
@@ -873,6 +936,7 @@ impl SignatureSpawner {
         let my_account_id = self.my_account_id.clone();
         let msg = self.msg.clone();
         let rpc = self.rpc.clone();
+        let backlog = self.backlog.clone();
         let task = async move {
             let generator = match SignatureGenerator::new(
                 me,
@@ -883,7 +947,7 @@ impl SignatureSpawner {
                 cfg,
                 msg,
                 rpc,
-                sign_bidirectional_signature_channel,
+                backlog,
                 &my_account_id,
             )
             .await
@@ -946,14 +1010,8 @@ impl SignatureSpawner {
                 self.presignatures.clone(),
             ),
         };
-        self.generate(
-            request,
-            presignature,
-            participants,
-            cfg,
-            self.sign_bidirectional_signature_channel.clone(),
-        )
-        .await;
+        self.generate(request, presignature, participants, cfg)
+            .await;
     }
 
     async fn handle_requests(
@@ -1137,7 +1195,7 @@ impl SignatureSpawnerTask {
             &ctx.presignature_storage,
             ctx.msg_channel.clone(),
             ctx.rpc_channel.clone(),
-            ctx.sign_bidirectional_signature_channel.clone(),
+            ctx.backlog.clone(),
         );
 
         Self {

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -28,7 +28,6 @@ use rand::rngs::StdRng;
 use rand::seq::IteratorRandom;
 use rand::SeedableRng;
 use std::collections::{BTreeSet, HashMap, VecDeque};
-use std::str::FromStr as _;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::error::TryRecvError;
@@ -655,18 +654,7 @@ impl SignatureGenerator {
                         &self.request.indexed.sign_request_type
                     {
                         let source_chain = self.request.indexed.chain;
-                        let target_chain = match Chain::from_str(&event.dest) {
-                            Ok(chain) => chain,
-                            Err(err) => {
-                                tracing::error!(
-                                    ?sign_id,
-                                    ?source_chain,
-                                    ?err,
-                                    "invalid target chain: unable to proceed w/ SignRespond"
-                                );
-                                break Ok(());
-                            }
-                        };
+                        let dest = event.dest.clone();
                         let expected_public_key = mpc_crypto::derive_key(
                             self.public_key,
                             self.request.indexed.args.epsilon,
@@ -683,7 +671,7 @@ impl SignatureGenerator {
                                 tracing::error!(
                                     ?sign_id,
                                     ?source_chain,
-                                    ?target_chain,
+                                    target_chain = ?dest,
                                     ?err,
                                     "failed to generate a valid signature"
                                 );
@@ -700,6 +688,8 @@ impl SignatureGenerator {
 
                         match BidirectionalTx::new(signature) {
                             Ok(tx) => {
+                                let target_chain = tx.target_chain;
+                                let source_chain = tx.source_chain;
                                 self.backlog.insert(target_chain, sign_id, tx).await;
                                 tracing::info!(
                                     ?sign_id,
@@ -712,7 +702,7 @@ impl SignatureGenerator {
                                 tracing::error!(
                                     ?sign_id,
                                     ?source_chain,
-                                    ?target_chain,
+                                    target_chain = ?dest,
                                     ?err,
                                     "failed to create SignRespondTx",
                                 );

--- a/chain-signatures/node/src/protocol/test_setup.rs
+++ b/chain-signatures/node/src/protocol/test_setup.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
+use crate::backlog::Backlog;
 use crate::config::Config;
 use crate::mesh::MeshState;
 use crate::protocol::{IndexedSignRequest, MessageChannel, MpcSignProtocol};
 use crate::rpc::{ContractStateWatcher, RpcChannel};
-use crate::sign_bidirectional::SignBidirectionalSignatureChannel;
 use crate::storage::secret_storage::SecretNodeStorageBox;
 use crate::storage::{PresignatureStorage, TripleStorage};
 use near_sdk::AccountId;
@@ -22,7 +22,6 @@ pub struct TestProtocolChannels {
     pub rpc_channel: RpcChannel,
     pub config: watch::Receiver<Config>,
     pub mesh_state: watch::Receiver<MeshState>,
-    pub sign_bidirectional_signature_channel: SignBidirectionalSignatureChannel,
 }
 
 impl MpcSignProtocol {
@@ -49,7 +48,7 @@ impl MpcSignProtocol {
             contract,
             config: channels.config,
             mesh_state: channels.mesh_state,
-            sign_bidirectional_signature_channel: channels.sign_bidirectional_signature_channel,
+            backlog: Backlog::new(),
         }
     }
 }

--- a/chain-signatures/node/src/respond_bidirectional.rs
+++ b/chain-signatures/node/src/respond_bidirectional.rs
@@ -1,3 +1,4 @@
+use crate::backlog::Backlog;
 use crate::protocol::{Chain, IndexedSignRequest};
 use crate::sign_bidirectional::BidirectionalTx;
 use crate::sign_bidirectional::BidirectionalTxId;
@@ -18,12 +19,8 @@ use alloy::rpc::types::TransactionRequest;
 use helios::ethereum::EthereumClient;
 use k256::Scalar;
 use mpc_crypto::ScalarExt;
-use mpc_primitives::SignArgs;
-use mpc_primitives::SignId;
-use std::collections::HashMap;
-use std::sync::Arc;
+use mpc_primitives::{SignArgs, SignId};
 use tokio::sync::mpsc;
-use tokio::sync::RwLock;
 use tokio::time::Duration;
 
 const MAGIC_ERROR_PREFIX: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
@@ -66,19 +63,22 @@ impl CompletedTx {
     #[cfg(not(feature = "light_client"))]
     pub(crate) async fn create_failed_sign_request_without_light_client(
         &self,
+        chain: Chain,
         signature_generation_total_timeout: Duration,
     ) -> anyhow::Result<IndexedSignRequest> {
-        self.process_failed_tx(signature_generation_total_timeout)
+        self.process_failed_tx(chain, signature_generation_total_timeout)
             .await
     }
 
     #[cfg(not(feature = "light_client"))]
     pub(crate) fn create_sign_request_from_serialized_output(
         &self,
+        chain: Chain,
         serialized_output: RespondBidirectionalSerializedOutput,
         signature_generation_total_timeout: Duration,
     ) -> anyhow::Result<IndexedSignRequest> {
         self.create_respond_bidirectional_sign_request(
+            chain,
             serialized_output,
             signature_generation_total_timeout,
         )
@@ -88,12 +88,14 @@ impl CompletedTx {
     pub async fn create_sign_request_from_completed_tx(
         &self,
         helios_client: &Arc<EthereumClient>,
+        chain: Chain,
         max_attempts: u8,
         signature_generation_total_timeout: Duration,
     ) -> Option<IndexedSignRequest> {
         match self
             .process_completed_tx(
                 helios_client,
+                chain,
                 max_attempts,
                 signature_generation_total_timeout,
             )
@@ -120,24 +122,27 @@ impl CompletedTx {
     async fn process_completed_tx(
         &self,
         helios_client: &Arc<EthereumClient>,
+        chain: Chain,
         max_attempts: u8,
         signature_generation_total_timeout: Duration,
     ) -> anyhow::Result<IndexedSignRequest> {
-        if self.tx.status == BidirectionalTxStatus::Success {
+        if self.tx.status == PendingRequestStatus::Success {
             self.process_success_tx(
                 helios_client,
+                chain,
                 max_attempts,
                 signature_generation_total_timeout,
             )
             .await
         } else {
-            self.process_failed_tx(signature_generation_total_timeout)
+            self.process_failed_tx(chain, signature_generation_total_timeout)
                 .await
         }
     }
 
     async fn process_failed_tx(
         &self,
+        chain: Chain,
         total_timeout: Duration,
     ) -> anyhow::Result<IndexedSignRequest> {
         tracing::info!("Tx failed: {:?}", self.tx.id);
@@ -160,8 +165,11 @@ impl CompletedTx {
                 Bytes::from(output).into()
             }
         };
-        let sign_request =
-            self.create_respond_bidirectional_sign_request(serialized_output, total_timeout)?;
+        let sign_request = self.create_respond_bidirectional_sign_request(
+            chain,
+            serialized_output,
+            total_timeout,
+        )?;
         Ok(sign_request)
     }
 
@@ -169,6 +177,7 @@ impl CompletedTx {
     async fn process_success_tx(
         &self,
         helios_client: &Arc<EthereumClient>,
+        chain: Chain,
         max_attempts: u8,
         signature_generation_total_timeout: Duration,
     ) -> anyhow::Result<IndexedSignRequest> {
@@ -182,6 +191,7 @@ impl CompletedTx {
             .output
             .serialize(respond_serialization_format, respond_serialization_schema)?;
         self.create_respond_bidirectional_sign_request(
+            chain,
             serialized_output,
             signature_generation_total_timeout,
         )
@@ -189,6 +199,7 @@ impl CompletedTx {
 
     fn create_respond_bidirectional_sign_request(
         &self,
+        chain: Chain,
         serialized_output: RespondBidirectionalSerializedOutput,
         signature_generation_total_timeout: Duration,
     ) -> anyhow::Result<IndexedSignRequest> {
@@ -219,7 +230,7 @@ impl CompletedTx {
         let entropy = self.tx.id.0;
         Ok(IndexedSignRequest {
             id: SignId::new(request_id_bytes),
-            chain: Chain::Solana,
+            chain,
             args: SignArgs {
                 entropy: entropy.into(),
                 epsilon,
@@ -354,14 +365,14 @@ async fn fetch_tx_from_helios(
 
 #[derive(Clone)]
 pub struct RespondBidirectionalTxChannel {
-    tx: mpsc::Sender<BidirectionalTxId>,
+    tx: mpsc::Sender<(Chain, SignId)>,
 }
 
 impl RespondBidirectionalTxChannel {
-    pub fn send(&self, tx_id: BidirectionalTxId) {
+    pub fn send(&self, chain: Chain, sign_id: SignId) {
         let tx = self.tx.clone();
         tokio::spawn(async move {
-            if let Err(err) = tx.send(tx_id).await {
+            if let Err(err) = tx.send((chain, sign_id)).await {
                 tracing::error!(%err, "failed to send respond bidirectional tx id");
             }
         });
@@ -369,7 +380,7 @@ impl RespondBidirectionalTxChannel {
 }
 
 pub struct RespondBidirectionalTxProcessor {
-    respond_bidirectional_tx_rx: mpsc::Receiver<BidirectionalTxId>,
+    rx: mpsc::Receiver<(Chain, SignId)>,
 }
 
 const MAX_CONCURRENT_RESPOND_BIDIRECTIONAL_TX_REQUESTS: usize = 1024;
@@ -377,31 +388,23 @@ const MAX_CONCURRENT_RESPOND_BIDIRECTIONAL_TX_REQUESTS: usize = 1024;
 impl RespondBidirectionalTxProcessor {
     pub fn new() -> (RespondBidirectionalTxChannel, Self) {
         let (tx, rx) = mpsc::channel(MAX_CONCURRENT_RESPOND_BIDIRECTIONAL_TX_REQUESTS);
-        (
-            RespondBidirectionalTxChannel { tx },
-            Self {
-                respond_bidirectional_tx_rx: rx,
-            },
-        )
+        (RespondBidirectionalTxChannel { tx }, Self { rx })
     }
 
-    pub async fn run(
-        mut self,
-        bidirectional_tx_map: Arc<RwLock<HashMap<BidirectionalTxId, BidirectionalTx>>>,
-        max_attempts: u8,
-    ) {
-        while let Some(bidirectional_tx_id) = self.respond_bidirectional_tx_rx.recv().await {
+    pub async fn run(mut self, backlog: Backlog, max_attempts: u8) {
+        while let Some((chain, sign_id)) = self.rx.recv().await {
             for attempt in 1..=max_attempts {
-                if bidirectional_tx_map
-                    .write()
-                    .await
-                    .remove(&bidirectional_tx_id)
-                    .is_some()
-                {
-                    tracing::info!(sign_id = ?bidirectional_tx_id, "removed bidirectional tx from map");
+                if backlog.remove(chain, &sign_id).await.is_some() {
+                    tracing::info!(?sign_id, ?chain, "removed bidirectional tx from backlog");
                     break;
                 } else if attempt == max_attempts {
-                    tracing::error!(sign_id = ?bidirectional_tx_id, "failed to remove bidirectional tx from map after {max_attempts} attempts");
+                    tracing::error!(
+                        ?sign_id,
+                        ?chain,
+                        "failed to remove bidirectional tx from backlog after {max_attempts} attempts"
+                    );
+                } else {
+                    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
                 }
             }
         }

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -1,18 +1,18 @@
+use crate::backlog::Backlog;
 use crate::config::{Config, ContractConfig, NetworkConfig};
 use crate::indexer_eth::EthConfig;
 use crate::indexer_sol::SolConfig;
 use crate::protocol::contract::primitives::{ParticipantMap, Participants};
 use crate::protocol::contract::RunningContractState;
 use crate::protocol::signature::SignRequest;
-use crate::protocol::{Chain, Governance, ProtocolState};
+use crate::protocol::{Chain, Governance, ProtocolState, SignRequestType};
+use crate::respond_bidirectional::RespondBidirectionalTxChannel;
 use crate::util::AffinePointExt as _;
+
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signer::keypair::Keypair;
 
-use crate::protocol::SignRequestType;
-use crate::respond_bidirectional::RespondBidirectionalTxChannel;
-use crate::sign_bidirectional::SignBidirectionalSignatureChannel;
 use alloy::primitives::Address;
 use alloy::providers::fillers::{FillProvider, JoinFill, WalletFiller};
 use alloy::providers::{Provider, RootProvider, WalletProvider};
@@ -284,6 +284,7 @@ pub struct RpcExecutor {
     eth: Option<EthClient>,
     solana: Option<SolanaClient>,
     action_rx: mpsc::Receiver<RpcAction>,
+    backlog: Backlog,
 }
 
 impl RpcExecutor {
@@ -291,6 +292,7 @@ impl RpcExecutor {
         near: &NearClient,
         eth: &Option<EthConfig>,
         solana: &Option<SolConfig>,
+        backlog: Backlog,
     ) -> (RpcChannel, Self) {
         let eth = eth.as_ref().map(EthClient::new);
         let solana = solana.as_ref().map(SolanaClient::new);
@@ -302,6 +304,7 @@ impl RpcExecutor {
                 eth,
                 solana,
                 action_rx: rx,
+                backlog,
             },
         )
     }
@@ -310,7 +313,6 @@ impl RpcExecutor {
         mut self,
         contract: watch::Sender<Option<ProtocolState>>,
         config: watch::Sender<Config>,
-        sign_bidirectional_signature_channel: SignBidirectionalSignatureChannel,
         respond_bidirectional_tx_channel: RespondBidirectionalTxChannel,
     ) {
         // spin up update task for updating contract state and config
@@ -349,9 +351,8 @@ impl RpcExecutor {
             let client = self.client(&chain);
             let near_account_id = self.near.my_account_id.clone();
             let eth_rpc_tx = eth_rpc_tx.clone(); // clone for task use
+            let backlog = self.backlog.clone();
 
-            let sign_bidirectional_signature_channel_clone =
-                sign_bidirectional_signature_channel.clone();
             let respond_bidirectional_tx_channel_clone = respond_bidirectional_tx_channel.clone();
             tokio::spawn(async move {
                 match chain {
@@ -360,7 +361,7 @@ impl RpcExecutor {
                             client,
                             action,
                             near_account_id,
-                            sign_bidirectional_signature_channel_clone,
+                            backlog,
                             respond_bidirectional_tx_channel_clone,
                         )
                         .await;
@@ -656,13 +657,14 @@ async fn execute_publish(
     client: ChainClient,
     mut action: PublishAction,
     near_account_id: AccountId,
-    sign_bidirectional_signature_channel: SignBidirectionalSignatureChannel,
+    backlog: Backlog,
     respond_bidirectional_tx_channel: RespondBidirectionalTxChannel,
 ) {
     let chain = action.request.indexed.chain;
+    let sign_id = action.request.indexed.id;
     tracing::info!(
-        sign_id = ?action.request.indexed.id,
-        chain = ?chain,
+        ?sign_id,
+        ?chain,
         started_at = ?action.timestamp.elapsed(),
         "trying to publish signature",
     );
@@ -683,7 +685,7 @@ async fn execute_publish(
         return;
     };
 
-    loop {
+    let publish_result = loop {
         let publish = match &client {
             ChainClient::Near(near) => {
                 try_publish_near(near, &action, &action.timestamp, &signature)
@@ -706,7 +708,6 @@ async fn execute_publish(
                 &action.timestamp,
                 &signature,
                 &near_account_id,
-                sign_bidirectional_signature_channel.clone(),
                 respond_bidirectional_tx_channel.clone(),
             )
             .await
@@ -717,7 +718,7 @@ async fn execute_publish(
             }
         };
         if publish.is_ok() {
-            break;
+            break publish;
         }
 
         action.retry_count += 1;
@@ -728,7 +729,7 @@ async fn execute_publish(
                 elapsed = ?action.timestamp.elapsed(),
                 "exceeded max retries, trashing publish request",
             );
-            break;
+            break publish;
         } else {
             tracing::info!(
                 sign_id = ?action.request.indexed.id,
@@ -736,6 +737,17 @@ async fn execute_publish(
                 elapsed = ?action.timestamp.elapsed(),
                 "failed to publish, retrying"
             );
+        }
+    };
+
+    // Mark completion in Backlog for SignBidirectional requests
+    if matches!(
+        action.request.indexed.sign_request_type,
+        SignRequestType::SignBidirectional(_)
+    ) {
+        let success = publish_result.is_ok();
+        if let Err(err) = backlog.mark_published(chain, &sign_id, success).await {
+            tracing::warn!(?sign_id, ?err, "failed to mark publish status in backlog");
         }
     }
 }
@@ -1312,7 +1324,6 @@ async fn try_publish_sol(
     timestamp: &Instant,
     signature: &Signature,
     near_account_id: &AccountId,
-    sign_bidirectional_signature_channel: SignBidirectionalSignatureChannel,
     respond_bidirectional_tx_channel: RespondBidirectionalTxChannel,
 ) -> Result<(), ()> {
     let chain = action.request.indexed.chain;
@@ -1400,17 +1411,8 @@ async fn try_publish_sol(
                 elapsed = ?timestamp.elapsed(),
                 "published respond bidirectional solana signature successfully"
             );
-            respond_bidirectional_tx_channel.send(respond_bidirectional_tx.tx_id);
+            respond_bidirectional_tx_channel.send(chain, action.request.indexed.id);
         }
-    }
-
-    if let SignRequestType::SignBidirectional(_) = action.request.indexed.sign_request_type {
-        sign_bidirectional_signature_channel.send(
-            action.public_key,
-            action.request.clone(),
-            action.output.clone(),
-            action.participants.clone(),
-        );
     }
 
     crate::metrics::NUM_SIGN_SUCCESS

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -1003,7 +1003,8 @@ async fn send_eth_transaction(
         Duration::from_secs(10),
         contract
             .provider()
-            .get_transaction_count(contract.provider().default_signer_address()),
+            .get_transaction_count(contract.provider().default_signer_address())
+            .pending(),
     )
     .await
     {

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -1,4 +1,5 @@
 use crate::protocol::signature::SignRequest;
+use crate::protocol::Chain;
 use crate::protocol::SignRequestType;
 use crate::respond_bidirectional::SerDeserFormat;
 use alloy::primitives::{keccak256, Address, Bytes, B256, I256, U256};
@@ -15,6 +16,7 @@ use serde_json::Value;
 use sha3::{Digest, Keccak256};
 use std::collections::HashMap;
 use std::io::Write;
+use std::str::FromStr;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Copy)]
 pub struct BidirectionalTxId(pub B256);
@@ -47,6 +49,8 @@ pub struct BidirectionalTx {
     pub id: BidirectionalTxId,
     pub sender: Pubkey,
     pub transaction_data: Vec<u8>,
+    pub source_chain: Chain,
+    pub target_chain: Chain,
     pub caip2_id: String,
     pub key_version: u32,
     pub deposit: u64,
@@ -72,6 +76,13 @@ impl BidirectionalTx {
         };
 
         let unsigned_rlp_data = &event.transaction_data;
+        let target_chain = Chain::from_str(&event.dest).map_err(|err| {
+            anyhow::anyhow!(
+                "invalid target chain '{}' for bidirectional transaction: {err}",
+                event.dest
+            )
+        })?;
+        let source_chain = signature.request.indexed.chain;
 
         let (signed_transaction_hash, nonce) =
             sign_and_hash_transaction(unsigned_rlp_data, signature.signature)?;
@@ -87,6 +98,8 @@ impl BidirectionalTx {
             id: BidirectionalTxId(signed_transaction_hash.into()),
             sender: event.sender,
             transaction_data: event.transaction_data,
+            source_chain,
+            target_chain,
             caip2_id: event.caip2_id,
             key_version: event.key_version,
             deposit: event.deposit,

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -6,9 +6,8 @@ use alloy_dyn_abi::{DynSolType, DynSolValue};
 use anchor_lang::prelude::Pubkey;
 use borsh::BorshSerialize;
 use cait_sith::protocol::Participant;
-use cait_sith::FullSignature;
 use k256::elliptic_curve::point::AffineCoordinates;
-use k256::{AffinePoint, Scalar, Secp256k1};
+use k256::{AffinePoint, Scalar};
 use mpc_crypto::derive_key;
 use mpc_primitives::Signature;
 use rlp::{Rlp, RlpStream};
@@ -16,9 +15,6 @@ use serde_json::Value;
 use sha3::{Digest, Keccak256};
 use std::collections::HashMap;
 use std::io::Write;
-use std::sync::Arc;
-use tokio::sync::mpsc;
-use tokio::sync::RwLock;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Copy)]
 pub struct BidirectionalTxId(pub B256);
@@ -39,8 +35,9 @@ struct AbiField {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub enum BidirectionalTxStatus {
-    Pending,
+pub enum PendingRequestStatus {
+    PendingExecution,
+    PendingPublish,
     Failed,
     Success,
 }
@@ -63,52 +60,47 @@ pub struct BidirectionalTx {
     pub from_address: Address,
     pub nonce: u64,
     pub participants: Vec<Participant>,
-    pub status: BidirectionalTxStatus,
+    pub status: PendingRequestStatus,
 }
 
 impl BidirectionalTx {
-    pub fn new(sign_respond_signature: SignBidirectionalSignature) -> anyhow::Result<Self> {
-        let SignRequestType::SignBidirectional(sign_respond_event) = sign_respond_signature
-            .request
-            .indexed
-            .sign_request_type
-            .clone()
+    pub fn new(signature: SignBidirectionalSignature) -> anyhow::Result<Self> {
+        let SignRequestType::SignBidirectional(event) =
+            signature.request.indexed.sign_request_type.clone()
         else {
             anyhow::bail!("sign request is not a sign bidirectional");
         };
 
-        let unsigned_rlp_data = &sign_respond_event.transaction_data;
+        let unsigned_rlp_data = &event.transaction_data;
 
         let (signed_transaction_hash, nonce) =
-            sign_and_hash_transaction(unsigned_rlp_data, sign_respond_signature.signature)?;
+            sign_and_hash_transaction(unsigned_rlp_data, signature.signature)?;
 
         tracing::info!(signed_transaction_hash = ?signed_transaction_hash, "signed_transaction_hash");
 
-        let from_address = derive_user_address(
-            sign_respond_signature.public_key,
-            sign_respond_signature.request.indexed.args.epsilon,
-        );
+        let from_address =
+            derive_user_address(signature.public_key, signature.request.indexed.args.epsilon);
 
         tracing::info!(from_address = ?from_address, "from_address");
 
         Ok(Self {
             id: BidirectionalTxId(signed_transaction_hash.into()),
-            sender: sign_respond_event.sender,
-            transaction_data: sign_respond_event.transaction_data,
-            caip2_id: sign_respond_event.caip2_id,
-            key_version: sign_respond_event.key_version,
-            deposit: sign_respond_event.deposit,
-            path: sign_respond_event.path,
-            algo: sign_respond_event.algo,
-            dest: sign_respond_event.dest,
-            params: sign_respond_event.params,
-            output_deserialization_schema: sign_respond_event.output_deserialization_schema,
-            respond_serialization_schema: sign_respond_event.respond_serialization_schema,
-            request_id: sign_respond_signature.request.indexed.id.request_id,
+            sender: event.sender,
+            transaction_data: event.transaction_data,
+            caip2_id: event.caip2_id,
+            key_version: event.key_version,
+            deposit: event.deposit,
+            path: event.path,
+            algo: event.algo,
+            dest: event.dest,
+            params: event.params,
+            output_deserialization_schema: event.output_deserialization_schema,
+            respond_serialization_schema: event.respond_serialization_schema,
+            request_id: signature.request.indexed.id.request_id,
             from_address,
             nonce,
-            participants: sign_respond_signature.participants,
-            status: BidirectionalTxStatus::Pending,
+            participants: signature.participants,
+            status: PendingRequestStatus::PendingExecution,
         })
     }
 }
@@ -250,7 +242,7 @@ pub fn decode_rlp(rlp_data: Vec<u8>, is_eip1559: bool) -> anyhow::Result<Vec<Byt
     Ok(result)
 }
 
-fn sign_and_hash_transaction(
+pub fn sign_and_hash_transaction(
     unsigned_rlp: &[u8],
     signature: Signature,
 ) -> anyhow::Result<([u8; 32], u64)> {
@@ -510,98 +502,4 @@ pub struct SignBidirectionalSignature {
     pub request: SignRequest,
     pub signature: Signature,
     pub participants: Vec<Participant>,
-}
-
-#[derive(Clone)]
-pub struct SignBidirectionalSignatureChannel {
-    tx: mpsc::Sender<SignBidirectionalSignature>,
-}
-
-impl SignBidirectionalSignatureChannel {
-    pub fn send(
-        &self,
-        public_key: mpc_crypto::PublicKey,
-        request: SignRequest,
-        output: FullSignature<Secp256k1>,
-        participants: Vec<Participant>,
-    ) {
-        let tx = self.tx.clone();
-        let expected_public_key = mpc_crypto::derive_key(public_key, request.indexed.args.epsilon);
-        let Ok(signature) = crate::kdf::into_eth_sig(
-            &expected_public_key,
-            &output.big_r,
-            &output.s,
-            request.indexed.args.payload,
-        ) else {
-            tracing::error!(
-                sign_id = ?request.indexed.id,
-                "failed to generate a recovery id; trashing publish request",
-            );
-            return;
-        };
-        tokio::spawn(async move {
-            if let Err(err) = tx
-                .send(SignBidirectionalSignature {
-                    public_key,
-                    request,
-                    signature,
-                    participants,
-                })
-                .await
-            {
-                tracing::error!(%err, "failed to send sign bidirectional signature");
-            }
-        });
-    }
-}
-
-pub struct SignBidirectionalSignatureProcessor {
-    sign_bidirectional_signature_rx: mpsc::Receiver<SignBidirectionalSignature>,
-}
-
-const MAX_CONCURRENT_SIGN_RESPOND_SIGNATURE_REQUESTS: usize = 1024;
-
-impl SignBidirectionalSignatureProcessor {
-    pub fn new() -> (SignBidirectionalSignatureChannel, Self) {
-        let (tx, rx) = mpsc::channel(MAX_CONCURRENT_SIGN_RESPOND_SIGNATURE_REQUESTS);
-        (
-            SignBidirectionalSignatureChannel { tx },
-            Self {
-                sign_bidirectional_signature_rx: rx,
-            },
-        )
-    }
-
-    pub async fn run(
-        mut self,
-        sign_respond_tx_map: Arc<RwLock<HashMap<BidirectionalTxId, BidirectionalTx>>>,
-        max_attempts: u8,
-    ) {
-        while let Some(sign_bidirectional_signature) =
-            self.sign_bidirectional_signature_rx.recv().await
-        {
-            let bidirectional_tx = match BidirectionalTx::new(sign_bidirectional_signature.clone())
-            {
-                Ok(tx) => tx,
-                Err(err) => {
-                    tracing::error!(sign_id = ?sign_bidirectional_signature.request.indexed.id, "failed to create sign bidirectional tx: {err:?}");
-                    continue;
-                }
-            };
-
-            for attempt in 1..=max_attempts {
-                if sign_respond_tx_map
-                    .write()
-                    .await
-                    .insert(bidirectional_tx.id, bidirectional_tx.clone())
-                    .is_some()
-                {
-                    tracing::info!(sign_id = ?bidirectional_tx.id, "inserted sign bidirectional tx into map");
-                    break;
-                } else if attempt == max_attempts {
-                    tracing::error!(sign_id = ?bidirectional_tx.id, "failed to insert sign bidirectional tx into map after {max_attempts} attempts");
-                }
-            }
-        }
-    }
 }

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -22,7 +22,6 @@ use mpc_node::protocol::state::NodeKeyInfo;
 use mpc_node::protocol::{self, MessageChannel, MpcSignProtocol, ProtocolState, SignQueue};
 use mpc_node::rpc::ContractStateWatcher;
 use mpc_node::rpc::RpcChannel;
-use mpc_node::sign_bidirectional::SignBidirectionalSignatureProcessor;
 use mpc_node::storage::{presignature_storage, secret_storage, triple_storage, Options};
 use near_sdk::AccountId;
 use std::collections::HashMap;
@@ -420,8 +419,6 @@ impl MpcFixtureNodeBuilder {
         let rpc_channel = RpcChannel { tx: rpc_tx };
         let (mesh_tx, mesh_rx) = watch::channel(context.init_mesh.clone());
         let (config_tx, config_rx) = watch::channel(self.config);
-        let (sign_bidirectional_signature_channel, _sign_bidirectional_signature_processor) =
-            SignBidirectionalSignatureProcessor::new();
 
         let channels = protocol::test_setup::TestProtocolChannels {
             sign_rx: Arc::new(RwLock::new(sign_rx)),
@@ -429,7 +426,6 @@ impl MpcFixtureNodeBuilder {
             rpc_channel,
             config: config_rx.clone(),
             mesh_state: mesh_rx.clone(),
-            sign_bidirectional_signature_channel: sign_bidirectional_signature_channel.clone(),
         };
 
         // We have to start the inbox job before calling


### PR DESCRIPTION
This is the initial work towards `Checkpoints` and `PendingRequests` and is merely a refactoring right now of what we have right now.

## Changes
- We use to use `SignRespondTxId` as the id for mapping into the `sign_respond_tx_map`, but this changes that to `SignId` since that will be more generic going forward for all chains.
- `SignatureGenerator` takes in `Checkpoints` to set it for pending publish. We're still using the old channels to send the request for publishing, but these channels will likely be moved to checkpoints in the future.
- `RpcExecutor` takes in `Checkpoints` to mark a request as completed (does nothing for now).