### PR TITLE
test: Message counting tests

### DIFF
--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -39,8 +39,8 @@ pub type PresignatureId = u64;
 /// that was used to generate it.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct FullPresignatureId {
-    id: PresignatureId,
-    pair_id: TripleId,
+    pub id: PresignatureId,
+    pub pair_id: TripleId,
 }
 
 impl FullPresignatureId {

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -5,6 +5,7 @@ use crate::containers::Redis;
 use crate::mpc_fixture::fixture_interface::SharedOutput;
 use crate::mpc_fixture::fixture_tasks::MessageFilter;
 use crate::mpc_fixture::input::FixtureInput;
+use crate::mpc_fixture::message_collector::CollectMessages;
 use crate::mpc_fixture::mock_governance::MockGovernance;
 use crate::mpc_fixture::{fixture_tasks, MpcFixture, MpcFixtureNode};
 use cait_sith::protocol::Participant;
@@ -29,8 +30,7 @@ use near_sdk::AccountId;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc::{self, Sender};
-use tokio::sync::watch;
-use tokio::sync::RwLock;
+use tokio::sync::{watch, Mutex, RwLock};
 
 pub struct MpcFixtureBuilder {
     prepared_nodes: Vec<MpcFixtureNodeBuilder>,
@@ -41,6 +41,7 @@ pub struct MpcFixtureBuilder {
     participants_by_id: ParticipantsById,
     candidates: Candidates,
     fixture_config: FixtureConfig,
+    output: SharedOutput,
 }
 
 struct MpcFixtureNodeBuilder {
@@ -150,6 +151,7 @@ impl MpcFixtureBuilder {
             participants_by_id,
             candidates,
             fixture_config: FixtureConfig::new(num_nodes),
+            output: SharedOutput::default(),
         }
     }
 
@@ -159,7 +161,7 @@ impl MpcFixtureBuilder {
         let routing_table = self.build_routing_table();
         let initial_mesh_state = self.build_mesh_state();
 
-        let output = SharedOutput::default();
+        let output = self.output;
         let mut nodes = vec![];
 
         let account_ids: Vec<_> = self
@@ -318,6 +320,15 @@ impl MpcFixtureBuilder {
     /// Specify a method that acts as message filter for all sent messages the given node.
     pub fn with_outgoing_message_filter(mut self, node_idx: usize, filter: MessageFilter) -> Self {
         self.prepared_nodes[node_idx].messaging.filter = filter;
+        self
+    }
+
+    /// Specify a method that acts as message filter for all sent messages the given node.
+    pub fn with_message_collector(
+        mut self,
+        collector: Arc<Mutex<dyn CollectMessages + Send>>,
+    ) -> Self {
+        self.output.msg_log = collector;
         self
     }
 

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -2,6 +2,7 @@
 //! it with controlled inputs, and assert on outputs.
 
 use crate::containers::Redis;
+use crate::mpc_fixture::message_collector::{CollectMessages, MessagePrinter};
 use cait_sith::protocol::Participant;
 use mpc_node::backlog::Backlog;
 use mpc_node::config::Config;
@@ -41,9 +42,8 @@ pub struct MpcFixtureNode {
 }
 
 /// Logs for reading outputs after a test run for assertions and debugging.
-#[derive(Default)]
 pub struct SharedOutput {
-    pub msg_log: Arc<Mutex<Vec<String>>>,
+    pub msg_log: Arc<Mutex<dyn CollectMessages + Send>>,
     pub rpc_actions: Arc<Mutex<HashSet<String>>>,
 }
 
@@ -72,14 +72,6 @@ impl MpcFixture {
 
             drop(actions);
             tokio::time::sleep(interval).await;
-        }
-    }
-
-    /// Print all messages to debug.
-    pub async fn print_msg_log(&self) {
-        let guard = self.output.msg_log.lock().await;
-        for msg in guard.iter() {
-            tracing::debug!("{msg}");
         }
     }
 }
@@ -132,5 +124,23 @@ impl std::ops::Index<usize> for MpcFixture {
 impl std::ops::IndexMut<usize> for MpcFixture {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.nodes[index]
+    }
+}
+
+impl SharedOutput {
+    pub fn new<M: CollectMessages + Default + Send + 'static>() -> Self {
+        Self {
+            msg_log: Arc::new(Mutex::new(M::default())),
+            rpc_actions: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+}
+
+impl Default for SharedOutput {
+    fn default() -> Self {
+        Self {
+            msg_log: Arc::new(Mutex::new(MessagePrinter)),
+            rpc_actions: Default::default(),
+        }
     }
 }

--- a/integration-tests/src/mpc_fixture/fixture_tasks.rs
+++ b/integration-tests/src/mpc_fixture/fixture_tasks.rs
@@ -6,7 +6,6 @@ use cait_sith::protocol::Participant;
 use mpc_keys::hpke::Ciphered;
 use mpc_node::config::Config;
 use mpc_node::mesh::MeshState;
-use mpc_node::protocol;
 use mpc_node::protocol::message::{MessageOutbox, SendMessage, SignedMessage};
 use mpc_node::rpc::RpcAction;
 use std::collections::HashMap;
@@ -34,32 +33,17 @@ pub(super) fn test_mock_network(
         loop {
             tokio::select! {
                 Some(send_message) = outbox.intercept_outgoing_messages().recv() => {
-                    let (msg, (from, to, ts)) = &send_message;
-
-                    tracing::debug!(target: "mock_network", ?to, ?ts, "Received MPC message");
-
-                    let log_msg = match msg {
-                        protocol::Message::Posit(_) => "Posit",
-                        protocol::Message::Generating(_) => "Generating",
-                        protocol::Message::Ready(_) => "Ready",
-                        protocol::Message::Resharing(_) => "Resharing",
-                        protocol::Message::Triple(_) => "Triple",
-                        protocol::Message::Presignature(_) => "Presignature",
-                        protocol::Message::Signature(_) => "Signature",
-                        protocol::Message::Unknown(_) => "Unknown",
-                    };
-                    msg_log.lock().await.push(format!("{log_msg} from {from:?} to {to:?}"));
-
-                    if !filter(&send_message) {
-                        tracing::info!("Dropping a message because it didn't pass the test's filter");
+                    let passes_filter = filter(&send_message);
+                    msg_log.lock().await.observe_message(&send_message, passes_filter);
+                    if !passes_filter {
                         continue;
                     }
-
 
                     // directly send out single message, no batching
                     // (might want to add MessageOutbox, too, but for now this is easier)
                     let config = config.borrow().clone();
                     let participants = mesh.borrow().active.clone();
+                    let (msg, (from, to, _ts)) = &send_message;
                     let receiver_info = participants.get(to).expect("TODO: support sending to non-active participants in tests");
                     match SignedMessage::encrypt(
                         &[msg],

--- a/integration-tests/src/mpc_fixture/message_collector.rs
+++ b/integration-tests/src/mpc_fixture/message_collector.rs
@@ -1,0 +1,163 @@
+use cait_sith::protocol::Participant;
+use mpc_node::protocol::message::{PositProtocolId, SendMessage};
+use mpc_node::protocol::Message;
+use std::collections::HashMap;
+
+/// Collect information about sent messages during a test.
+///
+/// Each test can in theory define what exactly they want to collect about
+/// messages. In practice, most tests should pick one of the collector
+/// implementations defined in this file.
+///
+/// Storing the full context of messages is usually too much and fills up memory
+/// quickly. But some tests may need that level of detail.
+pub trait CollectMessages {
+    fn observe_message(&mut self, msg: &SendMessage, passed_filter: bool);
+
+    /// May be called at the end of a test to print a summary of all collected
+    /// messages.
+    fn print_summary(&self);
+
+    /// Get back the discrete type for extra checks after running a test.
+    fn clone_as_message_counter(&self) -> Option<MessageCounter> {
+        None
+    }
+}
+
+/// Print a shortened from of all incoming messages to tracing::debug without
+/// keeping anything in memory.
+///
+/// This is the default message collector, allowing to inspect what happens in
+/// the test log output without requiring obsessive memory during the test.
+pub struct MessagePrinter;
+
+impl CollectMessages for MessagePrinter {
+    fn observe_message(&mut self, msg: &SendMessage, passed_filter: bool) {
+        let (msg, (from, to, _ts)) = msg;
+        let msg_type = message_type_str(msg);
+        let action = if passed_filter {
+            "Forwarded"
+        } else {
+            "Dropped"
+        };
+        tracing::debug!(target: "mock_network", "{action} {msg_type} from {from:?} to {to:?}");
+    }
+
+    fn print_summary(&self) {
+        // NOOP: Already printed everything when messages came in
+    }
+}
+
+/// Count how many messages have been sent between participants and of which
+/// type.
+///
+/// This is a good message collector when a test want to check what kind of
+/// messages have been sent. It has a low memory footprint and makes it quite
+/// easy to assert a specific message has (or has not been) sent during the
+/// test.
+#[derive(Default, Clone)]
+pub struct MessageCounter {
+    /// For each directed participant -> participant linke, collect message counters.
+    pub links: HashMap<Participant, HashMap<Participant, PerLinkCounter>>,
+}
+
+#[derive(Default, Clone)]
+pub struct PerLinkCounter {
+    pub message_counts: HashMap<String, u64>,
+}
+
+impl CollectMessages for MessageCounter {
+    fn observe_message(&mut self, msg: &SendMessage, passed_filter: bool) {
+        let (msg, (from, to, _ts)) = msg;
+
+        let sender_stats = self.links.entry(*from).or_default();
+        let link_stats = sender_stats.entry(*to).or_default();
+        link_stats.observe_message(msg, passed_filter);
+    }
+
+    fn print_summary(&self) {
+        for (from, to, link_stats) in self.link_stats() {
+            tracing::info!(target: "mock_network", "### {from:?} -> {to:?}");
+            for (key, num) in &link_stats.message_counts {
+                tracing::info!(target: "mock_network", "{num:>12}    {key}");
+            }
+            tracing::info!(target: "mock_network", "");
+        }
+    }
+
+    fn clone_as_message_counter(&self) -> Option<MessageCounter> {
+        Some(self.clone())
+    }
+}
+
+impl MessageCounter {
+    pub fn link_stats(&self) -> impl Iterator<Item = (Participant, Participant, &PerLinkCounter)> {
+        self.links.iter().flat_map(|(from, sent_stats)| {
+            sent_stats
+                .iter()
+                .map(|(to, link_stats)| (*from, *to, link_stats))
+        })
+    }
+}
+
+impl PerLinkCounter {
+    fn observe_message(&mut self, msg: &Message, passed_filter: bool) {
+        let msg_type = message_type_str(msg);
+        let id = message_id_num(msg);
+        let action = if passed_filter {
+            "Forwarded"
+        } else {
+            "Dropped"
+        };
+
+        let key = if let Some(id) = id {
+            format!("{action} {msg_type}({id})")
+        } else {
+            format!("{action} {msg_type}")
+        };
+
+        *self.message_counts.entry(key).or_default() += 1;
+    }
+}
+
+fn message_type_str(msg: &Message) -> &str {
+    match msg {
+        Message::Posit(_) => "Posit",
+        Message::Generating(_) => "Generating",
+        Message::Ready(_) => "Ready",
+        Message::Resharing(_) => "Resharing",
+        Message::Triple(_) => "Triple",
+        Message::Presignature(_) => "Presignature",
+        Message::Signature(_) => "Signature",
+        Message::Unknown(_) => "Unknown",
+    }
+}
+
+fn message_id_num(msg: &Message) -> Option<u64> {
+    match msg {
+        Message::Posit(inner) => Some(posit_id_num(&inner.id)),
+        Message::Generating(_) => None,
+        Message::Ready(_) => None,
+        Message::Resharing(_) => None,
+        Message::Triple(inner) => Some(inner.id),
+        Message::Presignature(inner) => Some(inner.id),
+        Message::Signature(inner) => Some(inner.presignature_id),
+        Message::Unknown(_) => None,
+    }
+}
+
+/// A single number that should be unique per posit invocation.
+fn posit_id_num(posit_id: &PositProtocolId) -> u64 {
+    match posit_id {
+        PositProtocolId::Triple(id) => *id,
+        PositProtocolId::Presignature(id) => id.id,
+        PositProtocolId::Signature(sig_id, _presig_id, _round) => {
+            // extract a 8-byte hash from a 32-byte hash
+            let mut hash8: u64 = 0;
+            for chunk in sig_id.request_id.chunks_exact(8) {
+                hash8 ^= u64::from_be_bytes(chunk.try_into().unwrap());
+            }
+            hash8
+        }
+    }
+}

--- a/integration-tests/src/mpc_fixture/mod.rs
+++ b/integration-tests/src/mpc_fixture/mod.rs
@@ -6,6 +6,7 @@ pub mod builder;
 pub mod fixture_interface;
 pub mod fixture_tasks;
 pub mod input;
+pub mod message_collector;
 pub mod mock_governance;
 
 pub use builder::MpcFixtureBuilder;

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -782,7 +782,7 @@ async fn test_triples_message_count() {
         .build()
         .await;
 
-    tokio::time::timeout(Duration::from_secs(60), network.wait_for_triples(1))
+    tokio::time::timeout(Duration::from_secs(120), network.wait_for_triples(1))
         .await
         .expect("should have enough triples eventually");
 

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -793,7 +793,7 @@ async fn test_triples_message_count() {
     // Check message counts are as expected. Right now, the expectation is:
     // Particpants with a lower id send around 10 messages to participant with higher ids.
     // Particpants with a higher id send around 135 messages to participant with lower ids.
-    // Tolerance +/- 4 for the smaller case, +/- 10 in the larger case.
+    // Tolerance +/- 6 for the smaller case, +/- 20 in the larger case.
     //
     // Note: We don't actually care about these sepcific numbers. But we want to
     // understand it and know it if somehow these numbers change.
@@ -801,13 +801,13 @@ async fn test_triples_message_count() {
         for (key, num) in &link_stats.message_counts {
             if key.contains("Triple") {
                 if from < to {
-                    let tolerance = 4;
+                    let tolerance = 6;
                     assert!(
                         num.abs_diff(10) <= tolerance,
                         "{from:?} -> {to:?} sent {num} messages"
                     );
                 } else {
-                    let tolerance = 10;
+                    let tolerance = 20;
                     assert!(
                         num.abs_diff(135) <= tolerance,
                         "{from:?} -> {to:?} sent {num} messages"

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -1,5 +1,6 @@
 use deadpool_redis::redis::AsyncCommands;
 use integration_tests::mpc_fixture::fixture_tasks::MessageFilter;
+use integration_tests::mpc_fixture::message_collector::MessageCounter;
 use integration_tests::mpc_fixture::MpcFixtureBuilder;
 use mpc_node::protocol::presignature::Presignature;
 use mpc_node::protocol::SignRequestType;
@@ -8,9 +9,11 @@ use mpc_node::storage::triple_storage::TriplePair;
 use mpc_primitives::{SignArgs, SignId, LATEST_MPC_KEY_VERSION};
 use test_log::test;
 use tokio::sync::oneshot;
+use tokio::sync::Mutex;
 
 use std::collections::BTreeMap;
 use std::fs;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Use this toggle locally to regenerate hard-coded inputs such as key shares,
@@ -169,21 +172,9 @@ async fn test_basic_sign() {
 
     tracing::info!("sending requests now");
     let request = sign_request(0);
-    network[0]
-        .sign_tx
-        .send(Sign::Request(request.clone()))
-        .await
-        .unwrap();
-    network[1]
-        .sign_tx
-        .send(Sign::Request(request.clone()))
-        .await
-        .unwrap();
-    network[2]
-        .sign_tx
-        .send(Sign::Request(request.clone()))
-        .await
-        .unwrap();
+    network[0].sign_tx.send(request.clone()).await.unwrap();
+    network[1].sign_tx.send(request.clone()).await.unwrap();
+    network[2].sign_tx.send(request.clone()).await.unwrap();
 
     let timeout = Duration::from_secs(10);
 
@@ -199,8 +190,8 @@ async fn test_basic_sign() {
     );
 }
 
-fn sign_request(seed: u8) -> IndexedSignRequest {
-    IndexedSignRequest {
+fn sign_request(seed: u8) -> Sign {
+    Sign::Request(IndexedSignRequest {
         id: SignId::new([seed; 32]),
         args: sign_arg(seed),
         chain: Chain::NEAR,
@@ -208,7 +199,7 @@ fn sign_request(seed: u8) -> IndexedSignRequest {
         timestamp_sign_queue: std::time::Instant::now(),
         total_timeout: Duration::from_secs(45),
         sign_request_type: SignRequestType::Sign,
-    }
+    })
 }
 
 fn sign_arg(seed: u8) -> SignArgs {
@@ -295,10 +286,7 @@ async fn test_sign_adequate_stockpile() {
     for seed in 0..NUM_SIGN_REQUESTS {
         let request = sign_request(seed);
         for node in &network.nodes {
-            node.sign_tx
-                .send(Sign::Request(request.clone()))
-                .await
-                .unwrap();
+            node.sign_tx.send(request.clone()).await.unwrap();
         }
     }
 
@@ -382,10 +370,7 @@ async fn test_sign_limited_stockpile_contention() {
     for seed in 0..NUM_SIGN_REQUESTS {
         let request = sign_request(seed);
         for node in &network.nodes {
-            node.sign_tx
-                .send(Sign::Request(request.clone()))
-                .await
-                .unwrap();
+            node.sign_tx.send(request.clone()).await.unwrap();
         }
     }
 
@@ -482,10 +467,7 @@ async fn test_sign_requests_wait_for_presignatures() {
     for seed in 0..TOTAL_SIGN_REQUESTS {
         let request = sign_request(seed);
         for node in &network.nodes {
-            node.sign_tx
-                .send(Sign::Request(request.clone()))
-                .await
-                .unwrap();
+            node.sign_tx.send(request.clone()).await.unwrap();
         }
     }
 
@@ -607,10 +589,7 @@ async fn test_sign_contention_5_nodes() {
     for seed in 0..NUM_SIGN_REQUESTS {
         let request = sign_request(seed);
         for node in &network.nodes {
-            node.sign_tx
-                .send(Sign::Request(request.clone()))
-                .await
-                .unwrap();
+            node.sign_tx.send(request.clone()).await.unwrap();
         }
     }
 
@@ -692,10 +671,7 @@ async fn test_sign_missing_presignature() {
     tracing::info!("sending requests now");
     let request = sign_request(0);
     for node in &network.nodes {
-        node.sign_tx
-            .send(Sign::Request(request.clone()))
-            .await
-            .unwrap();
+        node.sign_tx.send(request.clone()).await.unwrap();
     }
 
     // give 2 minutes to resolve the problem
@@ -706,7 +682,8 @@ async fn test_sign_missing_presignature() {
         .await
         .expect("should publish RPC action eventually");
 
-    network.print_msg_log().await;
+    let msg_log = network.output.msg_log.lock().await;
+    msg_log.print_summary();
 
     assert_eq!(actions.len(), 1);
     let action_str = actions.iter().next().unwrap();
@@ -760,10 +737,7 @@ async fn test_sign_missing_presignature_after_posits() {
     tracing::info!("sending requests now");
     let request = sign_request(0);
     for node in &network.nodes {
-        node.sign_tx
-            .send(Sign::Request(request.clone()))
-            .await
-            .unwrap();
+        node.sign_tx.send(request.clone()).await.unwrap();
     }
 
     // Wait for first round of posits to go through.
@@ -789,7 +763,8 @@ async fn test_sign_missing_presignature_after_posits() {
         .await
         .expect("should publish RPC action eventually");
 
-    network.print_msg_log().await;
+    let msg_log = network.output.msg_log.lock().await;
+    msg_log.print_summary();
 
     assert_eq!(actions.len(), 1);
     let action_str = actions.iter().next().unwrap();
@@ -797,4 +772,117 @@ async fn test_sign_missing_presignature_after_posits() {
         action_str.contains("RpcAction::Publish"),
         "unexpected rpc action {action_str}"
     );
+}
+
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_triples_message_count() {
+    let network = MpcFixtureBuilder::default()
+        .only_generate_triples()
+        .with_message_collector(Arc::new(Mutex::new(MessageCounter::default())))
+        .build()
+        .await;
+
+    tokio::time::timeout(Duration::from_secs(60), network.wait_for_triples(1))
+        .await
+        .expect("should have enough triples eventually");
+
+    // This prints a summary of all sent message counts for debugging
+    let msg_log = network.output.msg_log.lock().await;
+    msg_log.print_summary();
+
+    // Check message counts are as expected. Right now, the expectation is:
+    // Particpants with a lower id send around 10 messages to participant with higher ids.
+    // Particpants with a higher id send around 135 messages to participant with lower ids.
+    // Tolerance +/- 4 for the smaller case, +/- 10 in the larger case.
+    //
+    // Note: We don't actually care about these sepcific numbers. But we want to
+    // understand it and know it if somehow these numbers change.
+    for (from, to, link_stats) in msg_log.clone_as_message_counter().unwrap().link_stats() {
+        for (key, num) in &link_stats.message_counts {
+            if key.contains("Triple") {
+                if from < to {
+                    let tolerance = 4;
+                    assert!(
+                        num.abs_diff(10) <= tolerance,
+                        "{from:?} -> {to:?} sent {num} messages"
+                    );
+                } else {
+                    let tolerance = 10;
+                    assert!(
+                        num.abs_diff(135) <= tolerance,
+                        "{from:?} -> {to:?} sent {num} messages"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_presignature_message_count() {
+    let network = MpcFixtureBuilder::default()
+        .only_generate_presignatures()
+        .with_message_collector(Arc::new(Mutex::new(MessageCounter::default())))
+        .build()
+        .await;
+
+    tokio::time::timeout(Duration::from_secs(10), network.wait_for_presignatures(1))
+        .await
+        .expect("should have enough presignatures eventually");
+
+    // This prints a summary of all sent message counts for debugging
+    let msg_log = network.output.msg_log.lock().await;
+    msg_log.print_summary();
+
+    // Check message counts are as expected. Right now, the expectation is:
+    // Exactly 2 messages per link
+    for (from, to, link_stats) in msg_log.clone_as_message_counter().unwrap().link_stats() {
+        for (key, num) in &link_stats.message_counts {
+            if key.contains("Presignature") {
+                assert_eq!(2, *num, "{from:?} -> {to:?} sent {num} messages");
+            }
+        }
+    }
+}
+
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_signature_message_count() {
+    let network = MpcFixtureBuilder::default()
+        .only_generate_signatures()
+        .with_message_collector(Arc::new(Mutex::new(MessageCounter::default())))
+        .build()
+        .await;
+
+    tokio::time::timeout(
+        Duration::from_millis(300),
+        network.wait_for_presignatures(2),
+    )
+    .await
+    .expect("should start with enough presignatures");
+
+    tracing::info!("sending requests now");
+    let request = sign_request(0);
+    network[0].sign_tx.send(request.clone()).await.unwrap();
+    network[1].sign_tx.send(request.clone()).await.unwrap();
+    network[2].sign_tx.send(request.clone()).await.unwrap();
+
+    let timeout = Duration::from_secs(10);
+
+    tokio::time::timeout(timeout, network.wait_for_actions(1))
+        .await
+        .expect("should publish RPC action eventually");
+
+    // This prints a summary of all sent message counts for debugging
+    let msg_log = network.output.msg_log.lock().await;
+    msg_log.print_summary();
+
+    // Check message counts are as expected. Right now, the expectation is:
+    // Exactly 1 message per link
+    for (from, to, link_stats) in msg_log.clone_as_message_counter().unwrap().link_stats() {
+        for (key, num) in &link_stats.message_counts {
+            if key.contains("Signature") {
+                assert_eq!(1, *num, "{from:?} -> {to:?} sent {num} messages");
+            }
+        }
+    }
 }

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -790,28 +790,25 @@ async fn test_triples_message_count() {
     let msg_log = network.output.msg_log.lock().await;
     msg_log.print_summary();
 
-    // Check message counts are as expected. Right now, the expectation is:
-    // Particpants with a lower id send around 10 messages to participant with higher ids.
-    // Particpants with a higher id send around 135 messages to participant with lower ids.
-    // Tolerance +/- 6 for the smaller case, +/- 20 in the larger case.
+    // Check there are not too many sent messages.
     //
-    // Note: We don't actually care about these sepcific numbers. But we want to
-    // understand it and know it if somehow these numbers change.
+    // For finished protocols, there should be message counts as follows:
+    // Participants with a lower id send at most 16 messages to participant with higher ids.
+    // Participants with a higher id send at most 141 messages to participant with lower ids.
+    // In both cases, fewer messages are observed for ongoing protocols that
+    // already started but got interrupted.
+    //
+    // Note: We don't actually care about these specific numbers. But we want to
+    // understand what the numbers are and check they do not increase unexpectedly.
     for (from, to, link_stats) in msg_log.clone_as_message_counter().unwrap().link_stats() {
         for (key, num) in &link_stats.message_counts {
             if key.contains("Triple") {
                 if from < to {
-                    let tolerance = 6;
-                    assert!(
-                        num.abs_diff(10) <= tolerance,
-                        "{from:?} -> {to:?} sent {num} messages"
-                    );
+                    // receiver in shared multiplication sends fewer messages
+                    assert!(*num <= 16, "{from:?} -> {to:?} sent {num} messages");
                 } else {
-                    let tolerance = 20;
-                    assert!(
-                        num.abs_diff(135) <= tolerance,
-                        "{from:?} -> {to:?} sent {num} messages"
-                    );
+                    // sender in shared multiplication sends more messages
+                    assert!(*num <= 141, "{from:?} -> {to:?} sent {num} messages");
                 }
             }
         }
@@ -834,12 +831,14 @@ async fn test_presignature_message_count() {
     let msg_log = network.output.msg_log.lock().await;
     msg_log.print_summary();
 
-    // Check message counts are as expected. Right now, the expectation is:
-    // Exactly 2 messages per link
+    // Check there are not too many sent messages.
+    // There should be exactly 2 messages per link for finished protocols.
+    // But fewer messages are observed for ongoing protocols that already
+    // started but got interrupted.
     for (from, to, link_stats) in msg_log.clone_as_message_counter().unwrap().link_stats() {
         for (key, num) in &link_stats.message_counts {
             if key.contains("Presignature") {
-                assert_eq!(2, *num, "{from:?} -> {to:?} sent {num} messages");
+                assert!(*num <= 2, "{from:?} -> {to:?} sent {num} messages");
             }
         }
     }


### PR DESCRIPTION
Add tests checking that T / P / S protocols sent the expected amount of messages.

As noted in the comment, we may not necessarily care about the exact number. But we should understand roughly what they are and run tests to ensure it doesn't change unnoticed.

To implement this test, I also made the testing framework more flexible in how it observed outputs. We can now check specific counts for each protocol invocation.

The printed debug summary per test looks a bit like this:

```
### Participant(2) -> Participant(1)
           1    Forwarded Signature(15446211684585113244)

### Participant(2) -> Participant(0)
           1    Forwarded Posit(0)
           1    Forwarded Signature(15446211684585113244)

### Participant(0) -> Participant(1)
           2    Forwarded Posit(0)
           1    Forwarded Signature(15446211684585113244)

### Participant(0) -> Participant(2)
           1    Forwarded Signature(15446211684585113244)
           2    Forwarded Posit(0)

### Participant(1) -> Participant(0)
           1    Forwarded Posit(0)
           1    Forwarded Signature(15446211684585113244)

### Participant(1) -> Participant(2)
           1    Forwarded Signature(15446211684585113244)
```