### PR TITLE
Remove baked docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-FROM redis:7.4.2 AS redis-bin
-
 FROM node:20 AS eth-builder
 WORKDIR /usr/src/app/contract-eth
 COPY chain-signatures/contract-eth/package.json chain-signatures/contract-eth/package-lock.json ./
@@ -26,16 +24,11 @@ FROM debian:stable-slim AS runtime
 RUN apt-get update && apt-get install --assume-yes libssl-dev ca-certificates curl
 
 RUN update-ca-certificates
-
-COPY --from=redis-bin /usr/local/bin/redis-server /usr/local/bin/redis-server
 COPY --from=node-builder /usr/src/app/target/release/mpc-node /usr/local/bin/mpc-node
-COPY chain-signatures/node/redis.conf /etc/redis/redis.conf
-
-# Create a script to start both Redis and the Rust app
-RUN echo "#!/bin/bash\nredis-server /etc/redis/redis.conf &\nexec env RUST_LOG=${RUST_LOG:-mpc_node=debug,helios=info} mpc-node start" > /start.sh \
-    && chmod +x /start.sh
-
 WORKDIR /usr/local/bin
 
-# Start Redis and the Rust application
+# Create a script to start the Rust app
+RUN echo "#!/bin/bash\nexec env RUST_LOG=${RUST_LOG:-mpc_node=debug,helios=info} mpc-node start" > /start.sh \
+    && chmod +x /start.sh
+# Start the Rust app
 ENTRYPOINT [ "/start.sh" ]


### PR DESCRIPTION
Once we have time, let's test how our node behaves and uses memory without baked in Redis.