### PR TITLE
fix: mesh sync improperly

### DIFF
--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -128,7 +128,8 @@ impl NodeConnection {
                         | OtherNodeStatus::Started
                         | OtherNodeStatus::WaitingForConsensus { .. } => NodeStatus::Inactive,
                     };
-                    if old_status == NodeStatus::Inactive && new_status == NodeStatus::Active {
+                    if matches!(old_status, NodeStatus::Inactive | NodeStatus::Offline | NodeStatus::Syncing)
+                        && new_status == NodeStatus::Active {
                         // Sync when we want to enter an active state
                         //
                         // The peer is running. But before we can reliably
@@ -138,7 +139,7 @@ impl NodeConnection {
                         new_status = NodeStatus::Syncing;
                     }
                     if old_status != new_status {
-                        tracing::info!(?node, ?new_status, "updated with new status");
+                        tracing::info!(?node, ?old_status, ?new_status, "updated with new status");
                         status_tx.send_modify(|(status, _)| {
                             *status = new_status;
                         });
@@ -279,6 +280,7 @@ impl Pool {
     /// Update the node state after synchronization was successful.
     pub async fn report_node_synced(&self, participant: Participant) {
         if let Some(conn) = self.connections.get(&participant) {
+            tracing::info!(?participant, "reporting node synced");
             conn.status_tx.send_if_modified(|(status, _)| {
                 if *status == NodeStatus::Syncing {
                     *status = NodeStatus::Active;

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -47,6 +47,7 @@ impl MeshState {
         match status {
             NodeStatus::Active => {
                 self.active.insert(&participant, info);
+                self.need_sync.remove(&participant);
                 self.stable.insert(participant);
             }
             NodeStatus::Syncing => {
@@ -179,7 +180,7 @@ mod tests {
             servers.participants().clone(),
         );
 
-        let (_sync_peer_tx, synced_peer_rx) = mpsc::channel(16);
+        let (sync_peer_tx, synced_peer_rx) = mpsc::channel(16);
         let mesh = Mesh::new(
             &servers.client(),
             Options {
@@ -188,65 +189,61 @@ mod tests {
             synced_peer_rx,
         );
 
-        let mesh_state = mesh.watch();
+        let mut mesh_state = mesh.watch();
         let mesh_task = tokio::spawn(mesh.run(contract_watcher));
 
         // check that the mesh state is updated.
         {
             let expected_participants = servers.participants();
-            tokio::time::timeout(Duration::from_millis(1000), async {
-                let mut interval = tokio::time::interval(Duration::from_millis(10));
-                loop {
-                    interval.tick().await;
-                    let state = mesh_state.borrow();
-                    if state.active.len() == num_nodes && state.active == expected_participants {
-                        break;
-                    }
-                }
-            })
-            .await
-            .unwrap();
+            tokio::time::sleep(PING_INTERVAL * 3).await;
+
+            sync_peer_tx.send(servers[0].id()).await.unwrap();
+            sync_peer_tx.send(servers[1].id()).await.unwrap();
+            sync_peer_tx.send(servers[2].id()).await.unwrap();
+            tokio::time::sleep(PING_INTERVAL * 3).await;
+
+            let state = mesh_state.borrow();
+            assert_eq!(state.active.len(), num_nodes);
+            assert_eq!(state.active, expected_participants);
+            assert!(state.need_sync.is_empty());
+            assert!(state.active.contains_key(&servers[0].id()));
+            assert!(state.active.contains_key(&servers[1].id()));
+            assert!(state.active.contains_key(&servers[2].id()));
         }
 
         // check that the mesh state is updated when a participant goes offline
         {
             servers[0].make_offline().await;
+            tokio::time::sleep(PING_INTERVAL * 3).await;
 
-            tokio::time::timeout(Duration::from_millis(1000), async {
-                let mut interval = tokio::time::interval(Duration::from_millis(10));
-                loop {
-                    interval.tick().await;
-                    let state = mesh_state.borrow();
-                    if state.active.len() == num_nodes - 1
-                        && state.active.contains_key(&servers[1].id())
-                        && state.active.contains_key(&servers[2].id())
-                        && state.stable.contains(&servers[1].id())
-                        && state.stable.contains(&servers[2].id())
-                    {
-                        break;
-                    }
-                }
-            })
-            .await
-            .unwrap();
+            let state = mesh_state.borrow();
+            assert_eq!(state.active.len(), num_nodes - 1);
+            assert!(state.active.contains_key(&servers[1].id()));
+            assert!(state.active.contains_key(&servers[2].id()));
+            assert!(state.stable.contains(&servers[1].id()));
+            assert!(state.stable.contains(&servers[2].id()));
         }
 
         // check that the mesh state is updated when a participant goes back online.
         {
             servers[0].make_online().await;
+            tokio::time::sleep(PING_INTERVAL * 3).await;
 
-            tokio::time::timeout(Duration::from_millis(1000), async {
-                let mut interval = tokio::time::interval(Duration::from_millis(10));
-                loop {
-                    interval.tick().await;
-                    let state = mesh_state.borrow();
-                    if state.active.len() == num_nodes {
-                        break;
-                    }
-                }
-            })
-            .await
-            .unwrap();
+            let state = mesh_state.borrow_and_update().clone();
+            // We're still in syncing, make sure we report node 0 and mark it as synced.
+            assert_eq!(state.active.len(), num_nodes - 1);
+            sync_peer_tx.send(servers[0].id()).await.unwrap();
+            tokio::time::sleep(PING_INTERVAL).await;
+
+            let state = mesh_state.borrow_and_update().clone();
+            assert_eq!(state.active.len(), num_nodes);
+            assert!(state.need_sync.is_empty());
+            assert!(state.active.contains_key(&servers[0].id()));
+            assert!(state.active.contains_key(&servers[1].id()));
+            assert!(state.active.contains_key(&servers[2].id()));
+            assert!(state.stable.contains(&servers[0].id()));
+            assert!(state.stable.contains(&servers[1].id()));
+            assert!(state.stable.contains(&servers[2].id()));
         }
 
         mesh_task.abort();

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -145,24 +145,40 @@ mod tests {
         let mut watcher = pool.watch();
         pool.connect_nodes(&participants, &mut HashSet::new()).await;
 
-        tokio::time::timeout(Duration::from_millis(1000), async {
-            let mut active_count = HashSet::new();
-            while active_count.len() < num_nodes {
-                match tokio::time::timeout(Duration::from_millis(100), watcher.next()).await {
-                    Ok((participant, status, _info)) => {
-                        tracing::info!(?participant, ?status, "got connection update");
-                        if matches!(status, NodeStatus::Active) {
-                            active_count.insert(participant);
-                        }
-                    }
-                    Err(_) => {
-                        tokio::time::sleep(Duration::from_millis(10)).await;
+        tokio::time::sleep(PING_INTERVAL * 3).await;
+        let mut syncing = HashSet::new();
+        for i in 0..num_nodes {
+            match tokio::time::timeout(Duration::from_millis(100), watcher.next()).await {
+                Ok((participant, status, _info)) => {
+                    tracing::info!(?participant, ?status, "got connection update for syncing");
+                    if matches!(status, NodeStatus::Syncing) {
+                        syncing.insert(participant);
                     }
                 }
+                Err(_) => {
+                    panic!("timed out waiting for syncing nodes idx={i}");
+                }
             }
-        })
-        .await
-        .unwrap();
+        }
+
+        for i in 0..num_nodes {
+            pool.report_node_synced(servers[i].id()).await;
+        }
+
+        tokio::time::sleep(PING_INTERVAL * 3).await;
+        for i in 0..num_nodes {
+            match tokio::time::timeout(Duration::from_millis(100), watcher.next()).await {
+                Ok((participant, status, _info)) => {
+                    tracing::info!(?participant, ?status, "got connection update for active");
+                    if matches!(status, NodeStatus::Active) {
+                        syncing.insert(participant);
+                    }
+                }
+                Err(_) => {
+                    panic!("timed out waiting for active nodes idx={i}");
+                }
+            }
+        }
     }
 
     #[test(tokio::test)]
@@ -180,13 +196,13 @@ mod tests {
             servers.participants().clone(),
         );
 
-        let (sync_peer_tx, synced_peer_rx) = mpsc::channel(16);
+        let (sync_tx, sync_rx) = mpsc::channel(16);
         let mesh = Mesh::new(
             &servers.client(),
             Options {
                 ping_interval: PING_INTERVAL.as_millis() as u64,
             },
-            synced_peer_rx,
+            sync_rx,
         );
 
         let mut mesh_state = mesh.watch();
@@ -197,9 +213,9 @@ mod tests {
             let expected_participants = servers.participants();
             tokio::time::sleep(PING_INTERVAL * 3).await;
 
-            sync_peer_tx.send(servers[0].id()).await.unwrap();
-            sync_peer_tx.send(servers[1].id()).await.unwrap();
-            sync_peer_tx.send(servers[2].id()).await.unwrap();
+            sync_tx.send(servers[0].id()).await.unwrap();
+            sync_tx.send(servers[1].id()).await.unwrap();
+            sync_tx.send(servers[2].id()).await.unwrap();
             tokio::time::sleep(PING_INTERVAL * 3).await;
 
             let state = mesh_state.borrow();
@@ -232,7 +248,7 @@ mod tests {
             let state = mesh_state.borrow_and_update().clone();
             // We're still in syncing, make sure we report node 0 and mark it as synced.
             assert_eq!(state.active.len(), num_nodes - 1);
-            sync_peer_tx.send(servers[0].id()).await.unwrap();
+            sync_tx.send(servers[0].id()).await.unwrap();
             tokio::time::sleep(PING_INTERVAL).await;
 
             let state = mesh_state.borrow_and_update().clone();
@@ -263,7 +279,7 @@ mod tests {
             servers.participants(),
         );
 
-        let (_, synced_peer_rx) = mpsc::channel(100);
+        let (sync_tx, synced_peer_rx) = mpsc::channel(100);
         let mesh = Mesh::new(
             &servers.client(),
             Options {
@@ -293,23 +309,24 @@ mod tests {
             let expected_participants = servers.participants();
             let expected_stable: BTreeSet<_> = expected_participants.keys().copied().collect();
 
-            tokio::time::timeout(Duration::from_millis(1000), async {
-                let mut interval = tokio::time::interval(Duration::from_millis(10));
-                loop {
-                    interval.tick().await;
-                    let state = mesh_state.borrow();
-                    if state.active.len() == num_nodes
-                        && state.active == expected_participants
-                        && state.stable.len() == num_nodes
-                        && state.stable == expected_stable
-                    {
-                        break;
-                    }
-                }
-            })
-            .await
-            .map_err(|_| anyhow::anyhow!("timeout waiting for contract update"))
-            .unwrap();
+            tokio::time::sleep(PING_INTERVAL * 3).await;
+            for i in 0..num_nodes {
+                sync_tx.send(servers[i].id()).await.unwrap();
+            }
+
+            tokio::time::sleep(PING_INTERVAL * 3).await;
+            let state = mesh_state.borrow();
+
+            assert!(state.active.len() == num_nodes);
+            assert!(state.need_sync.is_empty());
+            for i in 0..num_nodes {
+                assert!(
+                    state.active.contains_key(&servers[i].id()),
+                    "missing {:?}",
+                    servers[i].id(),
+                );
+            }
+            assert_eq!(state.stable, expected_stable);
         }
 
         // check on node deletion with contract change.
@@ -328,22 +345,19 @@ mod tests {
             let expected_participants = servers.participants();
             let expected_stable: BTreeSet<_> = expected_participants.keys().copied().collect();
 
-            tokio::time::timeout(Duration::from_millis(1000), async {
-                let mut interval = tokio::time::interval(Duration::from_millis(10));
-                loop {
-                    interval.tick().await;
-                    let state = mesh_state.borrow();
-                    if state.active.len() == num_nodes
-                        && state.active == expected_participants
-                        && state.stable.len() == num_nodes
-                        && state.stable == expected_stable
-                    {
-                        break;
-                    }
-                }
-            })
-            .await
-            .unwrap();
+            tokio::time::sleep(PING_INTERVAL * 3).await;
+            let state = mesh_state.borrow();
+
+            assert!(state.need_sync.is_empty());
+            assert!(state.active.len() == num_nodes);
+            for i in 0..num_nodes {
+                assert!(
+                    state.active.contains_key(&servers[i].id()),
+                    "missing {:?}",
+                    servers[i].id(),
+                );
+            }
+            assert_eq!(state.stable, expected_stable);
         }
 
         mesh_task.abort();

--- a/chain-signatures/node/src/protocol/sync/mod.rs
+++ b/chain-signatures/node/src/protocol/sync/mod.rs
@@ -85,7 +85,7 @@ impl SyncTask {
     pub async fn run(mut self) {
         tracing::info!("task has been started");
         let mut watcher_interval = tokio::time::interval(Duration::from_millis(500));
-        let mut sync_interval = tokio::time::interval(Duration::from_millis(100));
+        let mut sync_interval = tokio::time::interval(Duration::from_millis(200));
         // Broadcast should generally not be necessary.
         let mut broadcast_interval = tokio::time::interval(RECURRING_SYNC_INTERVAL);
         let mut broadcast_check_interval = tokio::time::interval(Duration::from_millis(100));
@@ -201,17 +201,25 @@ async fn broadcast_sync(
     me: Participant,
 ) {
     if update.is_empty() {
+        for (participant, _) in receivers {
+            if synced_peer_tx.send(participant).await.is_err() {
+                tracing::error!(
+                    ?participant,
+                    "sync reporter is down: state sync will no longer work"
+                );
+            }
+        }
         return;
     }
 
     let start = Instant::now();
     let mut tasks = JoinSet::new();
-    let arc_update = Arc::new(update.clone());
+    let update = Arc::new(update);
     for (p, info) in receivers {
         let client = client.clone();
-        let update = arc_update.clone();
+        let update = update.clone();
         let url = info.url;
-        let synced_peer_tx_clone = synced_peer_tx.clone();
+        let sync_tx = synced_peer_tx.clone();
         tasks.spawn(async move {
             // Only actually do the sync on other peers, not on self. (Hack) We
             // still want to send the message to synced_peer_tx though, since
@@ -223,11 +231,8 @@ async fn broadcast_sync(
             } else {
                 None
             };
-            let result = synced_peer_tx_clone.send(p).await;
-            if result.is_err() {
-                tracing::error!(
-                    "synced_peer_tx failed, receiver is down. State sync will no longer work."
-                )
+            if sync_tx.send(p).await.is_err() {
+                tracing::error!("sync reporter is down: state sync will no longer work")
             }
             (p, sync_view)
         });
@@ -296,5 +301,41 @@ impl SyncChannel {
         if let Err(err) = self.request_update.send(update).await {
             tracing::warn!(?err, "failed to request update");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node_client::Options as NodeClientOptions;
+
+    #[tokio::test]
+    async fn test_broadcast_sync_on_empty_update() {
+        let client = NodeClient::new(&NodeClientOptions::default());
+        let update = SyncUpdate::empty();
+        let (tx, mut rx) = mpsc::channel(4);
+
+        let participants = vec![
+            (Participant::from(1u32), ParticipantInfo::new(1)),
+            (Participant::from(2u32), ParticipantInfo::new(2)),
+        ];
+
+        broadcast_sync(
+            client,
+            update,
+            participants.clone().into_iter(),
+            tx,
+            Participant::from(0u32),
+        )
+        .await;
+
+        let mut received = Vec::new();
+        for _ in 0..participants.len() {
+            received.push(rx.recv().await.expect("missing synced participant"));
+        }
+
+        let expected: Vec<_> = participants.iter().map(|(p, _)| *p).collect();
+        assert_eq!(received, expected);
+        assert!(rx.recv().await.is_none());
     }
 }


### PR DESCRIPTION
There was a point where in the update for `MeshState`, we weren't remove `need_sync` when transitioning to `Active`. Also, the connection wasn't transitioning properly as it would overwrite the syncing on the next ping. 

This fixes those issues, but might put us in the syncing state if sync is going to fail. If it becomes an issue on devnet, will fix later. Just trying to keep this fix small for now. The unit tests for mesh have been updated to accommodate syncing state.