### PR TITLE
Add revoke_join

### DIFF
--- a/chain-signatures/contract/src/errors/mod.rs
+++ b/chain-signatures/contract/src/errors/mod.rs
@@ -25,6 +25,8 @@ pub enum RespondError {
 pub enum JoinError {
     #[error("Account to join is already in the participant set.")]
     JoinAlreadyParticipant,
+    #[error("Account to revoke is not in the candidate set.")]
+    RevokeNotCandidate,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, thiserror::Error)]

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -332,6 +332,34 @@ impl VersionedMpcContract {
     }
 
     #[handle_result]
+    pub fn revoke_join(&mut self) -> Result<(), Error> {
+        log!("revoke_join: signer={}", env::signer_account_id());
+        let protocol_state = self.mutable_state();
+
+        match protocol_state {
+            ProtocolContractState::Running(RunningContractState {
+                candidates,
+                join_votes,
+                ..
+            }) => {
+                let signer_account_id = env::signer_account_id();
+                if candidates.get(&signer_account_id).is_none() {
+                    return Err(JoinError::RevokeNotCandidate.into());
+                }
+
+                // cleanup the existing votes
+                join_votes.remove(&signer_account_id);
+
+                // remove from candidates
+                candidates.remove(&signer_account_id);
+
+                Ok(())
+            }
+            _ => Err(InvalidState::ProtocolStateNotRunning.into()),
+        }
+    }
+
+    #[handle_result]
     pub fn vote_join(&mut self, candidate: AccountId) -> Result<bool, Error> {
         log!(
             "vote_join: signer={}, candidate={}",

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -332,8 +332,8 @@ impl VersionedMpcContract {
     }
 
     #[handle_result]
-    pub fn revoke_join(&mut self) -> Result<(), Error> {
-        log!("revoke_join: signer={}", env::signer_account_id());
+    pub fn remove_candidacy(&mut self) -> Result<(), Error> {
+        log!("remove_candidacy: signer={}", env::signer_account_id());
         let protocol_state = self.mutable_state();
 
         match protocol_state {

--- a/chain-signatures/contract/src/primitives.rs
+++ b/chain-signatures/contract/src/primitives.rs
@@ -302,6 +302,14 @@ impl Votes {
     pub fn is_empty(&self) -> bool {
         self.votes.is_empty()
     }
+
+    pub fn remove(&mut self, account_id: &AccountId) {
+        self.votes.remove(account_id);
+    }
+
+    pub fn contains_key(&self, account_id: &AccountId) -> bool {
+        self.votes.contains_key(account_id)
+    }
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]

--- a/chain-signatures/contract/tests/updates.rs
+++ b/chain-signatures/contract/tests/updates.rs
@@ -35,7 +35,7 @@ pub fn invalid_contract() -> ProposeUpdateArgs {
 /// This is the current deposit required for a contract deploy. This is subject to change but make
 /// sure that it's not larger than 1mb. We can go up to 1.5mb technically but our contract should
 /// not be getting that big.
-const CURRENT_CONTRACT_DEPLOY_DEPOSIT: NearToken = NearToken::from_millinear(9000);
+const CURRENT_CONTRACT_DEPLOY_DEPOSIT: NearToken = NearToken::from_millinear(10000);
 
 #[tokio::test]
 async fn test_propose_contract_max_size_upload() {

--- a/chain-signatures/contract/tests/vote.rs
+++ b/chain-signatures/contract/tests/vote.rs
@@ -57,6 +57,89 @@ async fn test_join() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_revoke_join() -> anyhow::Result<()> {
+    let (worker, contract, accounts, _) = init_env().await;
+
+    // Create a new account to join as candidate
+    let alice = worker.dev_create_account().await?;
+    let execution = alice
+        .call(contract.id(), "join")
+        .args_json(json!({
+            "url": "127.0.0.1",
+            "cipher_pk": vec![1u8; 32],
+            "sign_pk": "ed25519:J75xXmF7WUPS3xCm3hy2tgwLCKdYM1iJd4BWF8sWVnae",
+        }))
+        .transact()
+        .await?;
+    assert!(execution.is_success());
+
+    // Verify alice is in candidates
+    let state: mpc_contract::ProtocolContractState =
+        contract.view("state").await.unwrap().json().unwrap();
+    match state {
+        mpc_contract::ProtocolContractState::Running(r) => {
+            assert!(r.candidates.contains_key(alice.id()));
+        }
+        _ => panic!("should be in running state"),
+    };
+
+    // Vote for alice to join
+    let execution = accounts[0]
+        .call(contract.id(), "vote_join")
+        .args_json(json!({
+            "candidate": alice.id()
+        }))
+        .transact()
+        .await?;
+    assert!(execution.is_success());
+
+    // Verify votes exist for alice
+    let state: mpc_contract::ProtocolContractState =
+        contract.view("state").await.unwrap().json().unwrap();
+    match state {
+        mpc_contract::ProtocolContractState::Running(state) => {
+            assert!(state.candidates.contains_key(alice.id()));
+            assert!(state.join_votes.contains_key(alice.id()));
+            assert_eq!(state.join_votes.votes.get(alice.id()).unwrap().len(), 1);
+        }
+        _ => panic!("should be in running state"),
+    };
+
+    // Alice revokes her join request
+    let execution = alice.call(contract.id(), "revoke_join").transact().await?;
+    assert!(execution.is_success());
+
+    // Verify alice is no longer in candidates and votes are cleaned up
+    let state: mpc_contract::ProtocolContractState =
+        contract.view("state").await.unwrap().json().unwrap();
+    match state {
+        mpc_contract::ProtocolContractState::Running(r) => {
+            assert!(!r.candidates.contains_key(alice.id()));
+            assert!(!r.join_votes.contains_key(alice.id()));
+        }
+        _ => panic!("should be in running state"),
+    };
+
+    // Try to revoke again, should fail (not a candidate anymore)
+    let execution = alice.call(contract.id(), "revoke_join").transact().await?;
+    assert!(execution.is_failure());
+
+    // Random account tries to revoke (was never a candidate)
+    let bob = worker.dev_create_account().await?;
+    let execution = bob.call(contract.id(), "revoke_join").transact().await?;
+    assert!(execution.is_failure());
+
+    // Participant tries to revoke (not a candidate, is a participant)
+    let execution = accounts[0]
+        .call(contract.id(), "revoke_join")
+        .transact()
+        .await?;
+    assert!(execution.is_failure());
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_vote_join() -> anyhow::Result<()> {
     let (worker, contract, accounts, _) = init_env().await;
 

--- a/chain-signatures/contract/tests/vote.rs
+++ b/chain-signatures/contract/tests/vote.rs
@@ -57,7 +57,7 @@ async fn test_join() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_revoke_join() -> anyhow::Result<()> {
+async fn test_remove_candidacy() -> anyhow::Result<()> {
     let (worker, contract, accounts, _) = init_env().await;
 
     // Create a new account to join as candidate
@@ -106,7 +106,10 @@ async fn test_revoke_join() -> anyhow::Result<()> {
     };
 
     // Alice revokes her join request
-    let execution = alice.call(contract.id(), "revoke_join").transact().await?;
+    let execution = alice
+        .call(contract.id(), "remove_candidacy")
+        .transact()
+        .await?;
     assert!(execution.is_success());
 
     // Verify alice is no longer in candidates and votes are cleaned up
@@ -121,17 +124,23 @@ async fn test_revoke_join() -> anyhow::Result<()> {
     };
 
     // Try to revoke again, should fail (not a candidate anymore)
-    let execution = alice.call(contract.id(), "revoke_join").transact().await?;
+    let execution = alice
+        .call(contract.id(), "remove_candidacy")
+        .transact()
+        .await?;
     assert!(execution.is_failure());
 
     // Random account tries to revoke (was never a candidate)
     let bob = worker.dev_create_account().await?;
-    let execution = bob.call(contract.id(), "revoke_join").transact().await?;
+    let execution = bob
+        .call(contract.id(), "remove_candidacy")
+        .transact()
+        .await?;
     assert!(execution.is_failure());
 
     // Participant tries to revoke (not a candidate, is a participant)
     let execution = accounts[0]
-        .call(contract.id(), "revoke_join")
+        .call(contract.id(), "remove_candidacy")
         .transact()
         .await?;
     assert!(execution.is_failure());


### PR DESCRIPTION
Potential participants should have the ability to revoke their `join` call in case they want to update their data.
`revoke_join` is expected to be called manually. After this action, the node will call `join` automatically.