### PR TITLE
feat(debug-page): Proof of concept

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6679,6 +6679,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "maud"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8156733e27020ea5c684db5beac5d1d611e1272ab17901a49466294b84fc217e"
+dependencies = [
+ "itoa",
+ "maud_macros",
+]
+
+[[package]]
+name = "maud_macros"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7261b00f3952f617899bc012e3dbd56e4f0110a038175929fa5d18e5a19913ca"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6879,6 +6901,7 @@ dependencies = [
  "k256",
  "local-ip-address",
  "lru 0.13.0",
+ "maud",
  "mime",
  "mockito",
  "mpc-contract",

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -97,6 +97,8 @@ alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 alloy-json-abi.workspace = true
 
+maud = { version = "0.27.0", optional = true }
+
 [dev-dependencies]
 mockito = "1.7.0"
 test-log = { version = "0.2.12", features = ["log", "trace"] }
@@ -107,3 +109,5 @@ default = []
 bench = []
 # utilized by "integration-tests" package:
 test-feature = []
+# Show a debug page
+debug-page = ["maud"]

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -126,6 +126,8 @@ pub struct PresignatureGenerator {
     slot: PresignatureSlot,
     inbox: mpsc::Receiver<PresignatureMessage>,
     msg: MessageChannel,
+    #[cfg(feature = "debug-page")]
+    debug_view: crate::web::debug::DebugPageTaskHandle,
 }
 
 impl PresignatureGenerator {
@@ -204,6 +206,8 @@ impl PresignatureGenerator {
             total_pokes += 1;
             poke_last_time = Instant::now();
             poke_latency.observe(poke_start_time.elapsed().as_millis() as f64);
+            #[cfg(feature = "debug-page")]
+            self.render_debug(total_pokes);
 
             match action {
                 Action::Wait => {
@@ -281,6 +285,14 @@ impl PresignatureGenerator {
                 }
             }
         }
+    }
+
+    #[cfg(feature = "debug-page")]
+    fn render_debug(&self, total_pokes: i32) {
+        let markup = maud::html! {
+            p { (format!("{total_pokes} pokes")) }
+        };
+        self.debug_view.send(markup);
     }
 }
 
@@ -618,6 +630,11 @@ impl PresignatureSpawner {
                 slot,
                 inbox,
                 msg,
+                #[cfg(feature = "debug-page")]
+                debug_view: crate::web::debug::register_task(
+                    my_account_id.to_string(),
+                    format!("PresignatureGenerator {id:#?}"),
+                ),
             };
             generator.run(&my_account_id, me, epoch).await;
         };

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -389,6 +389,8 @@ struct SignatureGenerator {
     msg: MessageChannel,
     rpc: RpcChannel,
     sign_respond_signature_channel: SignRespondSignatureChannel,
+    #[cfg(feature = "debug-page")]
+    debug_view: crate::web::debug::DebugPageTaskHandle,
 }
 
 impl SignatureGenerator {
@@ -403,6 +405,7 @@ impl SignatureGenerator {
         msg: MessageChannel,
         rpc: RpcChannel,
         sign_respond_signature_channel: SignRespondSignatureChannel,
+        _my_account_id: &AccountId,
     ) -> Result<Self, InitializationError> {
         let sign_id = request.id();
         let request = request
@@ -462,6 +465,11 @@ impl SignatureGenerator {
             msg,
             rpc,
             sign_respond_signature_channel,
+            #[cfg(feature = "debug-page")]
+            debug_view: crate::web::debug::register_task(
+                _my_account_id.to_string(),
+                format!("SignatureGenerator {sign_id:#?}"),
+            ),
         })
     }
 
@@ -560,6 +568,8 @@ impl SignatureGenerator {
             total_pokes += 1;
             poke_last_time = Instant::now();
             poke_latency.observe(poke_start_time.elapsed().as_millis() as f64);
+            #[cfg(feature = "debug-page")]
+            self.render_debug(total_pokes);
 
             match action {
                 Action::Wait => {
@@ -649,6 +659,14 @@ impl SignatureGenerator {
                 }
             }
         }
+    }
+
+    #[cfg(feature = "debug-page")]
+    fn render_debug(&self, total_pokes: i32) {
+        let markup = maud::html! {
+            p { (format!("{total_pokes} pokes")) }
+        };
+        self.debug_view.send(markup);
     }
 }
 
@@ -865,6 +883,7 @@ impl SignatureSpawner {
                 msg,
                 rpc,
                 sign_respond_signature_channel,
+                &my_account_id,
             )
             .await
             {

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -53,6 +53,7 @@ struct TripleGenerator {
 }
 
 impl TripleGenerator {
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         id: TripleId,
         me: Participant,

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -48,6 +48,8 @@ struct TripleGenerator {
     created: Instant,
     inbox: mpsc::Receiver<TripleMessage>,
     msg: MessageChannel,
+    #[cfg(feature = "debug-page")]
+    debug_view: crate::web::debug::DebugPageTaskHandle,
 }
 
 impl TripleGenerator {
@@ -59,6 +61,7 @@ impl TripleGenerator {
         timeout: Duration,
         slot: TripleSlot,
         msg: &MessageChannel,
+        _my_account_id: &AccountId,
     ) -> Result<Self, InitializationError> {
         let mut participants = participants.to_vec();
         // Participants can be out of order, so let's sort them before doing anything. Critical
@@ -79,6 +82,11 @@ impl TripleGenerator {
             created: Instant::now(),
             inbox,
             msg: msg.clone(),
+            #[cfg(feature = "debug-page")]
+            debug_view: crate::web::debug::register_task(
+                _my_account_id.to_string(),
+                format!("TripleGenerator {id:#?}"),
+            ),
         })
     }
 
@@ -150,6 +158,8 @@ impl TripleGenerator {
             total_pokes += 1;
             poke_last_time = Instant::now();
             poke_latency.observe(poke_start_time.elapsed().as_millis() as f64);
+            #[cfg(feature = "debug-page")]
+            self.render_debug(total_pokes);
 
             match action {
                 Action::Wait => {
@@ -239,6 +249,14 @@ impl TripleGenerator {
                 }
             }
         }
+    }
+
+    #[cfg(feature = "debug-page")]
+    fn render_debug(&self, total_pokes: i32) {
+        let markup = maud::html! {
+            p { (format!("{total_pokes} pokes")) }
+        };
+        self.debug_view.send(markup);
     }
 }
 
@@ -475,6 +493,7 @@ impl TripleSpawner {
             timeout,
             slot,
             &self.msg,
+            &self.my_account_id,
         )
         .await?;
 

--- a/chain-signatures/node/src/web/debug.rs
+++ b/chain-signatures/node/src/web/debug.rs
@@ -1,0 +1,141 @@
+//! A debug page showing a live view of what the node it currently doing.
+
+use alloy_primitives::map::HashMap;
+use axum::response::Html;
+use axum::Extension;
+use maud::{html, Markup, Render};
+use std::sync::Arc;
+use std::{sync::LazyLock, time::Instant};
+use tokio::sync::{watch, Mutex, RwLock};
+
+use crate::web::AxumState;
+
+/// Global state used for easy access.
+///
+/// Using global state is a bit of a code-smell but it really helps to make it
+/// accessible from everywhere. Passing in a debug data to all tokio tasks that
+/// that need monitoring is going to be far worse for code maintainability.
+///
+/// One non-trivial problem with global state is testability. Running multiple
+/// nodes in the same process is normal for testing. These end up sharing the
+/// same global state. To give each node a "private" share of the state, the
+/// state is separate for each node.
+///
+/// Unfortunately, this means each code place accessing global state must have a
+/// way to identify the node. Currently, account_id serialized to a String is
+/// used to identify the node. (Still looking for a better solution...)
+///
+/// The outer RwLock should only be used in write mode once per node to
+/// initialize. All future calls are read-only and therefore will not create
+/// cross-node lock contention.
+static TASK_REGISTRY: LazyLock<RwLock<HashMap<String, Arc<Mutex<Vec<DebugPageTask>>>>>> =
+    LazyLock::new(|| Default::default());
+
+async fn read_registry(account_id: &str) -> Arc<Mutex<Vec<DebugPageTask>>> {
+    // first try a read lock - this should be the common case
+    {
+        let map = TASK_REGISTRY.read().await;
+        if let Some(tasks) = map.get(account_id) {
+            return Arc::clone(tasks);
+        }
+    }
+    // once per node: take a write lock and initialize
+    let mut map = TASK_REGISTRY.write().await;
+    Arc::clone(
+        map.entry(account_id.to_owned())
+            .or_insert_with(|| Arc::new(Mutex::new(Vec::new()))),
+    )
+}
+
+/// Register a task to be displayed on the debug page.
+///
+/// Returns a [`DebugPageTaskHandle`] that can be used to update the displayed
+/// content. Note that the debug page will display outdated information if the
+/// content is not updated frequently.
+///
+/// When the returned [`DebugPageTaskHandle`] is dropped, it's information is
+/// also removed from the debug page.
+pub fn register_task(node_account_id: String, name: String) -> DebugPageTaskHandle {
+    let (sender, receiver) = watch::channel(html! {p{"uninitialized task state"}});
+    let task = DebugPageTask {
+        name,
+        registered: Instant::now(),
+        state: receiver,
+    };
+    let node_id = node_account_id.to_string();
+    // spawn it here to avoid `async` on the interface
+    tokio::spawn(async move {
+        read_registry(&node_id).await.lock().await.push(task);
+    });
+    DebugPageTaskHandle {
+        sender,
+        node_account_id,
+    }
+}
+
+/// Unregister task by it's channel, since the name may not be unique.
+async fn unregister_task(account_id: &str, rx: &watch::Receiver<Markup>) {
+    let registry = read_registry(account_id).await;
+    let mut tasks = registry.lock().await;
+    tasks.retain(|task| !task.state.same_channel(rx));
+}
+
+pub(super) async fn page(Extension(web): Extension<Arc<AxumState>>) -> Html<String> {
+    let registry = read_registry(web.my_account_id.as_str()).await;
+    let tasks = registry.lock().await;
+
+    let markup = html! {
+        h1 { "Registered Tasks (" (tasks.len())  ")"}
+        style {
+            ".tasks { display: flex; flex-wrap: wrap; }"
+            ".task { margin: 1rem; padding: 1rem; border: solid 1px; }"
+            ".task-title { font-weight: bold; }"
+        }
+
+        .tasks {
+            @for task in tasks.iter() {
+                @let age = format!("{:#.2?}", task.registered.elapsed());
+                .task {
+                    .task-title {
+                        (task.name)
+                    }
+                    .task-state {
+                        "age: " (age)
+                        (task.state.borrow().render())
+                    }
+                }
+            }
+        }
+    };
+    Html(markup.into_string())
+}
+
+pub struct DebugPageTask {
+    name: String,
+    registered: Instant,
+    state: watch::Receiver<Markup>,
+}
+
+pub struct DebugPageTaskHandle {
+    sender: watch::Sender<Markup>,
+    node_account_id: String,
+}
+
+impl DebugPageTaskHandle {
+    pub fn send(&self, markup: Markup) {
+        self.sender
+            .send(markup)
+            .expect("sender should live longer than handles")
+    }
+}
+impl Drop for DebugPageTaskHandle {
+    fn drop(&mut self) {
+        // memory swap trick to avoid cloning the id right before it gets dropped anyway
+        let mut take_account_id = String::new();
+        std::mem::swap(&mut self.node_account_id, &mut take_account_id);
+        let rx = self.sender.subscribe();
+        tokio::spawn(async move {
+            unregister_task(&take_account_id, &rx).await;
+        });
+    }
+}

--- a/chain-signatures/node/src/web/debug.rs
+++ b/chain-signatures/node/src/web/debug.rs
@@ -28,10 +28,11 @@ use crate::web::AxumState;
 /// The outer RwLock should only be used in write mode once per node to
 /// initialize. All future calls are read-only and therefore will not create
 /// cross-node lock contention.
-static TASK_REGISTRY: LazyLock<RwLock<HashMap<String, Arc<Mutex<Vec<DebugPageTask>>>>>> =
-    LazyLock::new(|| Default::default());
+static TASK_REGISTRY: LazyLock<RwLock<HashMap<String, LocalTaskRegistry>>> =
+    LazyLock::new(Default::default);
+type LocalTaskRegistry = Arc<Mutex<Vec<DebugPageTask>>>;
 
-async fn read_registry(account_id: &str) -> Arc<Mutex<Vec<DebugPageTask>>> {
+async fn read_registry(account_id: &str) -> LocalTaskRegistry {
     // first try a read lock - this should be the common case
     {
         let map = TASK_REGISTRY.read().await;

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -3,6 +3,9 @@ mod error;
 #[cfg(test)]
 pub mod mock;
 
+#[cfg(feature = "debug-page")]
+pub mod debug;
+
 use self::error::Error;
 use crate::indexer::NearIndexer;
 use crate::metrics::WEB_ENDPOINT_LATENCY;
@@ -78,6 +81,7 @@ pub async fn run(
         .route("/state", get(state))
         .route("/status", get(status))
         .route("/metrics", get(metrics))
+        .route("/debug", get(debug::page))
         .merge(sync);
 
     if cfg!(feature = "bench") {
@@ -260,4 +264,11 @@ async fn sync(
         .with_label_values(&["sync", state.my_account_id.as_str()])
         .observe(start.elapsed().as_millis() as f64);
     Ok(Json(()))
+}
+
+#[cfg(not(feature = "debug-page"))]
+mod debug {
+    pub async fn page() -> axum::response::Html<String> {
+        format!("<html><body>Debug page disabled. Compile the node with --features=debug-page to show useful information here.</bod></html>").into()
+    }
 }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -54,7 +54,7 @@ near-workspaces = "0.15.0"
 mpc-crypto.workspace = true
 mpc-contract.workspace = true
 mpc-keys.workspace = true
-mpc-node = { path = "../chain-signatures/node", features = ["test-feature"] }
+mpc-node = { path = "../chain-signatures/node", features = ["test-feature", "debug-page"] }
 mpc-primitives.workspace = true
 
 [dev-dependencies]

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -481,16 +481,21 @@ impl MpcFixtureNodeBuilder {
             self.messaging.filter,
         );
 
-        MpcFixtureNode {
+        let mut node = MpcFixtureNode {
             me: self.me,
             state: node_state,
             mesh: mesh_tx,
             config: config_tx,
             sign_tx,
-            msg_tx: self.messaging.channel.inbox,
+            msg_channel: self.messaging.channel,
             triple_storage,
             presignature_storage,
-        }
+            web_handle: None,
+        };
+
+        node.start_web_interface(self.participant_info.account_id);
+
+        node
     }
 
     /// Build a node's triple, presignature, and secret storage.

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -3,12 +3,13 @@
 
 use crate::containers::Redis;
 use cait_sith::protocol::Participant;
-use mpc_keys::hpke::Ciphered;
 use mpc_node::config::Config;
 use mpc_node::mesh::MeshState;
 use mpc_node::protocol::state::NodeStateWatcher;
-use mpc_node::protocol::{IndexedSignRequest, ProtocolState};
+use mpc_node::protocol::sync::SyncChannel;
+use mpc_node::protocol::{IndexedSignRequest, MessageChannel, ProtocolState};
 use mpc_node::storage::{PresignatureStorage, TripleStorage};
+use near_sdk::AccountId;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
@@ -29,10 +30,12 @@ pub struct MpcFixtureNode {
     pub config: watch::Sender<Config>,
 
     pub sign_tx: Sender<IndexedSignRequest>,
-    pub msg_tx: Sender<Ciphered>,
+    pub msg_channel: MessageChannel,
 
     pub triple_storage: TripleStorage,
     pub presignature_storage: PresignatureStorage,
+
+    pub web_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
 /// Logs for reading outputs after a test run for assertions and debugging.
@@ -90,6 +93,21 @@ impl MpcFixtureNode {
             }
             tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
         }
+    }
+
+    pub fn start_web_interface(&mut self, account_id: AccountId) {
+        let task = mpc_node::web::run(
+            8200 + u32::from(self.me) as u16,
+            self.msg_channel.clone(),
+            self.state.clone(),
+            None,
+            self.triple_storage.clone(),
+            self.presignature_storage.clone(),
+            // unused but needed to call the web interface
+            SyncChannel::new().1,
+            account_id,
+        );
+        self.web_handle = Some(tokio::spawn(task));
     }
 }
 


### PR DESCRIPTION
A very basic display website hosted on /debug showing some live-data about the node.

For now, it just shows a (very poorly visualized) list of all running generator tasks with their id, age, and number of pokes so far.

Each task gets a `DebugPageTaskHandle` by calling `register_task`. The handle can be used to update the task's representation on the debug page. Tasks currently render their info eagerly in their main loop. The debug page itself then only collects all the info sent by tasks previously.

Rendering all tasks on-demand might be better for performance. But I didn't want to clutter users of a `DebugPageTaskHandle` (e.g. `struct TripleGenerator`) with too much code. This can be optimized later with different types of handles that render in different ways.

I have chosen https://maud.lambda.xyz/ for its `html!` macro to render information into HTML right inside Rust. I'm not sure if this is a good approach. But it gets us started and can be improved upon.

The debug page is entirely disabled unless the node is compiled with `--features=debug-page`.

When using it in component tests, it will host each node in `:8200/debug`, `:8201/debug`, ...

To make `register_task` easily accessible, without passing around a reference to the registry, I'm using some global state. It's split by account id to make it work with component tests. See comments in code for more details.