### PR TITLE
fix: resharing retrying & timeout

### DIFF
--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -317,7 +317,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 msg_channel: msg_channel.clone(),
                 generating: msg_channel.subscribe_generation().await,
                 resharing: msg_channel.subscribe_resharing().await,
-                resharing_ready: msg_channel.subscribe_resharing_ready().await,
+                ready: msg_channel.subscribe_ready().await,
                 sign_rx: Arc::new(RwLock::new(sign_rx)),
                 secret_storage: key_storage,
                 triple_storage: triple_storage.clone(),

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -317,6 +317,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 msg_channel: msg_channel.clone(),
                 generating: msg_channel.subscribe_generation().await,
                 resharing: msg_channel.subscribe_resharing().await,
+                resharing_ready: msg_channel.subscribe_resharing_ready().await,
                 sign_rx: Arc::new(RwLock::new(sign_rx)),
                 secret_storage: key_storage,
                 triple_storage: triple_storage.clone(),

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -323,7 +323,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 triple_storage: triple_storage.clone(),
                 presignature_storage: presignature_storage.clone(),
                 contract: contract_watcher.clone(),
-                config: config_rx.clone(),
+                config: config_rx,
                 mesh_state: mesh_state.clone(),
                 sign_bidirectional_signature_channel: sign_bidirectional_signature_channel.clone(),
             };
@@ -343,13 +343,8 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             tokio::spawn(respond_bidirectional_tx_processor.run(bidirectional_tx_map_clone, 5));
             tokio::spawn(mesh.run(contract_watcher.clone()));
             let system_handle = spawn_system_metrics(account_id.as_str()).await;
-            let protocol_handle = tokio::spawn(protocol.run(
-                node,
-                near_client,
-                contract_watcher,
-                config_rx,
-                mesh_state,
-            ));
+            let protocol_handle =
+                tokio::spawn(protocol.run(node, near_client, contract_watcher, mesh_state));
             tracing::info!("protocol thread spawned");
             let web_handle = tokio::spawn(web::run(
                 web_port,

--- a/chain-signatures/node/src/protocol/consensus.rs
+++ b/chain-signatures/node/src/protocol/consensus.rs
@@ -1,19 +1,22 @@
 use super::contract::{ProtocolState, ResharingContractState};
 use super::state::{
-    JoiningState, NodeState, PersistentNodeData, RunningState, StartedState,
-    WaitingForConsensusState,
+    JoiningState, NodeState, PersistentNodeData, ResharingPhase, ResharingReadyState,
+    ResharingState, RunningState, StartedState, WaitingForConsensusState,
+    RESHARING_READY_BROADCAST_INTERVAL,
 };
 use super::MpcSignProtocol;
 use crate::protocol::contract::primitives::Participants;
 use crate::protocol::presignature::PresignatureSpawnerTask;
 use crate::protocol::signature::SignatureSpawnerTask;
-use crate::protocol::state::{GeneratingState, ResharingState};
+use crate::protocol::state::GeneratingState;
 use crate::protocol::triple::TripleSpawnerTask;
 use crate::protocol::Governance;
-use crate::types::{KeygenProtocol, ReshareProtocol, SecretKeyShare};
+use crate::types::{KeygenProtocol, SecretKeyShare};
 use crate::util::AffinePointExt;
 
 use std::cmp::Ordering;
+use std::collections::BTreeSet;
+use std::time::Instant;
 
 pub(crate) trait ConsensusProtocol<G> {
     async fn advance(
@@ -648,10 +651,10 @@ impl<G: Governance> ConsensusProtocol<G> for ResharingState {
                 NodeState::Resharing(self)
             }
             ProtocolState::Running(contract_state) => {
-                match contract_state.epoch.cmp(&(self.old_epoch + 1)) {
+                match contract_state.epoch.cmp(&(self.contract.old_epoch + 1)) {
                     Ordering::Greater => {
                         tracing::warn!(
-                            next_epoch = self.old_epoch + 1,
+                            next_epoch = self.contract.old_epoch + 1,
                             contract_epoch = contract_state.epoch,
                             "resharing(running): our next epoch is behind contract, rejoining...",
                         );
@@ -662,7 +665,7 @@ impl<G: Governance> ConsensusProtocol<G> for ResharingState {
                     }
                     Ordering::Less => {
                         tracing::error!(
-                            next_epoch = self.old_epoch + 1,
+                            next_epoch = self.contract.old_epoch + 1,
                             contract_epoch = contract_state.epoch,
                             "resharing(running, unexpected): our next epoch is ahead of contract, rejoining...",
                         );
@@ -673,9 +676,9 @@ impl<G: Governance> ConsensusProtocol<G> for ResharingState {
                     }
                     Ordering::Equal => {
                         tracing::info!("resharing(running): contract state has finished resharing, trying to catch up");
-                        if contract_state.public_key != self.public_key {
+                        if contract_state.public_key != self.contract.public_key {
                             tracing::warn!(
-                                node_pk = ?self.public_key,
+                                node_pk = ?self.contract.public_key,
                                 contract_pk = ?contract_state.public_key,
                                 "resharing(running): our public key does not match contract, rejoining...",
                             );
@@ -684,9 +687,9 @@ impl<G: Governance> ConsensusProtocol<G> for ResharingState {
                                 public_key: contract_state.public_key,
                             });
                         }
-                        if contract_state.participants != self.new_participants {
+                        if contract_state.participants != self.contract.new_participants {
                             tracing::warn!(
-                                node_participants = ?self.new_participants,
+                                node_participants = ?self.contract.new_participants,
                                 contract_participants = ?contract_state.participants,
                                 "resharing(running): our participants do not match contract, rejoining...",
                             );
@@ -695,9 +698,9 @@ impl<G: Governance> ConsensusProtocol<G> for ResharingState {
                                 public_key: contract_state.public_key,
                             });
                         }
-                        if contract_state.threshold != self.threshold {
+                        if contract_state.threshold != self.contract.threshold {
                             tracing::warn!(
-                                node_threshold = self.threshold,
+                                node_threshold = self.contract.threshold,
                                 contract_threshold = contract_state.threshold,
                                 "resharing(running): our threshold does not match contract, rejoining...",
                             );
@@ -711,10 +714,10 @@ impl<G: Governance> ConsensusProtocol<G> for ResharingState {
                 }
             }
             ProtocolState::Resharing(contract_state) => {
-                match contract_state.old_epoch.cmp(&self.old_epoch) {
+                match contract_state.old_epoch.cmp(&self.contract.old_epoch) {
                     Ordering::Greater => {
                         tracing::warn!(
-                            old_epoch = self.old_epoch,
+                            old_epoch = self.contract.old_epoch,
                             contract_old_epoch = contract_state.old_epoch,
                             "resharing(resharing): our epoch is different from contract, rejoining...",
                         );
@@ -725,7 +728,7 @@ impl<G: Governance> ConsensusProtocol<G> for ResharingState {
                     }
                     Ordering::Less => {
                         tracing::error!(
-                            old_epoch = self.old_epoch,
+                            old_epoch = self.contract.old_epoch,
                             contract_old_epoch = contract_state.old_epoch,
                             "resharing(resharing, unexpected): our epoch is ahead of contract, rejoining...",
                         );
@@ -736,9 +739,9 @@ impl<G: Governance> ConsensusProtocol<G> for ResharingState {
                     }
                     Ordering::Equal => {
                         tracing::info!("resharing(resharing): continue to reshare as normal");
-                        if contract_state.public_key != self.public_key {
+                        if contract_state.public_key != self.contract.public_key {
                             tracing::warn!(
-                                node_pk = ?self.public_key,
+                                node_pk = ?self.contract.public_key,
                                 contract_pk = ?contract_state.public_key,
                                 "resharing(resharing): our public key does not match contract, rejoining...",
                             );
@@ -747,9 +750,9 @@ impl<G: Governance> ConsensusProtocol<G> for ResharingState {
                                 public_key: contract_state.public_key,
                             });
                         }
-                        if contract_state.old_participants != self.old_participants {
+                        if contract_state.old_participants != self.contract.old_participants {
                             tracing::warn!(
-                                node_participants = ?self.old_participants,
+                                node_participants = ?self.contract.old_participants,
                                 contract_participants = ?contract_state.old_participants,
                                 "resharing(resharing): our old participants do not match contract, rejoining...",
                             );
@@ -758,9 +761,9 @@ impl<G: Governance> ConsensusProtocol<G> for ResharingState {
                                 public_key: contract_state.public_key,
                             });
                         }
-                        if contract_state.new_participants != self.new_participants {
+                        if contract_state.new_participants != self.contract.new_participants {
                             tracing::warn!(
-                                node_participants = ?self.new_participants,
+                                node_participants = ?self.contract.new_participants,
                                 contract_participants = ?contract_state.new_participants,
                                 "resharing(resharing): our new participants do not match contract, rejoining...",
                             );
@@ -769,9 +772,9 @@ impl<G: Governance> ConsensusProtocol<G> for ResharingState {
                                 public_key: contract_state.public_key,
                             });
                         }
-                        if contract_state.threshold != self.threshold {
+                        if contract_state.threshold != self.contract.threshold {
                             tracing::warn!(
-                                node_threshold = self.threshold,
+                                node_threshold = self.contract.threshold,
                                 contract_threshold = contract_state.threshold,
                                 "resharing(resharing): our threshold does not match contract, rejoining...",
                             );
@@ -914,24 +917,15 @@ async fn start_resharing(
             public_key: contract_state.public_key,
         });
     };
-    let protocol = match ReshareProtocol::new(private_share, me, &contract_state) {
-        Ok(protocol) => protocol,
-        Err(err) => {
-            tracing::error!(?err, "resharing: failed to initialize resharing protocol");
-            return NodeState::Joining(JoiningState {
-                participants: contract_state.new_participants,
-                public_key: contract_state.public_key,
-            });
-        }
-    };
+    let mut ready = BTreeSet::new();
+    ready.insert(me);
     NodeState::Resharing(ResharingState {
         me,
-        old_epoch: contract_state.old_epoch,
-        old_participants: contract_state.old_participants,
-        new_participants: contract_state.new_participants,
-        threshold: contract_state.threshold,
-        public_key: contract_state.public_key,
-        protocol,
-        failed_store: Default::default(),
+        contract: contract_state,
+        local_private_share: private_share,
+        phase: ResharingPhase::AwaitingReady(ResharingReadyState {
+            ready,
+            last_broadcast: Instant::now() - RESHARING_READY_BROADCAST_INTERVAL,
+        }),
     })
 }

--- a/chain-signatures/node/src/protocol/consensus.rs
+++ b/chain-signatures/node/src/protocol/consensus.rs
@@ -13,6 +13,9 @@ use crate::protocol::Governance;
 use crate::types::{KeygenProtocol, SecretKeyShare};
 use crate::util::AffinePointExt;
 
+use rand::random;
+
+use std::collections::VecDeque;
 use std::cmp::Ordering;
 
 pub(crate) trait ConsensusProtocol<G> {
@@ -919,6 +922,7 @@ async fn resharing(
         contract: contract_state,
         local_private_share: private_share,
         phase: ResharingPhase::awaiting(me),
-        ready_nonce: 0,
+        ready_nonce: random(),
+        pending: VecDeque::new(),
     })
 }

--- a/chain-signatures/node/src/protocol/consensus.rs
+++ b/chain-signatures/node/src/protocol/consensus.rs
@@ -927,5 +927,6 @@ async fn start_resharing(
             ready,
             last_broadcast: Instant::now() - RESHARING_READY_BROADCAST_INTERVAL,
         }),
+        ready_nonce: 0,
     })
 }

--- a/chain-signatures/node/src/protocol/consensus.rs
+++ b/chain-signatures/node/src/protocol/consensus.rs
@@ -169,7 +169,7 @@ impl<G: Governance> ConsensusProtocol<G> for StartedState {
                             tracing::info!(
                                 "started(resharing): contract state is resharing with us, joining as a participant"
                             );
-                            start_resharing(Some(private_share), ctx, contract_state).await
+                            resharing(Some(private_share), ctx, contract_state).await
                         }
                     }
                 }
@@ -628,7 +628,7 @@ impl<G: Governance> ConsensusProtocol<G> for RunningState {
                                 public_key: contract_state.public_key,
                             });
                         }
-                        start_resharing(Some(self.private_share), ctx, contract_state).await
+                        resharing(Some(self.private_share), ctx, contract_state).await
                     }
                 }
             }
@@ -863,7 +863,7 @@ impl<G: Governance> ConsensusProtocol<G> for JoiningState {
                     .contains_account_id(&ctx.my_account_id)
                 {
                     tracing::info!("joining(resharing): joining as a new participant");
-                    start_resharing(None, ctx, contract_state).await
+                    resharing(None, ctx, contract_state).await
                 } else {
                     tracing::info!("joining(resharing): network is resharing without us, waiting for them to finish");
                     NodeState::Joining(self)
@@ -903,7 +903,7 @@ impl<G: Governance> ConsensusProtocol<G> for NodeState {
     }
 }
 
-async fn start_resharing(
+async fn resharing(
     private_share: Option<SecretKeyShare>,
     ctx: &MpcSignProtocol,
     contract_state: ResharingContractState,
@@ -925,7 +925,7 @@ async fn start_resharing(
         local_private_share: private_share,
         phase: ResharingPhase::AwaitingReady(ResharingReadyState {
             ready,
-            last_broadcast: Instant::now() - RESHARING_READY_BROADCAST_INTERVAL,
+            broadcast_interval: Instant::now() - RESHARING_READY_BROADCAST_INTERVAL,
         }),
         ready_nonce: 0,
     })

--- a/chain-signatures/node/src/protocol/consensus.rs
+++ b/chain-signatures/node/src/protocol/consensus.rs
@@ -1,8 +1,7 @@
 use super::contract::{ProtocolState, ResharingContractState};
 use super::state::{
-    JoiningState, NodeState, PersistentNodeData, ResharingPhase, ResharingReadyState,
-    ResharingState, RunningState, StartedState, WaitingForConsensusState,
-    RESHARING_READY_BROADCAST_INTERVAL,
+    JoiningState, NodeState, PersistentNodeData, ResharingPhase, ResharingState, RunningState,
+    StartedState, WaitingForConsensusState,
 };
 use super::MpcSignProtocol;
 use crate::protocol::contract::primitives::Participants;
@@ -15,8 +14,6 @@ use crate::types::{KeygenProtocol, SecretKeyShare};
 use crate::util::AffinePointExt;
 
 use std::cmp::Ordering;
-use std::collections::BTreeSet;
-use std::time::Instant;
 
 pub(crate) trait ConsensusProtocol<G> {
     async fn advance(
@@ -917,16 +914,11 @@ async fn resharing(
             public_key: contract_state.public_key,
         });
     };
-    let mut ready = BTreeSet::new();
-    ready.insert(me);
     NodeState::Resharing(ResharingState {
         me,
         contract: contract_state,
         local_private_share: private_share,
-        phase: ResharingPhase::AwaitingReady(ResharingReadyState {
-            ready,
-            broadcast_interval: Instant::now() - RESHARING_READY_BROADCAST_INTERVAL,
-        }),
+        phase: ResharingPhase::awaiting(me),
         ready_nonce: 0,
     })
 }

--- a/chain-signatures/node/src/protocol/consensus.rs
+++ b/chain-signatures/node/src/protocol/consensus.rs
@@ -16,7 +16,6 @@ use crate::util::AffinePointExt;
 use rand::random;
 
 use std::cmp::Ordering;
-use std::collections::{HashMap, VecDeque};
 
 pub(crate) trait ConsensusProtocol<G> {
     async fn advance(
@@ -923,9 +922,5 @@ async fn resharing(
         local_private_share: private_share,
         phase: ResharingPhase::awaiting(me),
         ready_nonce: random(),
-        pending: VecDeque::new(),
-        attempt_id: None,
-        last_attempt_id: None,
-        active_ready_tokens: HashMap::new(),
     })
 }

--- a/chain-signatures/node/src/protocol/consensus.rs
+++ b/chain-signatures/node/src/protocol/consensus.rs
@@ -15,8 +15,8 @@ use crate::util::AffinePointExt;
 
 use rand::random;
 
-use std::collections::VecDeque;
 use std::cmp::Ordering;
+use std::collections::{HashMap, VecDeque};
 
 pub(crate) trait ConsensusProtocol<G> {
     async fn advance(
@@ -924,5 +924,8 @@ async fn resharing(
         phase: ResharingPhase::awaiting(me),
         ready_nonce: random(),
         pending: VecDeque::new(),
+        attempt_id: None,
+        last_attempt_id: None,
+        active_ready_tokens: HashMap::new(),
     })
 }

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -6,6 +6,7 @@ use super::state::{
     ResharingState, RESHARING_READY_BROADCAST_INTERVAL,
 };
 use super::MpcSignProtocol;
+use crate::protocol::contract::ResharingContractState;
 use crate::protocol::message::{GeneratingMessage, ResharingMessage, ResharingReadyMessage};
 use crate::protocol::state::{PersistentNodeData, WaitingForConsensusState};
 use crate::protocol::MeshState;
@@ -165,184 +166,160 @@ impl CryptographicProtocol for ResharingState {
     async fn progress(mut self, ctx: &mut MpcSignProtocol, mesh_state: MeshState) -> NodeState {
         tracing::info!(active = ?mesh_state.active.keys_vec(), "progressing key reshare");
 
-        loop {
-            let mut phase = ResharingPhase::AwaitingReady(self.initial_ready_state());
-            std::mem::swap(&mut self.phase, &mut phase);
+        let mut resharing = match self.phase {
+            ResharingPhase::Resharing(running_state) => running_state,
+            ResharingPhase::AwaitingReady(mut state) => {
+                state.ready.insert(self.me);
+                if state.update(ctx, &self.contract) {
+                    tracing::debug!(?state.ready, "resharing: readiness updated");
+                }
 
-            match phase {
-                ResharingPhase::AwaitingReady(mut state) => {
-                    state.ready.insert(self.me);
-                    if self.update_readiness(ctx, &mut state) {
-                        tracing::debug!(?state.ready, "resharing: readiness updated");
-                    }
+                self.ready_nonce = state
+                    .broadcast_ready(self.me, ctx, &self.contract, self.ready_nonce)
+                    .await;
 
-                    // We will constantly broadcast our readiness until the running phase begins.
-                    // This is to ensure that all participants are aware of our readiness state.
-                    // Everyone maintains a set of ready participants, so repeatedly broadcasting
-                    // will not affect correctness and ensures liveness in case of message loss.
-                    if state.last_broadcast.elapsed() >= RESHARING_READY_BROADCAST_INTERVAL {
-                        self.broadcast_ready(ctx).await;
-                        state.last_broadcast = Instant::now();
-                    }
-
-                    let ready = self.ready_count(&state);
-                    let total = self.contract.new_participants.len();
-                    let threshold = self.contract.threshold;
-
-                    if total >= threshold && ready == total {
-                        match self.start_resharing() {
-                            Ok(running_state) => {
-                                tracing::info!(
-                                    "resharing: all participants ready, starting protocol"
-                                );
-                                self.phase = ResharingPhase::Running(running_state);
-                                continue;
-                            }
-                            Err(err) => {
-                                tracing::error!(
-                                    ?err,
-                                    "resharing: failed to initialize protocol from readiness"
-                                );
-                                state = self.initial_ready_state();
-                            }
-                        }
-                    } else {
-                        tracing::debug!(
-                            ready,
-                            total,
-                            "resharing: waiting for participants to announce readiness"
-                        );
-                    }
-
+                if !state.startable(&self.contract) {
                     self.phase = ResharingPhase::AwaitingReady(state);
                     return NodeState::Resharing(self);
                 }
-                ResharingPhase::Running(mut running_state) => {
-                    if let Some(sk_share) = running_state.failed_store.take() {
-                        match self.try_finalize(ctx, &mut running_state, sk_share).await {
-                            Ok(next_state) => return next_state,
-                            Err(()) => {
-                                self.phase = ResharingPhase::Running(running_state);
-                                return NodeState::Resharing(self);
-                            }
+
+                let protocol =
+                    match ReshareProtocol::new(self.local_private_share, self.me, &self.contract) {
+                        Ok(protocol) => protocol,
+                        Err(err) => {
+                            tracing::error!(?err, "resharing: failed to initialize/start protocol");
+                            state = Self::initial_awaiting(self.me);
+                            self.phase = ResharingPhase::AwaitingReady(state);
+                            return NodeState::Resharing(self);
                         }
-                    }
+                    };
 
-                    if running_state.last_activity.elapsed() > RESHARING_RUNNING_TIMEOUT {
-                        tracing::warn!(
-                            elapsed = ?running_state.last_activity.elapsed(),
-                            "resharing: protocol timed out, restarting readiness phase",
-                        );
-                        self.phase = ResharingPhase::AwaitingReady(self.initial_ready_state());
-                        return NodeState::Resharing(self);
-                    }
+                tracing::info!("resharing: all participants ready, starting protocol");
+                let now = Instant::now();
+                self.phase = ResharingPhase::Resharing(ResharingRunningState {
+                    protocol,
+                    failed_store: None,
+                    started_at: now,
+                    last_activity: now,
+                });
+                return NodeState::Resharing(self);
+            }
+        };
 
+        if let Some(sk_share) = resharing.failed_store.take() {
+            match Self::try_finalize(ctx, &mut resharing, sk_share, &self.contract).await {
+                Ok(next_state) => return next_state,
+                Err(()) => {
+                    self.phase = ResharingPhase::Resharing(resharing);
+                    return NodeState::Resharing(self);
+                }
+            }
+        }
+
+        if resharing.last_activity.elapsed() > RESHARING_RUNNING_TIMEOUT {
+            tracing::warn!(
+                elapsed = ?resharing.last_activity.elapsed(),
+                "resharing: protocol timed out, restarting readiness phase",
+            );
+            self.phase = ResharingPhase::AwaitingReady(Self::initial_awaiting(self.me));
+            return NodeState::Resharing(self);
+        }
+
+        loop {
+            let action = match resharing.protocol.poke() {
+                Ok(action) => action,
+                Err(err) => {
+                    tracing::warn!(?err, "resharing failed: refreshing...");
+                    if let Err(refresh_err) = resharing.protocol.refresh().await {
+                        tracing::warn!(?refresh_err, "unable to refresh reshare protocol");
+                    }
+                    self.phase = ResharingPhase::Resharing(resharing);
+                    return NodeState::Resharing(self);
+                }
+            };
+
+            match action {
+                Action::Wait => {
+                    tracing::debug!("resharing: waiting");
+                    let mut counts = HashMap::<Participant, usize>::new();
                     loop {
-                        let action = match running_state.protocol.poke() {
-                            Ok(action) => action,
-                            Err(err) => {
-                                tracing::warn!(?err, "resharing failed: refreshing...");
-                                if let Err(refresh_err) = running_state.protocol.refresh().await {
-                                    tracing::warn!(
-                                        ?refresh_err,
-                                        "unable to refresh reshare protocol"
-                                    );
-                                }
-                                self.phase = ResharingPhase::Running(running_state);
-                                return NodeState::Resharing(self);
+                        let msg = match ctx.resharing.try_recv() {
+                            Ok(msg) => msg,
+                            Err(mpsc::error::TryRecvError::Empty) => break,
+                            Err(mpsc::error::TryRecvError::Disconnected) => {
+                                tracing::warn!("resharing: unexpected channel closure, stopping");
+                                break;
                             }
                         };
 
-                        match action {
-                            Action::Wait => {
-                                tracing::debug!("resharing: waiting");
-                                let mut counts = HashMap::<Participant, usize>::new();
-                                loop {
-                                    let msg = match ctx.resharing.try_recv() {
-                                        Ok(msg) => msg,
-                                        Err(mpsc::error::TryRecvError::Empty) => break,
-                                        Err(mpsc::error::TryRecvError::Disconnected) => {
-                                            tracing::warn!(
-                                                "resharing: unexpected channel closure, stopping"
-                                            );
-                                            break;
-                                        }
-                                    };
+                        if msg.epoch != self.contract.old_epoch {
+                            tracing::debug!(
+                                expected = self.contract.old_epoch,
+                                actual = msg.epoch,
+                                "resharing: ignoring message for other epoch",
+                            );
+                            continue;
+                        }
 
-                                    if msg.epoch != self.contract.old_epoch {
-                                        tracing::debug!(
-                                            expected = self.contract.old_epoch,
-                                            actual = msg.epoch,
-                                            "resharing: ignoring message for other epoch",
-                                        );
-                                        continue;
-                                    }
-
-                                    counts.entry(msg.from).and_modify(|c| *c += 1).or_insert(1);
-                                    running_state.protocol.message(msg.from, msg.data);
-                                }
-                                if !counts.is_empty() {
-                                    running_state.last_activity = Instant::now();
-                                    tracing::info!(?counts, "resharing: handling new messages");
-                                }
-                                self.phase = ResharingPhase::Running(running_state);
-                                return NodeState::Resharing(self);
-                            }
-                            Action::SendMany(data) => {
-                                tracing::debug!("resharing: sending a message to all participants");
-                                running_state.last_activity = Instant::now();
-                                for p in self.contract.new_participants.keys() {
-                                    if p == &self.me {
-                                        continue;
-                                    }
-                                    ctx.msg_channel
-                                        .send(
-                                            self.me,
-                                            *p,
-                                            ResharingMessage {
-                                                epoch: self.contract.old_epoch,
-                                                from: self.me,
-                                                data: data.clone(),
-                                            },
-                                        )
-                                        .await;
-                                }
-                            }
-                            Action::SendPrivate(to, data) => {
-                                tracing::debug!("resharing: sending a private message to {to:?}");
-                                if self.contract.new_participants.get(&to).is_none() {
-                                    tracing::error!(
-                                        "resharing: send_private unknown participant {to:?}"
-                                    );
-                                } else {
-                                    running_state.last_activity = Instant::now();
-                                    ctx.msg_channel
-                                        .send(
-                                            self.me,
-                                            to,
-                                            ResharingMessage {
-                                                epoch: self.contract.old_epoch,
-                                                from: self.me,
-                                                data,
-                                            },
-                                        )
-                                        .await;
-                                }
-                            }
-                            Action::Return(private_share) => {
-                                tracing::info!("resharing: successfully completed key reshare");
-                                running_state.last_activity = Instant::now();
-                                match self
-                                    .try_finalize(ctx, &mut running_state, private_share)
-                                    .await
-                                {
-                                    Ok(next_state) => return next_state,
-                                    Err(()) => {
-                                        self.phase = ResharingPhase::Running(running_state);
-                                        return NodeState::Resharing(self);
-                                    }
-                                }
-                            }
+                        counts.entry(msg.from).and_modify(|c| *c += 1).or_insert(1);
+                        resharing.protocol.message(msg.from, msg.data);
+                    }
+                    if !counts.is_empty() {
+                        resharing.last_activity = Instant::now();
+                        tracing::info!(?counts, "resharing: handling new messages");
+                    }
+                    self.phase = ResharingPhase::Resharing(resharing);
+                    return NodeState::Resharing(self);
+                }
+                Action::SendMany(data) => {
+                    tracing::debug!("resharing: sending a message to all participants");
+                    resharing.last_activity = Instant::now();
+                    for p in self.contract.new_participants.keys() {
+                        if p == &self.me {
+                            continue;
+                        }
+                        ctx.msg_channel
+                            .send(
+                                self.me,
+                                *p,
+                                ResharingMessage {
+                                    epoch: self.contract.old_epoch,
+                                    from: self.me,
+                                    data: data.clone(),
+                                },
+                            )
+                            .await;
+                    }
+                }
+                Action::SendPrivate(to, data) => {
+                    tracing::debug!("resharing: sending a private message to {to:?}");
+                    if self.contract.new_participants.get(&to).is_none() {
+                        tracing::error!("resharing: send_private unknown participant {to:?}");
+                    } else {
+                        resharing.last_activity = Instant::now();
+                        ctx.msg_channel
+                            .send(
+                                self.me,
+                                to,
+                                ResharingMessage {
+                                    epoch: self.contract.old_epoch,
+                                    from: self.me,
+                                    data,
+                                },
+                            )
+                            .await;
+                    }
+                }
+                Action::Return(private_share) => {
+                    tracing::info!("resharing: successfully completed key reshare");
+                    resharing.last_activity = Instant::now();
+                    match Self::try_finalize(ctx, &mut resharing, private_share, &self.contract)
+                        .await
+                    {
+                        Ok(next_state) => return next_state,
+                        Err(()) => {
+                            self.phase = ResharingPhase::Resharing(resharing);
+                            return NodeState::Resharing(self);
                         }
                     }
                 }
@@ -352,93 +329,26 @@ impl CryptographicProtocol for ResharingState {
 }
 
 impl ResharingState {
-    fn initial_ready_state(&self) -> ResharingReadyState {
+    fn initial_awaiting(me: Participant) -> ResharingReadyState {
         ResharingReadyState {
-            ready: std::iter::once(self.me).collect(),
-            last_broadcast: Instant::now() - RESHARING_READY_BROADCAST_INTERVAL,
+            ready: std::iter::once(me).collect(),
+            // ready to broadcast immediately
+            broadcast_interval: Instant::now() - RESHARING_READY_BROADCAST_INTERVAL,
         }
-    }
-
-    fn ready_count(&self, ready_state: &ResharingReadyState) -> usize {
-        ready_state
-            .ready
-            .iter()
-            .filter(|participant| self.contract.new_participants.contains_key(participant))
-            .count()
-    }
-
-    fn update_readiness(
-        &self,
-        ctx: &mut MpcSignProtocol,
-        ready_state: &mut ResharingReadyState,
-    ) -> bool {
-        let mut updated = false;
-        loop {
-            match ctx.resharing_ready.try_recv() {
-                Ok(ResharingReadyMessage { epoch, from, .. }) => {
-                    if epoch != self.contract.old_epoch {
-                        continue;
-                    }
-                    if self.contract.new_participants.contains_key(&from)
-                        && ready_state.ready.insert(from)
-                    {
-                        updated = true;
-                    }
-                }
-                Err(mpsc::error::TryRecvError::Empty) => break,
-                Err(mpsc::error::TryRecvError::Disconnected) => {
-                    tracing::warn!("resharing: readiness channel closed unexpectedly");
-                    break;
-                }
-            }
-        }
-        updated
-    }
-
-    async fn broadcast_ready(&mut self, ctx: &mut MpcSignProtocol) {
-        let nonce = self.ready_nonce;
-        self.ready_nonce = self.ready_nonce.wrapping_add(1);
-        for participant in self.contract.new_participants.keys() {
-            if participant == &self.me {
-                continue;
-            }
-            ctx.msg_channel
-                .send(
-                    self.me,
-                    *participant,
-                    ResharingReadyMessage {
-                        epoch: self.contract.old_epoch,
-                        from: self.me,
-                        nonce,
-                    },
-                )
-                .await;
-        }
-    }
-
-    fn start_resharing(&mut self) -> Result<ResharingRunningState, InitializationError> {
-        let protocol = ReshareProtocol::new(self.local_private_share, self.me, &self.contract)?;
-        let now = Instant::now();
-        Ok(ResharingRunningState {
-            protocol,
-            failed_store: None,
-            started_at: now,
-            last_activity: now,
-        })
     }
 
     async fn try_finalize(
-        &mut self,
         ctx: &mut MpcSignProtocol,
         running_state: &mut ResharingRunningState,
         private_share: SecretKeyShare,
+        contract: &ResharingContractState,
     ) -> Result<NodeState, ()> {
         if let Err(err) = ctx
             .secret_storage
             .store(&PersistentNodeData {
-                epoch: self.contract.old_epoch + 1,
+                epoch: contract.old_epoch + 1,
                 private_share,
-                public_key: self.contract.public_key,
+                public_key: contract.public_key,
             })
             .await
         {
@@ -456,12 +366,87 @@ impl ResharingState {
         }
 
         Ok(NodeState::WaitingForConsensus(WaitingForConsensusState {
-            epoch: self.contract.old_epoch + 1,
-            participants: self.contract.new_participants.clone(),
-            threshold: self.contract.threshold,
+            epoch: contract.old_epoch + 1,
+            participants: contract.new_participants.clone(),
+            threshold: contract.threshold,
             private_share,
-            public_key: self.contract.public_key,
+            public_key: contract.public_key,
         }))
+    }
+}
+
+impl ResharingReadyState {
+    fn startable(&self, contract: &ResharingContractState) -> bool {
+        let ready = self.ready_count(contract);
+        let total = contract.new_participants.len();
+        let threshold = contract.threshold;
+
+        total >= threshold && ready == total
+    }
+
+    fn update(&mut self, ctx: &mut MpcSignProtocol, contract: &ResharingContractState) -> bool {
+        let mut updated = false;
+        loop {
+            match ctx.resharing_ready.try_recv() {
+                Ok(ResharingReadyMessage { epoch, from, .. }) => {
+                    if epoch != contract.old_epoch {
+                        continue;
+                    }
+                    if contract.new_participants.contains_key(&from) && self.ready.insert(from) {
+                        updated = true;
+                    }
+                }
+                Err(mpsc::error::TryRecvError::Empty) => break,
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    tracing::warn!("resharing: readiness channel closed unexpectedly");
+                    break;
+                }
+            }
+        }
+        updated
+    }
+
+    async fn broadcast_ready(
+        &mut self,
+        me: Participant,
+        ctx: &mut MpcSignProtocol,
+        contract: &ResharingContractState,
+        nonce: u64,
+    ) -> u64 {
+        // We will constantly broadcast our readiness until the running phase begins.
+        // This is to ensure that all participants are aware of our readiness state.
+        // Everyone maintains a set of ready participants, so repeatedly broadcasting
+        // will not affect correctness and ensures liveness in case of message loss.
+        if self.broadcast_interval.elapsed() < RESHARING_READY_BROADCAST_INTERVAL {
+            return nonce;
+        }
+        self.broadcast_interval = Instant::now();
+
+        for &participant in contract.new_participants.keys() {
+            if participant == me {
+                continue;
+            }
+            ctx.msg_channel
+                .send(
+                    me,
+                    participant,
+                    ResharingReadyMessage {
+                        epoch: contract.old_epoch,
+                        from: me,
+                        nonce,
+                    },
+                )
+                .await;
+        }
+
+        nonce.wrapping_add(1)
+    }
+
+    fn ready_count(&self, contract: &ResharingContractState) -> usize {
+        self.ready
+            .iter()
+            .filter(|participant| contract.new_participants.contains_key(participant))
+            .count()
     }
 }
 

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -381,14 +381,11 @@ impl ResharingState {
         self.contract.new_participants.len()
     }
 
-    fn ready_count(&self, ready_state: &ResharingReadyState, mesh_state: &MeshState) -> usize {
+    fn ready_count(&self, ready_state: &ResharingReadyState, _mesh_state: &MeshState) -> usize {
         ready_state
             .ready
             .iter()
-            .filter(|participant| {
-                self.contract.new_participants.contains_key(participant)
-                    && mesh_state.stable.contains(participant)
-            })
+            .filter(|participant| self.contract.new_participants.contains_key(participant))
             .count()
     }
 
@@ -487,6 +484,22 @@ impl ResharingState {
     }
 }
 
+impl CryptographicProtocol for NodeState {
+    async fn progress(
+        self,
+        ctx: &mut MpcSignProtocol,
+        cfg: Config,
+        mesh_state: MeshState,
+    ) -> NodeState {
+        match self {
+            NodeState::Generating(state) => state.progress(ctx, cfg, mesh_state).await,
+            NodeState::Resharing(state) => state.progress(ctx, cfg, mesh_state).await,
+            NodeState::WaitingForConsensus(state) => state.progress(ctx, cfg, mesh_state).await,
+            _ => self,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -555,21 +568,5 @@ mod tests {
 
         mesh_state.stable.insert(other);
         assert_eq!(state.ready_count(&ready, &mesh_state), 2);
-    }
-}
-
-impl CryptographicProtocol for NodeState {
-    async fn progress(
-        self,
-        ctx: &mut MpcSignProtocol,
-        cfg: Config,
-        mesh_state: MeshState,
-    ) -> NodeState {
-        match self {
-            NodeState::Generating(state) => state.progress(ctx, cfg, mesh_state).await,
-            NodeState::Resharing(state) => state.progress(ctx, cfg, mesh_state).await,
-            NodeState::WaitingForConsensus(state) => state.progress(ctx, cfg, mesh_state).await,
-            _ => self,
-        }
     }
 }

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -1,17 +1,23 @@
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
-use super::state::{GeneratingState, NodeState, ResharingState};
+use super::state::{
+    GeneratingState, NodeState, ResharingPhase, ResharingReadyState, ResharingRunningState,
+    ResharingState, RESHARING_READY_BROADCAST_INTERVAL,
+};
 use super::MpcSignProtocol;
 use crate::config::Config;
-use crate::protocol::message::{GeneratingMessage, ResharingMessage};
+use crate::protocol::message::{GeneratingMessage, ResharingMessage, ResharingReadyMessage};
 use crate::protocol::state::{PersistentNodeData, WaitingForConsensusState};
 use crate::protocol::MeshState;
-use crate::types::SecretKeyShare;
+use crate::types::{ReshareProtocol, SecretKeyShare};
 
 use cait_sith::protocol::{Action, InitializationError, Participant, ProtocolError};
 use k256::elliptic_curve::group::GroupEncoding;
 use mpc_crypto::PublicKey;
 use tokio::sync::mpsc;
+
+const RESHARING_RUNNING_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(thiserror::Error, Debug)]
 pub enum CryptographicError {
@@ -178,88 +184,185 @@ impl CryptographicProtocol for ResharingState {
         _cfg: Config,
         mesh_state: MeshState,
     ) -> NodeState {
-        // Previous save to secret storage failed, try again until successful.
-        if let Some(sk_share) = self.failed_store.take() {
-            return self.finalize(sk_share, ctx).await;
-        }
-
         tracing::info!(active = ?mesh_state.active.keys_vec(), "progressing key reshare");
+
         loop {
-            let action = match self.protocol.poke() {
-                Ok(action) => action,
-                Err(err) => {
-                    tracing::warn!(?err, "resharing failed: refreshing...");
-                    if let Err(refresh_err) = self.protocol.refresh().await {
-                        tracing::warn!(?refresh_err, "unable to refresh reshare protocol");
+            let mut phase = ResharingPhase::AwaitingReady(self.initial_ready_state());
+            std::mem::swap(&mut self.phase, &mut phase);
+
+            match phase {
+                ResharingPhase::AwaitingReady(mut ready_state) => {
+                    ready_state.ready.insert(self.me);
+                    let updated = self.drain_ready_messages(ctx, &mut ready_state);
+
+                    if updated {
+                        tracing::debug!(?ready_state.ready, "resharing: readiness updated");
                     }
+
+                    if ready_state.last_broadcast.elapsed() >= RESHARING_READY_BROADCAST_INTERVAL {
+                        self.broadcast_ready(ctx).await;
+                        ready_state.last_broadcast = Instant::now();
+                    }
+
+                    let ready_count = self.ready_count(&ready_state, &mesh_state);
+                    let total = self.expected_ready_count();
+
+                    if total > 0 && ready_count == total {
+                        match self.begin_running_phase() {
+                            Ok(running_state) => {
+                                tracing::info!(
+                                    "resharing: all participants ready, starting protocol"
+                                );
+                                self.phase = ResharingPhase::Running(running_state);
+                                continue;
+                            }
+                            Err(err) => {
+                                tracing::error!(
+                                    ?err,
+                                    "resharing: failed to initialize protocol from readiness"
+                                );
+                                ready_state = self.initial_ready_state();
+                            }
+                        }
+                    } else {
+                        tracing::debug!(
+                            ready = ready_count,
+                            total,
+                            "resharing: waiting for participants to announce readiness"
+                        );
+                    }
+
+                    self.phase = ResharingPhase::AwaitingReady(ready_state);
                     return NodeState::Resharing(self);
                 }
-            };
-            match action {
-                Action::Wait => {
-                    tracing::debug!("resharing: waiting");
-                    let mut counts = HashMap::<Participant, usize>::new();
-                    loop {
-                        let msg = match ctx.resharing.try_recv() {
-                            Ok(msg) => msg,
-                            Err(mpsc::error::TryRecvError::Empty) => {
-                                break;
+                ResharingPhase::Running(mut running_state) => {
+                    if let Some(sk_share) = running_state.failed_store.take() {
+                        match self.try_finalize(ctx, &mut running_state, sk_share).await {
+                            Ok(next_state) => return next_state,
+                            Err(()) => {
+                                self.phase = ResharingPhase::Running(running_state);
+                                return NodeState::Resharing(self);
                             }
-                            Err(mpsc::error::TryRecvError::Disconnected) => {
-                                tracing::warn!("resharing: unexpected channel closure, stopping");
-                                break;
+                        }
+                    }
+
+                    if running_state.last_activity.elapsed() > RESHARING_RUNNING_TIMEOUT {
+                        tracing::warn!(
+                            elapsed = ?running_state.last_activity.elapsed(),
+                            "resharing: protocol timed out, restarting readiness phase",
+                        );
+                        self.phase = ResharingPhase::AwaitingReady(self.initial_ready_state());
+                        return NodeState::Resharing(self);
+                    }
+
+                    loop {
+                        let action = match running_state.protocol.poke() {
+                            Ok(action) => action,
+                            Err(err) => {
+                                tracing::warn!(?err, "resharing failed: refreshing...");
+                                if let Err(refresh_err) = running_state.protocol.refresh().await {
+                                    tracing::warn!(
+                                        ?refresh_err,
+                                        "unable to refresh reshare protocol"
+                                    );
+                                }
+                                self.phase = ResharingPhase::Running(running_state);
+                                return NodeState::Resharing(self);
                             }
                         };
 
-                        counts.entry(msg.from).and_modify(|c| *c += 1).or_insert(1);
-                        self.protocol.message(msg.from, msg.data);
-                    }
-                    if !counts.is_empty() {
-                        tracing::info!(?counts, "resharing: handling new messages");
-                    }
-                    return NodeState::Resharing(self);
-                }
-                Action::SendMany(data) => {
-                    tracing::debug!("resharing: sending a message to all participants");
-                    for p in self.new_participants.keys() {
-                        if p == &self.me {
-                            // Skip yourself, cait-sith never sends messages to oneself
-                            continue;
+                        match action {
+                            Action::Wait => {
+                                tracing::debug!("resharing: waiting");
+                                let mut counts = HashMap::<Participant, usize>::new();
+                                loop {
+                                    let msg = match ctx.resharing.try_recv() {
+                                        Ok(msg) => msg,
+                                        Err(mpsc::error::TryRecvError::Empty) => break,
+                                        Err(mpsc::error::TryRecvError::Disconnected) => {
+                                            tracing::warn!(
+                                                "resharing: unexpected channel closure, stopping"
+                                            );
+                                            break;
+                                        }
+                                    };
+
+                                    if msg.epoch != self.contract.old_epoch {
+                                        tracing::debug!(
+                                            expected = self.contract.old_epoch,
+                                            actual = msg.epoch,
+                                            "resharing: ignoring message for other epoch",
+                                        );
+                                        continue;
+                                    }
+
+                                    counts.entry(msg.from).and_modify(|c| *c += 1).or_insert(1);
+                                    running_state.protocol.message(msg.from, msg.data);
+                                }
+                                if !counts.is_empty() {
+                                    running_state.last_activity = Instant::now();
+                                    tracing::info!(?counts, "resharing: handling new messages");
+                                }
+                                self.phase = ResharingPhase::Running(running_state);
+                                return NodeState::Resharing(self);
+                            }
+                            Action::SendMany(data) => {
+                                tracing::debug!("resharing: sending a message to all participants");
+                                running_state.last_activity = Instant::now();
+                                for p in self.contract.new_participants.keys() {
+                                    if p == &self.me {
+                                        continue;
+                                    }
+                                    ctx.msg_channel
+                                        .send(
+                                            self.me,
+                                            *p,
+                                            ResharingMessage {
+                                                epoch: self.contract.old_epoch,
+                                                from: self.me,
+                                                data: data.clone(),
+                                            },
+                                        )
+                                        .await;
+                                }
+                            }
+                            Action::SendPrivate(to, data) => {
+                                tracing::debug!("resharing: sending a private message to {to:?}");
+                                if self.contract.new_participants.get(&to).is_none() {
+                                    tracing::error!(
+                                        "resharing: send_private unknown participant {to:?}"
+                                    );
+                                } else {
+                                    running_state.last_activity = Instant::now();
+                                    ctx.msg_channel
+                                        .send(
+                                            self.me,
+                                            to,
+                                            ResharingMessage {
+                                                epoch: self.contract.old_epoch,
+                                                from: self.me,
+                                                data,
+                                            },
+                                        )
+                                        .await;
+                                }
+                            }
+                            Action::Return(private_share) => {
+                                tracing::info!("resharing: successfully completed key reshare");
+                                running_state.last_activity = Instant::now();
+                                match self
+                                    .try_finalize(ctx, &mut running_state, private_share)
+                                    .await
+                                {
+                                    Ok(next_state) => return next_state,
+                                    Err(()) => {
+                                        self.phase = ResharingPhase::Running(running_state);
+                                        return NodeState::Resharing(self);
+                                    }
+                                }
+                            }
                         }
-                        ctx.msg_channel
-                            .send(
-                                self.me,
-                                *p,
-                                ResharingMessage {
-                                    epoch: self.old_epoch,
-                                    from: self.me,
-                                    data: data.clone(),
-                                },
-                            )
-                            .await;
                     }
-                }
-                Action::SendPrivate(to, data) => {
-                    tracing::debug!("resharing: sending a private message to {to:?}");
-                    if self.new_participants.get(&to).is_none() {
-                        tracing::error!("resharing: send_private unknown participant {to:?}");
-                    } else {
-                        ctx.msg_channel
-                            .send(
-                                self.me,
-                                to,
-                                ResharingMessage {
-                                    epoch: self.old_epoch,
-                                    from: self.me,
-                                    data,
-                                },
-                            )
-                            .await;
-                    }
-                }
-                Action::Return(private_share) => {
-                    tracing::info!("resharing: successfully completed key reshare");
-                    return self.finalize(private_share, ctx).await;
                 }
             }
         }
@@ -267,27 +370,105 @@ impl CryptographicProtocol for ResharingState {
 }
 
 impl ResharingState {
-    async fn finalize(
-        mut self,
-        private_share: SecretKeyShare,
+    fn initial_ready_state(&self) -> ResharingReadyState {
+        ResharingReadyState {
+            ready: std::iter::once(self.me).collect(),
+            last_broadcast: Instant::now() - RESHARING_READY_BROADCAST_INTERVAL,
+        }
+    }
+
+    fn expected_ready_count(&self) -> usize {
+        self.contract.new_participants.len()
+    }
+
+    fn ready_count(&self, ready_state: &ResharingReadyState, mesh_state: &MeshState) -> usize {
+        ready_state
+            .ready
+            .iter()
+            .filter(|participant| {
+                self.contract.new_participants.contains_key(participant)
+                    && mesh_state.stable.contains(participant)
+            })
+            .count()
+    }
+
+    fn drain_ready_messages(
+        &self,
         ctx: &mut MpcSignProtocol,
-    ) -> NodeState {
+        ready_state: &mut ResharingReadyState,
+    ) -> bool {
+        let mut updated = false;
+        loop {
+            match ctx.resharing_ready.try_recv() {
+                Ok(ResharingReadyMessage { epoch, from }) => {
+                    if epoch != self.contract.old_epoch {
+                        continue;
+                    }
+                    if self.contract.new_participants.contains_key(&from)
+                        && ready_state.ready.insert(from)
+                    {
+                        updated = true;
+                    }
+                }
+                Err(mpsc::error::TryRecvError::Empty) => break,
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    tracing::warn!("resharing: readiness channel closed unexpectedly");
+                    break;
+                }
+            }
+        }
+        updated
+    }
+
+    async fn broadcast_ready(&self, ctx: &mut MpcSignProtocol) {
+        for participant in self.contract.new_participants.keys() {
+            if participant == &self.me {
+                continue;
+            }
+            ctx.msg_channel
+                .send(
+                    self.me,
+                    *participant,
+                    ResharingReadyMessage {
+                        epoch: self.contract.old_epoch,
+                        from: self.me,
+                    },
+                )
+                .await;
+        }
+    }
+
+    fn begin_running_phase(&mut self) -> Result<ResharingRunningState, InitializationError> {
+        let protocol = ReshareProtocol::new(self.local_private_share, self.me, &self.contract)?;
+        let now = Instant::now();
+        Ok(ResharingRunningState {
+            protocol,
+            failed_store: None,
+            started_at: now,
+            last_activity: now,
+        })
+    }
+
+    async fn try_finalize(
+        &mut self,
+        ctx: &mut MpcSignProtocol,
+        running_state: &mut ResharingRunningState,
+        private_share: SecretKeyShare,
+    ) -> Result<NodeState, ()> {
         if let Err(err) = ctx
             .secret_storage
             .store(&PersistentNodeData {
-                epoch: self.old_epoch + 1,
+                epoch: self.contract.old_epoch + 1,
                 private_share,
-                public_key: self.public_key,
+                public_key: self.contract.public_key.clone(),
             })
             .await
         {
             tracing::error!(?err, "resharing: failed to store secret");
-            self.failed_store.replace(private_share);
-            return NodeState::Resharing(self);
+            running_state.failed_store.replace(private_share);
+            return Err(());
         }
 
-        // Clear triples from storage before starting the new epoch. This is necessary if the node has accumulated
-        // triples from previous epochs. If it was not able to clear the previous triples, we'll leave them as-is
         if !ctx.triple_storage.clear().await {
             tracing::error!("failed to clear triples from storage on new epoch start");
         }
@@ -296,13 +477,84 @@ impl ResharingState {
             tracing::error!("failed to clear presignatures from storage on new epoch start");
         }
 
-        NodeState::WaitingForConsensus(WaitingForConsensusState {
-            epoch: self.old_epoch + 1,
-            participants: self.new_participants,
-            threshold: self.threshold,
+        Ok(NodeState::WaitingForConsensus(WaitingForConsensusState {
+            epoch: self.contract.old_epoch + 1,
+            participants: self.contract.new_participants.clone(),
+            threshold: self.contract.threshold,
             private_share,
-            public_key: self.public_key,
-        })
+            public_key: self.contract.public_key.clone(),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::contract::primitives::{ParticipantInfo, Participants};
+    use crate::protocol::contract::ResharingContractState;
+    use crate::protocol::MeshState;
+    use crate::util::NearPublicKeyExt;
+    use cait_sith::protocol::Participant;
+    use near_crypto::SecretKey;
+    use std::collections::{BTreeSet, HashSet};
+    use std::time::Instant;
+
+    fn sample_contract() -> (ResharingState, Participant, Participant) {
+        let me = Participant::from(0);
+        let other = Participant::from(1);
+
+        let mut old_participants = Participants::default();
+        old_participants.insert(&me, ParticipantInfo::new(0));
+        old_participants.insert(&other, ParticipantInfo::new(1));
+        let new_participants = old_participants.clone();
+
+        let public_key = SecretKey::from_seed(near_crypto::KeyType::SECP256K1, "reshare-test")
+            .public_key()
+            .into_affine_point();
+
+        let contract = ResharingContractState {
+            old_epoch: 3,
+            old_participants,
+            new_participants,
+            threshold: 2,
+            public_key,
+            finished_votes: HashSet::new(),
+        };
+
+        let state = ResharingState {
+            me,
+            contract,
+            local_private_share: None,
+            phase: ResharingPhase::AwaitingReady(ResharingReadyState {
+                ready: BTreeSet::new(),
+                last_broadcast: Instant::now(),
+            }),
+        };
+
+        (state, me, other)
+    }
+
+    #[test]
+    fn initial_ready_state_marks_self() {
+        let (state, me, _) = sample_contract();
+        let ready = state.initial_ready_state();
+        assert!(ready.ready.contains(&me));
+        let elapsed = Instant::now().duration_since(ready.last_broadcast);
+        assert!(elapsed >= RESHARING_READY_BROADCAST_INTERVAL);
+    }
+
+    #[test]
+    fn ready_count_respects_mesh_state() {
+        let (state, me, other) = sample_contract();
+        let mut ready = state.initial_ready_state();
+        ready.ready.insert(other);
+
+        let mut mesh_state = MeshState::default();
+        mesh_state.stable.insert(me);
+        assert_eq!(state.ready_count(&ready, &mesh_state), 1);
+
+        mesh_state.stable.insert(other);
+        assert_eq!(state.ready_count(&ready, &mesh_state), 2);
     }
 }
 

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -170,23 +170,23 @@ impl CryptographicProtocol for ResharingState {
             std::mem::swap(&mut self.phase, &mut phase);
 
             match phase {
-                ResharingPhase::AwaitingReady(mut ready_state) => {
-                    ready_state.ready.insert(self.me);
-                    let updated = self.drain_ready_messages(ctx, &mut ready_state);
+                ResharingPhase::AwaitingReady(mut state) => {
+                    state.ready.insert(self.me);
+                    let updated = self.drain_ready_messages(ctx, &mut state);
                     if updated {
-                        tracing::debug!(?ready_state.ready, "resharing: readiness updated");
+                        tracing::debug!(?state.ready, "resharing: readiness updated");
                     }
 
-                    if ready_state.last_broadcast.elapsed() >= RESHARING_READY_BROADCAST_INTERVAL {
+                    if state.last_broadcast.elapsed() >= RESHARING_READY_BROADCAST_INTERVAL {
                         self.broadcast_ready(ctx).await;
-                        ready_state.last_broadcast = Instant::now();
+                        state.last_broadcast = Instant::now();
                     }
 
-                    let ready_count = self.ready_count(&ready_state, &mesh_state);
+                    let ready = self.ready_count(&state);
                     let total = self.contract.new_participants.len();
                     let threshold = self.contract.threshold;
 
-                    if total >= threshold && ready_count == total {
+                    if total >= threshold && ready == total {
                         match self.begin_running_phase() {
                             Ok(running_state) => {
                                 tracing::info!(
@@ -200,18 +200,18 @@ impl CryptographicProtocol for ResharingState {
                                     ?err,
                                     "resharing: failed to initialize protocol from readiness"
                                 );
-                                ready_state = self.initial_ready_state();
+                                state = self.initial_ready_state();
                             }
                         }
                     } else {
                         tracing::debug!(
-                            ready = ready_count,
+                            ready,
                             total,
                             "resharing: waiting for participants to announce readiness"
                         );
                     }
 
-                    self.phase = ResharingPhase::AwaitingReady(ready_state);
+                    self.phase = ResharingPhase::AwaitingReady(state);
                     return NodeState::Resharing(self);
                 }
                 ResharingPhase::Running(mut running_state) => {
@@ -356,7 +356,7 @@ impl ResharingState {
         }
     }
 
-    fn ready_count(&self, ready_state: &ResharingReadyState, _mesh_state: &MeshState) -> usize {
+    fn ready_count(&self, ready_state: &ResharingReadyState) -> usize {
         ready_state
             .ready
             .iter()
@@ -372,7 +372,7 @@ impl ResharingState {
         let mut updated = false;
         loop {
             match ctx.resharing_ready.try_recv() {
-                Ok(ResharingReadyMessage { epoch, from }) => {
+                Ok(ResharingReadyMessage { epoch, from, .. }) => {
                     if epoch != self.contract.old_epoch {
                         continue;
                     }
@@ -392,7 +392,9 @@ impl ResharingState {
         updated
     }
 
-    async fn broadcast_ready(&self, ctx: &mut MpcSignProtocol) {
+    async fn broadcast_ready(&mut self, ctx: &mut MpcSignProtocol) {
+        let nonce = self.ready_nonce;
+        self.ready_nonce = self.ready_nonce.wrapping_add(1);
         for participant in self.contract.new_participants.keys() {
             if participant == &self.me {
                 continue;
@@ -404,6 +406,7 @@ impl ResharingState {
                     ResharingReadyMessage {
                         epoch: self.contract.old_epoch,
                         from: self.me,
+                        nonce,
                     },
                 )
                 .await;
@@ -467,76 +470,5 @@ impl CryptographicProtocol for NodeState {
             NodeState::WaitingForConsensus(state) => state.progress(ctx, mesh_state).await,
             _ => self,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::protocol::contract::primitives::{ParticipantInfo, Participants};
-    use crate::protocol::contract::ResharingContractState;
-    use crate::protocol::MeshState;
-    use crate::util::NearPublicKeyExt;
-    use cait_sith::protocol::Participant;
-    use near_crypto::SecretKey;
-    use std::collections::{BTreeSet, HashSet};
-    use std::time::Instant;
-
-    fn sample_contract() -> (ResharingState, Participant, Participant) {
-        let me = Participant::from(0);
-        let other = Participant::from(1);
-
-        let mut old_participants = Participants::default();
-        old_participants.insert(&me, ParticipantInfo::new(0));
-        old_participants.insert(&other, ParticipantInfo::new(1));
-        let new_participants = old_participants.clone();
-
-        let public_key = SecretKey::from_seed(near_crypto::KeyType::SECP256K1, "reshare-test")
-            .public_key()
-            .into_affine_point();
-
-        let contract = ResharingContractState {
-            old_epoch: 3,
-            old_participants,
-            new_participants,
-            threshold: 2,
-            public_key,
-            finished_votes: HashSet::new(),
-        };
-
-        let state = ResharingState {
-            me,
-            contract,
-            local_private_share: None,
-            phase: ResharingPhase::AwaitingReady(ResharingReadyState {
-                ready: BTreeSet::new(),
-                last_broadcast: Instant::now(),
-            }),
-        };
-
-        (state, me, other)
-    }
-
-    #[test]
-    fn initial_ready_state_marks_self() {
-        let (state, me, _) = sample_contract();
-        let ready = state.initial_ready_state();
-        assert!(ready.ready.contains(&me));
-        let elapsed = Instant::now().duration_since(ready.last_broadcast);
-        assert!(elapsed >= RESHARING_READY_BROADCAST_INTERVAL);
-    }
-
-    #[test]
-    fn ready_count_respects_mesh_state() {
-        let (state, me, other) = sample_contract();
-        let mut ready = state.initial_ready_state();
-        ready.ready.insert(other);
-
-        let mut mesh_state = MeshState::default();
-        mesh_state.stable.insert(me);
-        assert_eq!(state.ready_count(&ready, &mesh_state), 1);
-
-        mesh_state.stable.insert(other);
-        assert_eq!(state.ready_count(&ready, &mesh_state), 2);
     }
 }

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -237,11 +237,8 @@ impl CryptographicProtocol for ResharingState {
             let action = match resharing.protocol.poke() {
                 Ok(action) => action,
                 Err(err) => {
-                    tracing::warn!(?err, "resharing failed: refreshing...");
-                    if let Err(refresh_err) = resharing.protocol.refresh().await {
-                        tracing::warn!(?refresh_err, "unable to refresh reshare protocol");
-                    }
-                    self.phase = ResharingPhase::Resharing(resharing);
+                    tracing::warn!(?err, "resharing failed, going back to awaiting phase");
+                    self.phase = ResharingPhase::awaiting(self.me);
                     return NodeState::Resharing(self);
                 }
             };

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -180,7 +180,7 @@ impl CryptographicProtocol for ResharingState {
             ResharingPhase::Resharing(resharing) => resharing,
             ResharingPhase::Awaiting(mut state) => {
                 if state.update(ctx, &self.contract) {
-                    tracing::debug!(?state.ready, "resharing: readiness updated");
+                    tracing::debug!(?state.ready_tokens, "resharing: readiness updated");
                 }
 
                 self.ready_nonce = state
@@ -234,7 +234,6 @@ impl CryptographicProtocol for ResharingState {
             if let ResharingPhase::Awaiting(state) = &mut self.phase {
                 for (participant, token) in new_tokens {
                     if self.contract.new_participants.contains_key(&participant) {
-                        state.ready.insert(participant);
                         state.ready_tokens.insert(participant, token);
                     }
                 }
@@ -408,12 +407,7 @@ impl ReshareAwaiting {
         let total = contract.new_participants.len();
         let threshold = contract.threshold;
 
-        total >= threshold
-            && ready == total
-            && contract
-                .new_participants
-                .keys()
-                .all(|participant| self.ready_tokens.contains_key(participant))
+        total >= threshold && ready == total
     }
 
     fn update(&mut self, ctx: &mut MpcSignProtocol, contract: &ResharingContractState) -> bool {
@@ -421,10 +415,7 @@ impl ReshareAwaiting {
         loop {
             match ctx.ready.try_recv() {
                 Ok(ReadyMessage {
-                    epoch,
-                    from,
-                    attempt,
-                    ..
+                    epoch, from, token, ..
                 }) => {
                     if epoch != contract.old_epoch {
                         tracing::warn!(
@@ -435,10 +426,8 @@ impl ReshareAwaiting {
                         continue;
                     }
                     if contract.new_participants.contains_key(&from) {
-                        if self.ready.insert(from) {
-                            updated = true;
-                        }
-                        self.ready_tokens.insert(from, attempt);
+                        self.ready_tokens.insert(from, token);
+                        updated = true;
                     }
                 }
                 Err(mpsc::error::TryRecvError::Empty) => break,
@@ -479,7 +468,7 @@ impl ReshareAwaiting {
                         epoch: contract.old_epoch,
                         from: me,
                         nonce,
-                        attempt: self.local_attempt,
+                        token: self.my_token,
                     },
                 )
                 .await;
@@ -489,8 +478,8 @@ impl ReshareAwaiting {
     }
 
     fn ready_count(&self, contract: &ResharingContractState) -> usize {
-        self.ready
-            .iter()
+        self.ready_tokens
+            .keys()
             .filter(|participant| contract.new_participants.contains_key(participant))
             .count()
     }
@@ -528,7 +517,7 @@ impl ReshareRunning {
                 Ok(ReadyMessage {
                     epoch,
                     from,
-                    attempt,
+                    token: attempt,
                     ..
                 }) => {
                     if epoch != contract.old_epoch {

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -3,12 +3,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use super::state::{
-    GeneratingState, NodeState, ResharingPhase, ResharingReadyState, ResharingRunningState,
-    ResharingState, RESHARING_READY_BROADCAST_INTERVAL,
+    GeneratingState, NodeState, ReshareAwaiting, ReshareRunning, ResharingPhase, ResharingState,
+    RESHARING_READY_BROADCAST_INTERVAL,
 };
 use super::MpcSignProtocol;
 use crate::protocol::contract::ResharingContractState;
-use crate::protocol::message::{GeneratingMessage, ResharingMessage, ResharingReadyMessage};
+use crate::protocol::message::{GeneratingMessage, ReadyMessage, ResharingMessage};
 use crate::protocol::state::{PersistentNodeData, WaitingForConsensusState};
 use crate::protocol::MeshState;
 use crate::types::{ReshareProtocol, SecretKeyShare};
@@ -177,7 +177,7 @@ impl CryptographicProtocol for ResharingState {
 
         let mut resharing = match self.phase {
             ResharingPhase::Resharing(resharing) => resharing,
-            ResharingPhase::AwaitingReady(mut state) => {
+            ResharingPhase::Awaiting(mut state) => {
                 state.ready.insert(self.me);
                 if state.update(ctx, &self.contract) {
                     tracing::debug!(?state.ready, "resharing: readiness updated");
@@ -188,7 +188,7 @@ impl CryptographicProtocol for ResharingState {
                     .await;
 
                 if !state.startable(&self.contract) {
-                    self.phase = ResharingPhase::AwaitingReady(state);
+                    self.phase = ResharingPhase::Awaiting(state);
                     return NodeState::Resharing(self);
                 }
 
@@ -204,7 +204,7 @@ impl CryptographicProtocol for ResharingState {
 
                 tracing::info!("resharing: all participants ready, starting protocol");
                 let now = Instant::now();
-                self.phase = ResharingPhase::Resharing(ResharingRunningState {
+                self.phase = ResharingPhase::Resharing(ReshareRunning {
                     protocol,
                     failed_store: None,
                     started_at: now,
@@ -336,7 +336,7 @@ impl CryptographicProtocol for ResharingState {
 impl ResharingState {
     async fn try_finalize(
         ctx: &mut MpcSignProtocol,
-        running_state: &mut ResharingRunningState,
+        running_state: &mut ReshareRunning,
         private_share: SecretKeyShare,
         contract: &ResharingContractState,
     ) -> Result<NodeState, ()> {
@@ -372,7 +372,7 @@ impl ResharingState {
     }
 }
 
-impl ResharingReadyState {
+impl ReshareAwaiting {
     fn startable(&self, contract: &ResharingContractState) -> bool {
         let ready = self.ready_count(contract);
         let total = contract.new_participants.len();
@@ -384,8 +384,8 @@ impl ResharingReadyState {
     fn update(&mut self, ctx: &mut MpcSignProtocol, contract: &ResharingContractState) -> bool {
         let mut updated = false;
         loop {
-            match ctx.resharing_ready.try_recv() {
-                Ok(ResharingReadyMessage { epoch, from, .. }) => {
+            match ctx.ready.try_recv() {
+                Ok(ReadyMessage { epoch, from, .. }) => {
                     if epoch != contract.old_epoch {
                         tracing::warn!(
                             message_epoch = epoch,
@@ -432,7 +432,7 @@ impl ResharingReadyState {
                 .send(
                     me,
                     participant,
-                    ResharingReadyMessage {
+                    ReadyMessage {
                         epoch: contract.old_epoch,
                         from: me,
                         nonce,

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -17,7 +17,7 @@ use k256::elliptic_curve::group::GroupEncoding;
 use mpc_crypto::PublicKey;
 use tokio::sync::mpsc;
 
-const RESHARING_RUNNING_TIMEOUT: Duration = Duration::from_secs(60);
+pub const RESHARING_RUNNING_TIMEOUT: Duration = Duration::from_secs(300);
 
 #[derive(thiserror::Error, Debug)]
 pub enum CryptographicError {
@@ -167,7 +167,7 @@ impl CryptographicProtocol for ResharingState {
         tracing::info!(active = ?mesh_state.active.keys_vec(), "progressing key reshare");
 
         let mut resharing = match self.phase {
-            ResharingPhase::Resharing(running_state) => running_state,
+            ResharingPhase::Resharing(resharing) => resharing,
             ResharingPhase::AwaitingReady(mut state) => {
                 state.ready.insert(self.me);
                 if state.update(ctx, &self.contract) {
@@ -188,8 +188,7 @@ impl CryptographicProtocol for ResharingState {
                         Ok(protocol) => protocol,
                         Err(err) => {
                             tracing::error!(?err, "resharing: failed to initialize/start protocol");
-                            state = Self::initial_awaiting(self.me);
-                            self.phase = ResharingPhase::AwaitingReady(state);
+                            self.phase = ResharingPhase::awaiting(self.me);
                             return NodeState::Resharing(self);
                         }
                     };
@@ -221,7 +220,7 @@ impl CryptographicProtocol for ResharingState {
                 elapsed = ?resharing.last_activity.elapsed(),
                 "resharing: protocol timed out, restarting readiness phase",
             );
-            self.phase = ResharingPhase::AwaitingReady(Self::initial_awaiting(self.me));
+            self.phase = ResharingPhase::awaiting(self.me);
             return NodeState::Resharing(self);
         }
 
@@ -329,14 +328,6 @@ impl CryptographicProtocol for ResharingState {
 }
 
 impl ResharingState {
-    fn initial_awaiting(me: Participant) -> ResharingReadyState {
-        ResharingReadyState {
-            ready: std::iter::once(me).collect(),
-            // ready to broadcast immediately
-            broadcast_interval: Instant::now() - RESHARING_READY_BROADCAST_INTERVAL,
-        }
-    }
-
     async fn try_finalize(
         ctx: &mut MpcSignProtocol,
         running_state: &mut ResharingRunningState,
@@ -390,6 +381,11 @@ impl ResharingReadyState {
             match ctx.resharing_ready.try_recv() {
                 Ok(ResharingReadyMessage { epoch, from, .. }) => {
                     if epoch != contract.old_epoch {
+                        tracing::warn!(
+                            message_epoch = epoch,
+                            contract_epoch = contract.old_epoch,
+                            "resharing: ignoring readiness message for other epoch",
+                        );
                         continue;
                     }
                     if contract.new_participants.contains_key(&from) && self.ready.insert(from) {

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -172,11 +172,14 @@ impl CryptographicProtocol for ResharingState {
             match phase {
                 ResharingPhase::AwaitingReady(mut state) => {
                     state.ready.insert(self.me);
-                    let updated = self.drain_ready_messages(ctx, &mut state);
-                    if updated {
+                    if self.update_readiness(ctx, &mut state) {
                         tracing::debug!(?state.ready, "resharing: readiness updated");
                     }
 
+                    // We will constantly broadcast our readiness until the running phase begins.
+                    // This is to ensure that all participants are aware of our readiness state.
+                    // Everyone maintains a set of ready participants, so repeatedly broadcasting
+                    // will not affect correctness and ensures liveness in case of message loss.
                     if state.last_broadcast.elapsed() >= RESHARING_READY_BROADCAST_INTERVAL {
                         self.broadcast_ready(ctx).await;
                         state.last_broadcast = Instant::now();
@@ -187,7 +190,7 @@ impl CryptographicProtocol for ResharingState {
                     let threshold = self.contract.threshold;
 
                     if total >= threshold && ready == total {
-                        match self.begin_running_phase() {
+                        match self.start_resharing() {
                             Ok(running_state) => {
                                 tracing::info!(
                                     "resharing: all participants ready, starting protocol"
@@ -364,7 +367,7 @@ impl ResharingState {
             .count()
     }
 
-    fn drain_ready_messages(
+    fn update_readiness(
         &self,
         ctx: &mut MpcSignProtocol,
         ready_state: &mut ResharingReadyState,
@@ -413,7 +416,7 @@ impl ResharingState {
         }
     }
 
-    fn begin_running_phase(&mut self) -> Result<ResharingRunningState, InitializationError> {
+    fn start_resharing(&mut self) -> Result<ResharingRunningState, InitializationError> {
         let protocol = ReshareProtocol::new(self.local_private_share, self.me, &self.contract)?;
         let now = Instant::now();
         Ok(ResharingRunningState {

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -179,167 +179,43 @@ impl CryptographicProtocol for ResharingState {
         let mut resharing = match self.phase {
             ResharingPhase::Resharing(resharing) => resharing,
             ResharingPhase::Awaiting(mut state) => {
-                state.ready.insert(self.me);
-                state.ready_tokens.insert(self.me, state.local_attempt);
                 if state.update(ctx, &self.contract) {
                     tracing::debug!(?state.ready, "resharing: readiness updated");
                 }
-
-                let ready_tokens_snapshot = state.ready_tokens.clone();
-
 
                 self.ready_nonce = state
                     .broadcast_ready(self.me, ctx, &self.contract, self.ready_nonce)
                     .await;
 
                 if !state.startable(&self.contract) {
-                    if tracing::enabled!(tracing::Level::DEBUG) {
-                        let missing_ready: Vec<_> = self
-                            .contract
-                            .new_participants
-                            .keys()
-                            .filter(|participant| !state.ready.contains(participant))
-                            .copied()
-                            .collect();
-                        let missing_tokens: Vec<_> = self
-                            .contract
-                            .new_participants
-                            .keys()
-                            .filter(|participant| !state.ready_tokens.contains_key(participant))
-                            .copied()
-                            .collect();
-                        tracing::debug!(
-                            ?missing_ready,
-                            ?missing_tokens,
-                            ready = ?state.ready,
-                            ready_tokens = ?state.ready_tokens,
-                            "resharing: not all participants ready yet"
-                        );
-                    }
-                    self.active_ready_tokens = ready_tokens_snapshot;
                     self.phase = ResharingPhase::Awaiting(state);
                     return NodeState::Resharing(self);
                 }
 
-                let attempt_id = match state.combined_attempt_id(&self.contract) {
-                    Some(attempt_id) => attempt_id,
-                    None => {
-                        tracing::debug!(
-                            "resharing: waiting for attempt identifiers from all participants"
-                        );
-                        self.active_ready_tokens = ready_tokens_snapshot;
-                        self.phase = ResharingPhase::Awaiting(state);
-                        return NodeState::Resharing(self);
-                    }
-                };
-
-                self.last_attempt_id = self.attempt_id;
-                self.attempt_id = Some(attempt_id);
-                self.active_ready_tokens = ready_tokens_snapshot;
-
-                let mut protocol =
+                let protocol =
                     match ReshareProtocol::new(self.local_private_share, self.me, &self.contract) {
                         Ok(protocol) => protocol,
                         Err(err) => {
                             tracing::error!(?err, "resharing: failed to initialize/start protocol");
-                            self.last_attempt_id = self.attempt_id;
-                            self.attempt_id = None;
-                            self.active_ready_tokens.clear();
                             self.phase = ResharingPhase::awaiting(self.me);
-                            self.pending.clear();
                             return NodeState::Resharing(self);
                         }
                     };
 
-                let mut replayed = HashMap::<Participant, usize>::new();
-                while let Some(msg) = self.pending.pop_front() {
-                    replayed
-                        .entry(msg.from)
-                        .and_modify(|count| *count += 1)
-                        .or_insert(1);
-                    protocol.message(msg.from, msg.data);
-                }
-                if !replayed.is_empty() {
-                    tracing::info!(
-                        ?replayed,
-                        "resharing: replayed buffered protocol messages after starting"
-                    );
-                }
-
                 tracing::info!("resharing: all participants ready, starting protocol");
+                let token = state.combine_tokens();
                 let now = Instant::now();
-                let mut running = ReshareRunning {
+                self.phase = ResharingPhase::Resharing(ReshareRunning {
                     protocol,
+                    ready_tokens: state.ready_tokens,
+                    token,
                     failed_store: None,
                     started_at: now,
                     last_activity: now,
-                };
-                if !replayed.is_empty() {
-                    running.last_activity = Instant::now();
-                }
-                self.phase = ResharingPhase::Resharing(running);
+                });
                 return NodeState::Resharing(self);
             }
         };
-
-        let mut restart_ready = HashMap::<Participant, u64>::new();
-        loop {
-            match ctx.ready.try_recv() {
-                Ok(ReadyMessage {
-                    epoch,
-                    from,
-                    attempt,
-                    ..
-                }) => {
-                    if epoch != self.contract.old_epoch {
-                        tracing::debug!(
-                            message_epoch = epoch,
-                            contract_epoch = self.contract.old_epoch,
-                            "resharing: ignoring readiness message for other epoch while running",
-                        );
-                        continue;
-                    }
-                    if from == self.me {
-                        continue;
-                    }
-                    match self.active_ready_tokens.get(&from) {
-                        Some(current) if *current == attempt => {}
-                        _ => {
-                            restart_ready.insert(from, attempt);
-                        }
-                    }
-                }
-                Err(mpsc::error::TryRecvError::Empty) => break,
-                Err(mpsc::error::TryRecvError::Disconnected) => {
-                    tracing::warn!(
-                        "resharing: readiness channel closed unexpectedly while running"
-                    );
-                    break;
-                }
-            }
-        }
-
-        if !restart_ready.is_empty() {
-            let participants: Vec<_> = restart_ready.keys().copied().collect();
-            tracing::info!(
-                ?participants,
-                "resharing: received readiness for new attempt while running, restarting"
-            );
-            self.last_attempt_id = self.attempt_id;
-            self.attempt_id = None;
-            self.active_ready_tokens.clear();
-            self.phase = ResharingPhase::awaiting(self.me);
-            self.pending.clear();
-            if let ResharingPhase::Awaiting(state) = &mut self.phase {
-                for (participant, attempt) in restart_ready {
-                    if self.contract.new_participants.contains_key(&participant) {
-                        state.ready.insert(participant);
-                        state.ready_tokens.insert(participant, attempt);
-                    }
-                }
-            }
-            return NodeState::Resharing(self);
-        }
 
         if let Some(sk_share) = resharing.failed_store.take() {
             match Self::try_finalize(ctx, &mut resharing, sk_share, &self.contract).await {
@@ -351,16 +227,27 @@ impl CryptographicProtocol for ResharingState {
             }
         }
 
+        // If we have received new tokens while running (i.e. node restart while in the midst),
+        // short-circuit and restart the whole resharing protocol.
+        if let Some(new_tokens) = resharing.restartable(self.me, ctx, &self.contract) {
+            self.phase = ResharingPhase::awaiting(self.me);
+            if let ResharingPhase::Awaiting(state) = &mut self.phase {
+                for (participant, token) in new_tokens {
+                    if self.contract.new_participants.contains_key(&participant) {
+                        state.ready.insert(participant);
+                        state.ready_tokens.insert(participant, token);
+                    }
+                }
+            }
+            return NodeState::Resharing(self);
+        }
+
         if resharing.last_activity.elapsed() > resharing_running_timeout() {
             tracing::warn!(
                 elapsed = ?resharing.last_activity.elapsed(),
                 "resharing: protocol timed out, restarting readiness phase",
             );
-            self.last_attempt_id = self.attempt_id;
-            self.attempt_id = None;
-            self.active_ready_tokens.clear();
             self.phase = ResharingPhase::awaiting(self.me);
-            self.pending.clear();
             return NodeState::Resharing(self);
         }
 
@@ -369,11 +256,7 @@ impl CryptographicProtocol for ResharingState {
                 Ok(action) => action,
                 Err(err) => {
                     tracing::warn!(?err, "resharing failed, going back to awaiting phase");
-                    self.last_attempt_id = self.attempt_id;
-                    self.attempt_id = None;
-                    self.active_ready_tokens.clear();
                     self.phase = ResharingPhase::awaiting(self.me);
-                    self.pending.clear();
                     return NodeState::Resharing(self);
                 }
             };
@@ -401,17 +284,10 @@ impl CryptographicProtocol for ResharingState {
                             continue;
                         }
 
-                        let Some(current_attempt) = self.attempt_id else {
-                            tracing::warn!(
-                                participant = ?msg.from,
-                                "resharing: received protocol message without active attempt id"
-                            );
-                            continue;
-                        };
-                        if msg.attempt != current_attempt {
+                        if msg.token != resharing.token {
                             tracing::debug!(
-                                expected = ?current_attempt,
-                                actual = ?msg.attempt,
+                                expected = ?resharing.token,
+                                actual = ?msg.token,
                                 participant = ?msg.from,
                                 "resharing: ignoring message for different resharing attempt",
                             );
@@ -431,12 +307,6 @@ impl CryptographicProtocol for ResharingState {
                 Action::SendMany(data) => {
                     tracing::debug!("resharing: sending a message to all participants");
                     resharing.last_activity = Instant::now();
-                    let Some(attempt_id) = self.attempt_id else {
-                        tracing::error!(
-                            "resharing: unable to send broadcast without active attempt identifier"
-                        );
-                        continue;
-                    };
                     for p in self.contract.new_participants.keys() {
                         if p == &self.me {
                             continue;
@@ -448,7 +318,7 @@ impl CryptographicProtocol for ResharingState {
                                 ResharingMessage {
                                     epoch: self.contract.old_epoch,
                                     from: self.me,
-                                    attempt: attempt_id,
+                                    token: resharing.token,
                                     data: data.clone(),
                                 },
                             )
@@ -461,12 +331,6 @@ impl CryptographicProtocol for ResharingState {
                         tracing::error!("resharing: send_private unknown participant {to:?}");
                     } else {
                         resharing.last_activity = Instant::now();
-                        let Some(attempt_id) = self.attempt_id else {
-                            tracing::error!(
-                                "resharing: unable to send private message without active attempt identifier"
-                            );
-                            continue;
-                        };
                         ctx.msg_channel
                             .send(
                                 self.me,
@@ -474,7 +338,7 @@ impl CryptographicProtocol for ResharingState {
                                 ResharingMessage {
                                     epoch: self.contract.old_epoch,
                                     from: self.me,
-                                    attempt: attempt_id,
+                                    token: resharing.token,
                                     data,
                                 },
                             )
@@ -631,12 +495,13 @@ impl ReshareAwaiting {
             .count()
     }
 
-    fn combined_attempt_id(&self, contract: &ResharingContractState) -> Option<u64> {
-        let mut tokens = Vec::with_capacity(contract.new_participants.len());
-        for participant in contract.new_participants.keys() {
-            tokens.push(*self.ready_tokens.get(participant)?);
-        }
-        tokens.sort_unstable();
+    /// Combines all received readiness attempt identifiers into a single identifier
+    /// that will be used to identify the current resharing attempt. This is guaranteed
+    /// to be the same for all honest participants starting the protocol. If the ID differs
+    /// during resharing, we can just restart since a party had restarted.
+    fn combine_tokens(&self) -> u64 {
+        let mut tokens = self.ready_tokens.values().collect::<Vec<_>>();
+        tokens.sort();
 
         let mut hasher = Sha256::new();
         for token in tokens {
@@ -645,7 +510,64 @@ impl ReshareAwaiting {
         let digest = hasher.finalize();
         let mut bytes = [0u8; 8];
         bytes.copy_from_slice(&digest[..8]);
-        Some(u64::from_le_bytes(bytes))
+        u64::from_le_bytes(bytes)
+    }
+}
+
+impl ReshareRunning {
+    /// Checks if while running we have received readiness messages for a new attempt,
+    fn restartable(
+        &self,
+        me: Participant,
+        ctx: &mut MpcSignProtocol,
+        contract: &ResharingContractState,
+    ) -> Option<Vec<(Participant, u64)>> {
+        let mut new_tokens = HashMap::<Participant, u64>::new();
+        loop {
+            match ctx.ready.try_recv() {
+                Ok(ReadyMessage {
+                    epoch,
+                    from,
+                    attempt,
+                    ..
+                }) => {
+                    if epoch != contract.old_epoch {
+                        tracing::debug!(
+                            message_epoch = epoch,
+                            contract_epoch = contract.old_epoch,
+                            "resharing: ignoring readiness message for other epoch while running",
+                        );
+                        continue;
+                    }
+                    if from == me {
+                        continue;
+                    }
+                    match self.ready_tokens.get(&from) {
+                        Some(current) if *current == attempt => {}
+                        _ => {
+                            new_tokens.insert(from, attempt);
+                        }
+                    }
+                }
+                Err(mpsc::error::TryRecvError::Empty) => break,
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    tracing::warn!(
+                        "resharing: readiness channel closed unexpectedly while running"
+                    );
+                    break;
+                }
+            }
+        }
+
+        if !new_tokens.is_empty() {
+            tracing::info!(
+                ?new_tokens,
+                "resharing: received readiness for new attempt while running, restarting"
+            );
+            Some(new_tokens.into_iter().collect())
+        } else {
+            None
+        }
     }
 }
 

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use super::state::{
@@ -17,7 +18,15 @@ use k256::elliptic_curve::group::GroupEncoding;
 use mpc_crypto::PublicKey;
 use tokio::sync::mpsc;
 
-pub const RESHARING_RUNNING_TIMEOUT: Duration = Duration::from_secs(300);
+pub static RESHARING_RUNNING_TIMEOUT_SECS: AtomicU64 = AtomicU64::new(300);
+
+pub fn resharing_running_timeout() -> Duration {
+    Duration::from_secs(RESHARING_RUNNING_TIMEOUT_SECS.load(Ordering::SeqCst))
+}
+
+pub fn set_resharing_running_timeout(duration: Duration) {
+    RESHARING_RUNNING_TIMEOUT_SECS.swap(duration.as_secs(), Ordering::SeqCst);
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum CryptographicError {
@@ -215,7 +224,7 @@ impl CryptographicProtocol for ResharingState {
             }
         }
 
-        if resharing.last_activity.elapsed() > RESHARING_RUNNING_TIMEOUT {
+        if resharing.last_activity.elapsed() > resharing_running_timeout() {
             tracing::warn!(
                 elapsed = ?resharing.last_activity.elapsed(),
                 "resharing: protocol timed out, restarting readiness phase",

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -15,6 +15,7 @@ use crate::types::{ReshareProtocol, SecretKeyShare};
 
 use cait_sith::protocol::{Action, InitializationError, Participant, ProtocolError};
 use k256::elliptic_curve::group::GroupEncoding;
+use k256::sha2::{Digest, Sha256};
 use mpc_crypto::PublicKey;
 use tokio::sync::mpsc;
 
@@ -179,11 +180,15 @@ impl CryptographicProtocol for ResharingState {
             ResharingPhase::Resharing(resharing) => resharing,
             ResharingPhase::Awaiting(mut state) => {
                 state.ready.insert(self.me);
+                state.ready_tokens.insert(self.me, state.local_attempt);
                 if state.update(ctx, &self.contract) {
                     tracing::debug!(?state.ready, "resharing: readiness updated");
                 }
 
+                let ready_tokens_snapshot = state.ready_tokens.clone();
+
                 let mut buffered = HashMap::<Participant, usize>::new();
+                let mut skipped = HashMap::<Participant, usize>::new();
                 loop {
                     match ctx.resharing.try_recv() {
                         Ok(msg) => {
@@ -195,7 +200,31 @@ impl CryptographicProtocol for ResharingState {
                                 );
                                 continue;
                             }
-                            state.ready.insert(msg.from);
+                            if let Some(last) = self.last_attempt_id {
+                                if msg.attempt == last {
+                                    tracing::debug!(
+                                        participant = ?msg.from,
+                                        attempt = ?msg.attempt,
+                                        "resharing: skipping buffered message from previous attempt"
+                                    );
+                                    continue;
+                                }
+                            }
+                            if let Some(current) = self.attempt_id {
+                                if msg.attempt != current {
+                                    skipped
+                                        .entry(msg.from)
+                                        .and_modify(|count| *count += 1)
+                                        .or_insert(1);
+                                    tracing::debug!(
+                                        expected = ?current,
+                                        actual = ?msg.attempt,
+                                        participant = ?msg.from,
+                                        "resharing: buffered message does not match current attempt"
+                                    );
+                                    continue;
+                                }
+                            }
                             buffered
                                 .entry(msg.from)
                                 .and_modify(|count| *count += 1)
@@ -215,14 +244,79 @@ impl CryptographicProtocol for ResharingState {
                         "resharing: buffered protocol messages while awaiting readiness"
                     );
                 }
+                if !skipped.is_empty() {
+                    tracing::info!(
+                        ?skipped,
+                        "resharing: skipped protocol messages for different attempt while awaiting"
+                    );
+                }
 
                 self.ready_nonce = state
                     .broadcast_ready(self.me, ctx, &self.contract, self.ready_nonce)
                     .await;
 
                 if !state.startable(&self.contract) {
+                    if tracing::enabled!(tracing::Level::DEBUG) {
+                        let missing_ready: Vec<_> = self
+                            .contract
+                            .new_participants
+                            .keys()
+                            .filter(|participant| !state.ready.contains(participant))
+                            .copied()
+                            .collect();
+                        let missing_tokens: Vec<_> = self
+                            .contract
+                            .new_participants
+                            .keys()
+                            .filter(|participant| !state.ready_tokens.contains_key(participant))
+                            .copied()
+                            .collect();
+                        tracing::debug!(
+                            ?missing_ready,
+                            ?missing_tokens,
+                            ready = ?state.ready,
+                            ready_tokens = ?state.ready_tokens,
+                            "resharing: not all participants ready yet"
+                        );
+                    }
+                    self.active_ready_tokens = ready_tokens_snapshot;
                     self.phase = ResharingPhase::Awaiting(state);
                     return NodeState::Resharing(self);
+                }
+
+                let attempt_id = match state.combined_attempt_id(&self.contract) {
+                    Some(attempt_id) => attempt_id,
+                    None => {
+                        tracing::debug!(
+                            "resharing: waiting for attempt identifiers from all participants"
+                        );
+                        self.active_ready_tokens = ready_tokens_snapshot;
+                        self.phase = ResharingPhase::Awaiting(state);
+                        return NodeState::Resharing(self);
+                    }
+                };
+
+                self.last_attempt_id = self.attempt_id;
+                self.attempt_id = Some(attempt_id);
+                self.active_ready_tokens = ready_tokens_snapshot;
+
+                let mut dropped = HashMap::<Participant, usize>::new();
+                self.pending.retain(|msg| {
+                    if msg.attempt == attempt_id {
+                        true
+                    } else {
+                        dropped
+                            .entry(msg.from)
+                            .and_modify(|count| *count += 1)
+                            .or_insert(1);
+                        false
+                    }
+                });
+                if !dropped.is_empty() {
+                    tracing::info!(
+                        ?dropped,
+                        "resharing: discarded buffered messages for non-matching attempt before starting"
+                    );
                 }
 
                 let mut protocol =
@@ -230,6 +324,9 @@ impl CryptographicProtocol for ResharingState {
                         Ok(protocol) => protocol,
                         Err(err) => {
                             tracing::error!(?err, "resharing: failed to initialize/start protocol");
+                            self.last_attempt_id = self.attempt_id;
+                            self.attempt_id = None;
+                            self.active_ready_tokens.clear();
                             self.phase = ResharingPhase::awaiting(self.me);
                             self.pending.clear();
                             return NodeState::Resharing(self);
@@ -259,13 +356,72 @@ impl CryptographicProtocol for ResharingState {
                     started_at: now,
                     last_activity: now,
                 };
-                // if !replayed.is_empty() {
-                //     running.last_activity = Instant::now();
-                // }
+                if !replayed.is_empty() {
+                    running.last_activity = Instant::now();
+                }
                 self.phase = ResharingPhase::Resharing(running);
                 return NodeState::Resharing(self);
             }
         };
+
+        let mut restart_ready = HashMap::<Participant, u64>::new();
+        loop {
+            match ctx.ready.try_recv() {
+                Ok(ReadyMessage {
+                    epoch,
+                    from,
+                    attempt,
+                    ..
+                }) => {
+                    if epoch != self.contract.old_epoch {
+                        tracing::debug!(
+                            message_epoch = epoch,
+                            contract_epoch = self.contract.old_epoch,
+                            "resharing: ignoring readiness message for other epoch while running",
+                        );
+                        continue;
+                    }
+                    if from == self.me {
+                        continue;
+                    }
+                    match self.active_ready_tokens.get(&from) {
+                        Some(current) if *current == attempt => {}
+                        _ => {
+                            restart_ready.insert(from, attempt);
+                        }
+                    }
+                }
+                Err(mpsc::error::TryRecvError::Empty) => break,
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    tracing::warn!(
+                        "resharing: readiness channel closed unexpectedly while running"
+                    );
+                    break;
+                }
+            }
+        }
+
+        if !restart_ready.is_empty() {
+            let participants: Vec<_> = restart_ready.keys().copied().collect();
+            tracing::info!(
+                ?participants,
+                "resharing: received readiness for new attempt while running, restarting"
+            );
+            self.last_attempt_id = self.attempt_id;
+            self.attempt_id = None;
+            self.active_ready_tokens.clear();
+            self.phase = ResharingPhase::awaiting(self.me);
+            self.pending.clear();
+            if let ResharingPhase::Awaiting(state) = &mut self.phase {
+                for (participant, attempt) in restart_ready {
+                    if self.contract.new_participants.contains_key(&participant) {
+                        state.ready.insert(participant);
+                        state.ready_tokens.insert(participant, attempt);
+                    }
+                }
+            }
+            return NodeState::Resharing(self);
+        }
 
         if let Some(sk_share) = resharing.failed_store.take() {
             match Self::try_finalize(ctx, &mut resharing, sk_share, &self.contract).await {
@@ -282,6 +438,9 @@ impl CryptographicProtocol for ResharingState {
                 elapsed = ?resharing.last_activity.elapsed(),
                 "resharing: protocol timed out, restarting readiness phase",
             );
+            self.last_attempt_id = self.attempt_id;
+            self.attempt_id = None;
+            self.active_ready_tokens.clear();
             self.phase = ResharingPhase::awaiting(self.me);
             self.pending.clear();
             return NodeState::Resharing(self);
@@ -292,6 +451,9 @@ impl CryptographicProtocol for ResharingState {
                 Ok(action) => action,
                 Err(err) => {
                     tracing::warn!(?err, "resharing failed, going back to awaiting phase");
+                    self.last_attempt_id = self.attempt_id;
+                    self.attempt_id = None;
+                    self.active_ready_tokens.clear();
                     self.phase = ResharingPhase::awaiting(self.me);
                     self.pending.clear();
                     return NodeState::Resharing(self);
@@ -321,6 +483,23 @@ impl CryptographicProtocol for ResharingState {
                             continue;
                         }
 
+                        let Some(current_attempt) = self.attempt_id else {
+                            tracing::warn!(
+                                participant = ?msg.from,
+                                "resharing: received protocol message without active attempt id"
+                            );
+                            continue;
+                        };
+                        if msg.attempt != current_attempt {
+                            tracing::debug!(
+                                expected = ?current_attempt,
+                                actual = ?msg.attempt,
+                                participant = ?msg.from,
+                                "resharing: ignoring message for different resharing attempt",
+                            );
+                            continue;
+                        }
+
                         counts.entry(msg.from).and_modify(|c| *c += 1).or_insert(1);
                         resharing.protocol.message(msg.from, msg.data);
                     }
@@ -334,6 +513,12 @@ impl CryptographicProtocol for ResharingState {
                 Action::SendMany(data) => {
                     tracing::debug!("resharing: sending a message to all participants");
                     resharing.last_activity = Instant::now();
+                    let Some(attempt_id) = self.attempt_id else {
+                        tracing::error!(
+                            "resharing: unable to send broadcast without active attempt identifier"
+                        );
+                        continue;
+                    };
                     for p in self.contract.new_participants.keys() {
                         if p == &self.me {
                             continue;
@@ -345,6 +530,7 @@ impl CryptographicProtocol for ResharingState {
                                 ResharingMessage {
                                     epoch: self.contract.old_epoch,
                                     from: self.me,
+                                    attempt: attempt_id,
                                     data: data.clone(),
                                 },
                             )
@@ -357,6 +543,12 @@ impl CryptographicProtocol for ResharingState {
                         tracing::error!("resharing: send_private unknown participant {to:?}");
                     } else {
                         resharing.last_activity = Instant::now();
+                        let Some(attempt_id) = self.attempt_id else {
+                            tracing::error!(
+                                "resharing: unable to send private message without active attempt identifier"
+                            );
+                            continue;
+                        };
                         ctx.msg_channel
                             .send(
                                 self.me,
@@ -364,6 +556,7 @@ impl CryptographicProtocol for ResharingState {
                                 ResharingMessage {
                                     epoch: self.contract.old_epoch,
                                     from: self.me,
+                                    attempt: attempt_id,
                                     data,
                                 },
                             )
@@ -433,14 +626,24 @@ impl ReshareAwaiting {
         let total = contract.new_participants.len();
         let threshold = contract.threshold;
 
-        total >= threshold && ready == total
+        total >= threshold
+            && ready == total
+            && contract
+                .new_participants
+                .keys()
+                .all(|participant| self.ready_tokens.contains_key(participant))
     }
 
     fn update(&mut self, ctx: &mut MpcSignProtocol, contract: &ResharingContractState) -> bool {
         let mut updated = false;
         loop {
             match ctx.ready.try_recv() {
-                Ok(ReadyMessage { epoch, from, .. }) => {
+                Ok(ReadyMessage {
+                    epoch,
+                    from,
+                    attempt,
+                    ..
+                }) => {
                     if epoch != contract.old_epoch {
                         tracing::warn!(
                             message_epoch = epoch,
@@ -449,8 +652,11 @@ impl ReshareAwaiting {
                         );
                         continue;
                     }
-                    if contract.new_participants.contains_key(&from) && self.ready.insert(from) {
-                        updated = true;
+                    if contract.new_participants.contains_key(&from) {
+                        if self.ready.insert(from) {
+                            updated = true;
+                        }
+                        self.ready_tokens.insert(from, attempt);
                     }
                 }
                 Err(mpsc::error::TryRecvError::Empty) => break,
@@ -491,6 +697,7 @@ impl ReshareAwaiting {
                         epoch: contract.old_epoch,
                         from: me,
                         nonce,
+                        attempt: self.local_attempt,
                     },
                 )
                 .await;
@@ -504,6 +711,23 @@ impl ReshareAwaiting {
             .iter()
             .filter(|participant| contract.new_participants.contains_key(participant))
             .count()
+    }
+
+    fn combined_attempt_id(&self, contract: &ResharingContractState) -> Option<u64> {
+        let mut tokens = Vec::with_capacity(contract.new_participants.len());
+        for participant in contract.new_participants.keys() {
+            tokens.push(*self.ready_tokens.get(participant)?);
+        }
+        tokens.sort_unstable();
+
+        let mut hasher = Sha256::new();
+        for token in tokens {
+            hasher.update(token.to_le_bytes());
+        }
+        let digest = hasher.finalize();
+        let mut bytes = [0u8; 8];
+        bytes.copy_from_slice(&digest[..8]);
+        Some(u64::from_le_bytes(bytes))
     }
 }
 

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -6,7 +6,6 @@ use super::state::{
     ResharingState, RESHARING_READY_BROADCAST_INTERVAL,
 };
 use super::MpcSignProtocol;
-use crate::config::Config;
 use crate::protocol::message::{GeneratingMessage, ResharingMessage, ResharingReadyMessage};
 use crate::protocol::state::{PersistentNodeData, WaitingForConsensusState};
 use crate::protocol::MeshState;
@@ -28,21 +27,11 @@ pub enum CryptographicError {
 }
 
 pub(crate) trait CryptographicProtocol {
-    async fn progress(
-        self,
-        ctx: &mut MpcSignProtocol,
-        cfg: Config,
-        mesh_state: MeshState,
-    ) -> NodeState;
+    async fn progress(self, ctx: &mut MpcSignProtocol, mesh_state: MeshState) -> NodeState;
 }
 
 impl CryptographicProtocol for GeneratingState {
-    async fn progress(
-        mut self,
-        ctx: &mut MpcSignProtocol,
-        _cfg: Config,
-        mesh_state: MeshState,
-    ) -> NodeState {
+    async fn progress(mut self, ctx: &mut MpcSignProtocol, mesh_state: MeshState) -> NodeState {
         // Previous save to secret storage failed, try again until successful.
         if let Some((pk, sk_share)) = self.failed_store.take() {
             return self.finalize(pk, sk_share, ctx).await;
@@ -166,24 +155,14 @@ impl GeneratingState {
 }
 
 impl CryptographicProtocol for WaitingForConsensusState {
-    async fn progress(
-        self,
-        _ctx: &mut MpcSignProtocol,
-        _cfg: Config,
-        _mesh_state: MeshState,
-    ) -> NodeState {
+    async fn progress(self, _ctx: &mut MpcSignProtocol, _mesh_state: MeshState) -> NodeState {
         // Wait for ConsensusProtocol step to advance state
         NodeState::WaitingForConsensus(self)
     }
 }
 
 impl CryptographicProtocol for ResharingState {
-    async fn progress(
-        mut self,
-        ctx: &mut MpcSignProtocol,
-        _cfg: Config,
-        mesh_state: MeshState,
-    ) -> NodeState {
+    async fn progress(mut self, ctx: &mut MpcSignProtocol, mesh_state: MeshState) -> NodeState {
         tracing::info!(active = ?mesh_state.active.keys_vec(), "progressing key reshare");
 
         loop {
@@ -194,7 +173,6 @@ impl CryptographicProtocol for ResharingState {
                 ResharingPhase::AwaitingReady(mut ready_state) => {
                     ready_state.ready.insert(self.me);
                     let updated = self.drain_ready_messages(ctx, &mut ready_state);
-
                     if updated {
                         tracing::debug!(?ready_state.ready, "resharing: readiness updated");
                     }
@@ -205,9 +183,10 @@ impl CryptographicProtocol for ResharingState {
                     }
 
                     let ready_count = self.ready_count(&ready_state, &mesh_state);
-                    let total = self.expected_ready_count();
+                    let total = self.contract.new_participants.len();
+                    let threshold = self.contract.threshold;
 
-                    if total > 0 && ready_count == total {
+                    if total >= threshold && ready_count == total {
                         match self.begin_running_phase() {
                             Ok(running_state) => {
                                 tracing::info!(
@@ -377,10 +356,6 @@ impl ResharingState {
         }
     }
 
-    fn expected_ready_count(&self) -> usize {
-        self.contract.new_participants.len()
-    }
-
     fn ready_count(&self, ready_state: &ResharingReadyState, _mesh_state: &MeshState) -> usize {
         ready_state
             .ready
@@ -457,7 +432,7 @@ impl ResharingState {
             .store(&PersistentNodeData {
                 epoch: self.contract.old_epoch + 1,
                 private_share,
-                public_key: self.contract.public_key.clone(),
+                public_key: self.contract.public_key,
             })
             .await
         {
@@ -479,22 +454,17 @@ impl ResharingState {
             participants: self.contract.new_participants.clone(),
             threshold: self.contract.threshold,
             private_share,
-            public_key: self.contract.public_key.clone(),
+            public_key: self.contract.public_key,
         }))
     }
 }
 
 impl CryptographicProtocol for NodeState {
-    async fn progress(
-        self,
-        ctx: &mut MpcSignProtocol,
-        cfg: Config,
-        mesh_state: MeshState,
-    ) -> NodeState {
+    async fn progress(self, ctx: &mut MpcSignProtocol, mesh_state: MeshState) -> NodeState {
         match self {
-            NodeState::Generating(state) => state.progress(ctx, cfg, mesh_state).await,
-            NodeState::Resharing(state) => state.progress(ctx, cfg, mesh_state).await,
-            NodeState::WaitingForConsensus(state) => state.progress(ctx, cfg, mesh_state).await,
+            NodeState::Generating(state) => state.progress(ctx, mesh_state).await,
+            NodeState::Resharing(state) => state.progress(ctx, mesh_state).await,
+            NodeState::WaitingForConsensus(state) => state.progress(ctx, mesh_state).await,
             _ => self,
         }
     }

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -183,6 +183,39 @@ impl CryptographicProtocol for ResharingState {
                     tracing::debug!(?state.ready, "resharing: readiness updated");
                 }
 
+                let mut buffered = HashMap::<Participant, usize>::new();
+                loop {
+                    match ctx.resharing.try_recv() {
+                        Ok(msg) => {
+                            if msg.epoch != self.contract.old_epoch {
+                                tracing::debug!(
+                                    expected = self.contract.old_epoch,
+                                    actual = msg.epoch,
+                                    "resharing: ignoring protocol message for other epoch",
+                                );
+                                continue;
+                            }
+                            state.ready.insert(msg.from);
+                            buffered
+                                .entry(msg.from)
+                                .and_modify(|count| *count += 1)
+                                .or_insert(1);
+                            self.pending.push_back(msg);
+                        }
+                        Err(mpsc::error::TryRecvError::Empty) => break,
+                        Err(mpsc::error::TryRecvError::Disconnected) => {
+                            tracing::warn!("resharing: resharing channel closed unexpectedly");
+                            break;
+                        }
+                    }
+                }
+                if !buffered.is_empty() {
+                    tracing::info!(
+                        ?buffered,
+                        "resharing: buffered protocol messages while awaiting readiness"
+                    );
+                }
+
                 self.ready_nonce = state
                     .broadcast_ready(self.me, ctx, &self.contract, self.ready_nonce)
                     .await;
@@ -192,24 +225,44 @@ impl CryptographicProtocol for ResharingState {
                     return NodeState::Resharing(self);
                 }
 
-                let protocol =
+                let mut protocol =
                     match ReshareProtocol::new(self.local_private_share, self.me, &self.contract) {
                         Ok(protocol) => protocol,
                         Err(err) => {
                             tracing::error!(?err, "resharing: failed to initialize/start protocol");
                             self.phase = ResharingPhase::awaiting(self.me);
+                            self.pending.clear();
                             return NodeState::Resharing(self);
                         }
                     };
 
+                let mut replayed = HashMap::<Participant, usize>::new();
+                while let Some(msg) = self.pending.pop_front() {
+                    replayed
+                        .entry(msg.from)
+                        .and_modify(|count| *count += 1)
+                        .or_insert(1);
+                    protocol.message(msg.from, msg.data);
+                }
+                if !replayed.is_empty() {
+                    tracing::info!(
+                        ?replayed,
+                        "resharing: replayed buffered protocol messages after starting"
+                    );
+                }
+
                 tracing::info!("resharing: all participants ready, starting protocol");
                 let now = Instant::now();
-                self.phase = ResharingPhase::Resharing(ReshareRunning {
+                let mut running = ReshareRunning {
                     protocol,
                     failed_store: None,
                     started_at: now,
                     last_activity: now,
-                });
+                };
+                // if !replayed.is_empty() {
+                //     running.last_activity = Instant::now();
+                // }
+                self.phase = ResharingPhase::Resharing(running);
                 return NodeState::Resharing(self);
             }
         };
@@ -230,6 +283,7 @@ impl CryptographicProtocol for ResharingState {
                 "resharing: protocol timed out, restarting readiness phase",
             );
             self.phase = ResharingPhase::awaiting(self.me);
+            self.pending.clear();
             return NodeState::Resharing(self);
         }
 
@@ -239,6 +293,7 @@ impl CryptographicProtocol for ResharingState {
                 Err(err) => {
                     tracing::warn!(?err, "resharing failed, going back to awaiting phase");
                     self.phase = ResharingPhase::awaiting(self.me);
+                    self.pending.clear();
                     return NodeState::Resharing(self);
                 }
             };

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -187,69 +187,6 @@ impl CryptographicProtocol for ResharingState {
 
                 let ready_tokens_snapshot = state.ready_tokens.clone();
 
-                let mut buffered = HashMap::<Participant, usize>::new();
-                let mut skipped = HashMap::<Participant, usize>::new();
-                loop {
-                    match ctx.resharing.try_recv() {
-                        Ok(msg) => {
-                            if msg.epoch != self.contract.old_epoch {
-                                tracing::debug!(
-                                    expected = self.contract.old_epoch,
-                                    actual = msg.epoch,
-                                    "resharing: ignoring protocol message for other epoch",
-                                );
-                                continue;
-                            }
-                            if let Some(last) = self.last_attempt_id {
-                                if msg.attempt == last {
-                                    tracing::debug!(
-                                        participant = ?msg.from,
-                                        attempt = ?msg.attempt,
-                                        "resharing: skipping buffered message from previous attempt"
-                                    );
-                                    continue;
-                                }
-                            }
-                            if let Some(current) = self.attempt_id {
-                                if msg.attempt != current {
-                                    skipped
-                                        .entry(msg.from)
-                                        .and_modify(|count| *count += 1)
-                                        .or_insert(1);
-                                    tracing::debug!(
-                                        expected = ?current,
-                                        actual = ?msg.attempt,
-                                        participant = ?msg.from,
-                                        "resharing: buffered message does not match current attempt"
-                                    );
-                                    continue;
-                                }
-                            }
-                            buffered
-                                .entry(msg.from)
-                                .and_modify(|count| *count += 1)
-                                .or_insert(1);
-                            self.pending.push_back(msg);
-                        }
-                        Err(mpsc::error::TryRecvError::Empty) => break,
-                        Err(mpsc::error::TryRecvError::Disconnected) => {
-                            tracing::warn!("resharing: resharing channel closed unexpectedly");
-                            break;
-                        }
-                    }
-                }
-                if !buffered.is_empty() {
-                    tracing::info!(
-                        ?buffered,
-                        "resharing: buffered protocol messages while awaiting readiness"
-                    );
-                }
-                if !skipped.is_empty() {
-                    tracing::info!(
-                        ?skipped,
-                        "resharing: skipped protocol messages for different attempt while awaiting"
-                    );
-                }
 
                 self.ready_nonce = state
                     .broadcast_ready(self.me, ctx, &self.contract, self.ready_nonce)
@@ -299,25 +236,6 @@ impl CryptographicProtocol for ResharingState {
                 self.last_attempt_id = self.attempt_id;
                 self.attempt_id = Some(attempt_id);
                 self.active_ready_tokens = ready_tokens_snapshot;
-
-                let mut dropped = HashMap::<Participant, usize>::new();
-                self.pending.retain(|msg| {
-                    if msg.attempt == attempt_id {
-                        true
-                    } else {
-                        dropped
-                            .entry(msg.from)
-                            .and_modify(|count| *count += 1)
-                            .or_insert(1);
-                        false
-                    }
-                });
-                if !dropped.is_empty() {
-                    tracing::info!(
-                        ?dropped,
-                        "resharing: discarded buffered messages for non-matching attempt before starting"
-                    );
-                }
 
                 let mut protocol =
                     match ReshareProtocol::new(self.local_private_share, self.me, &self.contract) {

--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -7,7 +7,8 @@ use crate::protocol::message::sub::{
 };
 pub use crate::protocol::message::types::{
     GeneratingMessage, Message, MessageError, MessageFilterId, PositMessage, PositProtocolId,
-    PresignatureMessage, Protocols, ResharingMessage, SignatureMessage, TripleMessage,
+    PresignatureMessage, Protocols, ResharingMessage, ResharingReadyMessage, SignatureMessage,
+    TripleMessage,
 };
 use crate::protocol::posit::PositAction;
 use crate::protocol::presignature::FullPresignatureId;
@@ -59,6 +60,7 @@ pub struct MessageInbox {
 
     generating: Subscriber<GeneratingMessage>,
     resharing: Subscriber<ResharingMessage>,
+    resharing_ready: Subscriber<ResharingReadyMessage>,
     triple: HashMap<TripleId, Subscriber<TripleMessage>>,
     triple_init: Subscriber<(TripleId, Participant, PositAction)>,
     presignature: HashMap<PresignatureId, Subscriber<PresignatureMessage>>,
@@ -81,6 +83,7 @@ impl MessageInbox {
             subscribe_rx,
             generating: Subscriber::unsubscribed(),
             resharing: Subscriber::unsubscribed(),
+            resharing_ready: Subscriber::unsubscribed(),
             triple: HashMap::new(),
             triple_init: Subscriber::unsubscribed(),
             presignature: HashMap::new(),
@@ -117,6 +120,9 @@ impl MessageInbox {
             }
             Message::Resharing(message) => {
                 let _ = self.resharing.send(message).await;
+            }
+            Message::ResharingReady(message) => {
+                let _ = self.resharing_ready.send(message).await;
             }
             Message::Triple(message) => {
                 // NOTE: not logging the error because this is simply just channel closure.
@@ -281,6 +287,15 @@ impl MessageInbox {
                             "trying to unsub from an unknown signature subscription"
                         );
                     }
+                }
+            },
+            SubscribeId::ResharingReady => match sub.action {
+                SubscribeRequestAction::Subscribe(resp) => {
+                    let rx = self.resharing_ready.subscribe();
+                    let _ = resp.send(SubscribeResponse::ResharingReady(rx));
+                }
+                SubscribeRequestAction::Unsubscribe => {
+                    self.resharing_ready.unsubscribe();
                 }
             },
             SubscribeId::Triples => match sub.action {
@@ -635,6 +650,18 @@ impl MessageChannel {
             SubscribeResponse::Resharing(rx) => rx,
             _ => {
                 panic!("received unexpected subscribe response for resharing");
+            }
+        }
+    }
+
+    pub async fn subscribe_resharing_ready(&self) -> mpsc::Receiver<ResharingReadyMessage> {
+        let Some(subscription) = self.subscribe(SubscribeId::ResharingReady).await else {
+            panic!("failed to subscribe for resharing readiness");
+        };
+        match subscription {
+            SubscribeResponse::ResharingReady(rx) => rx,
+            _ => {
+                panic!("received unexpected subscribe response for resharing readiness");
             }
         }
     }

--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -7,7 +7,7 @@ use crate::protocol::message::sub::{
 };
 pub use crate::protocol::message::types::{
     GeneratingMessage, Message, MessageError, MessageFilterId, PositMessage, PositProtocolId,
-    PresignatureMessage, Protocols, ResharingMessage, ResharingReadyMessage, SignatureMessage,
+    PresignatureMessage, Protocols, ReadyMessage, ResharingMessage, SignatureMessage,
     TripleMessage,
 };
 use crate::protocol::posit::PositAction;
@@ -60,7 +60,7 @@ pub struct MessageInbox {
 
     generating: Subscriber<GeneratingMessage>,
     resharing: Subscriber<ResharingMessage>,
-    resharing_ready: Subscriber<ResharingReadyMessage>,
+    ready: Subscriber<ReadyMessage>,
     triple: HashMap<TripleId, Subscriber<TripleMessage>>,
     triple_init: Subscriber<(TripleId, Participant, PositAction)>,
     presignature: HashMap<PresignatureId, Subscriber<PresignatureMessage>>,
@@ -83,7 +83,7 @@ impl MessageInbox {
             subscribe_rx,
             generating: Subscriber::unsubscribed(),
             resharing: Subscriber::unsubscribed(),
-            resharing_ready: Subscriber::unsubscribed(),
+            ready: Subscriber::unsubscribed(),
             triple: HashMap::new(),
             triple_init: Subscriber::unsubscribed(),
             presignature: HashMap::new(),
@@ -121,8 +121,8 @@ impl MessageInbox {
             Message::Resharing(message) => {
                 let _ = self.resharing.send(message).await;
             }
-            Message::ResharingReady(message) => {
-                let _ = self.resharing_ready.send(message).await;
+            Message::Ready(message) => {
+                let _ = self.ready.send(message).await;
             }
             Message::Triple(message) => {
                 // NOTE: not logging the error because this is simply just channel closure.
@@ -289,13 +289,13 @@ impl MessageInbox {
                     }
                 }
             },
-            SubscribeId::ResharingReady => match sub.action {
+            SubscribeId::Ready => match sub.action {
                 SubscribeRequestAction::Subscribe(resp) => {
-                    let rx = self.resharing_ready.subscribe();
-                    let _ = resp.send(SubscribeResponse::ResharingReady(rx));
+                    let rx = self.ready.subscribe();
+                    let _ = resp.send(SubscribeResponse::Ready(rx));
                 }
                 SubscribeRequestAction::Unsubscribe => {
-                    self.resharing_ready.unsubscribe();
+                    self.ready.unsubscribe();
                 }
             },
             SubscribeId::Triples => match sub.action {
@@ -654,12 +654,12 @@ impl MessageChannel {
         }
     }
 
-    pub async fn subscribe_resharing_ready(&self) -> mpsc::Receiver<ResharingReadyMessage> {
-        let Some(subscription) = self.subscribe(SubscribeId::ResharingReady).await else {
+    pub async fn subscribe_ready(&self) -> mpsc::Receiver<ReadyMessage> {
+        let Some(subscription) = self.subscribe(SubscribeId::Ready).await else {
             panic!("failed to subscribe for resharing readiness");
         };
         match subscription {
-            SubscribeResponse::ResharingReady(rx) => rx,
+            SubscribeResponse::Ready(rx) => rx,
             _ => {
                 panic!("received unexpected subscribe response for resharing readiness");
             }

--- a/chain-signatures/node/src/protocol/message/sub.rs
+++ b/chain-signatures/node/src/protocol/message/sub.rs
@@ -3,7 +3,8 @@ use mpc_primitives::SignId;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::protocol::message::{
-    GeneratingMessage, PresignatureMessage, ResharingMessage, SignatureMessage, TripleMessage,
+    GeneratingMessage, PresignatureMessage, ResharingMessage, ResharingReadyMessage,
+    SignatureMessage, TripleMessage,
 };
 use crate::protocol::posit::PositAction;
 use crate::protocol::presignature::{FullPresignatureId, PresignatureId};
@@ -15,6 +16,7 @@ pub const MAX_MESSAGE_SUB_CHANNEL_SIZE: usize = 4 * 1024;
 pub enum SubscribeId {
     Generating,
     Resharing,
+    ResharingReady,
     Triples,
     Presignatures,
     Signatures,
@@ -26,6 +28,7 @@ pub enum SubscribeId {
 pub enum SubscribeResponse {
     Generating(mpsc::Receiver<GeneratingMessage>),
     Resharing(mpsc::Receiver<ResharingMessage>),
+    ResharingReady(mpsc::Receiver<ResharingReadyMessage>),
     Triple(mpsc::Receiver<TripleMessage>),
     TriplePosit(mpsc::Receiver<(TripleId, Participant, PositAction)>),
     Presignature(mpsc::Receiver<PresignatureMessage>),

--- a/chain-signatures/node/src/protocol/message/sub.rs
+++ b/chain-signatures/node/src/protocol/message/sub.rs
@@ -3,8 +3,8 @@ use mpc_primitives::SignId;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::protocol::message::{
-    GeneratingMessage, PresignatureMessage, ResharingMessage, ResharingReadyMessage,
-    SignatureMessage, TripleMessage,
+    GeneratingMessage, PresignatureMessage, ReadyMessage, ResharingMessage, SignatureMessage,
+    TripleMessage,
 };
 use crate::protocol::posit::PositAction;
 use crate::protocol::presignature::{FullPresignatureId, PresignatureId};
@@ -16,7 +16,7 @@ pub const MAX_MESSAGE_SUB_CHANNEL_SIZE: usize = 4 * 1024;
 pub enum SubscribeId {
     Generating,
     Resharing,
-    ResharingReady,
+    Ready,
     Triples,
     Presignatures,
     Signatures,
@@ -28,7 +28,7 @@ pub enum SubscribeId {
 pub enum SubscribeResponse {
     Generating(mpsc::Receiver<GeneratingMessage>),
     Resharing(mpsc::Receiver<ResharingMessage>),
-    ResharingReady(mpsc::Receiver<ResharingReadyMessage>),
+    Ready(mpsc::Receiver<ReadyMessage>),
     Triple(mpsc::Receiver<TripleMessage>),
     TriplePosit(mpsc::Receiver<(TripleId, Participant, PositAction)>),
     Presignature(mpsc::Receiver<PresignatureMessage>),

--- a/chain-signatures/node/src/protocol/message/types.rs
+++ b/chain-signatures/node/src/protocol/message/types.rs
@@ -72,6 +72,10 @@ impl From<GeneratingMessage> for Message {
 pub struct ResharingMessage {
     pub epoch: Epoch,
     pub from: Participant,
+    /// Unique identifier for the current resharing attempt. Messages belonging to earlier
+    /// attempts are discarded so nodes can safely restart readiness.
+    #[serde(default)]
+    pub attempt: u64,
     #[serde(with = "serde_bytes")]
     pub data: MessageData,
 }
@@ -90,6 +94,9 @@ pub struct ReadyMessage {
     /// Monotonic nonce attached by the sender so repeated ready broadcasts have distinct
     /// ciphertexts/signatures and aren’t removed by the inbox idempotent filter.
     pub nonce: u64,
+    /// Participant-scoped random identifier combined into a cluster-wide attempt identifier.
+    #[serde(default)]
+    pub attempt: u64,
 }
 
 impl From<ReadyMessage> for Message {

--- a/chain-signatures/node/src/protocol/message/types.rs
+++ b/chain-signatures/node/src/protocol/message/types.rs
@@ -75,7 +75,7 @@ pub struct ResharingMessage {
     /// Unique identifier for the current resharing attempt. Messages belonging to earlier
     /// attempts are discarded so nodes can safely restart readiness.
     #[serde(default)]
-    pub attempt: u64,
+    pub token: u64,
     #[serde(with = "serde_bytes")]
     pub data: MessageData,
 }

--- a/chain-signatures/node/src/protocol/message/types.rs
+++ b/chain-signatures/node/src/protocol/message/types.rs
@@ -86,6 +86,10 @@ impl From<ResharingMessage> for Message {
 pub struct ResharingReadyMessage {
     pub epoch: Epoch,
     pub from: Participant,
+    /// Monotonic nonce attached by the sender so repeated ready broadcasts have distinct
+    /// ciphertexts/signatures and aren’t removed by the inbox idempotent filter. Receivers
+    /// ignore the value—it exists purely to defeat deduplication.
+    pub nonce: u64,
 }
 
 impl From<ResharingReadyMessage> for Message {

--- a/chain-signatures/node/src/protocol/message/types.rs
+++ b/chain-signatures/node/src/protocol/message/types.rs
@@ -15,7 +15,7 @@ use mpc_primitives::SignId;
 pub enum Protocols {
     Generating,
     Resharing,
-    ResharingReady,
+    Ready,
     Triple,
     Presignature,
     Signature,
@@ -82,19 +82,19 @@ impl From<ResharingMessage> for Message {
     }
 }
 
+// TODO: make it work alongside generating
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct ResharingReadyMessage {
+pub struct ReadyMessage {
     pub epoch: Epoch,
     pub from: Participant,
     /// Monotonic nonce attached by the sender so repeated ready broadcasts have distinct
-    /// ciphertexts/signatures and aren’t removed by the inbox idempotent filter. Receivers
-    /// ignore the value—it exists purely to defeat deduplication.
+    /// ciphertexts/signatures and aren’t removed by the inbox idempotent filter.
     pub nonce: u64,
 }
 
-impl From<ResharingReadyMessage> for Message {
-    fn from(msg: ResharingReadyMessage) -> Self {
-        Message::ResharingReady(msg)
+impl From<ReadyMessage> for Message {
+    fn from(msg: ReadyMessage) -> Self {
+        Message::Ready(msg)
     }
 }
 
@@ -158,7 +158,7 @@ pub enum Message {
     Posit(PositMessage),
     Generating(GeneratingMessage),
     Resharing(ResharingMessage),
-    ResharingReady(ResharingReadyMessage),
+    Ready(ReadyMessage),
     Triple(TripleMessage),
     Presignature(PresignatureMessage),
     Signature(SignatureMessage),
@@ -175,7 +175,7 @@ impl Message {
             Message::Posit(_) => "Proposal",
             Message::Generating(_) => "Generating",
             Message::Resharing(_) => "Resharing",
-            Message::ResharingReady(_) => "ResharingReady",
+            Message::Ready(_) => "Ready",
             Message::Triple(_) => "Triple",
             Message::Presignature(_) => "Presignature",
             Message::Signature(_) => "Signature",
@@ -189,7 +189,7 @@ impl Message {
             Message::Posit(proposal) => std::mem::size_of::<PositMessage>() + proposal.data_len(),
             Message::Generating(msg) => std::mem::size_of::<GeneratingMessage>() + msg.data.len(),
             Message::Resharing(msg) => std::mem::size_of::<ResharingMessage>() + msg.data.len(),
-            Message::ResharingReady(_) => std::mem::size_of::<ResharingReadyMessage>(),
+            Message::Ready(_) => std::mem::size_of::<ReadyMessage>(),
             Message::Triple(msg) => std::mem::size_of::<TripleMessage>() + msg.data.len(),
             Message::Presignature(msg) => {
                 std::mem::size_of::<PresignatureMessage>() + msg.data.len()
@@ -228,8 +228,8 @@ impl ProtocolType for ResharingMessage {
     const PROTOCOL: Protocols = Protocols::Resharing;
 }
 
-impl ProtocolType for ResharingReadyMessage {
-    const PROTOCOL: Protocols = Protocols::ResharingReady;
+impl ProtocolType for ReadyMessage {
+    const PROTOCOL: Protocols = Protocols::Ready;
 }
 
 impl ProtocolType for TripleMessage {

--- a/chain-signatures/node/src/protocol/message/types.rs
+++ b/chain-signatures/node/src/protocol/message/types.rs
@@ -15,6 +15,7 @@ use mpc_primitives::SignId;
 pub enum Protocols {
     Generating,
     Resharing,
+    ResharingReady,
     Triple,
     Presignature,
     Signature,
@@ -82,6 +83,18 @@ impl From<ResharingMessage> for Message {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct ResharingReadyMessage {
+    pub epoch: Epoch,
+    pub from: Participant,
+}
+
+impl From<ResharingReadyMessage> for Message {
+    fn from(msg: ResharingReadyMessage) -> Self {
+        Message::ResharingReady(msg)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct TripleMessage {
     pub id: u64,
     pub epoch: Epoch,
@@ -141,6 +154,7 @@ pub enum Message {
     Posit(PositMessage),
     Generating(GeneratingMessage),
     Resharing(ResharingMessage),
+    ResharingReady(ResharingReadyMessage),
     Triple(TripleMessage),
     Presignature(PresignatureMessage),
     Signature(SignatureMessage),
@@ -157,6 +171,7 @@ impl Message {
             Message::Posit(_) => "Proposal",
             Message::Generating(_) => "Generating",
             Message::Resharing(_) => "Resharing",
+            Message::ResharingReady(_) => "ResharingReady",
             Message::Triple(_) => "Triple",
             Message::Presignature(_) => "Presignature",
             Message::Signature(_) => "Signature",
@@ -170,6 +185,7 @@ impl Message {
             Message::Posit(proposal) => std::mem::size_of::<PositMessage>() + proposal.data_len(),
             Message::Generating(msg) => std::mem::size_of::<GeneratingMessage>() + msg.data.len(),
             Message::Resharing(msg) => std::mem::size_of::<ResharingMessage>() + msg.data.len(),
+            Message::ResharingReady(_) => std::mem::size_of::<ResharingReadyMessage>(),
             Message::Triple(msg) => std::mem::size_of::<TripleMessage>() + msg.data.len(),
             Message::Presignature(msg) => {
                 std::mem::size_of::<PresignatureMessage>() + msg.data.len()
@@ -206,6 +222,10 @@ impl ProtocolType for GeneratingMessage {
 
 impl ProtocolType for ResharingMessage {
     const PROTOCOL: Protocols = Protocols::Resharing;
+}
+
+impl ProtocolType for ResharingReadyMessage {
+    const PROTOCOL: Protocols = Protocols::ResharingReady;
 }
 
 impl ProtocolType for TripleMessage {

--- a/chain-signatures/node/src/protocol/message/types.rs
+++ b/chain-signatures/node/src/protocol/message/types.rs
@@ -96,7 +96,7 @@ pub struct ReadyMessage {
     pub nonce: u64,
     /// Participant-scoped random identifier combined into a cluster-wide attempt identifier.
     #[serde(default)]
-    pub attempt: u64,
+    pub token: u64,
 }
 
 impl From<ReadyMessage> for Message {

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -83,7 +83,6 @@ impl MpcSignProtocol {
         mut node: Node,
         mut gov_client: G,
         contract_state: ContractStateWatcher,
-        config: watch::Receiver<Config>,
         mesh_state: watch::Receiver<MeshState>,
     ) {
         let my_account_id = self.my_account_id.as_str();
@@ -103,14 +102,9 @@ impl MpcSignProtocol {
                 .with_label_values(&[my_account_id.as_str()])
                 .inc();
 
-            let cfg = config.borrow().clone();
             let mesh_state = mesh_state.borrow().clone();
-
             let crypto_time = Instant::now();
-            node.state = node
-                .state
-                .progress(&mut self, cfg.clone(), mesh_state.clone())
-                .await;
+            node.state = node.state.progress(&mut self, mesh_state).await;
             node.update_watchers().await;
             crate::metrics::PROTOCOL_LATENCY_ITER_CRYPTO
                 .with_label_values(&[my_account_id.as_str()])

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -25,7 +25,7 @@ use crate::indexer_sol::SignBidirectionalEvent;
 use crate::mesh::MeshState;
 use crate::protocol::consensus::ConsensusProtocol;
 use crate::protocol::cryptography::CryptographicProtocol;
-use crate::protocol::message::{GeneratingMessage, ResharingMessage, ResharingReadyMessage};
+use crate::protocol::message::{GeneratingMessage, ReadyMessage, ResharingMessage};
 use crate::respond_bidirectional::RespondBidirectionalTx;
 use crate::rpc::{ContractStateWatcher, RpcChannel};
 use crate::sign_bidirectional::SignBidirectionalSignatureChannel;
@@ -51,7 +51,7 @@ pub struct MpcSignProtocol {
     pub(crate) sign_rx: Arc<RwLock<mpsc::Receiver<IndexedSignRequest>>>,
     pub(crate) generating: mpsc::Receiver<GeneratingMessage>,
     pub(crate) resharing: mpsc::Receiver<ResharingMessage>,
-    pub(crate) resharing_ready: mpsc::Receiver<ResharingReadyMessage>,
+    pub(crate) ready: mpsc::Receiver<ReadyMessage>,
     pub(crate) msg_channel: MessageChannel,
     pub(crate) rpc_channel: RpcChannel,
     pub(crate) contract: ContractStateWatcher,

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -1,7 +1,6 @@
-mod cryptography;
-
 pub mod consensus;
 pub mod contract;
+pub mod cryptography;
 pub mod error;
 pub mod message;
 pub mod posit;

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -26,7 +26,7 @@ use crate::indexer_sol::SignBidirectionalEvent;
 use crate::mesh::MeshState;
 use crate::protocol::consensus::ConsensusProtocol;
 use crate::protocol::cryptography::CryptographicProtocol;
-use crate::protocol::message::{GeneratingMessage, ResharingMessage};
+use crate::protocol::message::{GeneratingMessage, ResharingMessage, ResharingReadyMessage};
 use crate::respond_bidirectional::RespondBidirectionalTx;
 use crate::rpc::{ContractStateWatcher, RpcChannel};
 use crate::sign_bidirectional::SignBidirectionalSignatureChannel;
@@ -52,6 +52,7 @@ pub struct MpcSignProtocol {
     pub(crate) sign_rx: Arc<RwLock<mpsc::Receiver<IndexedSignRequest>>>,
     pub(crate) generating: mpsc::Receiver<GeneratingMessage>,
     pub(crate) resharing: mpsc::Receiver<ResharingMessage>,
+    pub(crate) resharing_ready: mpsc::Receiver<ResharingReadyMessage>,
     pub(crate) msg_channel: MessageChannel,
     pub(crate) rpc_channel: RpcChannel,
     pub(crate) contract: ContractStateWatcher,

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -85,7 +85,7 @@ pub struct ResharingState {
     pub ready_nonce: u64,
 }
 
-pub struct ResharingReadyState {
+pub struct ReshareAwaiting {
     pub ready: BTreeSet<Participant>,
     /// Interval to control broadcasting readiness messages.
     // NOTE: this is an Instant for now since generating/resharing tasks are not async
@@ -93,7 +93,7 @@ pub struct ResharingReadyState {
     pub broadcast_interval: Instant,
 }
 
-pub struct ResharingRunningState {
+pub struct ReshareRunning {
     pub protocol: ReshareProtocol,
     /// If the resharing state fails to store data after generating, it gets temporarily
     /// stored here and retried later.
@@ -104,13 +104,13 @@ pub struct ResharingRunningState {
 
 #[allow(clippy::large_enum_variant)]
 pub enum ResharingPhase {
-    AwaitingReady(ResharingReadyState),
-    Resharing(ResharingRunningState),
+    Awaiting(ReshareAwaiting),
+    Resharing(ReshareRunning),
 }
 
 impl ResharingPhase {
     pub fn awaiting(me: Participant) -> Self {
-        Self::AwaitingReady(ResharingReadyState {
+        Self::Awaiting(ReshareAwaiting {
             ready: std::iter::once(me).collect(),
             // ready to broadcast immediately
             broadcast_interval: Instant::now() - RESHARING_READY_BROADCAST_INTERVAL,

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -87,7 +87,10 @@ pub struct ResharingState {
 
 pub struct ResharingReadyState {
     pub ready: BTreeSet<Participant>,
-    pub last_broadcast: Instant,
+    /// Interval to control broadcasting readiness messages.
+    // NOTE: this is an Instant for now since generating/resharing tasks are not async
+    // and happen in main protocol loop. once it becomes async we can make this an interval.
+    pub broadcast_interval: Instant,
 }
 
 pub struct ResharingRunningState {
@@ -102,10 +105,10 @@ pub struct ResharingRunningState {
 #[allow(clippy::large_enum_variant)]
 pub enum ResharingPhase {
     AwaitingReady(ResharingReadyState),
-    Running(ResharingRunningState),
+    Resharing(ResharingRunningState),
 }
 
-pub const RESHARING_READY_BROADCAST_INTERVAL: Duration = Duration::from_secs(30);
+pub const RESHARING_READY_BROADCAST_INTERVAL: Duration = Duration::from_secs(10);
 
 pub struct JoiningState {
     pub participants: Participants,

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -98,12 +98,13 @@ pub struct ResharingRunningState {
     pub last_activity: Instant,
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum ResharingPhase {
     AwaitingReady(ResharingReadyState),
     Running(ResharingRunningState),
 }
 
-pub const RESHARING_READY_BROADCAST_INTERVAL: Duration = Duration::from_secs(5);
+pub const RESHARING_READY_BROADCAST_INTERVAL: Duration = Duration::from_secs(30);
 
 pub struct JoiningState {
     pub participants: Participants,

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -1,5 +1,6 @@
 use super::contract::{primitives::Participants, ResharingContractState};
 use super::triple::TripleSpawnerTask;
+use crate::protocol::message::ResharingMessage;
 use crate::protocol::presignature::PresignatureSpawnerTask;
 use crate::protocol::signature::SignatureSpawnerTask;
 use crate::types::{KeygenProtocol, ReshareProtocol, SecretKeyShare};
@@ -9,7 +10,7 @@ use mpc_crypto::PublicKey;
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::time::{Duration, Instant};
@@ -83,6 +84,7 @@ pub struct ResharingState {
     pub local_private_share: Option<SecretKeyShare>,
     pub phase: ResharingPhase,
     pub ready_nonce: u64,
+    pub pending: VecDeque<ResharingMessage>,
 }
 
 pub struct ReshareAwaiting {
@@ -118,6 +120,14 @@ impl ResharingPhase {
     }
 }
 
+#[cfg(feature = "test-feature")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResharingPhaseStatus {
+    Awaiting,
+    Running,
+}
+
 pub const RESHARING_READY_BROADCAST_INTERVAL: Duration = Duration::from_secs(10);
 
 pub struct JoiningState {
@@ -147,6 +157,8 @@ pub enum NodeStatus {
     Resharing {
         old_participants: Vec<Participant>,
         new_participants: Vec<Participant>,
+        #[cfg(feature = "test-feature")]
+        phase: ResharingPhaseStatus,
     },
     Joining {
         participants: Vec<Participant>,
@@ -244,9 +256,16 @@ impl Node {
                 });
             }
             NodeState::Resharing(state) => {
+                #[cfg(feature = "test-feature")]
+                let phase = match &state.phase {
+                    ResharingPhase::Awaiting(_) => ResharingPhaseStatus::Awaiting,
+                    ResharingPhase::Resharing(_) => ResharingPhaseStatus::Running,
+                };
                 let _ = self.watcher_tx.send(NodeStatus::Resharing {
                     old_participants: state.contract.old_participants.keys_vec(),
                     new_participants: state.contract.new_participants.keys_vec(),
+                    #[cfg(feature = "test-feature")]
+                    phase,
                 });
             }
             NodeState::Joining(state) => {

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -10,7 +10,8 @@ use mpc_crypto::PublicKey;
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 
-use std::collections::{HashSet, VecDeque};
+use rand::random;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::time::{Duration, Instant};
@@ -85,10 +86,15 @@ pub struct ResharingState {
     pub phase: ResharingPhase,
     pub ready_nonce: u64,
     pub pending: VecDeque<ResharingMessage>,
+    pub attempt_id: Option<u64>,
+    pub last_attempt_id: Option<u64>,
+    pub active_ready_tokens: HashMap<Participant, u64>,
 }
 
 pub struct ReshareAwaiting {
     pub ready: HashSet<Participant>,
+    pub ready_tokens: HashMap<Participant, u64>,
+    pub local_attempt: u64,
     /// Interval to control broadcasting readiness messages.
     // NOTE: this is an Instant for now since generating/resharing tasks are not async
     // and happen in main protocol loop. once it becomes async we can make this an interval.
@@ -112,8 +118,11 @@ pub enum ResharingPhase {
 
 impl ResharingPhase {
     pub fn awaiting(me: Participant) -> Self {
+        let local_attempt = random::<u64>();
         Self::Awaiting(ReshareAwaiting {
             ready: std::iter::once(me).collect(),
+            ready_tokens: std::iter::once((me, local_attempt)).collect(),
+            local_attempt,
             // ready to broadcast immediately
             broadcast_interval: Instant::now() - RESHARING_READY_BROADCAST_INTERVAL,
         })

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -7,12 +7,12 @@ use crate::types::{KeygenProtocol, ReshareProtocol, SecretKeyShare};
 use cait_sith::protocol::Participant;
 use mpc_crypto::PublicKey;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use tokio::sync::watch;
+
+use std::collections::HashSet;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::time::{Duration, Instant};
-
-use tokio::sync::watch;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct PersistentNodeData {
@@ -86,7 +86,7 @@ pub struct ResharingState {
 }
 
 pub struct ReshareAwaiting {
-    pub ready: BTreeSet<Participant>,
+    pub ready: HashSet<Participant>,
     /// Interval to control broadcasting readiness messages.
     // NOTE: this is an Instant for now since generating/resharing tasks are not async
     // and happen in main protocol loop. once it becomes async we can make this an interval.

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -108,6 +108,16 @@ pub enum ResharingPhase {
     Resharing(ResharingRunningState),
 }
 
+impl ResharingPhase {
+    pub fn awaiting(me: Participant) -> Self {
+        Self::AwaitingReady(ResharingReadyState {
+            ready: std::iter::once(me).collect(),
+            // ready to broadcast immediately
+            broadcast_interval: Instant::now() - RESHARING_READY_BROADCAST_INTERVAL,
+        })
+    }
+}
+
 pub const RESHARING_READY_BROADCAST_INTERVAL: Duration = Duration::from_secs(10);
 
 pub struct JoiningState {

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -1,4 +1,4 @@
-use super::contract::primitives::Participants;
+use super::contract::{primitives::Participants, ResharingContractState};
 use super::triple::TripleSpawnerTask;
 use crate::protocol::presignature::PresignatureSpawnerTask;
 use crate::protocol::signature::SignatureSpawnerTask;
@@ -7,8 +7,10 @@ use crate::types::{KeygenProtocol, ReshareProtocol, SecretKeyShare};
 use cait_sith::protocol::Participant;
 use mpc_crypto::PublicKey;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use std::fmt;
 use std::fmt::{Display, Formatter};
+use std::time::{Duration, Instant};
 
 use tokio::sync::watch;
 
@@ -77,17 +79,31 @@ pub struct RunningState {
 
 pub struct ResharingState {
     pub me: Participant,
-    pub old_epoch: u64,
-    pub old_participants: Participants,
-    pub new_participants: Participants,
-    pub threshold: usize,
-    pub public_key: PublicKey,
-    pub protocol: ReshareProtocol,
+    pub contract: ResharingContractState,
+    pub local_private_share: Option<SecretKeyShare>,
+    pub phase: ResharingPhase,
+}
 
+pub struct ResharingReadyState {
+    pub ready: BTreeSet<Participant>,
+    pub last_broadcast: Instant,
+}
+
+pub struct ResharingRunningState {
+    pub protocol: ReshareProtocol,
     /// If the resharing state fails to store data after generating, it gets temporarily
     /// stored here and retried later.
     pub failed_store: Option<SecretKeyShare>,
+    pub started_at: Instant,
+    pub last_activity: Instant,
 }
+
+pub enum ResharingPhase {
+    AwaitingReady(ResharingReadyState),
+    Running(ResharingRunningState),
+}
+
+pub const RESHARING_READY_BROADCAST_INTERVAL: Duration = Duration::from_secs(5);
 
 pub struct JoiningState {
     pub participants: Participants,
@@ -214,8 +230,8 @@ impl Node {
             }
             NodeState::Resharing(state) => {
                 let _ = self.watcher_tx.send(NodeStatus::Resharing {
-                    old_participants: state.old_participants.keys_vec(),
-                    new_participants: state.new_participants.keys_vec(),
+                    old_participants: state.contract.old_participants.keys_vec(),
+                    new_participants: state.contract.new_participants.keys_vec(),
                 });
             }
             NodeState::Joining(state) => {

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -1,6 +1,5 @@
 use super::contract::{primitives::Participants, ResharingContractState};
 use super::triple::TripleSpawnerTask;
-use crate::protocol::message::ResharingMessage;
 use crate::protocol::presignature::PresignatureSpawnerTask;
 use crate::protocol::signature::SignatureSpawnerTask;
 use crate::types::{KeygenProtocol, ReshareProtocol, SecretKeyShare};
@@ -11,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 
 use rand::random;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::time::{Duration, Instant};
@@ -85,10 +84,6 @@ pub struct ResharingState {
     pub local_private_share: Option<SecretKeyShare>,
     pub phase: ResharingPhase,
     pub ready_nonce: u64,
-    pub pending: VecDeque<ResharingMessage>,
-    pub attempt_id: Option<u64>,
-    pub last_attempt_id: Option<u64>,
-    pub active_ready_tokens: HashMap<Participant, u64>,
 }
 
 pub struct ReshareAwaiting {
@@ -103,6 +98,17 @@ pub struct ReshareAwaiting {
 
 pub struct ReshareRunning {
     pub protocol: ReshareProtocol,
+
+    /// Participants that have sent readiness messages along with their tokens. These
+    /// are retained for the duration of the resharing protocol until either completion
+    /// or restart. They will be combined to form the singular token for all resharing
+    /// messages.
+    pub ready_tokens: HashMap<Participant, u64>,
+
+    /// Unique identifier for the current resharing attempt. Messages that do not match
+    /// this token are discarded and ignored from processing.
+    pub token: u64,
+
     /// If the resharing state fails to store data after generating, it gets temporarily
     /// stored here and retried later.
     pub failed_store: Option<SecretKeyShare>,

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -10,10 +10,12 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 
 use rand::random;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::time::{Duration, Instant};
+
+pub const RESHARING_READY_BROADCAST_INTERVAL: Duration = Duration::from_secs(10);
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct PersistentNodeData {
@@ -87,9 +89,8 @@ pub struct ResharingState {
 }
 
 pub struct ReshareAwaiting {
-    pub ready: HashSet<Participant>,
     pub ready_tokens: HashMap<Participant, u64>,
-    pub local_attempt: u64,
+    pub my_token: u64,
     /// Interval to control broadcasting readiness messages.
     // NOTE: this is an Instant for now since generating/resharing tasks are not async
     // and happen in main protocol loop. once it becomes async we can make this an interval.
@@ -124,26 +125,22 @@ pub enum ResharingPhase {
 
 impl ResharingPhase {
     pub fn awaiting(me: Participant) -> Self {
-        let local_attempt = random::<u64>();
+        let my_token = random::<u64>();
         Self::Awaiting(ReshareAwaiting {
-            ready: std::iter::once(me).collect(),
-            ready_tokens: std::iter::once((me, local_attempt)).collect(),
-            local_attempt,
+            ready_tokens: std::iter::once((me, my_token)).collect(),
+            my_token,
             // ready to broadcast immediately
             broadcast_interval: Instant::now() - RESHARING_READY_BROADCAST_INTERVAL,
         })
     }
 }
 
-#[cfg(feature = "test-feature")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ResharingPhaseStatus {
+pub enum ResharingStatus {
     Awaiting,
     Running,
 }
-
-pub const RESHARING_READY_BROADCAST_INTERVAL: Duration = Duration::from_secs(10);
 
 pub struct JoiningState {
     pub participants: Participants,
@@ -172,8 +169,7 @@ pub enum NodeStatus {
     Resharing {
         old_participants: Vec<Participant>,
         new_participants: Vec<Participant>,
-        #[cfg(feature = "test-feature")]
-        phase: ResharingPhaseStatus,
+        phase: ResharingStatus,
     },
     Joining {
         participants: Vec<Participant>,
@@ -271,15 +267,13 @@ impl Node {
                 });
             }
             NodeState::Resharing(state) => {
-                #[cfg(feature = "test-feature")]
                 let phase = match &state.phase {
-                    ResharingPhase::Awaiting(_) => ResharingPhaseStatus::Awaiting,
-                    ResharingPhase::Resharing(_) => ResharingPhaseStatus::Running,
+                    ResharingPhase::Awaiting(_) => ResharingStatus::Awaiting,
+                    ResharingPhase::Resharing(_) => ResharingStatus::Running,
                 };
                 let _ = self.watcher_tx.send(NodeStatus::Resharing {
                     old_participants: state.contract.old_participants.keys_vec(),
                     new_participants: state.contract.new_participants.keys_vec(),
-                    #[cfg(feature = "test-feature")]
                     phase,
                 });
             }

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -82,6 +82,7 @@ pub struct ResharingState {
     pub contract: ResharingContractState,
     pub local_private_share: Option<SecretKeyShare>,
     pub phase: ResharingPhase,
+    pub ready_nonce: u64,
 }
 
 pub struct ResharingReadyState {

--- a/chain-signatures/node/src/protocol/test_setup.rs
+++ b/chain-signatures/node/src/protocol/test_setup.rs
@@ -34,6 +34,7 @@ impl MpcSignProtocol {
     ) -> Self {
         let generating = channels.msg_channel.subscribe_generation().await;
         let resharing = channels.msg_channel.subscribe_resharing().await;
+        let resharing_ready = channels.msg_channel.subscribe_resharing_ready().await;
         Self {
             my_account_id,
             secret_storage: storage.secret_storage,
@@ -43,6 +44,7 @@ impl MpcSignProtocol {
             msg_channel: channels.msg_channel,
             generating,
             resharing,
+            resharing_ready,
             rpc_channel: channels.rpc_channel,
             contract,
             config: channels.config,

--- a/chain-signatures/node/src/protocol/test_setup.rs
+++ b/chain-signatures/node/src/protocol/test_setup.rs
@@ -34,7 +34,7 @@ impl MpcSignProtocol {
     ) -> Self {
         let generating = channels.msg_channel.subscribe_generation().await;
         let resharing = channels.msg_channel.subscribe_resharing().await;
-        let resharing_ready = channels.msg_channel.subscribe_resharing_ready().await;
+        let ready = channels.msg_channel.subscribe_ready().await;
         Self {
             my_account_id,
             secret_storage: storage.secret_storage,
@@ -44,7 +44,7 @@ impl MpcSignProtocol {
             msg_channel: channels.msg_channel,
             generating,
             resharing,
-            resharing_ready,
+            ready,
             rpc_channel: channels.rpc_channel,
             contract,
             config: channels.config,

--- a/chain-signatures/node/src/types.rs
+++ b/chain-signatures/node/src/types.rs
@@ -3,7 +3,6 @@ use cait_sith::triples::TripleGenerationOutput;
 use cait_sith::{protocol::Protocol, KeygenOutput};
 use cait_sith::{FullSignature, PresignOutput};
 use k256::{elliptic_curve::CurveArithmetic, Secp256k1};
-use mpc_crypto::PublicKey;
 
 use crate::protocol::contract::ResharingContractState;
 
@@ -55,13 +54,7 @@ impl KeygenProtocol {
 }
 
 pub struct ReshareProtocol {
-    old_participants: Vec<Participant>,
-    new_participants: Vec<Participant>,
-    me: Participant,
-    threshold: usize,
-    private_share: Option<SecretKeyShare>,
     protocol: Box<dyn Protocol<Output = SecretKeyShare> + Send + Sync>,
-    root_pk: PublicKey,
 }
 
 impl ReshareProtocol {
@@ -78,42 +71,16 @@ impl ReshareProtocol {
             new_participants,
             me
         );
-        Ok(Self {
-            protocol: Box::new(cait_sith::reshare::<Secp256k1>(
-                &old_participants,
-                contract_state.threshold,
-                &new_participants,
-                contract_state.threshold,
-                me,
-                private_share,
-                contract_state.public_key,
-            )?),
-            private_share,
+        let protocol = Box::new(cait_sith::reshare::<Secp256k1>(
+            &old_participants,
+            contract_state.threshold,
+            &new_participants,
+            contract_state.threshold,
             me,
-            threshold: contract_state.threshold,
-            old_participants,
-            new_participants,
-            root_pk: contract_state.public_key,
-        })
-    }
-
-    pub async fn refresh(&mut self) -> Result<(), InitializationError> {
-        tracing::debug!(
-            "ReshareProtocol::refresh old participants {:?} new participants {:?} me {:?}",
-            self.old_participants,
-            self.new_participants,
-            self.me
-        );
-        self.protocol = Box::new(cait_sith::reshare::<Secp256k1>(
-            &self.old_participants,
-            self.threshold,
-            &self.new_participants,
-            self.threshold,
-            self.me,
-            self.private_share,
-            self.root_pk,
+            private_share,
+            contract_state.public_key,
         )?);
-        Ok(())
+        Ok(Self { protocol })
     }
 
     pub fn poke(&mut self) -> Result<Action<SecretKeyShare>, ProtocolError> {

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -9,6 +9,8 @@ pub mod debug;
 use self::error::Error;
 use crate::indexer::NearIndexer;
 use crate::metrics::WEB_ENDPOINT_LATENCY;
+#[cfg(feature = "test-feature")]
+use crate::protocol::state::ResharingPhaseStatus;
 use crate::protocol::state::{NodeStateWatcher, NodeStatus};
 use crate::protocol::sync::{SyncChannel, SyncUpdate};
 use crate::protocol::MessageChannel;
@@ -134,6 +136,8 @@ pub enum StateView {
         old_participants: Vec<Participant>,
         new_participants: Vec<Participant>,
         latest_block_height: BlockHeight,
+        #[cfg(feature = "test-feature")]
+        phase: ResharingPhaseStatus,
     },
     Joining {
         participants: Vec<Participant>,
@@ -182,10 +186,14 @@ async fn state(Extension(web): Extension<Arc<AxumState>>) -> Result<Json<StateVi
         NodeStatus::Resharing {
             old_participants,
             new_participants,
+            #[cfg(feature = "test-feature")]
+            phase,
         } => Ok(Json(StateView::Resharing {
             old_participants: old_participants.clone(),
             new_participants: new_participants.clone(),
             latest_block_height,
+            #[cfg(feature = "test-feature")]
+            phase,
         })),
         NodeStatus::Joining { participants } => Ok(Json(StateView::Joining {
             participants: participants.clone(),

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -9,9 +9,7 @@ pub mod debug;
 use self::error::Error;
 use crate::indexer::NearIndexer;
 use crate::metrics::WEB_ENDPOINT_LATENCY;
-#[cfg(feature = "test-feature")]
-use crate::protocol::state::ResharingPhaseStatus;
-use crate::protocol::state::{NodeStateWatcher, NodeStatus};
+use crate::protocol::state::{NodeStateWatcher, NodeStatus, ResharingStatus};
 use crate::protocol::sync::{SyncChannel, SyncUpdate};
 use crate::protocol::MessageChannel;
 use crate::storage::{PresignatureStorage, TripleStorage};
@@ -136,8 +134,7 @@ pub enum StateView {
         old_participants: Vec<Participant>,
         new_participants: Vec<Participant>,
         latest_block_height: BlockHeight,
-        #[cfg(feature = "test-feature")]
-        phase: ResharingPhaseStatus,
+        phase: ResharingStatus,
     },
     Joining {
         participants: Vec<Participant>,
@@ -186,13 +183,11 @@ async fn state(Extension(web): Extension<Arc<AxumState>>) -> Result<Json<StateVi
         NodeStatus::Resharing {
             old_participants,
             new_participants,
-            #[cfg(feature = "test-feature")]
             phase,
         } => Ok(Json(StateView::Resharing {
             old_participants: old_participants.clone(),
             new_participants: new_participants.clone(),
             latest_block_height,
-            #[cfg(feature = "test-feature")]
             phase,
         })),
         NodeStatus::Joining { participants } => Ok(Json(StateView::Joining {

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -465,7 +465,6 @@ impl MpcFixtureNodeBuilder {
                 protocol_state_tx,
             },
             context.contract_state,
-            config_rx.clone(),
             mesh_rx.clone(),
         ));
 

--- a/integration-tests/src/mpc_fixture/fixture_tasks.rs
+++ b/integration-tests/src/mpc_fixture/fixture_tasks.rs
@@ -41,6 +41,7 @@ pub(super) fn test_mock_network(
                     let log_msg = match msg {
                         protocol::Message::Posit(_) => "Posit",
                         protocol::Message::Generating(_) => "Generating",
+                        protocol::Message::ResharingReady(_) => "ResharingReady",
                         protocol::Message::Resharing(_) => "Resharing",
                         protocol::Message::Triple(_) => "Triple",
                         protocol::Message::Presignature(_) => "Presignature",

--- a/integration-tests/src/mpc_fixture/fixture_tasks.rs
+++ b/integration-tests/src/mpc_fixture/fixture_tasks.rs
@@ -41,7 +41,7 @@ pub(super) fn test_mock_network(
                     let log_msg = match msg {
                         protocol::Message::Posit(_) => "Posit",
                         protocol::Message::Generating(_) => "Generating",
-                        protocol::Message::ResharingReady(_) => "ResharingReady",
+                        protocol::Message::Ready(_) => "Ready",
                         protocol::Message::Resharing(_) => "Resharing",
                         protocol::Message::Triple(_) => "Triple",
                         protocol::Message::Presignature(_) => "Presignature",

--- a/integration-tests/tests/cases/mod.rs
+++ b/integration-tests/tests/cases/mod.rs
@@ -8,7 +8,7 @@ use mpc_contract::update::ProposeUpdateArgs;
 use mpc_crypto::{self, derive_epsilon_near, derive_key, x_coordinate, ScalarExt};
 use mpc_node::kdf::into_eth_sig;
 use mpc_node::protocol::cryptography::set_resharing_running_timeout;
-use mpc_node::protocol::state::ResharingPhaseStatus;
+use mpc_node::protocol::state::ResharingStatus;
 use mpc_node::util::NearPublicKeyExt as _;
 use mpc_node::web::StateView;
 use mpc_primitives::LATEST_MPC_KEY_VERSION;
@@ -326,7 +326,7 @@ async fn test_resharing_running_participant_restart() -> anyhow::Result<()> {
     wait_for_account_resharing_phase(
         &nodes,
         &target_account,
-        &[ResharingPhaseStatus::Running],
+        &[ResharingStatus::Running],
         Duration::from_secs(60),
     )
     .await?;
@@ -343,7 +343,7 @@ async fn test_resharing_running_participant_restart() -> anyhow::Result<()> {
     wait_for_account_resharing_phase(
         &nodes,
         &target_account,
-        &[ResharingPhaseStatus::Running],
+        &[ResharingStatus::Running],
         Duration::from_secs(90),
     )
     .await?;
@@ -383,7 +383,7 @@ async fn test_resharing_running_participant_restart() -> anyhow::Result<()> {
 async fn wait_for_account_resharing_phase(
     nodes: &cluster::Cluster,
     account_id: &near_workspaces::AccountId,
-    expected: &[ResharingPhaseStatus],
+    expected: &[ResharingStatus],
     timeout: Duration,
 ) -> anyhow::Result<()> {
     let start = Instant::now();

--- a/integration-tests/tests/cases/mod.rs
+++ b/integration-tests/tests/cases/mod.rs
@@ -7,6 +7,7 @@ use mpc_contract::config::Config;
 use mpc_contract::update::ProposeUpdateArgs;
 use mpc_crypto::{self, derive_epsilon_near, derive_key, x_coordinate, ScalarExt};
 use mpc_node::kdf::into_eth_sig;
+use mpc_node::protocol::cryptography::set_resharing_running_timeout;
 use mpc_node::util::NearPublicKeyExt as _;
 use mpc_primitives::LATEST_MPC_KEY_VERSION;
 use std::time::Duration;
@@ -222,6 +223,9 @@ async fn test_batch_duplicate_signature() -> anyhow::Result<()> {
 
 #[test(tokio::test)]
 async fn test_resharing_offline_participant_recovers() -> anyhow::Result<()> {
+    // have a short timeout for the resharing to complete in tests
+    set_resharing_running_timeout(Duration::from_secs(20));
+
     let mut nodes = cluster::spawn().disable_prestockpile().await?;
     nodes.wait().signable().await?;
     let initial_state = nodes.expect_running().await?;
@@ -251,7 +255,7 @@ async fn test_resharing_offline_participant_recovers() -> anyhow::Result<()> {
 
     // Now we should wait to see that we are still in the resharing state even after
     // a long time, since one participant is offline and cannot complete the resharing.
-    tokio::time::sleep(Duration::from_secs(90)).await;
+    tokio::time::sleep(Duration::from_secs(30)).await;
     assert!(matches!(
         nodes.contract_state().await?,
         mpc_contract::ProtocolContractState::Resharing(_)

--- a/integration-tests/tests/cases/mod.rs
+++ b/integration-tests/tests/cases/mod.rs
@@ -8,9 +8,11 @@ use mpc_contract::update::ProposeUpdateArgs;
 use mpc_crypto::{self, derive_epsilon_near, derive_key, x_coordinate, ScalarExt};
 use mpc_node::kdf::into_eth_sig;
 use mpc_node::protocol::cryptography::set_resharing_running_timeout;
+use mpc_node::protocol::state::ResharingPhaseStatus;
 use mpc_node::util::NearPublicKeyExt as _;
+use mpc_node::web::StateView;
 use mpc_primitives::LATEST_MPC_KEY_VERSION;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use test_log::test;
 
 pub mod mpc;
@@ -282,4 +284,139 @@ async fn test_resharing_offline_participant_recovers() -> anyhow::Result<()> {
     nodes.sign().await?;
 
     Ok(())
+}
+
+#[test(tokio::test)]
+async fn test_resharing_running_participant_restart() -> anyhow::Result<()> {
+    set_resharing_running_timeout(Duration::from_secs(60));
+
+    let mut nodes = cluster::spawn().disable_prestockpile().await?;
+    nodes.wait().signable().await?;
+    let initial_state = nodes.expect_running().await?;
+    let initial_epoch = initial_state.epoch;
+
+    let target_account = nodes.account_id(0).clone();
+
+    let new_account = nodes.start(None).await?;
+
+    let participant_accounts = nodes.participant_accounts().await?;
+    let voters = participant_accounts
+        .iter()
+        .take(nodes.cfg.threshold)
+        .cloned()
+        .collect::<Vec<_>>();
+    utils::vote_join(&voters, nodes.contract().id(), new_account.id()).await?;
+
+    nodes.wait().nodes_resharing().await?;
+
+    {
+        let states = nodes.fetch_states().await?;
+        for (account_id, state) in nodes.account_ids().into_iter().zip(states.iter()) {
+            match state {
+                StateView::Resharing { phase, .. } => {
+                    tracing::info!(%account_id, ?phase, "account resharing phase before kill");
+                }
+                other => {
+                    tracing::info!(%account_id, ?other, "account state before kill");
+                }
+            }
+        }
+    }
+
+    wait_for_account_resharing_phase(
+        &nodes,
+        &target_account,
+        &[ResharingPhaseStatus::Running],
+        Duration::from_secs(60),
+    )
+    .await?;
+
+    let target_config = nodes.kill_node(&target_account).await;
+
+    assert!(matches!(
+        nodes.contract_state().await?,
+        mpc_contract::ProtocolContractState::Resharing(_)
+    ));
+
+    nodes.restart_node(target_config).await?;
+
+    wait_for_account_resharing_phase(
+        &nodes,
+        &target_account,
+        &[ResharingPhaseStatus::Running],
+        Duration::from_secs(90),
+    )
+    .await?;
+
+    {
+        let states = nodes.fetch_states().await?;
+        for (account_id, state) in nodes.account_ids().into_iter().zip(states.iter()) {
+            match state {
+                StateView::Resharing { phase, .. } => {
+                    tracing::info!(%account_id, ?phase, "account resharing phase after restart");
+                }
+                other => {
+                    tracing::info!(%account_id, ?other, "account state after restart");
+                }
+            }
+        }
+    }
+
+    let final_state = nodes
+        .wait()
+        .running_on_epoch(initial_epoch + 1)
+        .nodes_running()
+        .await?;
+
+    assert_eq!(
+        final_state.participants.len(),
+        initial_state.participants.len() + 1
+    );
+    assert!(final_state.participants.contains_key(new_account.id()));
+
+    nodes.wait().signable().await?;
+    nodes.sign().await?;
+
+    Ok(())
+}
+
+async fn wait_for_account_resharing_phase(
+    nodes: &cluster::Cluster,
+    account_id: &near_workspaces::AccountId,
+    expected: &[ResharingPhaseStatus],
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let start = Instant::now();
+    loop {
+        if let Some(idx) = nodes
+            .account_ids()
+            .iter()
+            .position(|current| *current == account_id)
+        {
+            match nodes.fetch_state(idx).await? {
+                StateView::Resharing { phase, .. } if expected.contains(&phase) => return Ok(()),
+                StateView::Resharing { phase, .. } => {
+                    tracing::info!(
+                        %account_id,
+                        ?phase,
+                        ?expected,
+                        "node resharing phase does not yet match expectation"
+                    );
+                }
+                state => {
+                    tracing::info!(?state, %account_id, "node not yet in expected resharing phase");
+                }
+            }
+        } else {
+            tracing::info!(%account_id, "account not currently tracked in cluster while waiting for resharing phase");
+        }
+
+        if start.elapsed() > timeout {
+            anyhow::bail!(
+                "timed out waiting for {account_id} to reach resharing phase in {expected:?}"
+            );
+        }
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
 }

--- a/integration-tests/tests/cases/mod.rs
+++ b/integration-tests/tests/cases/mod.rs
@@ -1,5 +1,6 @@
 use integration_tests::actions;
 use integration_tests::cluster;
+use integration_tests::utils;
 
 use k256::elliptic_curve::point::AffineCoordinates;
 use mpc_contract::config::Config;
@@ -8,6 +9,7 @@ use mpc_crypto::{self, derive_epsilon_near, derive_key, x_coordinate, ScalarExt}
 use mpc_node::kdf::into_eth_sig;
 use mpc_node::util::NearPublicKeyExt as _;
 use mpc_primitives::LATEST_MPC_KEY_VERSION;
+use std::time::Duration;
 use test_log::test;
 
 pub mod mpc;
@@ -215,5 +217,56 @@ async fn test_batch_random_signature() -> anyhow::Result<()> {
 async fn test_batch_duplicate_signature() -> anyhow::Result<()> {
     let nodes = cluster::spawn().await?;
     actions::batch_duplicate_signature_production(&nodes).await?;
+    Ok(())
+}
+
+#[test(tokio::test)]
+async fn test_resharing_offline_participant_recovers() -> anyhow::Result<()> {
+    let mut nodes = cluster::spawn().disable_prestockpile().await?;
+    nodes.wait().signable().await?;
+    let initial_state = nodes.expect_running().await?;
+    let initial_epoch = initial_state.epoch;
+
+    // Shutdown the node that will be offline during the resharing initially.
+    let offline_account = nodes.account_id(0).clone();
+    let offline_config = nodes.kill_node(&offline_account).await;
+
+    let new_account = nodes.start(None).await?;
+
+    // Voting in the new participant with threshold number of online participants
+    let participant_accounts = nodes.participant_accounts().await?;
+    let voters = participant_accounts
+        .into_iter()
+        .filter(|account| account.id() != &offline_account)
+        .take(nodes.cfg.threshold)
+        .collect::<Vec<_>>();
+    utils::vote_join(&voters, nodes.contract().id(), new_account.id()).await?;
+
+    nodes.wait().node_resharing(0).node_resharing(1).await?;
+
+    // Now we should wait to see that we are still in the resharing state for a bit
+    tokio::time::sleep(Duration::from_secs(90)).await;
+
+    assert!(matches!(
+        nodes.contract_state().await?,
+        mpc_contract::ProtocolContractState::Resharing(_)
+    ));
+
+    // Restart the node that was offline during the resharing.
+    nodes.restart_node(offline_config).await?;
+
+    // We should now be able to complete the resharing.
+    let final_state = nodes
+        .wait()
+        .running_on_epoch(initial_epoch + 1)
+        .nodes_running()
+        .await?;
+
+    assert_eq!(
+        final_state.participants.len(),
+        initial_state.participants.len() + 1
+    );
+    assert!(final_state.participants.contains_key(new_account.id()));
+
     Ok(())
 }

--- a/integration-tests/tests/cases/mod.rs
+++ b/integration-tests/tests/cases/mod.rs
@@ -228,9 +228,13 @@ async fn test_resharing_offline_participant_recovers() -> anyhow::Result<()> {
     let initial_epoch = initial_state.epoch;
 
     // Shutdown the node that will be offline during the resharing initially.
+    // This node will not appear in our local cluster list but still be a part of the
+    // contract participants. Meaning they're not kicked, just offline for resharing.
+    // They will have to restart later for resharing to complete.
     let offline_account = nodes.account_id(0).clone();
     let offline_config = nodes.kill_node(&offline_account).await;
 
+    // Start a new node that will be added during the resharing.
     let new_account = nodes.start(None).await?;
 
     // Voting in the new participant with threshold number of online participants
@@ -242,11 +246,12 @@ async fn test_resharing_offline_participant_recovers() -> anyhow::Result<()> {
         .collect::<Vec<_>>();
     utils::vote_join(&voters, nodes.contract().id(), new_account.id()).await?;
 
-    nodes.wait().node_resharing(0).node_resharing(1).await?;
+    // Wait for all online nodes to move to resharing state.
+    nodes.wait().nodes_resharing().await?;
 
-    // Now we should wait to see that we are still in the resharing state for a bit
+    // Now we should wait to see that we are still in the resharing state even after
+    // a long time, since one participant is offline and cannot complete the resharing.
     tokio::time::sleep(Duration::from_secs(90)).await;
-
     assert!(matches!(
         nodes.contract_state().await?,
         mpc_contract::ProtocolContractState::Resharing(_)
@@ -267,6 +272,10 @@ async fn test_resharing_offline_participant_recovers() -> anyhow::Result<()> {
         initial_state.participants.len() + 1
     );
     assert!(final_state.participants.contains_key(new_account.id()));
+
+    // sign to ensure everything is working
+    nodes.wait().signable().await?;
+    nodes.sign().await?;
 
     Ok(())
 }

--- a/setup.sh
+++ b/setup.sh
@@ -9,14 +9,26 @@ CARGO_CMD_ARGS="$@"
 CARGO_BUILD_INDENT="            "
 echo "${CARGO_BUILD_INDENT} running MPC build script"
 
-# add additional features if we're benchmarking:
-if echo $CARGO_CMD_ARGS | grep -q "bench"; then
-    FEATURES="--features bench"
+# Default feature set for building local binaries used by tests.
+NODE_FEATURES="test-feature,debug-page"
+CONTRACT_FEATURES=""
+
+# Add additional features if we're benchmarking.
+if echo "$CARGO_CMD_ARGS" | grep -q "bench"; then
+    CONTRACT_FEATURES="--features bench"
+    NODE_FEATURES="${NODE_FEATURES},bench"
 fi
+
+NODE_FEATURE_ARGS="--features ${NODE_FEATURES}"
 
 set --
 set -e
-. $ROOT_DIR/build-contract.sh $FEATURES
-cargo build -p mpc-node --release $FEATURES
+if [ -n "$CONTRACT_FEATURES" ]; then
+    . $ROOT_DIR/build-contract.sh $CONTRACT_FEATURES
+else
+    . $ROOT_DIR/build-contract.sh
+fi
+
+cargo build -p mpc-node --release $NODE_FEATURE_ARGS
 
 exec $CARGO_CMD_ARGS


### PR DESCRIPTION
This adds a fix to the resharing process where we will timeout if it takes too long to progress. The progress is determined by the last action (i.e. receiving a new message, sending messages)

We will default to a timeout of 5 minutes from the last action which should give nodes plenty of time to restart if they are doing so.

Additionally, I made resharing a two phase process. One is awaiting ready, and the other is running the resharing.

The awaiting step is where we will constantly broadcast that we're ready to start every 10 seconds. When all new participants including us is ready, we will go to the next phase which is running the resharing.

So this fixes several cases where:
- node restart and then have to restart the whole resharing again. So here this is resolved by going back to awaiting ready and then running resharing.
- starting the resharing protocol at different times and then timeout at different times. The awaiting step fixes this as now we all start roughly at the same time withing a 10 second interval of the broadcasting of readiness


This also adds a new resharing test so we can see that it works properly when a node is offline and restarts.

