### PR TITLE
small: make derive_user_address() public so solana-contract-examples can use it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ alloy-dyn-abi = "1.4.1"
 ethers-core = "2.0.13"
 secp256k1 = "0.28.2"
 rlp = "0.5"
-alloy-consensus = "1.0.38"
+alloy-consensus = { version = "1.0.38", features = ["serde"] }
 alloy-primitives = "1.4.1"
 alloy-json-abi = "1.4.1"
 alloy-rlp = "0.3.12"

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -353,7 +353,7 @@ fn public_key_to_address(public_key: &secp256k1::PublicKey) -> Address {
     Address::from_slice(&hash[12..])
 }
 
-fn derive_user_address(mpc_pk: mpc_crypto::PublicKey, derivation_epsilon: Scalar) -> Address {
+pub fn derive_user_address(mpc_pk: mpc_crypto::PublicKey, derivation_epsilon: Scalar) -> Address {
     let user_pk: AffinePoint = derive_key(mpc_pk, derivation_epsilon);
     let parity = match user_pk.y_is_odd().unwrap_u8() {
         0 => secp256k1::Parity::Even,


### PR DESCRIPTION
This also includes adding serde feature to alloy-consensus so solana-contract-examples can use it