### PR TITLE
feat: disable helios, add regular eth indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,6 +1503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,6 +1794,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version 0.4.1",
+]
+
+[[package]]
 name = "asynchronous-codec"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,6 +2024,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,12 +2067,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -2329,6 +2370,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
+ "sha2 0.10.8",
  "tinyvec",
 ]
 
@@ -2464,12 +2506,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "caps"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190baaad529bcfbde9e1a19022c42781bdb6ff9de25721abdb8fd98c0807730b"
 dependencies = [
  "libc",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.26",
+ "serde",
+ "serde_json",
  "thiserror 1.0.69",
 ]
 
@@ -2654,6 +2728,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "coins-bip32"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b6be4a5df2098cd811f3194f64ddb96c267606bffd9689ac7b0160097b01ad3"
+dependencies = [
+ "bs58 0.5.1",
+ "coins-core",
+ "digest 0.10.7",
+ "hmac 0.12.1",
+ "k256",
+ "serde",
+ "sha2 0.10.8",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "coins-bip39"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8fba409ce3dc04f7d804074039eb68b960b0829161f8e06c95fea3f122528"
+dependencies = [
+ "bitvec",
+ "coins-bip32",
+ "hmac 0.12.1",
+ "once_cell",
+ "pbkdf2 0.12.2",
+ "rand 0.8.5",
+ "sha2 0.10.8",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "coins-core"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5286a0843c21f8367f7be734f89df9b822e0321d8bcce8d6e735aadff7d74979"
+dependencies = [
+ "base64 0.21.7",
+ "bech32",
+ "bs58 0.5.1",
+ "digest 0.10.7",
+ "generic-array",
+ "hex",
+ "ripemd",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.8",
+ "sha3",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2666,7 +2792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3208,7 +3334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3453,7 +3579,7 @@ dependencies = [
  "arrayvec",
  "ctr",
  "delay_map",
- "enr",
+ "enr 0.12.1",
  "fnv",
  "futures",
  "hashlink",
@@ -3665,6 +3791,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ena"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3677,6 +3812,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "enr"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "hex",
+ "k256",
+ "log",
+ "rand 0.8.5",
+ "rlp",
+ "serde",
+ "sha3",
+ "zeroize",
 ]
 
 [[package]]
@@ -3855,6 +4008,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "eth-keystore"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
+dependencies = [
+ "aes",
+ "ctr",
+ "digest 0.10.7",
+ "hex",
+ "hmac 0.12.1",
+ "pbkdf2 0.11.0",
+ "rand 0.8.5",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "sha3",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
 name = "ethabi"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3954,6 +4129,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816841ea989f0c69e459af1cf23a6b0033b19a55424a1ea3a30099becdb8dec0"
+dependencies = [
+ "ethers-addressbook",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-etherscan",
+ "ethers-middleware",
+ "ethers-providers",
+ "ethers-signers",
+ "ethers-solc",
+]
+
+[[package]]
+name = "ethers-addressbook"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5495afd16b4faa556c3bba1f21b98b4983e53c1755022377051a975c3b021759"
+dependencies = [
+ "ethers-core",
+ "once_cell",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ethers-contract"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fceafa3578c836eeb874af87abacfb041f92b4da0a78a5edd042564b8ecdaaa"
+dependencies = [
+ "const-hex",
+ "ethers-contract-abigen",
+ "ethers-contract-derive",
+ "ethers-core",
+ "ethers-providers",
+ "futures-util",
+ "once_cell",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ethers-contract-abigen"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04ba01fbc2331a38c429eb95d4a570166781f14290ef9fdb144278a90b5a739b"
+dependencies = [
+ "Inflector",
+ "const-hex",
+ "dunce",
+ "ethers-core",
+ "ethers-etherscan",
+ "eyre",
+ "prettyplease 0.2.34",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "syn 2.0.101",
+ "toml 0.8.22",
+ "walkdir",
+]
+
+[[package]]
+name = "ethers-contract-derive"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87689dcabc0051cde10caaade298f9e9093d65f6125c14575db3fd8c669a168f"
+dependencies = [
+ "Inflector",
+ "const-hex",
+ "ethers-contract-abigen",
+ "ethers-core",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "ethers-core"
 version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3961,6 +4223,7 @@ checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
 dependencies = [
  "arrayvec",
  "bytes",
+ "cargo_metadata",
  "chrono",
  "const-hex",
  "elliptic-curve",
@@ -3968,16 +4231,149 @@ dependencies = [
  "generic-array",
  "k256",
  "num_enum",
+ "once_cell",
  "open-fastrlp",
  "rand 0.8.5",
  "rlp",
  "serde",
  "serde_json",
  "strum 0.26.3",
+ "syn 2.0.101",
  "tempfile",
  "thiserror 1.0.69",
  "tiny-keccak",
  "unicode-xid",
+]
+
+[[package]]
+name = "ethers-etherscan"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
+dependencies = [
+ "chrono",
+ "ethers-core",
+ "reqwest 0.11.27",
+ "semver 1.0.26",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "ethers-middleware"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f9fdf09aec667c099909d91908d5eaf9be1bd0e2500ba4172c1d28bfaa43de"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-etherscan",
+ "ethers-providers",
+ "ethers-signers",
+ "futures-channel",
+ "futures-locks",
+ "futures-util",
+ "instant",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url 2.5.4",
+]
+
+[[package]]
+name = "ethers-providers"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6434c9a33891f1effc9c75472e12666db2fa5a0fec4b29af6221680a6fe83ab2"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "base64 0.21.7",
+ "bytes",
+ "const-hex",
+ "enr 0.10.0",
+ "ethers-core",
+ "futures-core",
+ "futures-timer",
+ "futures-util",
+ "hashers",
+ "http 0.2.12",
+ "instant",
+ "jsonwebtoken",
+ "once_cell",
+ "pin-project",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "tracing-futures",
+ "url 2.5.4",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "ws_stream_wasm",
+]
+
+[[package]]
+name = "ethers-signers"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228875491c782ad851773b652dd8ecac62cda8571d3bc32a5853644dd26766c2"
+dependencies = [
+ "async-trait",
+ "coins-bip32",
+ "coins-bip39",
+ "const-hex",
+ "elliptic-curve",
+ "eth-keystore",
+ "ethers-core",
+ "rand 0.8.5",
+ "sha2 0.10.8",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "ethers-solc"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66244a771d9163282646dbeffe0e6eca4dda4146b6498644e678ac6089b11edd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "const-hex",
+ "dirs",
+ "dunce",
+ "ethers-core",
+ "glob",
+ "home",
+ "md-5",
+ "num_cpus",
+ "once_cell",
+ "path-slash",
+ "rayon",
+ "regex",
+ "semver 1.0.26",
+ "serde",
+ "serde_json",
+ "solang-parser",
+ "svm-rs",
+ "thiserror 1.0.69",
+ "tiny-keccak",
+ "tokio",
+ "tracing",
+ "walkdir",
+ "yansi 0.5.1",
 ]
 
 [[package]]
@@ -4151,6 +4547,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4305,6 +4707,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-locks"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ec6fe3675af967e67c5536c0b9d44e34e6c52f86bedc4ea49c5317b8e94d06"
+dependencies = [
+ "futures-channel",
+ "futures-task",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4345,7 +4757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
  "gloo-timers 0.2.6",
- "send_wrapper",
+ "send_wrapper 0.4.0",
 ]
 
 [[package]]
@@ -4371,6 +4783,15 @@ name = "futures-utils-wasm"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "generic-array"
@@ -4719,6 +5140,15 @@ checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 dependencies = [
  "foldhash 0.2.0",
  "serde",
+]
+
+[[package]]
+name = "hashers"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
+dependencies = [
+ "fxhash",
 ]
 
 [[package]]
@@ -5746,6 +6176,7 @@ dependencies = [
  "deadpool-redis",
  "ecdsa",
  "elliptic-curve",
+ "ethers",
  "ethers-core",
  "futures",
  "generic-array",
@@ -5840,6 +6271,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -6120,6 +6560,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+dependencies = [
+ "base64 0.21.7",
+ "pem",
+ "ring 0.16.20",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6151,6 +6605,36 @@ checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set 0.5.3",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -6759,6 +7243,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if 1.0.0",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7146,7 +7640,7 @@ dependencies = [
  "convert_case 0.5.0",
  "near-abi-client-impl",
  "near-abi-client-macros",
- "prettyplease",
+ "prettyplease 0.1.25",
  "quote",
  "syn 1.0.109",
 ]
@@ -8116,6 +8610,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8840,6 +9340,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8852,6 +9358,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "pear"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8859,7 +9375,7 @@ checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
 dependencies = [
  "inlinable_string",
  "pear_codegen",
- "yansi",
+ "yansi 1.0.1",
 ]
 
 [[package]]
@@ -8913,6 +9429,26 @@ dependencies = [
  "memchr",
  "thiserror 2.0.12",
  "ucd-trie",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.9.0",
+]
+
+[[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -9121,6 +9657,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "prettyplease"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9128,6 +9670,16 @@ checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9256,7 +9808,7 @@ dependencies = [
  "quote",
  "syn 2.0.101",
  "version_check",
- "yansi",
+ "yansi 1.0.1",
 ]
 
 [[package]]
@@ -9303,8 +9855,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.9.0",
  "lazy_static",
  "num-traits",
@@ -10562,6 +11114,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10632,6 +11193,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
+dependencies = [
+ "hmac 0.12.1",
+ "pbkdf2 0.11.0",
+ "salsa20",
+ "sha2 0.10.8",
+]
 
 [[package]]
 name = "sct"
@@ -10772,6 +11345,9 @@ name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"
@@ -10787,6 +11363,12 @@ name = "send_wrapper"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -11097,6 +11679,18 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "thiserror 2.0.12",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -12823,7 +13417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36187af2324f079f65a675ec22b31c24919cb4ac22c79472e85d819db9bbbc15"
 dependencies = [
  "hmac 0.12.1",
- "pbkdf2",
+ "pbkdf2 0.11.0",
  "sha2 0.10.8",
 ]
 
@@ -13432,6 +14026,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "solang-parser"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c425ce1c59f4b154717592f0bdf4715c3a1d55058883622d3157e1f0908a5b26"
+dependencies = [
+ "itertools 0.11.0",
+ "lalrpop",
+ "lalrpop-util",
+ "phf",
+ "thiserror 1.0.69",
+ "unicode-xid",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13849,6 +14457,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot 0.12.3",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13967,6 +14587,26 @@ dependencies = [
  "quote",
  "smallvec",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "svm-rs"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11297baafe5fa0c99d5722458eac6a5e25c01eb1b8e5cd137f54079093daa7a4"
+dependencies = [
+ "dirs",
+ "fs2",
+ "hex",
+ "once_cell",
+ "reqwest 0.11.27",
+ "semver 1.0.26",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "thiserror 1.0.69",
+ "url 2.5.4",
+ "zip",
 ]
 
 [[package]]
@@ -14134,6 +14774,17 @@ dependencies = [
  "once_cell",
  "rustix 1.0.5",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -14630,6 +15281,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15016,6 +15677,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.16",
+ "serde",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15311,7 +15982,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15747,6 +16418,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
+name = "ws_stream_wasm"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version 0.4.1",
+ "send_wrapper 0.6.0",
+ "thiserror 2.0.12",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15802,6 +16492,12 @@ dependencies = [
  "libc",
  "rustix 1.0.5",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yansi"
@@ -16014,7 +16710,7 @@ dependencies = [
  "crossbeam-utils",
  "flate2",
  "hmac 0.12.1",
- "pbkdf2",
+ "pbkdf2 0.11.0",
  "sha1",
  "time",
  "zstd 0.11.2+zstd.1.5.2",

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -41,7 +41,7 @@ opentelemetry_sdk = { version = "0.29.0", default-features = false, features = [
 opentelemetry-appender-tracing = "0.29.1"
 alloy-signer-local = "1.0.38"
 alloy-sol-types = "1.4.1"
-helios = { git = "https://github.com/a16z/helios", rev = "0a96f31125b7948bbe5c7ab73aa5699efae24902"} 
+helios = { git = "https://github.com/a16z/helios", rev = "0a96f31125b7948bbe5c7ab73aa5699efae24902", optional = true }
 
 
 # workspace dependencies
@@ -104,6 +104,8 @@ test-log = { version = "0.2.12", features = ["log", "trace"] }
 
 [features]
 default = []
+# utilize ethereum light client via helios
+light_client = ["helios"]
 # utilized for benchmarking the node:
 bench = []
 # utilized by "integration-tests" package:

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -1388,9 +1388,14 @@ async fn process_block(
         sign_requests.extend(parse_filtered_logs(logs, total_timeout));
     }
 
-    let mut respond_requests =
-        process_bidirectional_requests(client, block_number, total_timeout, bidirectional_tx_map)
-            .await?;
+    let mut respond_requests = process_bidirectional_requests(
+        client,
+        block_number,
+        total_timeout,
+        bidirectional_tx_map,
+        &node_near_account_id,
+    )
+    .await?;
 
     sign_requests.append(&mut respond_requests);
 
@@ -1422,6 +1427,7 @@ async fn process_bidirectional_requests(
     block_number: u64,
     total_timeout: Duration,
     bidirectional_tx_map: &Arc<RwLock<HashMap<BidirectionalTxId, BidirectionalTx>>>,
+    node_near_account_id: &AccountId,
 ) -> anyhow::Result<Vec<IndexedSignRequest>> {
     let pending_txs: HashMap<BidirectionalTxId, BidirectionalTx> = {
         bidirectional_tx_map
@@ -1436,7 +1442,13 @@ async fn process_bidirectional_requests(
     let mut respond_requests = Vec::new();
 
     for (tx_id, pending_tx) in pending_txs {
-        let Some(receipt) = client.transaction_receipt(tx_id).await? else {
+        let start = Instant::now();
+        let receipt = client.transaction_receipt(tx_id).await;
+        crate::metrics::ETH_BLOCK_RECEIPT_LATENCY
+            .with_label_values(&[node_near_account_id.as_str()])
+            .observe(start.elapsed().as_millis() as f64);
+
+        let Some(receipt) = receipt? else {
             continue;
         };
 

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -3,27 +3,48 @@ use crate::sign_bidirectional::BidirectionalTx;
 use crate::sign_bidirectional::BidirectionalTxId;
 use crate::storage::app_data_storage::AppDataStorage;
 use alloy::consensus::BlockHeader;
+#[cfg(not(feature = "light_client"))]
+use alloy::consensus::Transaction as _;
+#[cfg(feature = "light_client")]
 use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::primitives::hex::{self, ToHexExt};
 use alloy::primitives::{Address, Bytes, U256};
 use alloy::rpc::types::Log;
+#[cfg(not(feature = "light_client"))]
+use alloy::rpc::types::Transaction;
+#[cfg(not(feature = "light_client"))]
+use alloy::rpc::types::TransactionReceipt;
 
+#[cfg(not(feature = "light_client"))]
+use crate::respond_bidirectional::{
+    CompletedTx, RespondBidirectionalSerializedOutput, SerDeserFormat,
+    OUTPUT_DESERIALIZATION_FORMAT, RESPOND_SERIALIZATION_FORMAT,
+};
 use crate::sign_bidirectional::BidirectionalTxStatus;
+#[cfg(not(feature = "light_client"))]
+use crate::sign_bidirectional::TransactionOutput;
 use alloy::sol_types::{sol, SolEvent};
+#[cfg(feature = "light_client")]
 use helios::common::types::{SubscriptionEvent, SubscriptionType};
+#[cfg(feature = "light_client")]
 use helios::ethereum::{config::networks::Network, EthereumClient, EthereumClientBuilder};
 use k256::Scalar;
 use mpc_crypto::{kdf::derive_epsilon_eth, ScalarExt as _};
 use mpc_primitives::{SignArgs, SignId, LATEST_MPC_KEY_VERSION};
 use near_account_id::AccountId;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::json;
 use std::collections::HashMap;
+#[cfg(feature = "light_client")]
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::{fmt, path::PathBuf, str::FromStr, sync::LazyLock, time::Instant};
+use std::{fmt, str::FromStr, sync::LazyLock, time::Instant};
+#[cfg(feature = "light_client")]
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::mpsc;
 use tokio::sync::RwLock;
-use tokio::time::Duration;
+use tokio::time::{sleep, Duration};
 
 pub(crate) static MAX_SECP256K1_SCALAR: LazyLock<Scalar> = LazyLock::new(|| {
     Scalar::from_bytes(
@@ -35,8 +56,10 @@ pub(crate) static MAX_SECP256K1_SCALAR: LazyLock<Scalar> = LazyLock::new(|| {
     .unwrap()
 });
 // This is the maximum number of blocks that Helios can look back to
+#[cfg(feature = "light_client")]
 const MAX_CATCHUP_BLOCKS: u64 = 8191;
 
+#[cfg(feature = "light_client")]
 type BlockNumber = u64;
 
 #[derive(Clone)]
@@ -211,11 +234,13 @@ impl EthArgs {
     }
 }
 
+#[cfg(feature = "light_client")]
 pub enum BlockToProcess {
     Catchup(BlockNumber),
     NewBlock(BlockNumberAndHash),
 }
 
+#[cfg(feature = "light_client")]
 #[derive(Clone)]
 pub struct BlockAndRequests {
     block_number: u64,
@@ -223,6 +248,7 @@ pub struct BlockAndRequests {
     indexed_requests: Vec<IndexedSignRequest>,
 }
 
+#[cfg(feature = "light_client")]
 impl BlockAndRequests {
     fn new(
         block_number: u64,
@@ -389,12 +415,16 @@ fn parse_string_args(data: &Bytes, offset_start: usize) -> String {
     String::from_utf8(bytes.to_vec()).unwrap_or_default()
 }
 
+#[cfg(feature = "light_client")]
 const MAX_BLOCKS_TO_PROCESS: usize = 10000;
+#[cfg(feature = "light_client")]
 fn blocks_to_process_channel() -> (mpsc::Sender<BlockToProcess>, mpsc::Receiver<BlockToProcess>) {
     mpsc::channel(MAX_BLOCKS_TO_PROCESS)
 }
 
+#[cfg(feature = "light_client")]
 const MAX_INDEXED_REQUESTS: usize = 1024;
+#[cfg(feature = "light_client")]
 fn indexed_channel() -> (
     mpsc::Sender<BlockAndRequests>,
     mpsc::Receiver<BlockAndRequests>,
@@ -402,8 +432,11 @@ fn indexed_channel() -> (
     mpsc::channel(MAX_INDEXED_REQUESTS)
 }
 
+#[cfg(feature = "light_client")]
 type BlockNumberAndHash = (u64, alloy::primitives::B256);
+#[cfg(feature = "light_client")]
 const MAX_FAILED_BLOCKS: usize = 1024;
+#[cfg(feature = "light_client")]
 fn failed_blocks_channel() -> (
     mpsc::Sender<BlockNumberAndHash>,
     mpsc::Receiver<BlockNumberAndHash>,
@@ -411,11 +444,14 @@ fn failed_blocks_channel() -> (
     mpsc::channel(MAX_FAILED_BLOCKS)
 }
 
+#[cfg(feature = "light_client")]
 const MAX_FINALIZED_BLOCKS: usize = 1024;
+#[cfg(feature = "light_client")]
 fn finalized_block_channel() -> (mpsc::Sender<BlockNumber>, mpsc::Receiver<BlockNumber>) {
     mpsc::channel(MAX_FINALIZED_BLOCKS)
 }
 
+#[cfg(feature = "light_client")]
 pub async fn run(
     eth: Option<EthConfig>,
     sign_tx: mpsc::Sender<IndexedSignRequest>,
@@ -627,6 +663,7 @@ pub async fn run(
     }
 }
 
+#[cfg(feature = "light_client")]
 #[allow(clippy::too_many_arguments)]
 async fn retry_failed_blocks(
     mut blocks_failed_rx: mpsc::Receiver<BlockNumberAndHash>,
@@ -663,6 +700,7 @@ async fn retry_failed_blocks(
     }
 }
 
+#[cfg(feature = "light_client")]
 async fn add_failed_block(
     blocks_failed: mpsc::Sender<BlockNumberAndHash>,
     block_number: u64,
@@ -676,6 +714,7 @@ async fn add_failed_block(
         });
 }
 
+#[cfg(feature = "light_client")]
 async fn add_new_block_to_process(
     mut block_heads_rx: tokio::sync::broadcast::Receiver<
         SubscriptionEvent<helios::ethereum::spec::Ethereum>,
@@ -724,6 +763,7 @@ async fn add_new_block_to_process(
     }
 }
 
+#[cfg(feature = "light_client")]
 async fn add_catchup_blocks_to_process(
     blocks_to_process: mpsc::Sender<BlockToProcess>,
     start_block_number: u64,
@@ -751,6 +791,7 @@ async fn add_catchup_blocks_to_process(
 }
 
 // retry getting block from helios with exponential backoff
+#[cfg(feature = "light_client")]
 async fn fetch_block(
     helios_client: &Arc<EthereumClient>,
     block_id: BlockId,
@@ -787,6 +828,7 @@ async fn fetch_block(
 }
 
 /// Polls for the latest finalized block and update finalized block channel.
+#[cfg(feature = "light_client")]
 async fn refresh_finalized_block(
     helios_client: &Arc<EthereumClient>,
     finalized_block_send: mpsc::Sender<BlockNumber>,
@@ -844,6 +886,7 @@ async fn refresh_finalized_block(
     }
 }
 
+#[cfg(feature = "light_client")]
 #[allow(clippy::too_many_arguments)]
 async fn process_block(
     block_number: u64,
@@ -1048,6 +1091,7 @@ async fn process_block(
 }
 
 /// Sends a request to the sign queue when the block where the request is in is finalized.
+#[cfg(feature = "light_client")]
 async fn send_requests_when_final(
     helios_client: &Arc<EthereumClient>,
     mut requests_indexed: mpsc::Receiver<BlockAndRequests>,
@@ -1211,4 +1255,492 @@ impl SignatureRequestedEvent {
         let abi_encoded = self.encode_abi();
         alloy::primitives::keccak256(abi_encoded).into()
     }
+}
+
+#[cfg(not(feature = "light_client"))]
+pub async fn run(
+    eth: Option<EthConfig>,
+    sign_tx: mpsc::Sender<IndexedSignRequest>,
+    app_data_storage: AppDataStorage,
+    node_near_account_id: AccountId,
+    bidirectional_tx_map: Arc<RwLock<HashMap<BidirectionalTxId, BidirectionalTx>>>,
+) {
+    let Some(eth) = eth else {
+        tracing::warn!("ethereum indexer is disabled");
+        return;
+    };
+
+    let client = RpcEthereumClient::new(&eth.execution_rpc_http_url);
+
+    let contract_address = match Address::from_str(&format!("0x{}", eth.contract_address)) {
+        Ok(addr) => addr,
+        Err(err) => {
+            tracing::error!("Failed to parse contract address: {}", err);
+            return;
+        }
+    };
+
+    let total_timeout = Duration::from_secs(eth.total_timeout);
+
+    let mut last_processed_block = app_data_storage
+        .last_processed_block_eth()
+        .await
+        .unwrap_or_else(|err| {
+            tracing::warn!("Failed to get last processed block: {err:?}");
+            None
+        });
+
+    if last_processed_block.is_none() {
+        match client.block_number().await {
+            Ok(latest) => {
+                last_processed_block = Some(latest.saturating_sub(1));
+            }
+            Err(err) => {
+                tracing::warn!("Failed to fetch latest block number: {err:?}");
+                last_processed_block = Some(0);
+            }
+        }
+    }
+
+    let mut current_block = last_processed_block.unwrap_or(0);
+    tracing::info!("ethereum rpc indexer starting at block {}", current_block);
+
+    loop {
+        let latest_block = match client.block_number().await {
+            Ok(num) => num,
+            Err(err) => {
+                tracing::warn!("Failed to fetch latest block number: {err:?}");
+                sleep(Duration::from_secs(2)).await;
+                continue;
+            }
+        };
+
+        if latest_block <= current_block {
+            sleep(Duration::from_millis(500)).await;
+            continue;
+        }
+
+        for block_number in (current_block + 1)..=latest_block {
+            match process_block_rpc(
+                &client,
+                block_number,
+                contract_address,
+                node_near_account_id.clone(),
+                sign_tx.clone(),
+                total_timeout,
+                &bidirectional_tx_map,
+            )
+            .await
+            {
+                Ok(_) => {
+                    crate::metrics::LATEST_BLOCK_NUMBER
+                        .with_label_values(&[
+                            Chain::Ethereum.as_str(),
+                            node_near_account_id.as_str(),
+                        ])
+                        .set(block_number as i64);
+                    if let Err(err) = app_data_storage
+                        .set_last_processed_block_eth(block_number)
+                        .await
+                    {
+                        tracing::warn!("Failed to set last processed block: {err:?}");
+                    }
+                    current_block = block_number;
+                }
+                Err(err) => {
+                    tracing::warn!("Failed to process block {block_number}: {err:?}");
+                    sleep(Duration::from_secs(1)).await;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "light_client"))]
+#[allow(clippy::too_many_arguments)]
+async fn process_block_rpc(
+    client: &RpcEthereumClient,
+    block_number: u64,
+    contract_address: Address,
+    node_near_account_id: AccountId,
+    sign_tx: mpsc::Sender<IndexedSignRequest>,
+    total_timeout: Duration,
+    bidirectional_tx_map: &Arc<RwLock<HashMap<BidirectionalTxId, BidirectionalTx>>>,
+) -> anyhow::Result<()> {
+    tracing::info!("Processing block number {}", block_number);
+
+    let block = match client.block_by_number(block_number).await? {
+        Some(block) => block,
+        None => {
+            tracing::warn!("Block {block_number} not found via rpc, skipping");
+            return Ok(());
+        }
+    };
+
+    let block_hash = block.header.hash;
+    let block_timestamp = block.header.timestamp();
+
+    let mut sign_requests = Vec::new();
+
+    let logs = client.get_logs(block_hash, contract_address).await?;
+    if !logs.is_empty() {
+        sign_requests.extend(parse_filtered_logs(logs, total_timeout));
+    }
+
+    let mut respond_requests =
+        process_bidirectional_requests(client, block_number, total_timeout, bidirectional_tx_map)
+            .await?;
+
+    sign_requests.append(&mut respond_requests);
+
+    if sign_requests.is_empty() {
+        return Ok(());
+    }
+
+    send_indexed_requests(
+        sign_requests.clone(),
+        sign_tx.clone(),
+        node_near_account_id.clone(),
+    );
+
+    for request in &sign_requests {
+        crate::metrics::INDEXER_DELAY
+            .with_label_values(&[Chain::Ethereum.as_str(), node_near_account_id.as_str()])
+            .observe(
+                crate::util::duration_between_unix(block_timestamp, request.unix_timestamp_indexed)
+                    .as_secs() as f64,
+            );
+    }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "light_client"))]
+async fn process_bidirectional_requests(
+    client: &RpcEthereumClient,
+    block_number: u64,
+    total_timeout: Duration,
+    bidirectional_tx_map: &Arc<RwLock<HashMap<BidirectionalTxId, BidirectionalTx>>>,
+) -> anyhow::Result<Vec<IndexedSignRequest>> {
+    let pending_txs: HashMap<BidirectionalTxId, BidirectionalTx> = {
+        bidirectional_tx_map
+            .read()
+            .await
+            .iter()
+            .filter(|(_, tx)| tx.status == BidirectionalTxStatus::Pending)
+            .map(|(id, tx)| (*id, tx.clone()))
+            .collect()
+    };
+
+    let mut respond_requests = Vec::new();
+
+    for (tx_id, pending_tx) in pending_txs {
+        let Some(receipt) = client.transaction_receipt(tx_id).await? else {
+            continue;
+        };
+
+        let status = receipt.status();
+        tracing::info!(
+            "Tx {:?} found in block {block_number}: {}",
+            tx_id,
+            if status { "success" } else { "failed" }
+        );
+
+        let mut updated_tx = pending_tx.clone();
+        updated_tx.status = if status {
+            BidirectionalTxStatus::Success
+        } else {
+            BidirectionalTxStatus::Failed
+        };
+
+        let completed_tx = CompletedTx::new(updated_tx.clone(), block_number);
+        if status {
+            match extract_success_output_with_rpc(client, &updated_tx, block_number).await {
+                Ok(serialized_output) => {
+                    match completed_tx.create_sign_request_from_serialized_output(
+                        serialized_output,
+                        total_timeout,
+                    ) {
+                        Ok(sign_request) => respond_requests.push(sign_request),
+                        Err(err) => tracing::warn!(
+                            ?tx_id,
+                            ?err,
+                            "Failed to build bidirectional respond sign request"
+                        ),
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        ?tx_id,
+                        ?err,
+                        "Failed to extract transaction output for bidirectional tx"
+                    );
+                }
+            }
+        } else {
+            match completed_tx
+                .create_failed_sign_request_without_light_client(total_timeout)
+                .await
+            {
+                Ok(sign_request) => respond_requests.push(sign_request),
+                Err(err) => tracing::warn!(
+                    ?tx_id,
+                    ?err,
+                    "Failed to build failed bidirectional sign request"
+                ),
+            }
+        }
+
+        bidirectional_tx_map.write().await.insert(tx_id, updated_tx);
+    }
+
+    let remaining_pending: HashMap<BidirectionalTxId, BidirectionalTx> = {
+        bidirectional_tx_map
+            .read()
+            .await
+            .iter()
+            .filter(|(_, tx)| tx.status == BidirectionalTxStatus::Pending)
+            .map(|(id, tx)| (*id, tx.clone()))
+            .collect()
+    };
+
+    for (tx_id, mut tx) in remaining_pending {
+        let current_nonce = match client
+            .transaction_count(tx.from_address, block_number)
+            .await
+        {
+            Ok(nonce) => nonce,
+            Err(err) => {
+                tracing::warn!(?tx_id, ?err, "Failed to fetch nonce for bidirectional tx");
+                continue;
+            }
+        };
+
+        if tx.nonce < current_nonce {
+            tracing::warn!(
+                "Nonce too low for tx {:?}: expected {}, got {}",
+                tx_id,
+                tx.nonce,
+                current_nonce
+            );
+            tx.status = BidirectionalTxStatus::Failed;
+            let completed_tx = CompletedTx::new(tx.clone(), block_number);
+            match completed_tx
+                .create_failed_sign_request_without_light_client(total_timeout)
+                .await
+            {
+                Ok(sign_request) => respond_requests.push(sign_request),
+                Err(err) => {
+                    tracing::warn!(?tx_id, ?err, "Failed to build sign request for stale nonce")
+                }
+            }
+            bidirectional_tx_map.write().await.insert(tx_id, tx);
+        }
+    }
+
+    Ok(respond_requests)
+}
+
+#[cfg(not(feature = "light_client"))]
+async fn extract_success_output_with_rpc(
+    client: &RpcEthereumClient,
+    tx: &BidirectionalTx,
+    block_number: u64,
+) -> anyhow::Result<RespondBidirectionalSerializedOutput> {
+    let Some(tx_info) = client.transaction_by_hash(tx.id).await? else {
+        anyhow::bail!("Failed to fetch transaction {:?} via rpc", tx.id);
+    };
+
+    let data = tx_info.inner.input().clone();
+    let is_contract_call = data.len() > 2 && data != Bytes::from("0x");
+    let output_deserialization_format = OUTPUT_DESERIALIZATION_FORMAT;
+    let output_deserialization_schema = &tx.output_deserialization_schema;
+
+    let transaction_output = match output_deserialization_format {
+        SerDeserFormat::Abi if is_contract_call => {
+            let to_address = tx_info
+                .inner
+                .to()
+                .ok_or_else(|| anyhow::anyhow!("Transaction {:?} missing destination", tx.id))?;
+            let call_block = block_number.saturating_sub(1);
+            let call_result = client
+                .call(tx.from_address, to_address, data.clone(), call_block)
+                .await?;
+            TransactionOutput::from_call_result(output_deserialization_schema, &call_result)?
+        }
+        _ => TransactionOutput::non_function_call_output(),
+    };
+
+    let respond_serialization_format = RESPOND_SERIALIZATION_FORMAT;
+    let respond_serialization_schema = &tx.respond_serialization_schema;
+    let serialized_output = transaction_output
+        .output
+        .serialize(respond_serialization_format, respond_serialization_schema)?;
+    Ok(serialized_output)
+}
+
+#[cfg(not(feature = "light_client"))]
+#[derive(Clone)]
+struct RpcEthereumClient {
+    http: reqwest::Client,
+    url: String,
+    id: Arc<AtomicU64>,
+}
+
+#[cfg(not(feature = "light_client"))]
+impl RpcEthereumClient {
+    fn new(endpoint: &str) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            url: endpoint.to_owned(),
+            id: Arc::new(AtomicU64::new(1)),
+        }
+    }
+
+    fn next_id(&self) -> u64 {
+        self.id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    async fn rpc_call<T: DeserializeOwned>(
+        &self,
+        method: &str,
+        params: Vec<serde_json::Value>,
+    ) -> anyhow::Result<T> {
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": self.next_id(),
+            "method": method,
+            "params": params,
+        });
+
+        let response = self.http.post(&self.url).json(&request).send().await?;
+        let value: serde_json::Value = response.json().await?;
+
+        if let Some(error) = value.get("error") {
+            anyhow::bail!("rpc {method} failed: {error}");
+        }
+
+        let result = value
+            .get("result")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        Ok(serde_json::from_value(result)?)
+    }
+
+    async fn block_number(&self) -> anyhow::Result<u64> {
+        let hex: String = self.rpc_call("eth_blockNumber", Vec::new()).await?;
+        hex_to_u64(&hex)
+    }
+
+    async fn block_by_number(
+        &self,
+        number: u64,
+    ) -> anyhow::Result<Option<alloy::rpc::types::Block>> {
+        self.rpc_call(
+            "eth_getBlockByNumber",
+            vec![json!(to_hex_u64(number)), json!(false)],
+        )
+        .await
+    }
+
+    async fn get_logs(
+        &self,
+        block_hash: alloy::primitives::B256,
+        contract_address: Address,
+    ) -> anyhow::Result<Vec<Log>> {
+        let topic = format!("0x{}", SignatureRequested::SIGNATURE_HASH.encode_hex());
+        let filter = json!({
+            "address": format_address(contract_address),
+            "blockHash": format!("{:#x}", block_hash),
+            "topics": [topic],
+        });
+        self.rpc_call("eth_getLogs", vec![filter]).await
+    }
+
+    async fn transaction_receipt(
+        &self,
+        tx_id: BidirectionalTxId,
+    ) -> anyhow::Result<Option<TransactionReceipt>> {
+        self.rpc_call(
+            "eth_getTransactionReceipt",
+            vec![json!(format!("{:#x}", tx_id.0))],
+        )
+        .await
+    }
+
+    async fn transaction_by_hash(
+        &self,
+        tx_id: BidirectionalTxId,
+    ) -> anyhow::Result<Option<Transaction>> {
+        self.rpc_call(
+            "eth_getTransactionByHash",
+            vec![json!(format!("{:#x}", tx_id.0))],
+        )
+        .await
+    }
+
+    async fn transaction_count(&self, address: Address, block_number: u64) -> anyhow::Result<u64> {
+        let hex: String = self
+            .rpc_call(
+                "eth_getTransactionCount",
+                vec![
+                    json!(format_address(address)),
+                    json!(to_hex_u64(block_number)),
+                ],
+            )
+            .await?;
+        hex_to_u64(&hex)
+    }
+
+    async fn call(
+        &self,
+        from: Address,
+        to: Address,
+        data: Bytes,
+        block_number: u64,
+    ) -> anyhow::Result<Bytes> {
+        let params = json!({
+            "from": format_address(from),
+            "to": format_address(to),
+            "data": format_bytes(&data),
+        });
+        let block = json!(to_hex_u64(block_number));
+        let result: String = self.rpc_call("eth_call", vec![params, block]).await?;
+        let stripped = result.trim_start_matches("0x");
+        if stripped.is_empty() {
+            return Ok(Bytes::default());
+        }
+        let decoded = hex::decode(stripped)?;
+        Ok(Bytes::from(decoded))
+    }
+}
+
+#[cfg(not(feature = "light_client"))]
+fn format_address(address: Address) -> String {
+    format!("0x{}", address.encode_hex())
+}
+
+#[cfg(not(feature = "light_client"))]
+fn format_bytes(data: &Bytes) -> String {
+    if data.is_empty() {
+        "0x".to_string()
+    } else {
+        format!("0x{}", hex::encode(data))
+    }
+}
+
+#[cfg(not(feature = "light_client"))]
+fn to_hex_u64(value: u64) -> String {
+    format!("0x{:x}", value)
+}
+
+#[cfg(not(feature = "light_client"))]
+fn hex_to_u64(value: &str) -> anyhow::Result<u64> {
+    let trimmed = value.trim_start_matches("0x");
+    if trimmed.is_empty() {
+        return Ok(0);
+    }
+    u64::from_str_radix(trimmed, 16)
+        .map_err(|err| anyhow::anyhow!("failed to parse hex value '{value}': {err}"))
 }

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -1321,7 +1321,7 @@ pub async fn run(
         }
 
         for block_number in (current_block + 1)..=latest_block {
-            match process_block_rpc(
+            match process_block(
                 &client,
                 block_number,
                 contract_address,
@@ -1359,7 +1359,7 @@ pub async fn run(
 
 #[cfg(not(feature = "light_client"))]
 #[allow(clippy::too_many_arguments)]
-async fn process_block_rpc(
+async fn process_block(
     client: &RpcEthereumClient,
     block_number: u64,
     contract_address: Address,

--- a/chain-signatures/node/src/respond_bidirectional.rs
+++ b/chain-signatures/node/src/respond_bidirectional.rs
@@ -1,12 +1,20 @@
 use crate::protocol::{Chain, IndexedSignRequest};
 use crate::sign_bidirectional::BidirectionalTx;
 use crate::sign_bidirectional::BidirectionalTxId;
+#[cfg(feature = "light_client")]
 use crate::sign_bidirectional::BidirectionalTxStatus;
+#[cfg(feature = "light_client")]
 use crate::sign_bidirectional::TransactionOutput;
+#[cfg(feature = "light_client")]
 use alloy::consensus::Transaction;
+#[cfg(feature = "light_client")]
 use alloy::eips::{BlockId, BlockNumberOrTag};
-use alloy::primitives::{Address, Bytes};
+#[cfg(feature = "light_client")]
+use alloy::primitives::Address;
+use alloy::primitives::Bytes;
+#[cfg(feature = "light_client")]
 use alloy::rpc::types::TransactionRequest;
+#[cfg(feature = "light_client")]
 use helios::ethereum::EthereumClient;
 use k256::Scalar;
 use mpc_crypto::ScalarExt;
@@ -21,9 +29,9 @@ use tokio::time::Duration;
 const MAGIC_ERROR_PREFIX: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
 const SOLANA_RESPOND_BIDIRECTIONAL_PATH: &str = "solana response key";
 // Use Borsh as this is what we are using for solana
-const RESPOND_SERIALIZATION_FORMAT: SerDeserFormat = SerDeserFormat::Borsh;
+pub(crate) const RESPOND_SERIALIZATION_FORMAT: SerDeserFormat = SerDeserFormat::Borsh;
 // Use Abi as this is what we are using for ethereum
-const OUTPUT_DESERIALIZATION_FORMAT: SerDeserFormat = SerDeserFormat::Abi;
+pub(crate) const OUTPUT_DESERIALIZATION_FORMAT: SerDeserFormat = SerDeserFormat::Abi;
 
 #[derive(PartialEq)]
 pub enum SerDeserFormat {
@@ -49,6 +57,28 @@ impl CompletedTx {
         Self { tx, block_number }
     }
 
+    #[cfg(not(feature = "light_client"))]
+    pub(crate) async fn create_failed_sign_request_without_light_client(
+        &self,
+        signature_generation_total_timeout: Duration,
+    ) -> anyhow::Result<IndexedSignRequest> {
+        self.process_failed_tx(signature_generation_total_timeout)
+            .await
+    }
+
+    #[cfg(not(feature = "light_client"))]
+    pub(crate) fn create_sign_request_from_serialized_output(
+        &self,
+        serialized_output: RespondBidirectionalSerializedOutput,
+        signature_generation_total_timeout: Duration,
+    ) -> anyhow::Result<IndexedSignRequest> {
+        self.create_respond_bidirectional_sign_request(
+            serialized_output,
+            signature_generation_total_timeout,
+        )
+    }
+
+    #[cfg(feature = "light_client")]
     pub async fn create_sign_request_from_completed_tx(
         &self,
         helios_client: &Arc<EthereumClient>,
@@ -80,6 +110,7 @@ impl CompletedTx {
         }
     }
 
+    #[cfg(feature = "light_client")]
     async fn process_completed_tx(
         &self,
         helios_client: &Arc<EthereumClient>,
@@ -128,6 +159,7 @@ impl CompletedTx {
         Ok(sign_request)
     }
 
+    #[cfg(feature = "light_client")]
     async fn process_success_tx(
         &self,
         helios_client: &Arc<EthereumClient>,
@@ -202,6 +234,7 @@ impl CompletedTx {
         })
     }
 
+    #[cfg(feature = "light_client")]
     async fn extract_success_tx_output(
         &self,
         helios_client: &Arc<EthereumClient>,
@@ -248,6 +281,7 @@ fn calculate_respond_bidirectional_hash_message(
     alloy::primitives::keccak256(&combined).into()
 }
 
+#[cfg(feature = "light_client")]
 async fn fetch_call_result(
     helios_client: &Arc<EthereumClient>,
     from_address: Address,
@@ -283,6 +317,7 @@ async fn fetch_call_result(
     }
 }
 
+#[cfg(feature = "light_client")]
 async fn fetch_tx_from_helios(
     helios_client: &Arc<EthereumClient>,
     tx_id: BidirectionalTxId,

--- a/chain-signatures/node/src/respond_bidirectional.rs
+++ b/chain-signatures/node/src/respond_bidirectional.rs
@@ -41,6 +41,7 @@ pub enum SerDeserFormat {
 
 pub struct CompletedTx {
     tx: BidirectionalTx,
+    #[cfg(feature = "light_client")]
     block_number: u64,
 }
 
@@ -53,8 +54,13 @@ pub struct RespondBidirectionalTx {
 pub type RespondBidirectionalSerializedOutput = Vec<u8>;
 
 impl CompletedTx {
+    #[cfg_attr(not(feature = "light_client"), allow(unused_variables))]
     pub fn new(tx: BidirectionalTx, block_number: u64) -> Self {
-        Self { tx, block_number }
+        Self {
+            tx,
+            #[cfg(feature = "light_client")]
+            block_number,
+        }
     }
 
     #[cfg(not(feature = "light_client"))]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -33,6 +33,7 @@ sha3.workspace = true
 # crypto dependencies
 ecdsa = "0.16.9"
 ethers-core.workspace = true
+ethers = { version = "2.0.13", features = ["abigen"] }
 cait-sith = { git = "https://github.com/sig-net/cait-sith", rev = "9f34e8c", features = ["k256"] }
 elliptic-curve = { version = "0.13.5", default-features = false }
 k256 = { version = "0.13.1", features = ["sha256", "ecdsa", "serde"] }

--- a/integration-tests/src/cluster/spawner.rs
+++ b/integration-tests/src/cluster/spawner.rs
@@ -38,6 +38,7 @@ pub struct ClusterSpawner {
     pub redis: Option<containers::Redis>,
     pub worker: Option<Worker<Sandbox>>,
     prestockpile: Option<Prestockpile>,
+    pub use_ethereum: bool,
 }
 
 impl Default for ClusterSpawner {
@@ -65,6 +66,7 @@ impl Default for ClusterSpawner {
             redis: None,
             worker: None,
             prestockpile: Some(Prestockpile { multiplier: 4 }),
+            use_ethereum: false,
         }
     }
 }
@@ -128,6 +130,11 @@ impl ClusterSpawner {
 
     pub fn network(mut self, network: &str) -> Self {
         self.network = network.to_string();
+        self
+    }
+
+    pub fn ethereum(mut self) -> Self {
+        self.use_ethereum = true;
         self
     }
 

--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -418,7 +418,7 @@ pub struct EthereumSandbox {
     pub container: Container,
     pub internal_http_endpoint: String,
     pub external_http_endpoint: String,
-    pub private_key: String,
+    pub secret_key: String,
     pub chain_id: u64,
 }
 
@@ -453,7 +453,7 @@ impl EthereumSandbox {
 
         let container = request.start().await?;
 
-        let private_key = extract_private_key(&spawner.docker, container.id()).await?;
+        let secret_key = extract_secret_key(&spawner.docker, container.id()).await?;
 
         let (internal_http_endpoint, external_http_endpoint) = if cfg!(feature = "docker-test") {
             let network_ip = spawner
@@ -481,7 +481,7 @@ impl EthereumSandbox {
         Ok(Self {
             internal_http_endpoint,
             external_http_endpoint,
-            private_key,
+            secret_key,
             chain_id: Self::DEFAULT_CHAIN_ID,
             container,
         })
@@ -531,7 +531,7 @@ async fn wait_for_rpc(endpoint: &str) -> anyhow::Result<()> {
     ))
 }
 
-async fn extract_private_key(docker: &DockerClient, container_id: &str) -> anyhow::Result<String> {
+async fn extract_secret_key(docker: &DockerClient, container_id: &str) -> anyhow::Result<String> {
     let mut logs = docker.docker.logs::<String>(
         container_id,
         Some(LogsOptions {
@@ -542,7 +542,7 @@ async fn extract_private_key(docker: &DockerClient, container_id: &str) -> anyho
         }),
     );
 
-    let mut in_private_keys = false;
+    let mut in_secret_keys = false;
     while let Some(Ok(entry)) = logs.next().await {
         let line = match entry {
             LogOutput::StdOut { message } | LogOutput::StdErr { message } => {
@@ -552,11 +552,11 @@ async fn extract_private_key(docker: &DockerClient, container_id: &str) -> anyho
             _ => continue,
         };
         if line.contains("Private Keys") {
-            in_private_keys = true;
+            in_secret_keys = true;
             continue;
         }
 
-        if in_private_keys {
+        if in_secret_keys {
             if let Some(key) = line.split_whitespace().nth(1) {
                 if key.starts_with("0x") {
                     return Ok(key.to_string());

--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -430,39 +430,56 @@ impl EthereumSandbox {
 
     pub async fn run(spawner: &ClusterSpawner) -> anyhow::Result<Self> {
         let chain_id_arg = Self::DEFAULT_CHAIN_ID.to_string();
-        let container = GenericImage::new("ghcr.io/foundry-rs/foundry", "nightly")
-            .with_exposed_port(Self::RPC_PORT.tcp())
-            .with_wait_for(WaitFor::message_on_stdout("Listening on"))
-            .with_network(&spawner.network)
-            .with_cmd(vec![
-                "anvil".to_string(),
-                "--host".to_string(),
-                "0.0.0.0".to_string(),
-                "--chain-id".to_string(),
-                chain_id_arg,
-                "--mnemonic".to_string(),
-                Self::DEFAULT_MNEMONIC.to_string(),
-            ])
-            .start()
-            .await?;
+        let command = vec![
+            "anvil".to_string(),
+            "--host".to_string(),
+            "0.0.0.0".to_string(),
+            "--chain-id".to_string(),
+            chain_id_arg,
+            "--mnemonic".to_string(),
+            Self::DEFAULT_MNEMONIC.to_string(),
+        ];
+
+        let request = if cfg!(feature = "docker-test") {
+            GenericImage::new("ghcr.io/foundry-rs/foundry", "nightly")
+                .with_exposed_port(Self::RPC_PORT.tcp())
+                .with_network(&spawner.network)
+                .with_cmd(command.clone())
+        } else {
+            GenericImage::new("ghcr.io/foundry-rs/foundry", "nightly")
+                .with_network("host")
+                .with_cmd(command)
+        };
+
+        let container = request.start().await?;
 
         let private_key = extract_private_key(&spawner.docker, container.id()).await?;
 
-        let network_ip = spawner
-            .docker
-            .get_network_ip_address(&container, &spawner.network)
-            .await?;
+        let (internal_http_endpoint, external_http_endpoint) = if cfg!(feature = "docker-test") {
+            let network_ip = spawner
+                .docker
+                .get_network_ip_address(&container, &spawner.network)
+                .await?;
 
-        let external_port = container
-            .get_host_port_ipv4(Self::RPC_PORT)
-            .await
-            .context("ethereum sandbox port mapping")?;
+            let external_port = container
+                .get_host_port_ipv4(Self::RPC_PORT)
+                .await
+                .context("ethereum sandbox port mapping")?;
 
-        let external_http_endpoint = format!("http://127.0.0.1:{external_port}");
+            let external_http_endpoint = format!("http://127.0.0.1:{external_port}");
+            (
+                format!("http://{}:{}", network_ip, Self::RPC_PORT),
+                external_http_endpoint,
+            )
+        } else {
+            let endpoint = format!("http://127.0.0.1:{}", Self::RPC_PORT);
+            (endpoint.clone(), endpoint)
+        };
+
         wait_for_rpc(&external_http_endpoint).await?;
 
         Ok(Self {
-            internal_http_endpoint: format!("http://{}:{}", network_ip, Self::RPC_PORT),
+            internal_http_endpoint,
             external_http_endpoint,
             private_key,
             chain_id: Self::DEFAULT_CHAIN_ID,
@@ -518,7 +535,7 @@ async fn extract_private_key(docker: &DockerClient, container_id: &str) -> anyho
     let mut logs = docker.docker.logs::<String>(
         container_id,
         Some(LogsOptions {
-            follow: false,
+            follow: true,
             stdout: true,
             stderr: true,
             ..Default::default()

--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -5,8 +5,8 @@ use crate::cluster::spawner::ClusterSpawner;
 use crate::local::NodeEnvConfig;
 use crate::NodeConfig;
 
-use anyhow::anyhow;
-use bollard::container::LogsOptions;
+use anyhow::{anyhow, Context};
+use bollard::container::{LogOutput, LogsOptions};
 use bollard::network::CreateNetworkOptions;
 use bollard::secret::Ipam;
 use bollard::Docker;
@@ -22,6 +22,8 @@ use mpc_node::indexer_eth::EthArgs;
 use mpc_node::protocol::triple::Triple;
 use near_account_id::AccountId;
 use near_workspaces::Account;
+use reqwest::Client;
+use serde_json::json;
 use testcontainers::core::ExecCommand;
 use testcontainers::ContainerAsync;
 use testcontainers::{
@@ -30,6 +32,7 @@ use testcontainers::{
     GenericImage, ImageExt,
 };
 use tokio::io::AsyncWriteExt;
+use tokio::time::{sleep, Duration};
 use tracing;
 
 pub type Container = ContainerAsync<GenericImage>;
@@ -409,6 +412,143 @@ impl Redis {
 
         tracing::info!("stockpiled {num_triples} triples");
     }
+}
+
+pub struct EthereumSandbox {
+    pub container: Container,
+    pub internal_http_endpoint: String,
+    pub external_http_endpoint: String,
+    pub private_key: String,
+    pub chain_id: u64,
+}
+
+impl EthereumSandbox {
+    const RPC_PORT: u16 = 8545;
+    const DEFAULT_CHAIN_ID: u64 = 31337;
+    const DEFAULT_MNEMONIC: &'static str =
+        "test test test test test test test test test test test junk";
+
+    pub async fn run(spawner: &ClusterSpawner) -> anyhow::Result<Self> {
+        let chain_id_arg = Self::DEFAULT_CHAIN_ID.to_string();
+        let container = GenericImage::new("ghcr.io/foundry-rs/foundry", "nightly")
+            .with_exposed_port(Self::RPC_PORT.tcp())
+            .with_wait_for(WaitFor::message_on_stdout("Listening on"))
+            .with_network(&spawner.network)
+            .with_cmd(vec![
+                "anvil".to_string(),
+                "--host".to_string(),
+                "0.0.0.0".to_string(),
+                "--chain-id".to_string(),
+                chain_id_arg,
+                "--mnemonic".to_string(),
+                Self::DEFAULT_MNEMONIC.to_string(),
+            ])
+            .start()
+            .await?;
+
+        let private_key = extract_private_key(&spawner.docker, container.id()).await?;
+
+        let network_ip = spawner
+            .docker
+            .get_network_ip_address(&container, &spawner.network)
+            .await?;
+
+        let external_port = container
+            .get_host_port_ipv4(Self::RPC_PORT)
+            .await
+            .context("ethereum sandbox port mapping")?;
+
+        let external_http_endpoint = format!("http://127.0.0.1:{external_port}");
+        wait_for_rpc(&external_http_endpoint).await?;
+
+        Ok(Self {
+            internal_http_endpoint: format!("http://{}:{}", network_ip, Self::RPC_PORT),
+            external_http_endpoint,
+            private_key,
+            chain_id: Self::DEFAULT_CHAIN_ID,
+            container,
+        })
+    }
+}
+
+async fn wait_for_rpc(endpoint: &str) -> anyhow::Result<()> {
+    const MAX_ATTEMPTS: usize = 120;
+    let client = Client::new();
+    let mut last_err: Option<String> = None;
+    let payload = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "eth_chainId",
+        "params": []
+    });
+
+    for _ in 0..MAX_ATTEMPTS {
+        match client.post(endpoint).json(&payload).send().await {
+            Ok(response) => {
+                if response.status().is_success() {
+                    match response.json::<serde_json::Value>().await {
+                        Ok(body) if body.get("result").is_some() => return Ok(()),
+                        Ok(body) => {
+                            last_err = Some(format!("missing result in response: {body:?}"));
+                        }
+                        Err(err) => {
+                            last_err = Some(format!("json parse error: {err}"));
+                        }
+                    }
+                } else {
+                    last_err = Some(format!("status {}", response.status()));
+                }
+            }
+            Err(err) => {
+                last_err = Some(err.to_string());
+            }
+        }
+
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    Err(anyhow!(
+        "ethereum sandbox rpc '{}' did not become ready: {:?}",
+        endpoint,
+        last_err
+    ))
+}
+
+async fn extract_private_key(docker: &DockerClient, container_id: &str) -> anyhow::Result<String> {
+    let mut logs = docker.docker.logs::<String>(
+        container_id,
+        Some(LogsOptions {
+            follow: false,
+            stdout: true,
+            stderr: true,
+            ..Default::default()
+        }),
+    );
+
+    let mut in_private_keys = false;
+    while let Some(Ok(entry)) = logs.next().await {
+        let line = match entry {
+            LogOutput::StdOut { message } | LogOutput::StdErr { message } => {
+                String::from_utf8_lossy(&message).trim().to_owned()
+            }
+            LogOutput::Console { message } => String::from_utf8_lossy(&message).trim().to_owned(),
+            _ => continue,
+        };
+        if line.contains("Private Keys") {
+            in_private_keys = true;
+            continue;
+        }
+
+        if in_private_keys {
+            if let Some(key) = line.split_whitespace().nth(1) {
+                if key.starts_with("0x") {
+                    return Ok(key.to_string());
+                }
+            }
+        }
+    }
+
+    anyhow::bail!("failed to read private key from anvil logs")
 }
 
 fn shares_to_triples(

--- a/integration-tests/src/eth.rs
+++ b/integration-tests/src/eth.rs
@@ -18,11 +18,11 @@ pub type SandboxMiddleware = SignerMiddleware<Provider<Http>, LocalWallet>;
 
 pub fn client(
     endpoint: &str,
-    private_key: &str,
+    secret_key: &str,
     chain_id: u64,
 ) -> Result<(Arc<SandboxMiddleware>, Address)> {
     let provider = Provider::<Http>::try_from(endpoint)?;
-    let wallet = LocalWallet::from_str(private_key)?;
+    let wallet = LocalWallet::from_str(secret_key)?;
     let address = wallet.address();
     let wallet = wallet.with_chain_id(chain_id);
     let client = Arc::new(SignerMiddleware::new(provider, wallet));

--- a/integration-tests/src/eth.rs
+++ b/integration-tests/src/eth.rs
@@ -41,6 +41,7 @@ pub async fn deploy_chain_signatures(
     Ok(contract.address())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn compute_request_id(
     requester: Address,
     payload: [u8; 32],

--- a/integration-tests/src/eth.rs
+++ b/integration-tests/src/eth.rs
@@ -1,0 +1,69 @@
+use anyhow::Result;
+use ethers::abi::{encode, Token};
+use ethers::contract::abigen;
+use ethers::middleware::SignerMiddleware;
+use ethers::providers::{Http, Provider};
+use ethers::signers::{LocalWallet, Signer};
+use ethers::types::{Address, H256, U256};
+use ethers::utils::keccak256;
+use std::str::FromStr;
+use std::sync::Arc;
+
+abigen!(
+    ChainSignaturesContract,
+    "../chain-signatures/contract-eth/artifacts/contracts/ChainSignatures.sol/ChainSignatures.json"
+);
+
+pub type SandboxMiddleware = SignerMiddleware<Provider<Http>, LocalWallet>;
+
+pub fn client(
+    endpoint: &str,
+    private_key: &str,
+    chain_id: u64,
+) -> Result<(Arc<SandboxMiddleware>, Address)> {
+    let provider = Provider::<Http>::try_from(endpoint)?;
+    let wallet = LocalWallet::from_str(private_key)?;
+    let address = wallet.address();
+    let wallet = wallet.with_chain_id(chain_id);
+    let client = Arc::new(SignerMiddleware::new(provider, wallet));
+    Ok((client, address))
+}
+
+pub async fn deploy_chain_signatures(
+    client: Arc<SandboxMiddleware>,
+    mpc_address: Address,
+    signature_deposit: U256,
+) -> Result<Address> {
+    let contract =
+        ChainSignaturesContract::deploy(client.clone(), (mpc_address, signature_deposit))?
+            .send()
+            .await?;
+    Ok(contract.address())
+}
+
+pub fn compute_request_id(
+    requester: Address,
+    payload: [u8; 32],
+    path: &str,
+    key_version: u32,
+    chain_id: U256,
+    algo: &str,
+    dest: &str,
+    params: &str,
+) -> H256 {
+    let tokens = vec![
+        Token::Address(requester),
+        Token::Bytes(payload.to_vec()),
+        Token::String(path.to_string()),
+        Token::Uint(U256::from(key_version)),
+        Token::Uint(chain_id),
+        Token::String(algo.to_string()),
+        Token::String(dest.to_string()),
+        Token::String(params.to_string()),
+    ];
+    H256::from(keccak256(encode(&tokens)))
+}
+
+pub use chain_signatures_contract::{
+    ChainSignaturesContract, ChainSignaturesContractEvents, SignRequest, SignatureRespondedFilter,
+};

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -294,7 +294,7 @@ pub async fn setup(spawner: &mut ClusterSpawner) -> anyhow::Result<Context> {
 
         let (client, deployer_address) = eth::client(
             &sandbox.external_http_endpoint,
-            &sandbox.private_key,
+            &sandbox.secret_key,
             sandbox.chain_id,
         )?;
         let contract_address =
@@ -308,7 +308,7 @@ pub async fn setup(spawner: &mut ClusterSpawner) -> anyhow::Result<Context> {
 
         let contract_address_hex = hex::encode(contract_address);
         spawner.cfg.eth = Some(EthConfig {
-            account_sk: sandbox.private_key.clone(),
+            account_sk: sandbox.secret_key.clone(),
             consensus_rpc_http_url: rpc_endpoint.clone(),
             execution_rpc_http_url: rpc_endpoint,
             contract_address: contract_address_hex.clone(),

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod actions;
 pub mod cluster;
 pub mod containers;
+pub mod eth;
 pub mod execute;
 pub mod local;
 pub mod mpc_fixture;
@@ -14,8 +15,8 @@ use std::collections::HashMap;
 
 use self::local::NodeEnvConfig;
 use crate::containers::DockerClient;
-
 use anyhow::Context as _;
+use ethers::types::{Address, U256};
 use mpc_contract::config::{PresignatureConfig, ProtocolConfig, TripleConfig};
 use mpc_contract::primitives::CandidateInfo;
 use mpc_node::gcp::GcpService;
@@ -248,6 +249,12 @@ impl Drop for Nodes {
     }
 }
 
+pub struct EthereumContext {
+    pub sandbox: containers::EthereumSandbox,
+    pub contract_address: Address,
+    pub deployer_address: Address,
+}
+
 pub struct Context {
     pub docker_client: DockerClient,
     pub docker_network: String,
@@ -260,6 +267,7 @@ pub struct Context {
     pub log_options: logs::Options,
     pub mesh_options: mesh::Options,
     pub message_options: node_client::Options,
+    pub ethereum: Option<EthereumContext>,
 }
 
 pub async fn setup(spawner: &mut ClusterSpawner) -> anyhow::Result<Context> {
@@ -279,6 +287,43 @@ pub async fn setup(spawner: &mut ClusterSpawner) -> anyhow::Result<Context> {
     let sk_share_local_path = spawner.tmp_dir.join("secrets");
     std::fs::create_dir_all(&sk_share_local_path).expect("could not create secrets dir");
     let sk_share_local_path = sk_share_local_path.to_string_lossy().to_string();
+
+    let mut ethereum = None;
+    if spawner.use_ethereum {
+        let sandbox = containers::EthereumSandbox::run(spawner).await?;
+
+        let (client, deployer_address) = eth::client(
+            &sandbox.external_http_endpoint,
+            &sandbox.private_key,
+            sandbox.chain_id,
+        )?;
+        let contract_address =
+            eth::deploy_chain_signatures(client, deployer_address, U256::zero()).await?;
+
+        let rpc_endpoint = if cfg!(feature = "docker-test") {
+            sandbox.internal_http_endpoint.clone()
+        } else {
+            sandbox.external_http_endpoint.clone()
+        };
+
+        let contract_address_hex = hex::encode(contract_address);
+        spawner.cfg.eth = Some(EthConfig {
+            account_sk: sandbox.private_key.clone(),
+            consensus_rpc_http_url: rpc_endpoint.clone(),
+            execution_rpc_http_url: rpc_endpoint,
+            contract_address: contract_address_hex.clone(),
+            network: "sepolia".to_string(),
+            helios_data_path: format!("/tmp/helios-{}", contract_address_hex),
+            refresh_finalized_interval: 1_000,
+            total_timeout: 600,
+        });
+
+        ethereum = Some(EthereumContext {
+            sandbox,
+            contract_address,
+            deployer_address,
+        });
+    }
 
     let storage_options = mpc_node::storage::Options {
         env: spawner.env.clone(),
@@ -310,6 +355,7 @@ pub async fn setup(spawner: &mut ClusterSpawner) -> anyhow::Result<Context> {
         log_options,
         mesh_options,
         message_options,
+        ethereum,
     })
 }
 

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -117,11 +117,6 @@ impl FixtureConfig {
 
 impl MpcFixtureBuilder {
     pub fn new(num_nodes: u32, threshold: usize) -> Self {
-        // This is a bit of a weird place to install the subscriber but every
-        // test needs to call it somewhere. Since tests will usually call this
-        // before doing anything interesting, might as well do it here.
-        crate::utils::init_tracing_log();
-
         let prepared_nodes: Vec<_> = (0..num_nodes).map(MpcFixtureNodeBuilder::new).collect();
 
         // construct full list of participants and candidates (same set)

--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -71,7 +71,7 @@ async fn test_signature_ethereum() -> Result<()> {
             .query()
             .await?;
         if let Some(event) = events.into_iter().find(|event| {
-            event.request_id == &expected_request_id[..] && event.responder == requester
+            event.request_id == expected_request_id[..] && event.responder == requester
         }) {
             matching_event = Some(event);
             break;

--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -21,17 +21,17 @@ async fn test_signature_ethereum() -> Result<()> {
         .as_ref()
         .context("ethereum sandbox not initialized")?;
     let endpoint = eth_ctx.sandbox.external_http_endpoint.clone();
-    let private_key = eth_ctx.sandbox.private_key.clone();
+    let secret_key = eth_ctx.sandbox.secret_key.clone();
     let chain_id = eth_ctx.sandbox.chain_id;
     let contract_address = eth_ctx.contract_address;
 
-    let (client, requester) = eth::client(&endpoint, &private_key, chain_id)?;
+    let (client, requester) = eth::client(&endpoint, &secret_key, chain_id)?;
     let contract = eth::ChainSignaturesContract::new(contract_address, client.clone());
 
     let payload = [7u8; 32];
-    let path = "m/44'/60'/0'/0/0";
+    let path = "test";
     let algo = "secp256k1";
-    let dest = "http://localhost/callback";
+    let dest = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
     let params = "{}";
 
     let request = eth::SignRequest {
@@ -107,10 +107,10 @@ async fn test_signature_ethereum() -> Result<()> {
         actions::recover_eth_address(&payload, &signature_bytes, event.signature.recovery_id);
 
     let network_public_key = cluster.root_public_key().await?;
-    let mut network_pk_bytes = vec![0x04];
-    network_pk_bytes.extend_from_slice(&network_public_key.as_bytes()[1..]);
-    let encoded_network_pk = EncodedPoint::from_bytes(&network_pk_bytes)
-        .context("invalid network public key encoding")?;
+    let mut network_pk = vec![0x04];
+    network_pk.extend_from_slice(&network_public_key.as_bytes()[1..]);
+    let encoded_network_pk =
+        EncodedPoint::from_bytes(&network_pk).context("invalid network public key encoding")?;
     let network_affine = AffinePoint::from_encoded_point(&encoded_network_pk)
         .into_option()
         .ok_or_else(|| anyhow!("invalid network public key"))?;

--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -1,0 +1,80 @@
+use anyhow::{Context, Result};
+use ethers::types::{BlockNumber, U256};
+use integration_tests::{cluster, eth};
+use mpc_primitives::LATEST_MPC_KEY_VERSION;
+use test_log::test;
+use tokio::time::{sleep, Duration};
+
+#[test(tokio::test)]
+async fn test_ethereum_signature_roundtrip() -> Result<()> {
+    let cluster = cluster::spawn().disable_prestockpile().ethereum().await?;
+    cluster.wait().signable().await?;
+
+    let ctx = cluster.nodes.ctx();
+    let eth_ctx = ctx
+        .ethereum
+        .as_ref()
+        .context("ethereum sandbox not initialized")?;
+    let endpoint = eth_ctx.sandbox.external_http_endpoint.clone();
+    let private_key = eth_ctx.sandbox.private_key.clone();
+    let chain_id = eth_ctx.sandbox.chain_id;
+    let contract_address = eth_ctx.contract_address;
+
+    let (client, requester) = eth::client(&endpoint, &private_key, chain_id)?;
+    let contract = eth::ChainSignaturesContract::new(contract_address, client.clone());
+
+    let payload = [7u8; 32];
+    let path = "m/44'/60'/0'/0/0";
+    let algo = "secp256k1";
+    let dest = "http://localhost/callback";
+    let params = "{}";
+
+    let request = eth::SignRequest {
+        payload,
+        path: path.to_string(),
+        key_version: LATEST_MPC_KEY_VERSION,
+        algo: algo.to_string(),
+        dest: dest.to_string(),
+        params: params.to_string(),
+    };
+
+    let call = contract.sign(request).value(U256::from(1_u64));
+    let pending = call.send().await?;
+    let receipt = pending.await?.context("sign transaction failed")?;
+    let from_block = BlockNumber::Number(
+        receipt
+            .block_number
+            .context("missing block number in receipt")?,
+    );
+
+    let expected_request_id = eth::compute_request_id(
+        requester,
+        payload,
+        path,
+        LATEST_MPC_KEY_VERSION,
+        U256::from(chain_id),
+        algo,
+        dest,
+        params,
+    );
+
+    let mut found = false;
+    for _ in 0..30 {
+        let events = contract
+            .event::<eth::SignatureRespondedFilter>()
+            .from_block(from_block)
+            .query()
+            .await?;
+        if events.iter().any(|event| {
+            event.request_id == &expected_request_id[..] && event.responder == requester
+        }) {
+            found = true;
+            break;
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+
+    anyhow::ensure!(found, "did not observe signature response on ethereum");
+
+    Ok(())
+}

--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -1,12 +1,17 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use ethers::types::{BlockNumber, U256};
-use integration_tests::{cluster, eth};
+use integration_tests::{actions, cluster, eth};
+use k256::ecdsa::VerifyingKey;
+use k256::elliptic_curve::sec1::FromEncodedPoint;
+use k256::{AffinePoint, EncodedPoint, FieldBytes, PublicKey as K256PublicKey};
+use mpc_crypto::derive_key;
+use mpc_crypto::kdf::derive_epsilon_eth;
 use mpc_primitives::LATEST_MPC_KEY_VERSION;
 use test_log::test;
 use tokio::time::{sleep, Duration};
 
 #[test(tokio::test)]
-async fn test_ethereum_signature_roundtrip() -> Result<()> {
+async fn test_signature_ethereum() -> Result<()> {
     let cluster = cluster::spawn().disable_prestockpile().ethereum().await?;
     cluster.wait().signable().await?;
 
@@ -58,23 +63,70 @@ async fn test_ethereum_signature_roundtrip() -> Result<()> {
         params,
     );
 
-    let mut found = false;
+    let mut matching_event = None;
     for _ in 0..30 {
         let events = contract
             .event::<eth::SignatureRespondedFilter>()
             .from_block(from_block)
             .query()
             .await?;
-        if events.iter().any(|event| {
+        if let Some(event) = events.into_iter().find(|event| {
             event.request_id == &expected_request_id[..] && event.responder == requester
         }) {
-            found = true;
+            matching_event = Some(event);
             break;
         }
         sleep(Duration::from_secs(1)).await;
     }
 
-    anyhow::ensure!(found, "did not observe signature response on ethereum");
+    let event =
+        matching_event.ok_or_else(|| anyhow!("did not observe signature response on ethereum"))?;
+
+    let mut x_bytes = [0u8; 32];
+    event.signature.big_r.x.to_big_endian(&mut x_bytes);
+    let mut y_bytes = [0u8; 32];
+    event.signature.big_r.y.to_big_endian(&mut y_bytes);
+    let x_field: &FieldBytes = FieldBytes::from_slice(&x_bytes);
+    let y_field: &FieldBytes = FieldBytes::from_slice(&y_bytes);
+    let encoded_r = EncodedPoint::from_affine_coordinates(x_field, y_field, false);
+    let big_r = AffinePoint::from_encoded_point(&encoded_r)
+        .into_option()
+        .ok_or_else(|| anyhow!("invalid R component in signature"))?;
+
+    let r_scalar = actions::x_coordinate::<k256::Secp256k1>(&big_r);
+    let r_bytes = r_scalar.to_bytes();
+
+    let mut s_bytes = [0u8; 32];
+    event.signature.s.to_big_endian(&mut s_bytes);
+
+    let mut signature_bytes = [0u8; 64];
+    signature_bytes[..32].copy_from_slice(r_bytes.as_slice());
+    signature_bytes[32..].copy_from_slice(&s_bytes);
+
+    let recovered_address =
+        actions::recover_eth_address(&payload, &signature_bytes, event.signature.recovery_id);
+
+    let network_public_key = cluster.root_public_key().await?;
+    let mut network_pk_bytes = vec![0x04];
+    network_pk_bytes.extend_from_slice(&network_public_key.as_bytes()[1..]);
+    let encoded_network_pk = EncodedPoint::from_bytes(&network_pk_bytes)
+        .context("invalid network public key encoding")?;
+    let network_affine = AffinePoint::from_encoded_point(&encoded_network_pk)
+        .into_option()
+        .ok_or_else(|| anyhow!("invalid network public key"))?;
+
+    let sender_hex = format!("0x{}", hex::encode(requester));
+    let epsilon = derive_epsilon_eth(LATEST_MPC_KEY_VERSION, &sender_hex, path);
+    let user_affine = derive_key(network_affine, epsilon);
+    let user_public_key = K256PublicKey::from_affine(user_affine)
+        .map_err(|_| anyhow!("invalid derived public key"))?;
+    let verifying_key = VerifyingKey::from(&user_public_key);
+    let expected_address = ethers::utils::public_key_to_address(&verifying_key);
+
+    anyhow::ensure!(
+        recovered_address == expected_address,
+        "signature recovered address mismatch: expected {expected_address:?}, got {recovered_address:?}"
+    );
 
     Ok(())
 }

--- a/integration-tests/tests/cases/mod.rs
+++ b/integration-tests/tests/cases/mod.rs
@@ -10,6 +10,7 @@ use mpc_node::util::NearPublicKeyExt as _;
 use mpc_primitives::LATEST_MPC_KEY_VERSION;
 use test_log::test;
 
+pub mod ethereum;
 pub mod mpc;
 pub mod nightly;
 pub mod store;

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -6,6 +6,8 @@ use mpc_node::protocol::triple::Triple;
 use mpc_node::protocol::SignRequestType;
 use mpc_node::protocol::{Chain, IndexedSignRequest, ProtocolState};
 use mpc_primitives::{SignArgs, SignId, LATEST_MPC_KEY_VERSION};
+use test_log::test;
+
 use std::collections::BTreeMap;
 use std::fs;
 use std::time::Duration;
@@ -18,7 +20,7 @@ const KEY_SHARE_FILE: &str = "tmp/key_shares.json";
 const TRIPLES_FILE: &str = "tmp/triples.json";
 const PRESIGNATURES_FILE: &str = "tmp/presignatures.json";
 
-#[tokio::test(flavor = "multi_thread")]
+#[test(tokio::test(flavor = "multi_thread"))]
 async fn test_basic_generate_keys() {
     let network = MpcFixtureBuilder::new(5, 4).build().await;
 
@@ -65,7 +67,7 @@ async fn test_basic_generate_keys() {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test(tokio::test(flavor = "multi_thread"))]
 async fn test_basic_generate_triples() {
     let network = MpcFixtureBuilder::default()
         .only_generate_triples()
@@ -106,7 +108,7 @@ async fn test_basic_generate_triples() {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test(tokio::test(flavor = "multi_thread"))]
 async fn test_basic_generate_presignature() {
     let network = MpcFixtureBuilder::default()
         .only_generate_presignatures()
@@ -150,7 +152,7 @@ async fn test_basic_generate_presignature() {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test(tokio::test(flavor = "multi_thread"))]
 async fn test_basic_sign() {
     let network = MpcFixtureBuilder::default()
         .only_generate_signatures()
@@ -211,7 +213,7 @@ fn sign_arg(seed: u8) -> SignArgs {
 
 /// drop the first 20 presignature messages on each node and see if the system
 /// can recover
-#[tokio::test(flavor = "multi_thread")]
+#[test(tokio::test(flavor = "multi_thread"))]
 async fn test_presignature_timeout() {
     fn create_filter() -> MessageFilter {
         let mut drop_counter = 20;


### PR DESCRIPTION
Since dev/testnet is broken right now due to helios not working properly. I'm just going to outright disable it as we need to make progress here.

So, this disables helios by default. Adds a new `light_client` feature flag that enables it. If disabled, we regular ethereum RPC. This also adds a local ethereum sandbox to make sure it works properly.