### PR TITLE
fix: remove self connection and purely follow contract for status

### DIFF
--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -255,7 +255,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let client = NodeClient::new(&message_options);
             let signer = InMemorySigner::from_secret_key(account_id.clone(), account_sk);
             let (synced_peer_tx, synced_peer_rx) = SyncTask::synced_nodes_channel();
-            let mesh = Mesh::new(&client, mesh_options, synced_peer_rx);
+            let mesh = Mesh::new(&client, mesh_options, &account_id, synced_peer_rx);
             let mesh_state = mesh.watch();
             let (contract_watcher, contract_state_tx) = ContractStateWatcher::new(&account_id);
 

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use cait_sith::protocol::Participant;
+use near_account_id::AccountId;
 use tokio::sync::{broadcast, watch};
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::WatchStream;
@@ -174,18 +175,22 @@ pub struct Pool {
     /// to join the network within the next epoch.
     connections: HashMap<Participant, NodeConnection>,
 
+    /// Account id of this node. Used to avoid creating self connections.
+    node_account_id: AccountId,
+
     conn_update_tx: broadcast::Sender<ConnectionUpdate>,
     conn_update_rx: broadcast::Receiver<ConnectionUpdate>,
 }
 
 impl Pool {
-    pub fn new(client: &NodeClient, ping_interval: Duration) -> Self {
+    pub fn new(client: &NodeClient, node_account_id: &AccountId, ping_interval: Duration) -> Self {
         tracing::info!("creating new connection pool");
         let (conn_update_tx, conn_update_rx) = broadcast::channel(256);
         Self {
             client: client.clone(),
             ping_interval,
             connections: HashMap::new(),
+            node_account_id: node_account_id.clone(),
 
             conn_update_tx,
             conn_update_rx,
@@ -222,6 +227,19 @@ impl Pool {
         seen: &mut HashSet<Participant>,
     ) {
         for (&participant, info) in participants.iter() {
+            if info.account_id == self.node_account_id {
+                tracing::debug!(?participant, "skipping self connection");
+                if self.connections.remove(&participant).is_some()
+                    && self
+                        .conn_update_tx
+                        .send(ConnectionUpdate::Drop(participant))
+                        .is_err()
+                {
+                    tracing::warn!(?participant, "unable to send drop for self connection");
+                }
+                continue;
+            }
+
             seen.insert(participant);
 
             let node = (participant, &info.url);

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -5,8 +5,10 @@ use crate::mesh::connection::NodeStatus;
 use crate::node_client::NodeClient;
 use crate::protocol::contract::primitives::Participants;
 use crate::protocol::ParticipantInfo;
+use crate::protocol::ProtocolState;
 use crate::rpc::ContractStateWatcher;
 use cait_sith::protocol::Participant;
+use near_account_id::AccountId;
 use tokio::sync::{mpsc, watch};
 
 pub mod connection;
@@ -70,22 +72,27 @@ pub struct Mesh {
     state_tx: watch::Sender<MeshState>,
     state_rx: watch::Receiver<MeshState>,
     synced_peer_rx: mpsc::Receiver<Participant>,
+    my_id: AccountId,
+    me: Option<Participant>,
 }
 
 impl Mesh {
     pub fn new(
         client: &NodeClient,
         options: Options,
+        my_id: &AccountId,
         synced_peer_rx: mpsc::Receiver<Participant>,
     ) -> Self {
         let ping_interval = Duration::from_millis(options.ping_interval);
         let (state_tx, state_rx) = watch::channel(MeshState::default());
-        let connections = connection::Pool::new(client, ping_interval);
+        let connections = connection::Pool::new(client, my_id, ping_interval);
         Self {
             connections,
             state_tx,
             state_rx,
             synced_peer_rx,
+            my_id: my_id.clone(),
+            me: None,
         }
     }
 
@@ -110,12 +117,63 @@ impl Mesh {
             tokio::select! {
                 Some(contract) = contract.next_state() => {
                     tracing::info!(?contract, "new contract state received");
-                    self.connections.connect(contract).await;
+                    let my_info = self.find_myself(&contract);
+                    let previous_me = self.me.take();
+                    self.me = my_info.as_ref().map(|(participant, _)| *participant);
+
+                    // Check that we are indeed part of the contract participants.
+                    if let Some((participant, info)) = my_info {
+                        let new_status = match &contract {
+                            ProtocolState::Initializing(_) | ProtocolState::Resharing(_) => NodeStatus::Inactive,
+                            ProtocolState::Running(_) => NodeStatus::Active,
+                        };
+                        self.connections.connect(contract).await;
+                        self.state_tx.send_modify(|state| {
+                            // if the previous me is different from the current me, remove the
+                            // previous me from the MeshState.
+                            if let Some(previous_me) = previous_me.filter(|old| *old != participant) {
+                                state.active.remove(&previous_me);
+                                state.need_sync.remove(&previous_me);
+                                state.stable.remove(&previous_me);
+                            }
+                            state.update(participant, new_status, info);
+                        });
+                    } else {
+                        tracing::warn!(?previous_me, ?contract, "we are no longer part of the MPC network");
+                        self.state_tx.send_modify(|state| {
+                            state.active.clear();
+                            state.need_sync.clear();
+                            state.stable.clear();
+                        });
+                    }
                 }
                 Some(participant) = self.synced_peer_rx.recv() => {
+                    if self.me == Some(participant) {
+                        tracing::warn!(?participant, "ignoring self sync report");
+                        continue;
+                    }
                     self.connections.report_node_synced(participant).await;
                 }
             }
+        }
+    }
+
+    fn find_myself(&self, contract: &ProtocolState) -> Option<(Participant, ParticipantInfo)> {
+        match contract {
+            ProtocolState::Initializing(init) => {
+                let participants: Participants = init.candidates.clone().into();
+                participants
+                    .find(&self.my_id)
+                    .map(|(p, info)| (*p, info.clone()))
+            }
+            ProtocolState::Running(running) => running
+                .participants
+                .find(&self.my_id)
+                .map(|(p, info)| (*p, info.clone())),
+            ProtocolState::Resharing(resharing) => resharing
+                .new_participants
+                .find(&self.my_id)
+                .map(|(p, info)| (*p, info.clone())),
         }
     }
 }
@@ -140,14 +198,16 @@ mod tests {
         let num_nodes = 3;
         let servers = MockServers::new(num_nodes).await;
         let participants = servers.participants();
+        let my_id = servers[0].account_id().clone();
 
-        let mut pool = Pool::new(&servers.client(), PING_INTERVAL);
+        let mut pool = Pool::new(&servers.client(), &my_id, PING_INTERVAL);
         let mut watcher = pool.watch();
         pool.connect_nodes(&participants, &mut HashSet::new()).await;
 
+        // We do not sync with ourselves, so only expect 1..num_nodes
         tokio::time::sleep(PING_INTERVAL * 3).await;
         let mut syncing = HashSet::new();
-        for i in 0..num_nodes {
+        for i in 1..num_nodes {
             match tokio::time::timeout(Duration::from_millis(100), watcher.next()).await {
                 Ok((participant, status, _info)) => {
                     tracing::info!(?participant, ?status, "got connection update for syncing");
@@ -160,13 +220,13 @@ mod tests {
                 }
             }
         }
-
-        for i in 0..num_nodes {
+        for i in 1..num_nodes {
             pool.report_node_synced(servers[i].id()).await;
         }
 
+        // Same with active. We only expect 1..num_nodes for new statuses
         tokio::time::sleep(PING_INTERVAL * 3).await;
-        for i in 0..num_nodes {
+        for i in 1..num_nodes {
             match tokio::time::timeout(Duration::from_millis(100), watcher.next()).await {
                 Ok((participant, status, _info)) => {
                     tracing::info!(?participant, ?status, "got connection update for active");
@@ -183,17 +243,21 @@ mod tests {
 
     #[test(tokio::test)]
     async fn test_mesh_update() {
-        let node_id = "node0.testnet".parse().unwrap();
         let root_sk = near_crypto::SecretKey::from_seed(near_crypto::KeyType::SECP256K1, "root");
         let num_nodes = 3;
 
         let mut servers = MockServers::new(num_nodes).await;
 
+        let participants = servers.participants();
+        let me = servers[0].id();
+        let node_id = servers[0].account_id().clone();
+        let expected_participants = participants.clone();
+
         let (contract_watcher, _contract_tx) = ContractStateWatcher::with_running(
             &node_id,
             root_sk.public_key().into_affine_point(),
             2,
-            servers.participants().clone(),
+            participants.clone(),
         );
 
         let (sync_tx, sync_rx) = mpsc::channel(16);
@@ -202,6 +266,7 @@ mod tests {
             Options {
                 ping_interval: PING_INTERVAL.as_millis() as u64,
             },
+            &node_id,
             sync_rx,
         );
 
@@ -210,56 +275,59 @@ mod tests {
 
         // check that the mesh state is updated.
         {
-            let expected_participants = servers.participants();
             tokio::time::sleep(PING_INTERVAL * 3).await;
+            let state = mesh_state.borrow();
+            assert!(state.active.contains_key(&me));
+            assert!(state.stable.contains(&me));
+            drop(state);
 
-            sync_tx.send(servers[0].id()).await.unwrap();
-            sync_tx.send(servers[1].id()).await.unwrap();
-            sync_tx.send(servers[2].id()).await.unwrap();
+            for idx in 0..num_nodes {
+                sync_tx.send(servers[idx].id()).await.unwrap();
+            }
             tokio::time::sleep(PING_INTERVAL * 3).await;
 
             let state = mesh_state.borrow();
             assert_eq!(state.active.len(), num_nodes);
             assert_eq!(state.active, expected_participants);
             assert!(state.need_sync.is_empty());
-            assert!(state.active.contains_key(&servers[0].id()));
-            assert!(state.active.contains_key(&servers[1].id()));
-            assert!(state.active.contains_key(&servers[2].id()));
+            for idx in 0..num_nodes {
+                assert!(state.active.contains_key(&servers[idx].id()));
+            }
+            assert!(state.active.contains_key(&me));
         }
 
         // check that the mesh state is updated when a participant goes offline
         {
-            servers[0].make_offline().await;
+            servers[1].make_offline().await;
             tokio::time::sleep(PING_INTERVAL * 3).await;
 
             let state = mesh_state.borrow();
             assert_eq!(state.active.len(), num_nodes - 1);
-            assert!(state.active.contains_key(&servers[1].id()));
+            assert!(state.active.contains_key(&me));
+            assert!(state.active.contains_key(&servers[0].id()));
+            assert!(!state.active.contains_key(&servers[1].id()));
             assert!(state.active.contains_key(&servers[2].id()));
-            assert!(state.stable.contains(&servers[1].id()));
-            assert!(state.stable.contains(&servers[2].id()));
         }
 
         // check that the mesh state is updated when a participant goes back online.
         {
-            servers[0].make_online().await;
+            servers[1].make_online().await;
             tokio::time::sleep(PING_INTERVAL * 3).await;
 
             let state = mesh_state.borrow_and_update().clone();
-            // We're still in syncing, make sure we report node 0 and mark it as synced.
             assert_eq!(state.active.len(), num_nodes - 1);
-            sync_tx.send(servers[0].id()).await.unwrap();
+            sync_tx.send(servers[1].id()).await.unwrap();
             tokio::time::sleep(PING_INTERVAL).await;
 
             let state = mesh_state.borrow_and_update().clone();
             assert_eq!(state.active.len(), num_nodes);
             assert!(state.need_sync.is_empty());
-            assert!(state.active.contains_key(&servers[0].id()));
-            assert!(state.active.contains_key(&servers[1].id()));
-            assert!(state.active.contains_key(&servers[2].id()));
-            assert!(state.stable.contains(&servers[0].id()));
-            assert!(state.stable.contains(&servers[1].id()));
-            assert!(state.stable.contains(&servers[2].id()));
+            for idx in 0..num_nodes {
+                assert!(state.active.contains_key(&servers[idx].id()));
+                assert!(state.stable.contains(&servers[idx].id()));
+            }
+            assert!(state.active.contains_key(&me));
+            assert!(state.stable.contains(&me));
         }
 
         mesh_task.abort();
@@ -267,10 +335,10 @@ mod tests {
 
     #[test(tokio::test)]
     async fn test_mesh_contract_update() {
-        let node_id = "node0.testnet".parse().unwrap();
         let root_sk = near_crypto::SecretKey::from_seed(near_crypto::KeyType::SECP256K1, "root");
         let mut num_nodes = 3;
         let mut servers = MockServers::new(num_nodes).await;
+        let node_id = servers[0].account_id().clone();
 
         let (contract_watcher, contract_tx) = ContractStateWatcher::with_running(
             &node_id,
@@ -285,6 +353,7 @@ mod tests {
             Options {
                 ping_interval: PING_INTERVAL.as_millis() as u64,
             },
+            &node_id,
             synced_peer_rx,
         );
         let mesh_state = mesh.watch();

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -196,7 +196,7 @@ mod tests {
     #[test(tokio::test)]
     async fn test_pool_update() {
         let num_nodes = 3;
-        let servers = MockServers::new(num_nodes).await;
+        let servers = MockServers::run(num_nodes).await;
         let participants = servers.participants();
         let my_id = servers[0].account_id().clone();
 
@@ -246,7 +246,7 @@ mod tests {
         let root_sk = near_crypto::SecretKey::from_seed(near_crypto::KeyType::SECP256K1, "root");
         let num_nodes = 3;
 
-        let mut servers = MockServers::new(num_nodes).await;
+        let mut servers = MockServers::run(num_nodes).await;
 
         let participants = servers.participants();
         let me = servers[0].id();
@@ -337,7 +337,7 @@ mod tests {
     async fn test_mesh_contract_update() {
         let root_sk = near_crypto::SecretKey::from_seed(near_crypto::KeyType::SECP256K1, "root");
         let mut num_nodes = 3;
-        let mut servers = MockServers::new(num_nodes).await;
+        let mut servers = MockServers::run(num_nodes).await;
         let node_id = servers[0].account_id().clone();
 
         let (contract_watcher, contract_tx) = ContractStateWatcher::with_running(
@@ -401,7 +401,7 @@ mod tests {
         // check on node deletion with contract change.
         {
             num_nodes -= 1;
-            servers.swap_remove_front().await;
+            servers.remove_back();
             // update the contract after removing the participant.
             contract_tx.send_modify(|contract| match contract.as_mut().unwrap() {
                 ProtocolState::Running(RunningContractState { participants, .. }) => {

--- a/chain-signatures/node/src/protocol/contract/primitives.rs
+++ b/chain-signatures/node/src/protocol/contract/primitives.rs
@@ -197,6 +197,10 @@ impl Participants {
             participants: intersect,
         }
     }
+
+    pub fn clear(&mut self) {
+        self.participants.clear();
+    }
 }
 
 /// ParticipantMap used to find a participant by specific amount of participants.

--- a/chain-signatures/node/src/web/mock.rs
+++ b/chain-signatures/node/src/web/mock.rs
@@ -1,5 +1,6 @@
 use cait_sith::protocol::Participant;
 use mockito::ServerGuard;
+use near_sdk::AccountId;
 
 use crate::{
     node_client::NodeClient,
@@ -10,6 +11,7 @@ use super::StateView;
 
 pub struct MockServer {
     id: u32,
+    node_id: AccountId,
     server: ServerGuard,
 }
 
@@ -40,7 +42,12 @@ impl MockServer {
             .create_async()
             .await;
 
-        Self { id, server }
+        let node_id = format!("p{id}.test").parse().unwrap();
+        Self {
+            id,
+            node_id,
+            server,
+        }
     }
 
     pub fn id(&self) -> Participant {
@@ -50,11 +57,15 @@ impl MockServer {
     pub fn info(&self) -> ParticipantInfo {
         ParticipantInfo {
             id: self.id,
-            account_id: format!("p{}.test", self.id).parse().unwrap(),
+            account_id: self.node_id.clone(),
             url: self.server.url(),
             cipher_pk: mpc_keys::hpke::PublicKey::from_bytes(&[0; 32]),
             sign_pk: near_crypto::PublicKey::empty(near_crypto::KeyType::ED25519),
         }
+    }
+
+    pub fn account_id(&self) -> &AccountId {
+        &self.node_id
     }
 
     pub async fn make_offline(&mut self) {

--- a/chain-signatures/node/src/web/mock.rs
+++ b/chain-signatures/node/src/web/mock.rs
@@ -16,7 +16,7 @@ pub struct MockServer {
 }
 
 impl MockServer {
-    async fn new(id: u32) -> Self {
+    async fn run(id: u32) -> Self {
         let mut server = mockito::Server::new_async().await;
         server
             .mock("GET", "/state")
@@ -92,7 +92,7 @@ pub struct MockServers {
 }
 
 impl MockServers {
-    pub async fn new(nodes: usize) -> Self {
+    pub async fn run(nodes: usize) -> Self {
         let mut servers = Self {
             servers: Vec::new(),
         };
@@ -115,7 +115,7 @@ impl MockServers {
     }
 
     pub async fn push(&mut self, id: u32) {
-        self.servers.push(MockServer::new(id).await);
+        self.servers.push(MockServer::run(id).await);
     }
 
     pub async fn push_next(&mut self) -> Participant {
@@ -124,15 +124,15 @@ impl MockServers {
         Participant::from(id)
     }
 
-    pub async fn remove(&mut self, id: u32) {
+    pub fn remove(&mut self, id: u32) {
         self.servers.retain(|server| server.id != id);
     }
 
-    pub async fn remove_back(&mut self) {
+    pub fn remove_back(&mut self) {
         self.servers.pop();
     }
 
-    pub async fn swap_remove_front(&mut self) {
+    pub fn swap_remove_front(&mut self) {
         self.servers.swap_remove(0);
     }
 }

--- a/integration-tests/benches/store.rs
+++ b/integration-tests/benches/store.rs
@@ -102,6 +102,7 @@ fn env() -> (Runtime, SyncEnv) {
             mpc_node::mesh::Options {
                 ping_interval: 1000,
             },
+            &node_id,
             synced_peer_rx,
         );
 

--- a/integration-tests/tests/cases/sync.rs
+++ b/integration-tests/tests/cases/sync.rs
@@ -60,6 +60,7 @@ async fn test_state_sync_update() -> anyhow::Result<()> {
         mpc_node::mesh::Options {
             ping_interval: ping_interval.as_millis() as u64,
         },
+        &node0_account_id,
         synced_peer_rx,
     );
     let (sync_channel, sync) = SyncTask::new(


### PR DESCRIPTION
Mesh/connection pool no longer maintains a connection to ourselves. This means that we will set ourselves as active when we're in running, and inactive otherwise. This saves us from pinging ourselves and further draining resources.