### PR TITLE
feat: Add backlog checkpoints w/ simpler bidirectional requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6174,6 +6174,7 @@ dependencies = [
  "borsh 1.5.7",
  "bs58 0.5.1",
  "cait-sith",
+ "ciborium",
  "clap",
  "criterion",
  "deadpool-redis",

--- a/chain-signatures/contract-sol/src/lib.rs
+++ b/chain-signatures/contract-sol/src/lib.rs
@@ -119,13 +119,13 @@ pub mod signet_program {
     }
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq, Eq)]
 pub struct AffinePoint {
     pub x: [u8; 32],
     pub y: [u8; 32],
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Signature {
     pub big_r: AffinePoint,
     pub s: [u8; 32],
@@ -188,6 +188,7 @@ pub struct SignBidirectional<'info> {
 }
 
 #[event]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SignatureRespondedEvent {
     pub request_id: [u8; 32],
     pub responder: Pubkey,
@@ -203,6 +204,7 @@ pub struct RespondBidirectionalEvent {
 }
 
 #[event]
+#[derive(Clone, Debug)]
 pub struct SignatureRequestedEvent {
     pub sender: Pubkey,
     pub payload: [u8; 32],
@@ -217,6 +219,7 @@ pub struct SignatureRequestedEvent {
 }
 
 #[event]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SignBidirectionalEvent {
     pub sender: Pubkey,
     pub serialized_transaction: Vec<u8>,

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -24,10 +24,10 @@ use near_sdk::{
     PromiseError, PublicKey,
 };
 use primitives::{
-    CandidateInfo, Candidates, InternalSignRequest, Participants, PendingRequest, PkVotes,
-    SignPoll, SignRequest, StorageKey, Votes, YieldIndex,
+    CandidateInfo, Candidates, Chain, Checkpoint, InternalSignRequest, Participants,
+    PendingRequest, PkVotes, SignPoll, SignRequest, StorageKey, Votes, YieldIndex,
 };
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::config::Config;
 use crate::errors::Error;
@@ -477,6 +477,8 @@ impl VersionedMpcContract {
                         candidates: Candidates::new(),
                         join_votes: Votes::new(),
                         leave_votes: Votes::new(),
+                        checkpoint_votes: HashMap::new(),
+                        latest_checkpoints: HashMap::new(),
                     });
                     Ok(true)
                 } else {
@@ -520,6 +522,8 @@ impl VersionedMpcContract {
                         candidates: Candidates::new(),
                         join_votes: Votes::new(),
                         leave_votes: Votes::new(),
+                        checkpoint_votes: HashMap::new(),
+                        latest_checkpoints: HashMap::new(),
                     });
                     Ok(true)
                 } else {
@@ -561,6 +565,8 @@ impl VersionedMpcContract {
                         candidates: Candidates::new(),
                         join_votes: Votes::new(),
                         leave_votes: Votes::new(),
+                        checkpoint_votes: HashMap::new(),
+                        latest_checkpoints: HashMap::new(),
                     });
                     Ok(true)
                 } else {
@@ -568,6 +574,58 @@ impl VersionedMpcContract {
                 }
             }
             _ => Err(InvalidState::UnexpectedProtocolState.message(protocol_state.name())),
+        }
+    }
+
+    /// Vote on a checkpoint for a specific chain. When threshold votes are reached
+    /// for the exact same checkpoint (same block_height and pending_transactions),
+    /// it is stored as the latest checkpoint for that chain.
+    ///
+    /// Returns Ok(true) if threshold was reached and checkpoint was stored.
+    /// Returns Ok(false) if threshold was not yet reached.
+    #[handle_result]
+    pub fn vote_checkpoint(&mut self, chain: Chain, checkpoint: Checkpoint) -> Result<bool, Error> {
+        let voter = self.voter()?;
+        let checkpoint_height = checkpoint.block_height;
+        log!("vote_checkpoint: signer={voter}, chain={chain:?}, block_height={checkpoint_height}");
+        let ProtocolContractState::Running(RunningContractState {
+            threshold,
+            checkpoint_votes,
+            latest_checkpoints,
+            ..
+        }) = self.mutable_state()
+        else {
+            return Err(InvalidState::ProtocolStateNotRunning.into());
+        };
+
+        if let Some(latest) = latest_checkpoints.get(&chain) {
+            if checkpoint.block_height <= latest.block_height {
+                log!(
+                    "checkpoint ignored: chain={chain:?} block_height={checkpoint_height} <= latest_height={}",
+                    latest.block_height
+                );
+                return Ok(true);
+            }
+        }
+
+        let chain_votes = checkpoint_votes.entry(chain).or_default();
+
+        // Add this voter's vote for this specific checkpoint
+        let voted = chain_votes.entry(checkpoint.clone());
+        voted.insert(voter);
+        let vote_count = voted.len();
+
+        if vote_count >= *threshold {
+            log!("checkpoint latest updated: chain={chain:?} block_height={checkpoint_height}");
+
+            // Store as latest checkpoint
+            latest_checkpoints.insert(chain, checkpoint);
+            // latest checkpoint reached, clear previous ones:
+            checkpoint_votes.remove(&chain);
+            Ok(true)
+        } else {
+            log!("checkpoint voted: chain={chain:?} block_height={checkpoint_height}, votes={vote_count}/{threshold}");
+            Ok(false)
         }
     }
 
@@ -698,6 +756,8 @@ impl VersionedMpcContract {
                 candidates: Candidates::new(),
                 join_votes: Votes::new(),
                 leave_votes: Votes::new(),
+                checkpoint_votes: HashMap::new(),
+                latest_checkpoints: HashMap::new(),
             }),
             pending_requests: IterableMap::new(StorageKey::PendingRequests),
             proposed_updates: ProposedUpdates::default(),
@@ -715,8 +775,74 @@ impl VersionedMpcContract {
     #[init(ignore_state)]
     #[handle_result]
     pub fn migrate() -> Result<Self, Error> {
-        let old: MpcContract = env::state_read().ok_or(InvalidState::ContractStateIsMissing)?;
-        Ok(VersionedMpcContract::V0(old))
+        #[derive(BorshDeserialize)]
+        struct OldRunningContractState {
+            pub epoch: u64,
+            pub participants: Participants,
+            pub threshold: usize,
+            pub public_key: PublicKey,
+            pub candidates: Candidates,
+            pub join_votes: Votes,
+            pub leave_votes: Votes,
+        }
+
+        #[derive(BorshDeserialize)]
+        enum OldProtocolContractState {
+            NotInitialized,
+            Initializing(InitializingContractState),
+            Running(OldRunningContractState),
+            Resharing(ResharingContractState),
+        }
+
+        #[derive(BorshDeserialize)]
+        struct OldMpcContract {
+            protocol_state: OldProtocolContractState,
+            pending_requests: IterableMap<SignId, PendingRequest>,
+            proposed_updates: ProposedUpdates,
+            config: Config,
+        }
+
+        // Try to read as old state first (for migration)
+        if let Some(old_contract) = env::state_read::<OldMpcContract>() {
+            log!("Migrating from old contract state (adding checkpoint fields)");
+
+            // Convert old state to new state
+            let new_protocol_state = match old_contract.protocol_state {
+                OldProtocolContractState::NotInitialized => ProtocolContractState::NotInitialized,
+                OldProtocolContractState::Initializing(state) => {
+                    ProtocolContractState::Initializing(state)
+                }
+                OldProtocolContractState::Running(old_running) => {
+                    ProtocolContractState::Running(RunningContractState {
+                        epoch: old_running.epoch,
+                        participants: old_running.participants,
+                        threshold: old_running.threshold,
+                        public_key: old_running.public_key,
+                        candidates: old_running.candidates,
+                        join_votes: old_running.join_votes,
+                        leave_votes: old_running.leave_votes,
+                        checkpoint_votes: HashMap::new(),
+                        latest_checkpoints: HashMap::new(),
+                    })
+                }
+                OldProtocolContractState::Resharing(state) => {
+                    ProtocolContractState::Resharing(state)
+                }
+            };
+
+            return Ok(VersionedMpcContract::V0(MpcContract {
+                protocol_state: new_protocol_state,
+                pending_requests: old_contract.pending_requests,
+                proposed_updates: old_contract.proposed_updates,
+                config: old_contract.config,
+            }));
+        }
+
+        // If old state read failed, try reading as new state (no migration needed)
+        let new_contract: MpcContract =
+            env::state_read().ok_or(InvalidState::ContractStateIsMissing)?;
+        log!("Contract state is already up to date");
+        Ok(VersionedMpcContract::V0(new_contract))
     }
 
     pub fn state(&self) -> &ProtocolContractState {
@@ -753,6 +879,19 @@ impl VersionedMpcContract {
     // contract version
     pub fn version(&self) -> String {
         env!("CARGO_PKG_VERSION").to_string()
+    }
+
+    /// Get the latest agreed checkpoint for a specific chain
+    pub fn latest_checkpoint(&self, chain: Chain) -> Option<&Checkpoint> {
+        match self {
+            Self::V0(mpc_contract) => {
+                if let ProtocolContractState::Running(state) = &mpc_contract.protocol_state {
+                    state.latest_checkpoints.get(&chain)
+                } else {
+                    None
+                }
+            }
+        }
     }
 
     #[private]

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -24,10 +24,10 @@ use near_sdk::{
     PromiseError, PublicKey,
 };
 use primitives::{
-    CandidateInfo, Candidates, Chain, Checkpoint, InternalSignRequest, Participants,
-    PendingRequest, PkVotes, SignPoll, SignRequest, StorageKey, Votes, YieldIndex,
+    CandidateInfo, Candidates, InternalSignRequest, Participants, PendingRequest, PkVotes,
+    SignPoll, SignRequest, StorageKey, Votes, YieldIndex,
 };
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 
 use crate::config::Config;
 use crate::errors::Error;
@@ -477,8 +477,6 @@ impl VersionedMpcContract {
                         candidates: Candidates::new(),
                         join_votes: Votes::new(),
                         leave_votes: Votes::new(),
-                        checkpoint_votes: HashMap::new(),
-                        latest_checkpoints: HashMap::new(),
                     });
                     Ok(true)
                 } else {
@@ -522,8 +520,6 @@ impl VersionedMpcContract {
                         candidates: Candidates::new(),
                         join_votes: Votes::new(),
                         leave_votes: Votes::new(),
-                        checkpoint_votes: HashMap::new(),
-                        latest_checkpoints: HashMap::new(),
                     });
                     Ok(true)
                 } else {
@@ -565,8 +561,6 @@ impl VersionedMpcContract {
                         candidates: Candidates::new(),
                         join_votes: Votes::new(),
                         leave_votes: Votes::new(),
-                        checkpoint_votes: HashMap::new(),
-                        latest_checkpoints: HashMap::new(),
                     });
                     Ok(true)
                 } else {
@@ -574,58 +568,6 @@ impl VersionedMpcContract {
                 }
             }
             _ => Err(InvalidState::UnexpectedProtocolState.message(protocol_state.name())),
-        }
-    }
-
-    /// Vote on a checkpoint for a specific chain. When threshold votes are reached
-    /// for the exact same checkpoint (same block_height and pending_transactions),
-    /// it is stored as the latest checkpoint for that chain.
-    ///
-    /// Returns Ok(true) if threshold was reached and checkpoint was stored.
-    /// Returns Ok(false) if threshold was not yet reached.
-    #[handle_result]
-    pub fn vote_checkpoint(&mut self, chain: Chain, checkpoint: Checkpoint) -> Result<bool, Error> {
-        let voter = self.voter()?;
-        let checkpoint_height = checkpoint.block_height;
-        log!("vote_checkpoint: signer={voter}, chain={chain:?}, block_height={checkpoint_height}");
-        let ProtocolContractState::Running(RunningContractState {
-            threshold,
-            checkpoint_votes,
-            latest_checkpoints,
-            ..
-        }) = self.mutable_state()
-        else {
-            return Err(InvalidState::ProtocolStateNotRunning.into());
-        };
-
-        if let Some(latest) = latest_checkpoints.get(&chain) {
-            if checkpoint.block_height <= latest.block_height {
-                log!(
-                    "checkpoint ignored: chain={chain:?} block_height={checkpoint_height} <= latest_height={}",
-                    latest.block_height
-                );
-                return Ok(true);
-            }
-        }
-
-        let chain_votes = checkpoint_votes.entry(chain).or_default();
-
-        // Add this voter's vote for this specific checkpoint
-        let voted = chain_votes.entry(checkpoint.clone());
-        voted.insert(voter);
-        let vote_count = voted.len();
-
-        if vote_count >= *threshold {
-            log!("checkpoint latest updated: chain={chain:?} block_height={checkpoint_height}");
-
-            // Store as latest checkpoint
-            latest_checkpoints.insert(chain, checkpoint);
-            // latest checkpoint reached, clear previous ones:
-            checkpoint_votes.remove(&chain);
-            Ok(true)
-        } else {
-            log!("checkpoint voted: chain={chain:?} block_height={checkpoint_height}, votes={vote_count}/{threshold}");
-            Ok(false)
         }
     }
 
@@ -756,8 +698,6 @@ impl VersionedMpcContract {
                 candidates: Candidates::new(),
                 join_votes: Votes::new(),
                 leave_votes: Votes::new(),
-                checkpoint_votes: HashMap::new(),
-                latest_checkpoints: HashMap::new(),
             }),
             pending_requests: IterableMap::new(StorageKey::PendingRequests),
             proposed_updates: ProposedUpdates::default(),
@@ -821,8 +761,6 @@ impl VersionedMpcContract {
                         candidates: old_running.candidates,
                         join_votes: old_running.join_votes,
                         leave_votes: old_running.leave_votes,
-                        checkpoint_votes: HashMap::new(),
-                        latest_checkpoints: HashMap::new(),
                     })
                 }
                 OldProtocolContractState::Resharing(state) => {
@@ -879,19 +817,6 @@ impl VersionedMpcContract {
     // contract version
     pub fn version(&self) -> String {
         env!("CARGO_PKG_VERSION").to_string()
-    }
-
-    /// Get the latest agreed checkpoint for a specific chain
-    pub fn latest_checkpoint(&self, chain: Chain) -> Option<&Checkpoint> {
-        match self {
-            Self::V0(mpc_contract) => {
-                if let ProtocolContractState::Running(state) = &mpc_contract.protocol_state {
-                    state.latest_checkpoints.get(&chain)
-                } else {
-                    None
-                }
-            }
-        }
     }
 
     #[private]

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -715,71 +715,9 @@ impl VersionedMpcContract {
     #[init(ignore_state)]
     #[handle_result]
     pub fn migrate() -> Result<Self, Error> {
-        #[derive(BorshDeserialize)]
-        struct OldRunningContractState {
-            pub epoch: u64,
-            pub participants: Participants,
-            pub threshold: usize,
-            pub public_key: PublicKey,
-            pub candidates: Candidates,
-            pub join_votes: Votes,
-            pub leave_votes: Votes,
-        }
-
-        #[derive(BorshDeserialize)]
-        enum OldProtocolContractState {
-            NotInitialized,
-            Initializing(InitializingContractState),
-            Running(OldRunningContractState),
-            Resharing(ResharingContractState),
-        }
-
-        #[derive(BorshDeserialize)]
-        struct OldMpcContract {
-            protocol_state: OldProtocolContractState,
-            pending_requests: IterableMap<SignId, PendingRequest>,
-            proposed_updates: ProposedUpdates,
-            config: Config,
-        }
-
-        // Try to read as old state first (for migration)
-        if let Some(old_contract) = env::state_read::<OldMpcContract>() {
-            log!("Migrating from old contract state (adding checkpoint fields)");
-
-            // Convert old state to new state
-            let new_protocol_state = match old_contract.protocol_state {
-                OldProtocolContractState::NotInitialized => ProtocolContractState::NotInitialized,
-                OldProtocolContractState::Initializing(state) => {
-                    ProtocolContractState::Initializing(state)
-                }
-                OldProtocolContractState::Running(old_running) => {
-                    ProtocolContractState::Running(RunningContractState {
-                        epoch: old_running.epoch,
-                        participants: old_running.participants,
-                        threshold: old_running.threshold,
-                        public_key: old_running.public_key,
-                        candidates: old_running.candidates,
-                        join_votes: old_running.join_votes,
-                        leave_votes: old_running.leave_votes,
-                    })
-                }
-                OldProtocolContractState::Resharing(state) => {
-                    ProtocolContractState::Resharing(state)
-                }
-            };
-
-            return Ok(VersionedMpcContract::V0(MpcContract {
-                protocol_state: new_protocol_state,
-                pending_requests: old_contract.pending_requests,
-                proposed_updates: old_contract.proposed_updates,
-                config: old_contract.config,
-            }));
-        }
-
         // If old state read failed, try reading as new state (no migration needed)
         let new_contract: MpcContract =
             env::state_read().ok_or(InvalidState::ContractStateIsMissing)?;
-        log!("Contract state is already up to date");
         Ok(VersionedMpcContract::V0(new_contract))
     }
 

--- a/chain-signatures/contract/src/primitives.rs
+++ b/chain-signatures/contract/src/primitives.rs
@@ -1,3 +1,5 @@
+pub use mpc_primitives::{Chain, Checkpoint, PendingTx};
+
 use mpc_primitives::{bytes::borsh_scalar, SignId, Signature};
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
@@ -355,4 +357,41 @@ pub struct SignRequest {
 pub enum SignPoll {
     Ready(Signature),
     Timeout,
+}
+
+/// Manages votes for checkpoints
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
+#[borsh(crate = "near_sdk::borsh")]
+pub struct CheckpointVotes {
+    pub votes: HashMap<Checkpoint, HashSet<AccountId>>,
+}
+
+impl Default for CheckpointVotes {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CheckpointVotes {
+    pub fn new() -> Self {
+        CheckpointVotes {
+            votes: HashMap::new(),
+        }
+    }
+
+    pub fn entry(&mut self, checkpoint: Checkpoint) -> &mut HashSet<AccountId> {
+        self.votes.entry(checkpoint).or_default()
+    }
+
+    pub fn get(&self, checkpoint: &Checkpoint) -> Option<&HashSet<AccountId>> {
+        self.votes.get(checkpoint)
+    }
+
+    pub fn len(&self) -> usize {
+        self.votes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.votes.is_empty()
+    }
 }

--- a/chain-signatures/contract/src/state.rs
+++ b/chain-signatures/contract/src/state.rs
@@ -1,12 +1,10 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{AccountId, PublicKey};
 
-use crate::primitives::{
-    Candidates, Chain, Checkpoint, CheckpointVotes, Participants, PkVotes, Votes,
-};
+use crate::primitives::{Candidates, Participants, PkVotes, Votes};
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]
 pub struct InitializingContractState {
@@ -24,9 +22,6 @@ pub struct RunningContractState {
     pub candidates: Candidates,
     pub join_votes: Votes,
     pub leave_votes: Votes,
-    pub checkpoint_votes: HashMap<Chain, CheckpointVotes>,
-    /// The latest agreed checkpoint per chain
-    pub latest_checkpoints: HashMap<Chain, Checkpoint>,
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]

--- a/chain-signatures/contract/src/state.rs
+++ b/chain-signatures/contract/src/state.rs
@@ -1,10 +1,12 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{AccountId, PublicKey};
 
-use crate::primitives::{Candidates, Participants, PkVotes, Votes};
+use crate::primitives::{
+    Candidates, Chain, Checkpoint, CheckpointVotes, Participants, PkVotes, Votes,
+};
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]
 pub struct InitializingContractState {
@@ -22,6 +24,9 @@ pub struct RunningContractState {
     pub candidates: Candidates,
     pub join_votes: Votes,
     pub leave_votes: Votes,
+    pub checkpoint_votes: HashMap<Chain, CheckpointVotes>,
+    /// The latest agreed checkpoint per chain
+    pub latest_checkpoints: HashMap<Chain, Checkpoint>,
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]

--- a/chain-signatures/node/src/backlog.rs
+++ b/chain-signatures/node/src/backlog.rs
@@ -1,15 +1,23 @@
-use crate::protocol::Chain;
-use crate::sign_bidirectional::{BidirectionalTx, PendingRequestStatus};
-use mpc_primitives::SignId;
-use std::collections::{HashMap, VecDeque};
+use crate::protocol::{Chain, SignRequestType};
+use crate::rpc::NearClient;
+use crate::sign_bidirectional::{BidirectionalTx, BidirectionalTxId, PendingRequestStatus};
+use anyhow::Context;
+use mpc_primitives::{PendingTx, SignId};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+pub use mpc_primitives::Checkpoint;
+
+/// Checkpoint interval for Ethereum (every 5 blocks)
+const CHECKPOINT_INTERVAL_ETH: u64 = 5;
+
+/// Checkpoint interval for Solana (every 10 blocks)
+const CHECKPOINT_INTERVAL_SOL: u64 = 10;
+
 #[derive(Debug, Clone)]
 pub struct PendingRequests {
-    requests: HashMap<SignId, BidirectionalTx>,
-    /// Queue of transaction IDs waiting to be published
-    pending_publish: VecDeque<SignId>,
+    requests: HashMap<SignId, BacklogTransaction>,
     /// The highest block height that has been processed for this chain
     processed_block_height: Option<u64>,
 }
@@ -25,26 +33,25 @@ impl PendingRequests {
     pub fn new() -> Self {
         Self {
             requests: HashMap::new(),
-            pending_publish: VecDeque::new(),
             processed_block_height: None,
         }
     }
 
     /// Inserts a sign-respond transaction into the pending requests map
     /// Returns Some(old_value) if the key was already present
-    fn insert(&mut self, id: SignId, tx: BidirectionalTx) -> Option<BidirectionalTx> {
+    fn insert(&mut self, id: SignId, tx: BacklogTransaction) -> Option<BacklogTransaction> {
         self.requests.insert(id, tx)
     }
 
     /// Removes a sign-respond transaction from the pending requests map
     /// Returns Some(value) if the key was present
-    fn remove(&mut self, id: &SignId) -> Option<BidirectionalTx> {
+    fn remove(&mut self, id: &SignId) -> Option<BacklogTransaction> {
         self.requests.remove(id)
     }
 
     /// Gets a clone of a sign-respond transaction from the pending requests map
     /// Returns Some(value) if the key is present
-    fn get(&self, id: &SignId) -> Option<BidirectionalTx> {
+    fn get(&self, id: &SignId) -> Option<BacklogTransaction> {
         self.requests.get(id).cloned()
     }
 
@@ -54,37 +61,22 @@ impl PendingRequests {
     }
 
     /// Returns all sign-respond transactions with a specific status
-    pub fn get_by_status(&self, status: PendingRequestStatus) -> HashMap<SignId, BidirectionalTx> {
+    pub fn get_by_status(
+        &self,
+        status: PendingRequestStatus,
+    ) -> HashMap<SignId, BacklogTransaction> {
         self.requests
             .iter()
-            .filter(|(_, tx)| tx.status == status)
+            .filter(|(_, tx)| tx.status() == status)
             .map(|(id, tx)| (*id, tx.clone()))
             .collect()
     }
 
-    /// Add a transaction ID to the pending publish queue
-    pub fn push_pending_publish(&mut self, id: SignId) {
-        self.pending_publish.push_back(id);
-    }
-
-    /// Pop the next transaction ID from the pending publish queue
-    /// Returns the transaction if found
-    pub fn pop_pending_publish(&mut self) -> Option<(SignId, BidirectionalTx)> {
-        let id = self.pending_publish.pop_front()?;
-        let tx = self.get(&id)?;
-        Some((id, tx))
-    }
-
-    /// Get the number of transactions waiting to be published
-    fn pending_publish_count(&self) -> usize {
-        self.pending_publish.len()
-    }
-
-    /// Get all pending transaction IDs and their transactions
-    fn pending_execution(&self) -> Vec<(SignId, BidirectionalTx)> {
-        self.pending_publish
+    fn pending_execution(&self) -> Vec<(SignId, BacklogTransaction)> {
+        self.requests
             .iter()
-            .filter_map(|id| self.get(id).map(|tx| (*id, tx)))
+            .filter(|(_, tx)| tx.status() == PendingRequestStatus::PendingExecution)
+            .map(|(&id, tx)| (id, tx.clone()))
             .collect()
     }
 
@@ -97,6 +89,85 @@ impl PendingRequests {
     fn set_processed_block(&mut self, height: u64) {
         self.processed_block_height = Some(height);
     }
+
+    fn checkpoint(&self, chain: Chain) -> Checkpoint {
+        let mut encoded = self
+            .requests
+            .iter()
+            .map(|(&sign_id, tx)| {
+                let transaction = serde_json::to_vec(&tx)
+                    .expect("serialize bidirectional transaction for checkpoint");
+                PendingTx {
+                    sign_id,
+                    transaction,
+                }
+            })
+            .collect::<Vec<_>>();
+        encoded.sort_by_key(|pending| pending.sign_id);
+
+        Checkpoint {
+            chain,
+            block_height: self.processed_block_height.unwrap_or(0),
+            pending_requests: encoded,
+        }
+    }
+
+    fn from_checkpoint(checkpoint: Checkpoint) -> anyhow::Result<Self> {
+        fn decode(
+            pending: mpc_primitives::PendingTx,
+        ) -> anyhow::Result<(SignId, BacklogTransaction)> {
+            let tx: BacklogTransaction = serde_json::from_slice(&pending.transaction)
+                .with_context(|| {
+                    format!(
+                        "failed to deserialize pending transaction for sign_id {:?}",
+                        pending.sign_id
+                    )
+                })?;
+            Ok((pending.sign_id, tx))
+        }
+
+        let mut requests = HashMap::new();
+        for pending_tx in checkpoint.pending_requests {
+            let (sign_id, tx) = decode(pending_tx)?;
+            requests.insert(sign_id, tx);
+        }
+        Ok(Self {
+            requests,
+            processed_block_height: Some(checkpoint.block_height),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ExecutionWatcher {
+    sign_id: SignId,
+    tx: BidirectionalTx,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ExecutionWatchers {
+    watchers: HashMap<BidirectionalTxId, ExecutionWatcher>,
+}
+
+impl ExecutionWatchers {
+    fn insert(
+        &mut self,
+        tx_id: BidirectionalTxId,
+        watcher: ExecutionWatcher,
+    ) -> Option<ExecutionWatcher> {
+        self.watchers.insert(tx_id, watcher)
+    }
+
+    fn remove(&mut self, tx_id: &BidirectionalTxId) -> Option<ExecutionWatcher> {
+        self.watchers.remove(tx_id)
+    }
+
+    fn all(&self) -> HashMap<BidirectionalTxId, (SignId, BidirectionalTx)> {
+        self.watchers
+            .iter()
+            .map(|(id, watcher)| (*id, (watcher.sign_id, watcher.tx.clone())))
+            .collect()
+    }
 }
 
 /// Backlog manages pending sign-respond requests across multiple chains.
@@ -105,6 +176,8 @@ impl PendingRequests {
 #[derive(Debug, Clone)]
 pub struct Backlog {
     requests: Arc<RwLock<HashMap<Chain, PendingRequests>>>,
+    execution_watchers: Arc<RwLock<HashMap<Chain, ExecutionWatchers>>>,
+    sign_request_types: Arc<RwLock<HashMap<(Chain, SignId), SignRequestType>>>,
 }
 
 impl Default for Backlog {
@@ -117,6 +190,8 @@ impl Backlog {
     pub fn new() -> Self {
         Self {
             requests: Arc::new(RwLock::new(HashMap::new())),
+            execution_watchers: Arc::new(RwLock::new(HashMap::new())),
+            sign_request_types: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -124,8 +199,13 @@ impl Backlog {
         &self,
         chain: Chain,
         id: SignId,
-        tx: BidirectionalTx,
-    ) -> Option<BidirectionalTx> {
+        tx: BacklogTransaction,
+        sign_request_type: SignRequestType,
+    ) -> Option<BacklogTransaction> {
+        // Also track the sign request type
+        self.set_sign_request_type(chain, id, sign_request_type)
+            .await;
+
         self.requests
             .write()
             .await
@@ -134,7 +214,10 @@ impl Backlog {
             .insert(id, tx)
     }
 
-    pub async fn remove(&self, chain: Chain, id: &SignId) -> Option<BidirectionalTx> {
+    pub async fn remove(&self, chain: Chain, id: &SignId) -> Option<BacklogTransaction> {
+        // Also remove the sign request type tracking
+        self.remove_sign_request_type(chain, id).await;
+
         self.requests
             .write()
             .await
@@ -143,7 +226,7 @@ impl Backlog {
             .remove(id)
     }
 
-    pub async fn get(&self, chain: Chain, id: &SignId) -> Option<BidirectionalTx> {
+    pub async fn get(&self, chain: Chain, id: &SignId) -> Option<BacklogTransaction> {
         self.requests
             .read()
             .await
@@ -166,12 +249,40 @@ impl Backlog {
         self.requests.read().await.is_empty()
     }
 
+    /// Track the sign request type for a given sign ID
+    /// Store the sign request type for a given sign ID (internal only, set during insert)
+    async fn set_sign_request_type(
+        &self,
+        chain: Chain,
+        id: SignId,
+        sign_request_type: SignRequestType,
+    ) {
+        self.sign_request_types
+            .write()
+            .await
+            .insert((chain, id), sign_request_type);
+    }
+
+    /// Get the sign request type for a given sign ID
+    pub async fn sign_type(&self, chain: Chain, id: &SignId) -> Option<SignRequestType> {
+        self.sign_request_types
+            .read()
+            .await
+            .get(&(chain, *id))
+            .cloned()
+    }
+
+    /// Remove the sign request type tracking for a given sign ID (internal only, removed during remove)
+    async fn remove_sign_request_type(&self, chain: Chain, id: &SignId) {
+        self.sign_request_types.write().await.remove(&(chain, *id));
+    }
+
     /// Returns all sign-respond transactions with a specific status
     pub async fn get_by_status(
         &self,
         chain: Chain,
         status: PendingRequestStatus,
-    ) -> HashMap<SignId, BidirectionalTx> {
+    ) -> HashMap<SignId, BacklogTransaction> {
         self.requests
             .read()
             .await
@@ -200,24 +311,87 @@ impl Backlog {
         Ok(())
     }
 
-    /// Get the number of transactions waiting to be published for a specific chain
-    pub async fn pending_publish_count(&self, chain: Chain) -> usize {
-        self.requests
-            .read()
-            .await
-            .get(&chain)
-            .map(|pr| pr.pending_publish_count())
-            .unwrap_or(0)
+    /// Begin watching for execution of a bidirectional transaction on the destination chain.
+    pub async fn watch_execution(
+        &self,
+        chain: Chain,
+        sign_id: SignId,
+        tx: BidirectionalTx,
+    ) -> Option<(SignId, BidirectionalTx)> {
+        let mut watchers = self.execution_watchers.write().await;
+        let entry = watchers.entry(chain).or_default();
+        entry
+            .insert(tx.id, ExecutionWatcher { sign_id, tx })
+            .map(|previous| (previous.sign_id, previous.tx))
     }
 
-    /// Get all pending transactions for a specific chain
-    pub async fn pending_execution(&self, chain: Chain) -> Vec<(SignId, BidirectionalTx)> {
-        self.requests
+    /// Stop watching for execution of a bidirectional transaction on the destination chain.
+    pub async fn unwatch_execution(
+        &self,
+        chain: Chain,
+        tx_id: &BidirectionalTxId,
+    ) -> Option<(SignId, BidirectionalTx)> {
+        let mut watchers = self.execution_watchers.write().await;
+        watchers
+            .get_mut(&chain)
+            .and_then(|entry| entry.remove(tx_id))
+            .map(|watcher| (watcher.sign_id, watcher.tx))
+    }
+
+    /// Get the set of bidirectional transactions currently awaiting execution on the
+    /// specified destination chain.
+    pub async fn pending_execution(
+        &self,
+        chain: Chain,
+    ) -> HashMap<BidirectionalTxId, (SignId, BidirectionalTx)> {
+        self.execution_watchers
             .read()
             .await
             .get(&chain)
-            .map(|pr| pr.pending_execution())
+            .map(ExecutionWatchers::all)
             .unwrap_or_default()
+    }
+
+    /// Update the status of a tracked bidirectional transaction on the source chain.
+    pub async fn set_status(
+        &self,
+        chain: Chain,
+        id: &SignId,
+        status: PendingRequestStatus,
+    ) -> Option<BacklogTransaction> {
+        let mut requests = self.requests.write().await;
+        let pending = requests.get_mut(&chain)?;
+        let tx = pending.requests.get_mut(id)?;
+        tx.set_status(status);
+        Some(tx.clone())
+    }
+
+    /// Advances a `Sign` transaction to its execution phase and register execution watcher.
+    /// This is called after the protocol generates the signature for a SignBidirectional request.
+    pub async fn advance(
+        &self,
+        chain: Chain,
+        sign_id: SignId,
+        bidirectional_tx: BidirectionalTx,
+    ) -> Result<(), BacklogError> {
+        // Update the transaction in the backlog from Sign to Bidirectional
+        let mut requests = self.requests.write().await;
+        let pending = requests
+            .get_mut(&chain)
+            .ok_or(BacklogError::ChainNotFound)?;
+
+        // Replace the Sign transaction with the Bidirectional transaction
+        pending.requests.insert(
+            sign_id,
+            BacklogTransaction::Bidirectional(bidirectional_tx.clone()),
+        );
+
+        // Registration successful, now register the execution watcher on the target chain
+        let target_chain = bidirectional_tx.target_chain;
+        drop(requests);
+        self.watch_execution(target_chain, sign_id, bidirectional_tx)
+            .await;
+        Ok(())
     }
 
     /// Get the processed block height for a specific chain
@@ -229,12 +403,138 @@ impl Backlog {
             .and_then(|pr| pr.processed_block_height())
     }
 
-    /// Set the processed block height for a specific chain
-    pub async fn set_processed_block(&self, chain: Chain, height: u64) {
-        let mut map = self.requests.write().await;
-        let pending_requests = map.entry(chain).or_default();
-        pending_requests.set_processed_block(height);
-        tracing::debug!(?chain, height, "updated processed block height");
+    /// Set the processed block height for a specific chain.
+    /// Returns Some(Checkpoint) if a checkpoint should be created and submitted at this block height.
+    pub async fn set_processed_block(&self, chain: Chain, height: u64) -> Option<Checkpoint> {
+        let mut requests = self.requests.write().await;
+        let pending = requests.entry(chain).or_default();
+        pending.set_processed_block(height);
+        tracing::debug!(?chain, height, "backlog updated processed block height");
+
+        // Determine checkpoint interval based on chain
+        // TODO: need an interface for this in the future for more chains.
+        let checkpoint_interval = match chain {
+            Chain::Ethereum => CHECKPOINT_INTERVAL_ETH,
+            Chain::Solana => CHECKPOINT_INTERVAL_SOL,
+            Chain::NEAR => return None,
+        };
+
+        // create a checkpoint on interval
+        if height.is_multiple_of(checkpoint_interval) {
+            tracing::info!(
+                ?chain,
+                height,
+                tx_count = pending.len(),
+                "creating checkpoint"
+            );
+            Some(pending.checkpoint(chain))
+        } else {
+            None
+        }
+    }
+
+    /// Create a checkpoint of the current backlog state for a specific chain
+    pub async fn checkpoint(&self, chain: Chain) -> Checkpoint {
+        self.requests
+            .read()
+            .await
+            .get(&chain)
+            .map(|pr| pr.checkpoint(chain))
+            .unwrap_or_else(|| Checkpoint::empty(chain))
+    }
+
+    /// Recover backlog state from a checkpoint
+    /// This is called when a node restarts and needs to catch up
+    pub async fn recover_by_checkpoint(&self, checkpoint: Checkpoint) -> anyhow::Result<()> {
+        let chain = checkpoint.chain;
+        tracing::info!(
+            ?chain,
+            block_height = checkpoint.block_height,
+            num_pending = checkpoint.pending_requests.len(),
+            "recovering from checkpoint"
+        );
+
+        let mut requests = self.requests.write().await;
+        let pending = requests
+            .entry(checkpoint.chain)
+            .or_insert_with(PendingRequests::new);
+
+        let previous_height = pending.processed_block_height().unwrap_or(0);
+        let checkpoint_height = checkpoint.block_height;
+
+        // Execution watchers are ephemeral, we need to get all the execution watchers here
+        let execution_to_watch = if checkpoint_height > previous_height {
+            let cleared = pending.len();
+            *pending = PendingRequests::from_checkpoint(checkpoint)?;
+            let execution_to_watch = pending.pending_execution();
+
+            tracing::info!(
+                ?chain,
+                old_block = previous_height,
+                new_block = checkpoint_height,
+                cleared_requests = cleared,
+                restored_requests = pending.len(),
+                "successfully recovered from checkpoint"
+            );
+
+            execution_to_watch
+        } else {
+            tracing::warn!(
+                chain = ?checkpoint.chain,
+                checkpoint_block = checkpoint.block_height,
+                previous_height,
+                "checkpoint block is not newer than current block, skipping recovery"
+            );
+
+            Vec::new()
+        };
+        drop(requests);
+
+        // now repopulate our execution watchers
+        for (sign_id, tx) in execution_to_watch {
+            // Only restore execution watchers for bidirectional transactions
+            if let Some(target_chain) = tx.target_chain() {
+                // Extract the BidirectionalTx from the BacklogTransaction
+                if let BacklogTransaction::Bidirectional(bidirectional_tx) = tx {
+                    self.watch_execution(target_chain, sign_id, bidirectional_tx)
+                        .await;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn recover(&self, near: &NearClient, chains: &[Chain]) {
+        tracing::info!("attempting to recover from latest checkpoints");
+        for &chain in chains {
+            match near.fetch_latest_checkpoint(chain).await {
+                Ok(Some(checkpoint)) => {
+                    tracing::info!(
+                        ?chain,
+                        block_height = checkpoint.block_height,
+                        "found checkpoint, attempting recovery"
+                    );
+                    if let Err(err) = self.recover_by_checkpoint(checkpoint).await {
+                        tracing::warn!(
+                            ?chain,
+                            %err,
+                            "failed to recover from checkpoint, continuing with empty state"
+                        );
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!(?chain, "no checkpoint found, starting fresh");
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        ?chain,
+                        %err,
+                        "failed to fetch checkpoint, continuing with empty state"
+                    );
+                }
+            }
+        }
     }
 }
 
@@ -245,15 +545,87 @@ pub enum BacklogError {
     NotFound { chain: Chain, id: SignId },
     #[error("chain not initialized: {chain:?}")]
     ChainNotInitialized { chain: Chain },
+    #[error("chain not found")]
+    ChainNotFound,
+    #[error("transaction not found")]
+    TransactionNotFound,
+}
+
+/// Sign request transaction metadata (non-bidirectional).
+#[derive(Debug, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct SignTx {
+    pub request_id: [u8; 32],
+    pub source_chain: Chain,
+    pub key_version: u32,
+    pub status: PendingRequestStatus,
+}
+
+/// Pending transaction in the backlog - can be either a sign-only or bidirectional.
+#[derive(Debug, Clone, Hash, serde::Serialize, serde::Deserialize)]
+#[allow(clippy::large_enum_variant)]
+pub enum BacklogTransaction {
+    Sign(SignTx),
+    Bidirectional(BidirectionalTx),
+}
+
+impl BacklogTransaction {
+    /// Get the request ID for this transaction
+    pub fn request_id(&self) -> [u8; 32] {
+        match self {
+            Self::Sign(tx) => tx.request_id,
+            Self::Bidirectional(tx) => tx.request_id,
+        }
+    }
+
+    /// Get the source chain for this transaction
+    pub fn source_chain(&self) -> Chain {
+        match self {
+            Self::Sign(tx) => tx.source_chain,
+            Self::Bidirectional(tx) => tx.source_chain,
+        }
+    }
+
+    /// Get the status of this transaction
+    pub fn status(&self) -> PendingRequestStatus {
+        match self {
+            Self::Sign(tx) => tx.status,
+            Self::Bidirectional(tx) => tx.status,
+        }
+    }
+
+    /// Set the status of this transaction
+    pub fn set_status(&mut self, status: PendingRequestStatus) {
+        match self {
+            Self::Sign(tx) => tx.status = status,
+            Self::Bidirectional(tx) => tx.status = status,
+        }
+    }
+
+    /// Get target chain if this is a bidirectional transaction
+    pub fn target_chain(&self) -> Option<Chain> {
+        match self {
+            Self::Sign(_) => None,
+            Self::Bidirectional(tx) => Some(tx.target_chain),
+        }
+    }
+
+    /// Check if this is a bidirectional transaction
+    pub fn is_bidirectional(&self) -> bool {
+        matches!(self, Self::Bidirectional(_))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sign_bidirectional::{BidirectionalTx, BidirectionalTxId, PendingRequestStatus};
+    use crate::{
+        protocol::SignRequestType,
+        sign_bidirectional::{BidirectionalTx, BidirectionalTxId, PendingRequestStatus},
+    };
     use alloy::primitives::{Address, B256};
     use anchor_lang::prelude::Pubkey;
     use mpc_primitives::SignId;
+    use signet_program::SignBidirectionalEvent;
 
     fn create_test_tx(id: u8, status: PendingRequestStatus) -> BidirectionalTx {
         BidirectionalTx {
@@ -274,7 +646,6 @@ mod tests {
             request_id: [id; 32],
             from_address: Address::ZERO,
             nonce: 0,
-            participants: vec![],
             status,
         }
     }
@@ -283,23 +654,79 @@ mod tests {
     async fn test_backlog_chain_isolation() {
         let backlog = Backlog::new();
 
-        let tx_eth = create_test_tx(1, PendingRequestStatus::PendingExecution);
-        let tx_sol = create_test_tx(2, PendingRequestStatus::PendingExecution);
-        let tx_near = create_test_tx(3, PendingRequestStatus::PendingExecution);
+        let tx_eth = create_test_tx(1, PendingRequestStatus::AwaitingResponse);
+        let tx_sol = create_test_tx(2, PendingRequestStatus::AwaitingResponse);
+        let tx_near = create_test_tx(3, PendingRequestStatus::AwaitingResponse);
 
         let sign_id_eth = SignId::new(tx_eth.request_id);
         let sign_id_sol = SignId::new(tx_sol.request_id);
         let sign_id_near = SignId::new(tx_near.request_id);
 
+        let program_id = Pubkey::new_unique();
+
         // Insert into different chains
         backlog
-            .insert(Chain::Ethereum, sign_id_eth, tx_eth.clone())
+            .insert(
+                Chain::Ethereum,
+                sign_id_eth,
+                BacklogTransaction::Bidirectional(tx_eth.clone()),
+                SignRequestType::SignBidirectional(SignBidirectionalEvent {
+                    sender: Default::default(),
+                    serialized_transaction: vec![],
+                    dest: "ethereum".to_string(),
+                    caip2_id: "eip155:1".to_string(),
+                    key_version: 0,
+                    deposit: 0,
+                    path: "".to_string(),
+                    algo: "".to_string(),
+                    params: "".to_string(),
+                    program_id,
+                    output_deserialization_schema: vec![],
+                    respond_serialization_schema: vec![],
+                }),
+            )
             .await;
         backlog
-            .insert(Chain::Solana, sign_id_sol, tx_sol.clone())
+            .insert(
+                Chain::Solana,
+                sign_id_sol,
+                BacklogTransaction::Bidirectional(tx_sol.clone()),
+                SignRequestType::SignBidirectional(SignBidirectionalEvent {
+                    sender: Default::default(),
+                    serialized_transaction: vec![],
+                    dest: "solana".to_string(),
+                    caip2_id: "solana:5eykt4UsFY6PZFX8nTM1".to_string(),
+                    key_version: 0,
+                    deposit: 0,
+                    path: "".to_string(),
+                    algo: "".to_string(),
+                    params: "".to_string(),
+                    program_id,
+                    output_deserialization_schema: vec![],
+                    respond_serialization_schema: vec![],
+                }),
+            )
             .await;
         backlog
-            .insert(Chain::NEAR, sign_id_near, tx_near.clone())
+            .insert(
+                Chain::NEAR,
+                sign_id_near,
+                BacklogTransaction::Bidirectional(tx_near.clone()),
+                SignRequestType::SignBidirectional(SignBidirectionalEvent {
+                    sender: Default::default(),
+                    serialized_transaction: vec![],
+                    dest: "near".to_string(),
+                    caip2_id: "near:mainnet".to_string(),
+                    key_version: 0,
+                    deposit: 0,
+                    path: "".to_string(),
+                    algo: "".to_string(),
+                    params: "".to_string(),
+                    program_id,
+                    output_deserialization_schema: vec![],
+                    respond_serialization_schema: vec![],
+                }),
+            )
             .await;
 
         // Verify correct transactions in each chain
@@ -316,31 +743,56 @@ mod tests {
         let backlog = Backlog::new();
 
         // Add transactions with different statuses to Ethereum
-        let tx1 = create_test_tx(1, PendingRequestStatus::PendingExecution);
+        let tx1 = create_test_tx(1, PendingRequestStatus::AwaitingResponse);
         let tx2 = create_test_tx(2, PendingRequestStatus::Success);
         let tx3 = create_test_tx(3, PendingRequestStatus::PendingExecution);
 
         backlog
-            .insert(Chain::Ethereum, SignId::new(tx1.request_id), tx1)
+            .insert(
+                Chain::Ethereum,
+                SignId::new(tx1.request_id),
+                BacklogTransaction::Bidirectional(tx1),
+                SignRequestType::Sign,
+            )
             .await;
         backlog
-            .insert(Chain::Ethereum, SignId::new(tx2.request_id), tx2)
+            .insert(
+                Chain::Ethereum,
+                SignId::new(tx2.request_id),
+                BacklogTransaction::Bidirectional(tx2),
+                SignRequestType::Sign,
+            )
             .await;
         backlog
-            .insert(Chain::Ethereum, SignId::new(tx3.request_id), tx3)
+            .insert(
+                Chain::Ethereum,
+                SignId::new(tx3.request_id),
+                BacklogTransaction::Bidirectional(tx3),
+                SignRequestType::Sign,
+            )
             .await;
 
         // Add transactions to Solana
         let tx4 = create_test_tx(4, PendingRequestStatus::PendingExecution);
         backlog
-            .insert(Chain::Solana, SignId::new(tx4.request_id), tx4)
+            .insert(
+                Chain::Solana,
+                SignId::new(tx4.request_id),
+                BacklogTransaction::Bidirectional(tx4),
+                SignRequestType::Sign,
+            )
             .await;
 
         // Filter Ethereum by Pending
         let eth_pending = backlog
             .get_by_status(Chain::Ethereum, PendingRequestStatus::PendingExecution)
             .await;
-        assert_eq!(eth_pending.len(), 2);
+        assert_eq!(eth_pending.len(), 1);
+
+        let eth_awaiting = backlog
+            .get_by_status(Chain::Ethereum, PendingRequestStatus::AwaitingResponse)
+            .await;
+        assert_eq!(eth_awaiting.len(), 1);
 
         // Filter Ethereum by Success
         let eth_success = backlog
@@ -370,9 +822,16 @@ mod tests {
         for i in 0..5 {
             let backlog = backlog.clone();
             let handle = tokio::spawn(async move {
-                let tx = create_test_tx(i, PendingRequestStatus::PendingExecution);
+                let tx = create_test_tx(i, PendingRequestStatus::AwaitingResponse);
                 let sign_id = SignId::new(tx.request_id);
-                backlog.insert(Chain::Ethereum, sign_id, tx).await;
+                backlog
+                    .insert(
+                        Chain::Ethereum,
+                        sign_id,
+                        BacklogTransaction::Bidirectional(tx),
+                        SignRequestType::Sign,
+                    )
+                    .await;
             });
             handles.push(handle);
         }
@@ -380,9 +839,16 @@ mod tests {
         for i in 5..10 {
             let backlog = backlog.clone();
             let handle = tokio::spawn(async move {
-                let tx = create_test_tx(i, PendingRequestStatus::PendingExecution);
+                let tx = create_test_tx(i, PendingRequestStatus::AwaitingResponse);
                 let sign_id = SignId::new(tx.request_id);
-                backlog.insert(Chain::Solana, sign_id, tx).await;
+                backlog
+                    .insert(
+                        Chain::Solana,
+                        sign_id,
+                        BacklogTransaction::Bidirectional(tx),
+                        SignRequestType::Sign,
+                    )
+                    .await;
             });
             handles.push(handle);
         }
@@ -414,5 +880,211 @@ mod tests {
         // Verify Ethereum chain is now empty, but Solana still has data
         assert_eq!(backlog.len_by_chain(Chain::Ethereum).await, 0);
         assert_eq!(backlog.len_by_chain(Chain::Solana).await, 5);
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_creation() {
+        let backlog = Backlog::new();
+
+        // Add some transactions
+        let tx1 = create_test_tx(1, PendingRequestStatus::PendingExecution);
+        let tx2 = create_test_tx(2, PendingRequestStatus::Success);
+        backlog.set_processed_block(Chain::Ethereum, 100).await;
+
+        backlog
+            .insert(
+                Chain::Ethereum,
+                SignId::new(tx1.request_id),
+                BacklogTransaction::Bidirectional(tx1.clone()),
+                SignRequestType::Sign,
+            )
+            .await;
+        backlog
+            .insert(
+                Chain::Ethereum,
+                SignId::new(tx2.request_id),
+                BacklogTransaction::Bidirectional(tx2.clone()),
+                SignRequestType::Sign,
+            )
+            .await;
+
+        let checkpoint = backlog.checkpoint(Chain::Ethereum).await;
+        assert_eq!(checkpoint.block_height, 100);
+        assert_eq!(checkpoint.chain, Chain::Ethereum);
+        assert_eq!(checkpoint.pending_requests.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_equality() {
+        let tx1 = create_test_tx(1, PendingRequestStatus::AwaitingResponse);
+        let tx2 = create_test_tx(2, PendingRequestStatus::AwaitingResponse);
+        let mut pending1 = PendingRequests::new();
+        pending1.insert(
+            SignId::new(tx1.request_id),
+            BacklogTransaction::Bidirectional(tx1.clone()),
+        );
+        pending1.insert(
+            SignId::new(tx2.request_id),
+            BacklogTransaction::Bidirectional(tx2.clone()),
+        );
+        pending1.set_processed_block(100);
+
+        let mut pending2 = PendingRequests::new();
+        pending2.insert(
+            SignId::new(tx1.request_id),
+            BacklogTransaction::Bidirectional(tx1.clone()),
+        );
+        pending2.insert(
+            SignId::new(tx2.request_id),
+            BacklogTransaction::Bidirectional(tx2.clone()),
+        );
+        pending2.set_processed_block(100);
+
+        let checkpoint1 = pending1.checkpoint(Chain::Ethereum);
+        let checkpoint2 = pending2.checkpoint(Chain::Ethereum);
+        // Same data should be equal
+        assert_eq!(checkpoint1, checkpoint2);
+
+        // Different block height should not be equal
+        let mut checkpoint3 = pending2.checkpoint(Chain::Ethereum);
+        checkpoint3.block_height = 101;
+        assert_ne!(checkpoint1, checkpoint3);
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_serialization() {
+        let tx1 = create_test_tx(1, PendingRequestStatus::AwaitingResponse);
+
+        let mut pending = PendingRequests::new();
+        pending.insert(
+            SignId::new(tx1.request_id),
+            BacklogTransaction::Bidirectional(tx1.clone()),
+        );
+        pending.set_processed_block(100);
+        let checkpoint = pending.checkpoint(Chain::Ethereum);
+
+        // Test JSON serialization
+        let json = serde_json::to_string(&checkpoint).unwrap();
+        let deserialized: Checkpoint = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(checkpoint, deserialized);
+
+        let (sign_id, restored_tx): (SignId, BidirectionalTx) = {
+            let pending = &checkpoint.pending_requests[0];
+            let backlog_tx: BacklogTransaction =
+                serde_json::from_slice(&pending.transaction).unwrap();
+            let tx = match backlog_tx {
+                BacklogTransaction::Bidirectional(tx) => tx,
+                BacklogTransaction::Sign(_) => panic!("Expected Bidirectional transaction"),
+            };
+            (pending.sign_id, tx)
+        };
+        assert_eq!(sign_id, SignId::new(tx1.request_id));
+        assert_eq!(
+            restored_tx.serialized_transaction,
+            tx1.serialized_transaction
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recover_restores_execution_watchers() {
+        let backlog = Backlog::new();
+        let tx = create_test_tx(6, PendingRequestStatus::PendingExecution);
+        let sign_id = SignId::new(tx.request_id);
+
+        backlog
+            .insert(
+                Chain::Solana,
+                sign_id,
+                BacklogTransaction::Bidirectional(tx.clone()),
+                SignRequestType::Sign,
+            )
+            .await;
+        backlog.set_processed_block(Chain::Solana, 10).await;
+
+        let checkpoint = backlog.checkpoint(Chain::Solana).await;
+
+        let recovered = Backlog::new();
+        recovered
+            .recover_by_checkpoint(checkpoint)
+            .await
+            .expect("failed to recover");
+
+        let watchers = recovered.pending_execution(Chain::Ethereum).await;
+        assert_eq!(watchers.len(), 1);
+        assert!(watchers.contains_key(&tx.id));
+    }
+
+    #[tokio::test]
+    async fn test_automatic_checkpoint_on_interval() {
+        let backlog = Backlog::new();
+
+        // Add some transactions
+        let tx1 = create_test_tx(1, PendingRequestStatus::PendingExecution);
+        backlog
+            .insert(
+                Chain::Ethereum,
+                SignId::new(tx1.request_id),
+                BacklogTransaction::Bidirectional(tx1.clone()),
+                SignRequestType::Sign,
+            )
+            .await;
+
+        // First few blocks shouldn't create checkpoints
+        let checkpoint = backlog.set_processed_block(Chain::Ethereum, 1).await;
+        assert!(checkpoint.is_none());
+
+        let checkpoint = backlog.set_processed_block(Chain::Ethereum, 2).await;
+        assert!(checkpoint.is_none());
+
+        // At block 5 (CHECKPOINT_INTERVAL_ETH), should create checkpoint
+        let checkpoint = backlog.set_processed_block(Chain::Ethereum, 5).await;
+        assert!(checkpoint.is_some());
+        let checkpoint = checkpoint.unwrap();
+        assert_eq!(checkpoint.block_height, 5);
+        assert_eq!(checkpoint.chain, Chain::Ethereum);
+        assert_eq!(checkpoint.pending_requests.len(), 1);
+
+        // Next checkpoint should be at block 10
+        let checkpoint = backlog.set_processed_block(Chain::Ethereum, 7).await;
+        assert!(checkpoint.is_none());
+
+        let checkpoint = backlog.set_processed_block(Chain::Ethereum, 10).await;
+        assert!(checkpoint.is_some());
+        let checkpoint = checkpoint.unwrap();
+        assert_eq!(checkpoint.block_height, 10);
+    }
+
+    #[tokio::test]
+    async fn test_automatic_checkpoint_solana_interval() {
+        let backlog = Backlog::new();
+
+        // Add transaction
+        let tx1 = create_test_tx(1, PendingRequestStatus::PendingExecution);
+        backlog
+            .insert(
+                Chain::Solana,
+                SignId::new(tx1.request_id),
+                BacklogTransaction::Bidirectional(tx1.clone()),
+                SignRequestType::Sign,
+            )
+            .await;
+
+        // Solana interval is 10 blocks
+        for i in 1..10 {
+            let checkpoint = backlog.set_processed_block(Chain::Solana, i).await;
+            assert!(
+                checkpoint.is_none(),
+                "Block {} should not create checkpoint",
+                i
+            );
+        }
+
+        // At block 10, should create checkpoint
+        let checkpoint = backlog.set_processed_block(Chain::Solana, 10).await;
+        assert!(checkpoint.is_some());
+        let checkpoint = checkpoint.unwrap();
+        assert_eq!(checkpoint.block_height, 10);
+        assert_eq!(checkpoint.chain, Chain::Solana);
     }
 }

--- a/chain-signatures/node/src/backlog.rs
+++ b/chain-signatures/node/src/backlog.rs
@@ -1,19 +1,20 @@
+use crate::checkpoint_consensus::fetch_consensus_checkpoints;
+use crate::mesh::MeshState;
+use crate::node_client::NodeClient;
 use crate::protocol::{Chain, SignRequestType};
-use crate::rpc::NearClient;
 use crate::sign_bidirectional::{BidirectionalTx, BidirectionalTxId, PendingRequestStatus};
 use anyhow::Context;
 use mpc_primitives::{PendingTx, SignId};
-use std::collections::HashMap;
+use std::collections::{hash_map, HashMap};
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
 pub use mpc_primitives::Checkpoint;
 
-/// Checkpoint interval for Ethereum (every 5 blocks)
-const CHECKPOINT_INTERVAL_ETH: u64 = 5;
-
-/// Checkpoint interval for Solana (every 10 blocks)
-const CHECKPOINT_INTERVAL_SOL: u64 = 10;
+// Clean up old checkpoints (older than 30 minutes)
+const RETENTION_DURATION: Duration = Duration::from_secs(30 * 60);
 
 #[derive(Debug, Clone)]
 pub struct PendingRequests {
@@ -170,6 +171,13 @@ impl ExecutionWatchers {
     }
 }
 
+/// Historical checkpoint with timestamp for retention management
+#[derive(Debug, Clone)]
+struct HistoricalCheckpoint {
+    checkpoint: Checkpoint,
+    created_at: Instant,
+}
+
 /// Backlog manages pending sign-respond requests across multiple chains.
 /// Each chain has its own isolated set of pending requests with their own
 /// publish queues.
@@ -178,6 +186,8 @@ pub struct Backlog {
     requests: Arc<RwLock<HashMap<Chain, PendingRequests>>>,
     execution_watchers: Arc<RwLock<HashMap<Chain, ExecutionWatchers>>>,
     sign_request_types: Arc<RwLock<HashMap<(Chain, SignId), SignRequestType>>>,
+    /// Historical checkpoints kept for 30 minutes, indexed by chain
+    historical_checkpoints: Arc<RwLock<HashMap<Chain, Vec<HistoricalCheckpoint>>>>,
 }
 
 impl Default for Backlog {
@@ -192,6 +202,7 @@ impl Backlog {
             requests: Arc::new(RwLock::new(HashMap::new())),
             execution_watchers: Arc::new(RwLock::new(HashMap::new())),
             sign_request_types: Arc::new(RwLock::new(HashMap::new())),
+            historical_checkpoints: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -409,25 +420,23 @@ impl Backlog {
         let mut requests = self.requests.write().await;
         let pending = requests.entry(chain).or_default();
         pending.set_processed_block(height);
-        tracing::debug!(?chain, height, "backlog updated processed block height");
 
-        // Determine checkpoint interval based on chain
-        // TODO: need an interface for this in the future for more chains.
-        let checkpoint_interval = match chain {
-            Chain::Ethereum => CHECKPOINT_INTERVAL_ETH,
-            Chain::Solana => CHECKPOINT_INTERVAL_SOL,
-            Chain::NEAR => return None,
-        };
+        let interval = chain.checkpoint_interval();
+        tracing::trace!(
+            ?chain,
+            height,
+            ?interval,
+            "backlog updated processed block height"
+        );
 
         // create a checkpoint on interval
-        if height.is_multiple_of(checkpoint_interval) {
-            tracing::info!(
-                ?chain,
-                height,
-                tx_count = pending.len(),
-                "creating checkpoint"
-            );
-            Some(pending.checkpoint(chain))
+        if height.is_multiple_of(interval?) {
+            let tx_count = pending.len();
+            drop(requests);
+            let checkpoint = self.checkpoint(chain).await;
+            tracing::info!(?chain, height, tx_count, ?checkpoint, "creating checkpoint");
+
+            Some(checkpoint)
         } else {
             None
         }
@@ -435,12 +444,49 @@ impl Backlog {
 
     /// Create a checkpoint of the current backlog state for a specific chain
     pub async fn checkpoint(&self, chain: Chain) -> Checkpoint {
-        self.requests
+        let checkpoint = self
+            .requests
             .read()
             .await
             .get(&chain)
             .map(|pr| pr.checkpoint(chain))
-            .unwrap_or_else(|| Checkpoint::empty(chain))
+            .unwrap_or_else(|| Checkpoint::empty(chain));
+
+        // Store checkpoint in historical checkpoints
+        let mut historical = self.historical_checkpoints.write().await;
+        let historical = historical.entry(chain).or_insert_with(Vec::new);
+        historical.push(HistoricalCheckpoint {
+            checkpoint: checkpoint.clone(),
+            created_at: Instant::now(),
+        });
+        historical.retain(|hcp| hcp.created_at.elapsed() < RETENTION_DURATION);
+
+        checkpoint
+    }
+
+    pub async fn latest_checkpoint(&self, chain: Chain) -> Option<Checkpoint> {
+        let historical = self.historical_checkpoints.read().await;
+        historical.get(&chain).and_then(|checkpoints| {
+            checkpoints
+                .iter()
+                .max_by_key(|hcp| hcp.checkpoint.block_height)
+                .map(|hcp| hcp.checkpoint.clone())
+        })
+    }
+
+    /// Find a historical checkpoint by hash
+    pub async fn find_checkpoint_by_hash(&self, chain: Chain, hash: u64) -> Option<Checkpoint> {
+        let historical = self.historical_checkpoints.read().await;
+        if let Some(checkpoints) = historical.get(&chain) {
+            for hcp in checkpoints {
+                let mut hasher = hash_map::DefaultHasher::new();
+                hcp.checkpoint.hash(&mut hasher);
+                if hasher.finish() == hash {
+                    return Some(hcp.checkpoint.clone());
+                }
+            }
+        }
+        None
     }
 
     /// Recover backlog state from a checkpoint
@@ -505,34 +551,38 @@ impl Backlog {
         Ok(())
     }
 
-    pub async fn recover(&self, near: &NearClient, chains: &[Chain]) {
-        tracing::info!("attempting to recover from latest checkpoints");
-        for &chain in chains {
-            match near.fetch_latest_checkpoint(chain).await {
-                Ok(Some(checkpoint)) => {
-                    tracing::info!(
-                        ?chain,
-                        block_height = checkpoint.block_height,
-                        "found checkpoint, attempting recovery"
-                    );
-                    if let Err(err) = self.recover_by_checkpoint(checkpoint).await {
-                        tracing::warn!(
-                            ?chain,
-                            %err,
-                            "failed to recover from checkpoint, continuing with empty state"
-                        );
-                    }
-                }
-                Ok(None) => {
-                    tracing::info!(?chain, "no checkpoint found, starting fresh");
-                }
-                Err(err) => {
-                    tracing::warn!(
-                        ?chain,
-                        %err,
-                        "failed to fetch checkpoint, continuing with empty state"
-                    );
-                }
+    pub async fn recover(
+        &self,
+        mesh_state: &MeshState,
+        node_client: &NodeClient,
+        threshold: usize,
+        chains: &[Chain],
+    ) {
+        tracing::info!("attempting to recover from latest checkpoints via node consensus");
+
+        // p2p node consensus to find checkpoints.
+        // Fetches all checkpoints from active participants and creates a consensus checkpoint:
+        // - sorts all checkpoints by block height
+        // - selects threshold lowest block height checkpoint
+        let checkpoints =
+            fetch_consensus_checkpoints(mesh_state, node_client, threshold, chains).await;
+        if checkpoints.is_empty() {
+            tracing::info!("no consensus checkpoints found, starting with empty state");
+            return;
+        }
+
+        for (chain, checkpoint) in checkpoints {
+            tracing::info!(
+                ?chain,
+                block_height = checkpoint.block_height,
+                "found consensus checkpoint, attempting recovery"
+            );
+            if let Err(err) = self.recover_by_checkpoint(checkpoint).await {
+                tracing::warn!(
+                    ?chain,
+                    %err,
+                    "failed to recover from consensus checkpoint, continuing with empty state"
+                );
             }
         }
     }
@@ -1030,34 +1080,39 @@ mod tests {
             )
             .await;
 
+        let interval = Chain::Ethereum.checkpoint_interval().unwrap();
+
         // First few blocks shouldn't create checkpoints
-        let checkpoint = backlog.set_processed_block(Chain::Ethereum, 1).await;
-        assert!(checkpoint.is_none());
+        for i in 1..interval {
+            let checkpoint = backlog.set_processed_block(Chain::Ethereum, i).await;
+            assert!(checkpoint.is_none(), "Block {i} should not make checkpoint");
+        }
 
-        let checkpoint = backlog.set_processed_block(Chain::Ethereum, 2).await;
-        assert!(checkpoint.is_none());
-
-        // At block 5 (CHECKPOINT_INTERVAL_ETH), should create checkpoint
-        let checkpoint = backlog.set_processed_block(Chain::Ethereum, 5).await;
+        // At block interval, should create checkpoint
+        let checkpoint = backlog.set_processed_block(Chain::Ethereum, interval).await;
         assert!(checkpoint.is_some());
         let checkpoint = checkpoint.unwrap();
-        assert_eq!(checkpoint.block_height, 5);
+        assert_eq!(checkpoint.block_height, interval);
         assert_eq!(checkpoint.chain, Chain::Ethereum);
         assert_eq!(checkpoint.pending_requests.len(), 1);
 
-        // Next checkpoint should be at block 10
-        let checkpoint = backlog.set_processed_block(Chain::Ethereum, 7).await;
+        let checkpoint = backlog
+            .set_processed_block(Chain::Ethereum, interval + 1)
+            .await;
         assert!(checkpoint.is_none());
 
-        let checkpoint = backlog.set_processed_block(Chain::Ethereum, 10).await;
+        let checkpoint = backlog
+            .set_processed_block(Chain::Ethereum, 2 * interval)
+            .await;
         assert!(checkpoint.is_some());
         let checkpoint = checkpoint.unwrap();
-        assert_eq!(checkpoint.block_height, 10);
+        assert_eq!(checkpoint.block_height, 2 * interval);
     }
 
     #[tokio::test]
     async fn test_automatic_checkpoint_solana_interval() {
         let backlog = Backlog::new();
+        let interval = Chain::Solana.checkpoint_interval().unwrap();
 
         // Add transaction
         let tx1 = create_test_tx(1, PendingRequestStatus::PendingExecution);
@@ -1071,20 +1126,16 @@ mod tests {
             .await;
 
         // Solana interval is 10 blocks
-        for i in 1..10 {
+        for i in 1..interval {
             let checkpoint = backlog.set_processed_block(Chain::Solana, i).await;
-            assert!(
-                checkpoint.is_none(),
-                "Block {} should not create checkpoint",
-                i
-            );
+            assert!(checkpoint.is_none(), "Block {i} should not make checkpoint");
         }
 
-        // At block 10, should create checkpoint
-        let checkpoint = backlog.set_processed_block(Chain::Solana, 10).await;
+        // At block interval, should create checkpoint
+        let checkpoint = backlog.set_processed_block(Chain::Solana, interval).await;
         assert!(checkpoint.is_some());
         let checkpoint = checkpoint.unwrap();
-        assert_eq!(checkpoint.block_height, 10);
+        assert_eq!(checkpoint.block_height, interval);
         assert_eq!(checkpoint.chain, Chain::Solana);
     }
 }

--- a/chain-signatures/node/src/checkpoint_consensus.rs
+++ b/chain-signatures/node/src/checkpoint_consensus.rs
@@ -13,7 +13,9 @@ use cait_sith::protocol::Participant;
 use std::collections::HashMap;
 
 /// Queries all participants for their checkpoints and returns a consensus checkpoint
-/// for each chain based on the threshold-lowest block height.
+/// for each chain based on the threshold-lowest block height: select the checkpoint
+/// at position (total_count - threshold), which ensures at least threshold nodes
+/// have this checkpoint or a newer one
 ///
 /// # Algorithm
 /// 1. Query all active participants' /checkpoint endpoints

--- a/chain-signatures/node/src/checkpoint_consensus.rs
+++ b/chain-signatures/node/src/checkpoint_consensus.rs
@@ -1,0 +1,238 @@
+//! Node-based checkpoint consensus
+//!
+//! This module implements checkpoint recovery through node consensus rather than
+//! querying the NEAR contract. Nodes query each other's `/checkpoint` endpoints,
+//! collect checkpoints for each chain, and reach consensus on the threshold-lowest
+//! block height checkpoint.
+
+use crate::backlog::Checkpoint;
+use crate::mesh::MeshState;
+use crate::node_client::NodeClient;
+use crate::protocol::Chain;
+use cait_sith::protocol::Participant;
+use std::collections::HashMap;
+
+/// Queries all participants for their checkpoints and returns a consensus checkpoint
+/// for each chain based on the threshold-lowest block height.
+///
+/// # Algorithm
+/// 1. Query all active participants' /checkpoint endpoints
+/// 2. For each chain, collect all checkpoints into a flat list
+/// 3. Sort checkpoints by block height (ascending)
+/// 4. Select checkpoint at position threshold-1 (the threshold-lowest checkpoint)
+///
+/// # Returns
+/// Map of chains to consensus checkpoints
+pub async fn fetch_consensus_checkpoints(
+    mesh_state: &MeshState,
+    node_client: &NodeClient,
+    threshold: usize,
+    chains: &[Chain],
+) -> HashMap<Chain, Checkpoint> {
+    if threshold == 0 {
+        tracing::warn!("threshold must be greater than 0");
+        return HashMap::new();
+    }
+    if mesh_state.active.participants.is_empty() {
+        tracing::warn!("no active participants available for checkpoint recovery");
+        return HashMap::new();
+    }
+
+    tracing::info!(
+        participant_count = mesh_state.active.participants.len(),
+        ?chains,
+        threshold,
+        "starting checkpoint consensus recovery"
+    );
+
+    // Query all active participants for their latest checkpoints
+    let all_checkpoints = fetch_latest(mesh_state, node_client, chains).await;
+
+    // For each chain, find consensus checkpoint
+    let mut consensus = HashMap::new();
+    for &chain in chains {
+        let Some(checkpoint) = find_consensus_checkpoint(&all_checkpoints, chain, threshold).await
+        else {
+            tracing::warn!(?chain, "no consensus checkpoint found");
+            continue;
+        };
+
+        tracing::info!(
+            ?chain,
+            block_height = checkpoint.block_height,
+            "found consensus checkpoint"
+        );
+        consensus.insert(chain, checkpoint.clone());
+    }
+
+    // TODO: make sure that the consensus checkpoint is present on all nodes via
+    // all_checkpoints or by calling /checkpoint for each.
+
+    consensus
+}
+
+/// Query all active participants for their latest checkpoints for each chain specified.
+async fn fetch_latest(
+    mesh_state: &MeshState,
+    node_client: &NodeClient,
+    chains: &[Chain],
+) -> HashMap<Participant, HashMap<Chain, Checkpoint>> {
+    let mut all_checkpoints = HashMap::new();
+
+    // Build query string for chains
+    let chains_query = if chains.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "?query={}",
+            chains
+                .iter()
+                .map(|c| c.as_str())
+                .collect::<Vec<_>>()
+                .join(",")
+        )
+    };
+
+    for (participant_id, info) in &mesh_state.active.participants {
+        let node_url = &info.url;
+        let url = format!("{node_url}{chains_query}");
+
+        match node_client.checkpoint(&url).await {
+            Ok(checkpoints) => {
+                tracing::debug!(
+                    participant = ?participant_id,
+                    checkpoint_count = checkpoints.len(),
+                    "received checkpoints from participant"
+                );
+                all_checkpoints.insert(*participant_id, checkpoints);
+            }
+            Err(err) => {
+                tracing::warn!(
+                    participant = ?participant_id,
+                    url = %info.url,
+                    %err,
+                    "failed to query participant for checkpoints"
+                );
+            }
+        }
+    }
+
+    all_checkpoints
+}
+
+/// Find consensus checkpoint for a specific chain
+async fn find_consensus_checkpoint(
+    all_checkpoints: &HashMap<Participant, HashMap<Chain, Checkpoint>>,
+    chain: Chain,
+    threshold: usize,
+) -> Option<&Checkpoint> {
+    // Collect all checkpoints for this chain into a flat list
+    let mut checkpoints = Vec::with_capacity(all_checkpoints.len());
+    for node_checkpoints in all_checkpoints.values() {
+        if let Some(checkpoint) = node_checkpoints.get(&chain) {
+            checkpoints.push(checkpoint);
+        }
+    }
+
+    if checkpoints.is_empty() {
+        tracing::debug!(?chain, "no checkpoints found for chain");
+        return None;
+    }
+    if checkpoints.len() < threshold {
+        tracing::warn!(
+            ?chain,
+            checkpoint_count = checkpoints.len(),
+            threshold,
+            "not enough checkpoints to reach threshold"
+        );
+        return None;
+    }
+
+    // Sort checkpoints by block height (ascending)
+    checkpoints.sort_by_key(|c| c.block_height);
+
+    // Take the threshold-lowest checkpoint (at index n - threshold)
+    let consensus_checkpoint = checkpoints.swap_remove(checkpoints.len() - threshold);
+
+    tracing::info!(
+        ?chain,
+        block_height = consensus_checkpoint.block_height,
+        total_checkpoints = checkpoints.len(),
+        threshold,
+        "selected threshold-lowest checkpoint"
+    );
+
+    Some(consensus_checkpoint)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_checkpoint_selects_threshold_lowest() {
+        let mut checkpoints = HashMap::new();
+
+        // Node 0: height 100
+        let mut node0 = HashMap::new();
+        node0.insert(
+            Chain::Ethereum,
+            Checkpoint {
+                chain: Chain::Ethereum,
+                block_height: 100,
+                pending_requests: vec![],
+            },
+        );
+        checkpoints.insert(Participant::from(0), node0);
+
+        // Node 1: height 105
+        let mut node1 = HashMap::new();
+        node1.insert(
+            Chain::Ethereum,
+            Checkpoint {
+                chain: Chain::Ethereum,
+                block_height: 105,
+                pending_requests: vec![],
+            },
+        );
+        checkpoints.insert(Participant::from(1), node1);
+
+        // Node 2: height 110
+        let mut node2 = HashMap::new();
+        node2.insert(
+            Chain::Ethereum,
+            Checkpoint {
+                chain: Chain::Ethereum,
+                block_height: 110,
+                pending_requests: vec![],
+            },
+        );
+        checkpoints.insert(Participant::from(2), node2.clone());
+        checkpoints.insert(Participant::from(3), node2);
+
+        // should select height 105 (3rd lowest)
+        let threshold = 3;
+        let result = find_consensus_checkpoint(&checkpoints, Chain::Ethereum, threshold).await;
+        assert_eq!(result.unwrap().block_height, 105);
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_insufficient() {
+        let mut all_checkpoints = HashMap::new();
+
+        let mut node0 = HashMap::new();
+        node0.insert(
+            Chain::Ethereum,
+            Checkpoint {
+                chain: Chain::Ethereum,
+                block_height: 100,
+                pending_requests: vec![],
+            },
+        );
+        all_checkpoints.insert(Participant::from(0), node0);
+
+        // Only 1 checkpoint, threshold=2 should fail
+        let result = find_consensus_checkpoint(&all_checkpoints, Chain::Ethereum, 2).await;
+        assert!(result.is_none());
+    }
+}

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -7,7 +7,6 @@ use crate::protocol::message::MessageChannel;
 use crate::protocol::state::Node;
 use crate::protocol::sync::SyncTask;
 use crate::protocol::{spawn_system_metrics, MpcSignProtocol, SignQueue};
-use crate::respond_bidirectional::RespondBidirectionalTxProcessor;
 use crate::rpc::{ContractStateWatcher, NearClient, RpcExecutor};
 use crate::storage::app_data_storage;
 use crate::{indexer, indexer_eth, indexer_sol, logs, mesh, storage, web};
@@ -268,8 +267,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 NearClient::new(&near_rpc, &my_address, &network, &mpc_contract_id, signer);
 
             let (rpc_channel, rpc) = RpcExecutor::new(&near_client, &eth, &sol, backlog.clone());
-            let (respond_bidirectional_tx_channel, respond_bidirectional_tx_processor) =
-                RespondBidirectionalTxProcessor::new();
+
             let (sync_channel, sync) = SyncTask::new(
                 &client,
                 triple_storage.clone(),
@@ -326,17 +324,16 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
 
             tracing::info!("protocol initialized");
             tokio::spawn(sync.run());
-            tokio::spawn(rpc.run(
-                contract_state_tx,
-                config_tx.clone(),
-                respond_bidirectional_tx_channel.clone(),
-            ));
+            tokio::spawn(rpc.run(contract_state_tx, config_tx.clone()));
 
-            tokio::spawn(respond_bidirectional_tx_processor.run(backlog.clone(), 5));
             tokio::spawn(mesh.run(contract_watcher.clone()));
             let system_handle = spawn_system_metrics(account_id.as_str()).await;
-            let protocol_handle =
-                tokio::spawn(protocol.run(node, near_client, contract_watcher, mesh_state));
+            let protocol_handle = tokio::spawn(protocol.run(
+                node,
+                near_client.clone(),
+                contract_watcher.clone(),
+                mesh_state,
+            ));
             tracing::info!("protocol thread spawned");
             let web_handle = tokio::spawn(web::run(
                 web_port,
@@ -347,6 +344,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 presignature_storage,
                 sync_channel,
                 account_id.clone(),
+                backlog.clone(),
             ));
             tokio::spawn(indexer_eth::run(
                 eth,
@@ -354,8 +352,16 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 app_data_storage.clone(),
                 account_id.clone(),
                 backlog.clone(),
+                near_client.clone(),
             ));
-            tokio::spawn(indexer_sol::run(sol, sign_tx, account_id, backlog));
+            tokio::spawn(indexer_sol::run(
+                sol,
+                sign_tx,
+                account_id,
+                backlog,
+                near_client,
+                contract_watcher,
+            ));
             tracing::info!("protocol http server spawned");
             protocol_handle.await?;
             web_handle.await?;

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -299,7 +299,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let node_watcher = node.watch();
 
             let msg_channel = MessageChannel::spawn(
-                client,
+                client.clone(),
                 &account_id,
                 config_rx.clone(),
                 contract_watcher.clone(),
@@ -330,9 +330,9 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let system_handle = spawn_system_metrics(account_id.as_str()).await;
             let protocol_handle = tokio::spawn(protocol.run(
                 node,
-                near_client.clone(),
+                near_client,
                 contract_watcher.clone(),
-                mesh_state,
+                mesh_state.clone(),
             ));
             tracing::info!("protocol thread spawned");
             let web_handle = tokio::spawn(web::run(
@@ -352,15 +352,18 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 app_data_storage.clone(),
                 account_id.clone(),
                 backlog.clone(),
-                near_client.clone(),
+                contract_watcher.clone(),
+                mesh_state.clone(),
+                client.clone(),
             ));
             tokio::spawn(indexer_sol::run(
                 sol,
                 sign_tx,
                 account_id,
                 backlog,
-                near_client,
                 contract_watcher,
+                mesh_state,
+                client,
             ));
             tracing::info!("protocol http server spawned");
             protocol_handle.await?;

--- a/chain-signatures/node/src/indexer.rs
+++ b/chain-signatures/node/src/indexer.rs
@@ -112,10 +112,9 @@ impl NearIndexer {
             },
             chain: Chain::NEAR,
             unix_timestamp_indexed: crate::util::current_unix_timestamp(),
-            timestamp_sign_queue: Some(Instant::now()),
+            timestamp_sign_queue: Instant::now(),
             total_timeout: Duration::from_secs(200),
             sign_request_type: crate::protocol::SignRequestType::Sign,
-            participants: None,
         }
     }
 

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -31,8 +31,10 @@ use crate::respond_bidirectional::{
     CompletedTx, RespondBidirectionalSerializedOutput, SerDeserFormat,
     OUTPUT_DESERIALIZATION_FORMAT, RESPOND_SERIALIZATION_FORMAT,
 };
+use crate::rpc::NearClient;
 #[cfg(not(feature = "light_client"))]
 use crate::sign_bidirectional::TransactionOutput;
+
 use alloy::sol_types::{sol, SolEvent};
 #[cfg(feature = "light_client")]
 use helios::common::types::{SubscriptionEvent, SubscriptionType};
@@ -312,6 +314,18 @@ sol! {
         string dest,
         string params
     );
+
+    struct Signature {
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+    }
+
+    event SignatureResponded(
+        bytes32 indexed requestId,
+        address responder,
+        Signature signature
+    );
 }
 
 fn sign_request_from_filtered_log(
@@ -367,10 +381,9 @@ fn sign_request_from_filtered_log(
         },
         chain: Chain::Ethereum,
         unix_timestamp_indexed: crate::util::current_unix_timestamp(),
-        timestamp_sign_queue: None,
+        timestamp_sign_queue: Instant::now(),
         total_timeout,
         sign_request_type: SignRequestType::Sign,
-        participants: None,
     })
 }
 // Helper function to parse event logs
@@ -477,11 +490,14 @@ pub async fn run(
     app_data_storage: AppDataStorage,
     node_near_account_id: AccountId,
     backlog: Backlog,
+    near_client: NearClient,
 ) {
     let Some(eth) = eth else {
         tracing::warn!("ethereum indexer is disabled");
         return;
     };
+
+    backlog.recover(&near_client, &[Chain::Ethereum]).await;
 
     let last_processed_block = app_data_storage
         .last_processed_block_eth()
@@ -648,6 +664,7 @@ pub async fn run(
             requests_indexed_send_clone.clone(),
             total_timeout,
             backlog.clone(),
+            &near_client,
         )
         .await
         {
@@ -694,6 +711,7 @@ async fn retry_failed_blocks(
             requests_indexed.clone(),
             total_timeout,
             backlog.clone(),
+            &near_client,
         )
         .await
         {
@@ -902,6 +920,7 @@ async fn process_block(
     requests_indexed: mpsc::Sender<BlockAndRequests>,
     total_timeout: Duration,
     backlog: Backlog,
+    near_client: &NearClient,
 ) -> anyhow::Result<()> {
     tracing::info!(
         "Processing block number {} with hash {:?}",
@@ -926,115 +945,142 @@ async fn process_block(
         return Ok(());
     };
 
-    let pending_txs = backlog
-        .get_by_status(Chain::Ethereum, PendingRequestStatus::PendingExecution)
-        .await;
+    let pending_watchers = backlog.pending_execution(Chain::Ethereum).await;
+
+    tracing::info!(
+        pending_watchers_count = pending_watchers.len(),
+        block_number,
+        "checking pending watchers for bidirectional execution"
+    );
 
     let mut respond_bidirectional_requests: Vec<IndexedSignRequest> = Vec::new();
 
     for receipt in &block_receipts {
-        let tx_id = receipt.transaction_hash.into();
-        let Some(pending_tx) = pending_txs.get(&tx_id) else {
+        let tx_id: BidirectionalTxId = receipt.transaction_hash.into();
+        tracing::debug!(?tx_id, "checking receipt against pending watchers");
+        let Some((sign_id, pending_tx)) = pending_watchers.get(&tx_id).cloned() else {
             continue;
         };
-        let status = receipt.status();
-        tracing::info!(
-            "Tx {} found in block {block_number}: {}",
-            receipt.transaction_hash,
-            if status { "success" } else { "failed" }
-        );
-        let client_clone = client.clone();
-        let mut pending_tx = pending_tx.clone();
-        pending_tx.status = if status {
+        let status = if receipt.status() {
             PendingRequestStatus::Success
         } else {
             PendingRequestStatus::Failed
         };
+        tracing::info!(
+            ?tx_id,
+            ?sign_id,
+            block_number,
+            "observed bidirectional execution on destination chain"
+        );
 
-        let pending_tx_clone = pending_tx.clone();
+        let mut updated_tx = pending_tx.clone();
+        updated_tx.status = status;
+
         let completed_tx =
-            crate::respond_bidirectional::CompletedTx::new(pending_tx_clone, block_number);
+            crate::respond_bidirectional::CompletedTx::new(updated_tx.clone(), block_number);
 
-        let respond_bidirectional_sign_request: Option<IndexedSignRequest> = completed_tx
-            .create_sign_request_from_completed_tx(&client_clone, 6, total_timeout)
-            .await;
-        if let Some(respond_bidirectional_sign_request) = respond_bidirectional_sign_request {
-            respond_bidirectional_requests.push(respond_bidirectional_sign_request);
-            tracing::info!(?tx_id, "eth/inserting updated tx with new status into map");
-            backlog.insert(Chain::Ethereum, *sign_id, pending_tx).await;
+        if let Some(respond_request) = completed_tx
+            .create_sign_request_from_completed_tx(client, Chain::Ethereum, 6, total_timeout)
+            .await
+        {
+            respond_bidirectional_requests.push(respond_request);
         } else {
-            // failed to create sign request from completed tx, remove the tx from the map
-            // TODO: we need to implement a better solution for not finding such txs in helios. possible: https://github.com/sig-net/mpc/issues/499
             tracing::warn!(
-                "Failed to create sign request from completed tx, removing tx from map: {:?}",
-                receipt.transaction_hash
+                ?tx_id,
+                ?sign_id,
+                "failed to create respond_bidirectional request from executed tx"
             );
-            backlog.remove(Chain::Ethereum, sign_id).await;
         }
+
+        backlog
+            .set_status(pending_tx.source_chain, &sign_id, status)
+            .await;
+        backlog.unwatch_execution(Chain::Ethereum, &tx_id).await;
     }
 
-    let remaining_pending_txs = backlog
-        .get_by_status(Chain::Ethereum, PendingRequestStatus::PendingExecution)
-        .await;
+    let remaining_watchers = backlog.pending_execution(Chain::Ethereum).await;
 
-    for (tx_id, mut tx) in remaining_pending_txs {
-        let current_nonce = client
+    for (tx_id, (sign_id, tx)) in remaining_watchers {
+        let current_nonce = match client
             .get_nonce(
                 tx.from_address,
                 BlockId::Number(BlockNumberOrTag::Number(block_number)),
             )
-            .await;
-        if current_nonce.is_err() {
-            tracing::warn!("Failed to get current nonce: {:?}", current_nonce.err());
-            continue;
-        }
-        let current_nonce = current_nonce.unwrap();
+            .await
+        {
+            Ok(nonce) => nonce,
+            Err(err) => {
+                tracing::warn!(?tx_id, ?sign_id, ?err, "failed to get current nonce");
+                continue;
+            }
+        };
+
         if tx.nonce < current_nonce {
             tracing::warn!(
+                ?tx_id,
                 ?sign_id,
                 expected_nonce = tx.nonce,
                 actual_nonce = current_nonce,
                 "nonce too low for tx",
             );
-            tx.status = PendingRequestStatus::Failed;
-            let pending_tx = tx.clone();
 
+            let mut failed_tx = tx.clone();
+            failed_tx.status = PendingRequestStatus::Failed;
             let completed_tx =
-                crate::respond_bidirectional::CompletedTx::new(pending_tx, block_number);
+                crate::respond_bidirectional::CompletedTx::new(failed_tx.clone(), block_number);
 
-            let respond_bidirectional_sign_request: Option<IndexedSignRequest> = completed_tx
+            if let Some(request) = completed_tx
                 .create_sign_request_from_completed_tx(client, Chain::Ethereum, 6, total_timeout)
-                .await;
-            if let Some(request) = respond_bidirectional_sign_request {
+                .await
+            {
                 respond_bidirectional_requests.push(request);
-                backlog.insert(Chain::Ethereum, sign_id, tx).await;
             } else {
-                // failed to create sign request from completed tx, remove the tx from the map
                 tracing::warn!(
+                    ?tx_id,
                     ?sign_id,
-                    "failed to create sign request from completed tx, removing tx from map",
+                    "failed to create sign request from completed tx"
                 );
-                backlog.remove(Chain::Ethereum, &sign_id).await;
             }
+
+            backlog
+                .set_status(tx.source_chain, &sign_id, PendingRequestStatus::Failed)
+                .await;
+            backlog.unwatch_execution(Chain::Ethereum, &tx_id).await;
         }
     }
 
-    let filtered_logs: Vec<Log> = block_receipts
+    let relevant_logs: Vec<Log> = block_receipts
         .into_iter()
         .filter_map(|receipt| receipt.as_ref().as_receipt().cloned())
         .flat_map(|receipt| {
-            receipt.logs.into_iter().filter(|log| {
-                log.address() == eth_contract_addr
-                    && log
-                        .topic0()
-                        .is_some_and(|topic0| *topic0 == SignatureRequested::SIGNATURE_HASH)
-            })
+            receipt
+                .logs
+                .into_iter()
+                .filter(|log| log.address() == eth_contract_addr)
+        })
+        .collect();
+
+    let (respond_logs, potential_request_logs): (Vec<Log>, Vec<Log>) =
+        relevant_logs.into_iter().partition(|log| {
+            log.topic0()
+                .is_some_and(|topic| *topic == SignatureResponded::SIGNATURE_HASH)
+        });
+
+    if !respond_logs.is_empty() {
+        process_respond_events(&respond_logs, &backlog).await;
+    }
+
+    let request_logs: Vec<Log> = potential_request_logs
+        .into_iter()
+        .filter(|log| {
+            log.topic0()
+                .is_some_and(|topic| *topic == SignatureRequested::SIGNATURE_HASH)
         })
         .collect();
 
     let mut all_sign_requests = Vec::new();
-    if !filtered_logs.is_empty() {
-        all_sign_requests.extend(parse_filtered_logs(filtered_logs, total_timeout));
+    if !request_logs.is_empty() {
+        all_sign_requests.extend(parse_filtered_logs(request_logs, total_timeout));
     }
     if !respond_bidirectional_requests.is_empty() {
         all_sign_requests.extend(respond_bidirectional_requests);
@@ -1183,6 +1229,59 @@ fn parse_filtered_logs(logs: Vec<Log>, total_timeout: Duration) -> Vec<IndexedSi
     indexed_requests
 }
 
+async fn process_respond_events(logs: &[Log], backlog: &Backlog) {
+    for log in logs {
+        if let Some(sign_id) = sign_id_from_signature_responded_log(log) {
+            // Check the sign request type to determine if it's a bidirectional request
+            if let Some(sign_type) = backlog.sign_type(Chain::Ethereum, &sign_id).await {
+                match sign_type {
+                    SignRequestType::SignBidirectional(_) => {
+                        // This is a bidirectional request, keep it in the backlog.
+                        // It will be removed when we receive the respond_bidirectional event.
+                        tracing::info!(
+                            ?sign_id,
+                            "observed SignatureResponded event for bidirectional request, keeping in backlog"
+                        );
+                    }
+                    SignRequestType::Sign => {
+                        tracing::info!(
+                            ?sign_id,
+                            "observed SignatureResponded event for regular sign request, removing from backlog"
+                        );
+                        backlog.remove(Chain::Ethereum, &sign_id).await;
+                    }
+                    SignRequestType::RespondBidirectional(_) => {
+                        tracing::warn!(
+                            ?sign_id,
+                            "observed SignatureResponded event for respond_bidirectional request, which should not happen"
+                        );
+                    }
+                }
+            } else {
+                // If we don't have the type tracked, just remove it (fallback behavior for backward compatibility)
+                tracing::debug!(
+                    ?sign_id,
+                    "sign request type not found, removing from backlog"
+                );
+                backlog.remove(Chain::Ethereum, &sign_id).await;
+            }
+        }
+    }
+}
+
+fn sign_id_from_signature_responded_log(log: &Log) -> Option<SignId> {
+    if log
+        .topic0()
+        .is_none_or(|topic| *topic != SignatureResponded::SIGNATURE_HASH)
+    {
+        return None;
+    }
+
+    let request_topic = log.topics().get(1)?;
+    let request_id: [u8; 32] = (*request_topic).into();
+    Some(SignId { request_id })
+}
+
 fn send_indexed_requests(
     requests: Vec<IndexedSignRequest>,
     sign_tx: mpsc::Sender<IndexedSignRequest>,
@@ -1192,16 +1291,6 @@ fn send_indexed_requests(
         let sign_tx = sign_tx.clone();
         let node_near_account_id = node_near_account_id.clone();
         tokio::spawn(async move {
-            let request = IndexedSignRequest {
-                id: request.id,
-                chain: request.chain,
-                args: request.args,
-                unix_timestamp_indexed: request.unix_timestamp_indexed,
-                timestamp_sign_queue: Some(Instant::now()),
-                total_timeout: request.total_timeout,
-                sign_request_type: request.sign_request_type,
-                participants: request.participants,
-            };
             match sign_tx.send(request).await {
                 Ok(_) => {
                     crate::metrics::NUM_SIGN_REQUESTS
@@ -1260,11 +1349,15 @@ pub async fn run(
     app_data_storage: AppDataStorage,
     node_near_account_id: AccountId,
     backlog: Backlog,
+    near_client: NearClient,
 ) {
     let Some(eth) = eth else {
         tracing::warn!("ethereum indexer is disabled");
         return;
     };
+
+    // Recover backlog before doing anything.
+    backlog.recover(&near_client, &[Chain::Ethereum]).await;
 
     let client = RpcEthereumClient::new(&eth.execution_rpc_http_url);
 
@@ -1325,6 +1418,7 @@ pub async fn run(
                 sign_tx.clone(),
                 total_timeout,
                 &backlog,
+                &near_client,
             )
             .await
             {
@@ -1363,6 +1457,7 @@ async fn process_block(
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     total_timeout: Duration,
     backlog: &Backlog,
+    near_client: &crate::rpc::NearClient,
 ) -> anyhow::Result<()> {
     tracing::info!("Processing block number {}", block_number);
 
@@ -1380,8 +1475,26 @@ async fn process_block(
     let mut sign_requests = Vec::new();
 
     let logs = client.get_logs(block_hash, contract_address).await?;
-    if !logs.is_empty() {
-        sign_requests.extend(parse_filtered_logs(logs, total_timeout));
+    let (respond_logs, potential_request_logs): (Vec<Log>, Vec<Log>) =
+        logs.into_iter().partition(|log| {
+            log.topic0()
+                .is_some_and(|topic| *topic == SignatureResponded::SIGNATURE_HASH)
+        });
+
+    if !respond_logs.is_empty() {
+        process_respond_events(&respond_logs, backlog).await;
+    }
+
+    let request_logs: Vec<Log> = potential_request_logs
+        .into_iter()
+        .filter(|log| {
+            log.topic0()
+                .is_some_and(|topic| *topic == SignatureRequested::SIGNATURE_HASH)
+        })
+        .collect();
+
+    if !request_logs.is_empty() {
+        sign_requests.extend(parse_filtered_logs(request_logs, total_timeout));
     }
 
     let mut respond_requests = process_bidirectional_requests(
@@ -1414,6 +1527,28 @@ async fn process_block(
             );
     }
 
+    // Submit checkpoint if one was created at this block height
+    if let Some(checkpoint) = backlog
+        .set_processed_block(Chain::Ethereum, block_number)
+        .await
+    {
+        tracing::info!(block_number, "submitting Ethereum checkpoint");
+        match near_client
+            .vote_checkpoint(Chain::Ethereum, checkpoint)
+            .await
+        {
+            Ok(true) => {
+                tracing::info!(block_number, "Ethereum checkpoint threshold reached");
+            }
+            Ok(false) => {
+                tracing::debug!(block_number, "Ethereum checkpoint vote recorded");
+            }
+            Err(e) => {
+                tracing::warn!(block_number, %e, "failed to vote for Ethereum checkpoint");
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -1425,13 +1560,17 @@ async fn process_bidirectional_requests(
     backlog: &Backlog,
     node_near_account_id: &AccountId,
 ) -> anyhow::Result<Vec<IndexedSignRequest>> {
-    let pending_txs = backlog
-        .get_by_status(Chain::Ethereum, PendingRequestStatus::PendingExecution)
-        .await;
-
     let mut respond_requests = Vec::new();
 
-    for (tx_id, pending_tx) in pending_txs {
+    let watchers = backlog.pending_execution(Chain::Ethereum).await;
+    tracing::info!(
+        watchers_count = watchers.len(),
+        block_number,
+        "process_bidirectional_requests checking watchers"
+    );
+
+    for (tx_id, (sign_id, pending_tx)) in watchers {
+        tracing::info!(?tx_id, ?sign_id, "querying receipt for bidirectional tx");
         let start = Instant::now();
         let receipt = client.transaction_receipt(pending_tx.id).await;
         crate::metrics::ETH_BLOCK_RECEIPT_LATENCY
@@ -1442,25 +1581,31 @@ async fn process_bidirectional_requests(
             continue;
         };
 
-        let status = receipt.status();
-        tracing::info!(
-            "Tx {:?} found in block {block_number}: {}",
-            tx_id,
-            if status { "success" } else { "failed" }
-        );
-
-        let mut updated_tx = pending_tx.clone();
-        updated_tx.status = if status {
+        let status = if receipt.status() {
             PendingRequestStatus::Success
         } else {
             PendingRequestStatus::Failed
         };
+        tracing::info!(
+            ?tx_id,
+            ?sign_id,
+            block_number,
+            "bidirectional execution observed via rpc"
+        );
+
+        let mut updated_tx = pending_tx.clone();
+        updated_tx.status = status;
 
         let completed_tx = CompletedTx::new(updated_tx.clone(), block_number);
         let source_chain = updated_tx.source_chain;
-        if status {
+        if status == PendingRequestStatus::Success {
             match extract_success_output_with_rpc(client, &updated_tx, block_number).await {
                 Ok(serialized_output) => {
+                    tracing::info!(
+                        ?tx_id,
+                        ?sign_id,
+                        "extracted transaction output for bidirectional tx"
+                    );
                     match completed_tx.create_sign_request_from_serialized_output(
                         source_chain,
                         serialized_output,
@@ -1469,6 +1614,7 @@ async fn process_bidirectional_requests(
                         Ok(sign_request) => respond_requests.push(sign_request),
                         Err(err) => tracing::warn!(
                             ?tx_id,
+                            ?sign_id,
                             ?err,
                             "Failed to build bidirectional respond sign request"
                         ),
@@ -1477,9 +1623,24 @@ async fn process_bidirectional_requests(
                 Err(err) => {
                     tracing::warn!(
                         ?tx_id,
+                        ?sign_id,
                         ?err,
-                        "Failed to extract transaction output for bidirectional tx"
+                        "Failed to extract transaction output for bidirectional tx, using empty output"
                     );
+                    // If output extraction fails (e.g., empty schema), use empty output
+                    match completed_tx.create_sign_request_from_serialized_output(
+                        source_chain,
+                        vec![], // empty serialized output
+                        total_timeout,
+                    ) {
+                        Ok(sign_request) => respond_requests.push(sign_request),
+                        Err(err) => tracing::warn!(
+                            ?tx_id,
+                            ?sign_id,
+                            ?err,
+                            "Failed to build bidirectional respond sign request with empty output"
+                        ),
+                    }
                 }
             }
         } else {
@@ -1490,50 +1651,67 @@ async fn process_bidirectional_requests(
                 Ok(sign_request) => respond_requests.push(sign_request),
                 Err(err) => tracing::warn!(
                     ?tx_id,
+                    ?sign_id,
                     ?err,
                     "Failed to build failed bidirectional sign request"
                 ),
             }
         }
 
-        backlog.insert(Chain::Ethereum, tx_id, updated_tx).await;
+        backlog
+            .set_status(pending_tx.source_chain, &sign_id, status)
+            .await;
+        backlog.unwatch_execution(Chain::Ethereum, &tx_id).await;
     }
 
-    let remaining_pending = backlog
-        .get_by_status(Chain::Ethereum, PendingRequestStatus::PendingExecution)
-        .await;
+    let remaining_pending = backlog.pending_execution(Chain::Ethereum).await;
 
-    for (tx_id, mut tx) in remaining_pending {
+    for (tx_id, (sign_id, tx)) in remaining_pending {
         let current_nonce = match client
             .transaction_count(tx.from_address, block_number)
             .await
         {
             Ok(nonce) => nonce,
             Err(err) => {
-                tracing::warn!(?tx_id, ?err, "Failed to fetch nonce for bidirectional tx");
+                tracing::warn!(
+                    ?tx_id,
+                    ?sign_id,
+                    ?err,
+                    "Failed to fetch nonce for bidirectional tx"
+                );
                 continue;
             }
         };
 
         if tx.nonce < current_nonce {
             tracing::warn!(
+                ?sign_id,
                 "Nonce too low for tx {:?}: expected {}, got {}",
                 tx_id,
                 tx.nonce,
                 current_nonce
             );
-            tx.status = PendingRequestStatus::Failed;
-            let completed_tx = CompletedTx::new(tx.clone(), block_number);
+            let mut failed_tx = tx.clone();
+            failed_tx.status = PendingRequestStatus::Failed;
+            let completed_tx = CompletedTx::new(failed_tx.clone(), block_number);
             match completed_tx
                 .create_failed_sign_request_without_light_client(tx.source_chain, total_timeout)
                 .await
             {
                 Ok(sign_request) => respond_requests.push(sign_request),
                 Err(err) => {
-                    tracing::warn!(?tx_id, ?err, "Failed to build sign request for stale nonce")
+                    tracing::warn!(
+                        ?tx_id,
+                        ?sign_id,
+                        ?err,
+                        "Failed to build sign request for stale nonce"
+                    )
                 }
             }
-            backlog.insert(Chain::Ethereum, tx_id, tx).await;
+            backlog
+                .set_status(tx.source_chain, &sign_id, PendingRequestStatus::Failed)
+                .await;
+            backlog.unwatch_execution(Chain::Ethereum, &tx_id).await;
         }
     }
 
@@ -1647,11 +1825,12 @@ impl RpcEthereumClient {
         block_hash: alloy::primitives::B256,
         contract_address: Address,
     ) -> anyhow::Result<Vec<Log>> {
-        let topic = format!("0x{}", SignatureRequested::SIGNATURE_HASH.encode_hex());
+        let topic_requested = format!("0x{}", SignatureRequested::SIGNATURE_HASH.encode_hex());
+        let topic_responded = format!("0x{}", SignatureResponded::SIGNATURE_HASH.encode_hex());
         let filter = json!({
             "address": format_address(contract_address),
             "blockHash": format!("{:#x}", block_hash),
-            "topics": [topic],
+            "topics": [[topic_requested, topic_responded]],
         });
         self.rpc_call("eth_getLogs", vec![filter]).await
     }

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -502,8 +502,6 @@ pub async fn run(
     };
 
     // Wait for threshold to be available
-
-    // Wait for threshold to be available
     let threshold = contract_watcher.wait_threshold().await;
     if threshold > 0 {
         let mesh_state = mesh_state.borrow().clone();

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -5,10 +5,12 @@ use std::sync::LazyLock;
 use std::time::Instant;
 
 use crate::backlog::Backlog;
+use crate::mesh::{wait_threshold_active, MeshState};
+use crate::node_client::NodeClient;
 use crate::protocol::{Chain, IndexedSignRequest, SignRequestType};
+use crate::rpc::ContractStateWatcher;
 #[cfg(not(feature = "light_client"))]
 use crate::sign_bidirectional::BidirectionalTx;
-#[cfg(not(feature = "light_client"))]
 use crate::sign_bidirectional::BidirectionalTxId;
 use crate::sign_bidirectional::PendingRequestStatus;
 use crate::storage::app_data_storage::AppDataStorage;
@@ -25,13 +27,13 @@ use alloy::rpc::types::Log;
 use alloy::rpc::types::Transaction;
 #[cfg(not(feature = "light_client"))]
 use alloy::rpc::types::TransactionReceipt;
+use tokio::sync::watch;
 
 #[cfg(not(feature = "light_client"))]
 use crate::respond_bidirectional::{
     CompletedTx, RespondBidirectionalSerializedOutput, SerDeserFormat,
     OUTPUT_DESERIALIZATION_FORMAT, RESPOND_SERIALIZATION_FORMAT,
 };
-use crate::rpc::NearClient;
 #[cfg(not(feature = "light_client"))]
 use crate::sign_bidirectional::TransactionOutput;
 
@@ -490,14 +492,25 @@ pub async fn run(
     app_data_storage: AppDataStorage,
     node_near_account_id: AccountId,
     backlog: Backlog,
-    near_client: NearClient,
+    mut contract_watcher: ContractStateWatcher,
+    mesh_state: watch::Receiver<MeshState>,
+    node_client: NodeClient,
 ) {
     let Some(eth) = eth else {
         tracing::warn!("ethereum indexer is disabled");
         return;
     };
 
-    backlog.recover(&near_client, &[Chain::Ethereum]).await;
+    // Wait for threshold to be available
+
+    // Wait for threshold to be available
+    let threshold = contract_watcher.wait_threshold().await;
+    if threshold > 0 {
+        let mesh_state = mesh_state.borrow().clone();
+        backlog
+            .recover(&mesh_state, &node_client, threshold, &[Chain::Ethereum])
+            .await;
+    }
 
     let last_processed_block = app_data_storage
         .last_processed_block_eth()
@@ -1343,13 +1356,16 @@ impl SignatureRequestedEvent {
 }
 
 #[cfg(not(feature = "light_client"))]
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     eth: Option<EthConfig>,
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     app_data_storage: AppDataStorage,
     node_near_account_id: AccountId,
     backlog: Backlog,
-    near_client: NearClient,
+    mut contract_watcher: ContractStateWatcher,
+    mut mesh_state: watch::Receiver<MeshState>,
+    node_client: NodeClient,
 ) {
     let Some(eth) = eth else {
         tracing::warn!("ethereum indexer is disabled");
@@ -1357,7 +1373,16 @@ pub async fn run(
     };
 
     // Recover backlog before doing anything.
-    backlog.recover(&near_client, &[Chain::Ethereum]).await;
+    // Wait for threshold to be available
+    let threshold = contract_watcher.wait_threshold().await;
+    if threshold > 0 {
+        wait_threshold_active(&mut mesh_state, threshold).await;
+
+        let mesh_state = mesh_state.borrow().clone();
+        backlog
+            .recover(&mesh_state, &node_client, threshold, &[Chain::Ethereum])
+            .await;
+    }
 
     let client = RpcEthereumClient::new(&eth.execution_rpc_http_url);
 
@@ -1418,7 +1443,6 @@ pub async fn run(
                 sign_tx.clone(),
                 total_timeout,
                 &backlog,
-                &near_client,
             )
             .await
             {
@@ -1457,7 +1481,6 @@ async fn process_block(
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     total_timeout: Duration,
     backlog: &Backlog,
-    near_client: &crate::rpc::NearClient,
 ) -> anyhow::Result<()> {
     tracing::info!("Processing block number {}", block_number);
 
@@ -1497,7 +1520,7 @@ async fn process_block(
         sign_requests.extend(parse_filtered_logs(request_logs, total_timeout));
     }
 
-    let mut respond_requests = process_bidirectional_requests(
+    let respond_requests = process_bidirectional_requests(
         client,
         block_number,
         total_timeout,
@@ -1505,48 +1528,32 @@ async fn process_block(
         &node_near_account_id,
     )
     .await?;
+    sign_requests.extend(respond_requests);
 
-    sign_requests.append(&mut respond_requests);
+    if !sign_requests.is_empty() {
+        let timestamps = sign_requests
+            .iter()
+            .map(|r| r.unix_timestamp_indexed)
+            .collect::<Vec<_>>();
 
-    if sign_requests.is_empty() {
-        return Ok(());
+        send_indexed_requests(sign_requests, sign_tx.clone(), node_near_account_id.clone());
+
+        for request_timestamp in timestamps {
+            crate::metrics::INDEXER_DELAY
+                .with_label_values(&[Chain::Ethereum.as_str(), node_near_account_id.as_str()])
+                .observe(
+                    crate::util::duration_between_unix(block_timestamp, request_timestamp).as_secs()
+                        as f64,
+                );
+        }
     }
 
-    send_indexed_requests(
-        sign_requests.clone(),
-        sign_tx.clone(),
-        node_near_account_id.clone(),
-    );
-
-    for request in &sign_requests {
-        crate::metrics::INDEXER_DELAY
-            .with_label_values(&[Chain::Ethereum.as_str(), node_near_account_id.as_str()])
-            .observe(
-                crate::util::duration_between_unix(block_timestamp, request.unix_timestamp_indexed)
-                    .as_secs() as f64,
-            );
-    }
-
-    // Submit checkpoint if one was created at this block height
+    // Create checkpoint if one was created at this block height
     if let Some(checkpoint) = backlog
         .set_processed_block(Chain::Ethereum, block_number)
         .await
     {
-        tracing::info!(block_number, "submitting Ethereum checkpoint");
-        match near_client
-            .vote_checkpoint(Chain::Ethereum, checkpoint)
-            .await
-        {
-            Ok(true) => {
-                tracing::info!(block_number, "Ethereum checkpoint threshold reached");
-            }
-            Ok(false) => {
-                tracing::debug!(block_number, "Ethereum checkpoint vote recorded");
-            }
-            Err(e) => {
-                tracing::warn!(block_number, %e, "failed to vote for Ethereum checkpoint");
-            }
-        }
+        tracing::info!(block_number, ?checkpoint, "created Ethereum checkpoint");
     }
 
     Ok(())

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -1,22 +1,27 @@
-use crate::backlog::Backlog;
-use crate::protocol::SignRequestType;
-use crate::protocol::{Chain, IndexedSignRequest};
-use crate::sign_bidirectional::hash_rlp_data;
+use crate::backlog::{Backlog, BacklogTransaction, SignTx};
+use crate::protocol::{Chain, IndexedSignRequest, SignRequestType};
+use crate::sign_bidirectional::{
+    hash_rlp_data, BidirectionalTx, BidirectionalTxId, PendingRequestStatus,
+};
 use alloy_sol_types::SolValue;
-use anchor_client::anchor_lang::{AnchorDeserialize, AnchorSerialize};
+use anchor_client::anchor_lang::AnchorDeserialize;
 use anchor_client::{Client, Cluster, Program};
-use anchor_lang::prelude::*;
 use anchor_lang::solana_program::keccak;
 use anchor_lang::Discriminator;
 use ethabi::{encode, Token};
 use futures_util::StreamExt;
-use k256::Scalar;
+use k256::elliptic_curve::sec1::FromEncodedPoint;
+use k256::{AffinePoint, Scalar};
 use mpc_crypto::kdf::derive_epsilon_sol;
 use mpc_crypto::ScalarExt as _;
 use mpc_primitives::{SignArgs, SignId, LATEST_MPC_KEY_VERSION};
 use near_account_id::AccountId;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
+use signet_program::{
+    RespondBidirectionalEvent, SignBidirectionalEvent, SignatureRequestedEvent,
+    SignatureRespondedEvent,
+};
 use solana_client::{
     nonblocking::{pubsub_client::PubsubClient, rpc_client::RpcClient},
     rpc_config::{RpcTransactionLogsConfig, RpcTransactionLogsFilter},
@@ -31,11 +36,6 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
-
-// Needed for anchor_client/lang to operate well. They use a different version of borsh
-// than the one we use in MPC. This older version can have security implications but for
-// now only effects Solana.
-use borsh_sol as borsh;
 
 pub(crate) static MAX_SECP256K1_SCALAR: LazyLock<Scalar> = LazyLock::new(|| {
     Scalar::from_bytes(
@@ -173,21 +173,6 @@ trait SignatureEvent: SignatureEventTrait + std::fmt::Debug {}
 
 type SignatureEventBox = Box<dyn SignatureEvent + Send>;
 
-#[event]
-#[derive(Clone, Debug)]
-pub struct SignatureRequestedEvent {
-    pub sender: Pubkey,
-    pub payload: [u8; 32],
-    pub key_version: u32,
-    pub deposit: u64,
-    pub chain_id: String,
-    pub path: String,
-    pub algo: String,
-    pub dest: String,
-    pub params: String,
-    pub fee_payer: Option<Pubkey>,
-}
-
 impl SignatureEvent for SignatureRequestedEvent {}
 
 impl SignatureEventTrait for SignatureRequestedEvent {
@@ -259,30 +244,12 @@ impl SignatureEventTrait for SignatureRequestedEvent {
                 key_version: self.key_version,
             },
             chain: Chain::Solana,
-            timestamp_sign_queue: Some(Instant::now()),
+            timestamp_sign_queue: Instant::now(),
             unix_timestamp_indexed: crate::util::current_unix_timestamp(),
             total_timeout,
             sign_request_type: SignRequestType::Sign,
-            participants: None,
         })
     }
-}
-
-#[event]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct SignBidirectionalEvent {
-    pub sender: Pubkey,
-    pub serialized_transaction: Vec<u8>,
-    pub caip2_id: String,
-    pub key_version: u32,
-    pub deposit: u64,
-    pub path: String,
-    pub algo: String,
-    pub dest: String,
-    pub params: String,
-    pub program_id: Pubkey,
-    pub output_deserialization_schema: Vec<u8>,
-    pub respond_serialization_schema: Vec<u8>,
 }
 
 impl SignatureEvent for SignBidirectionalEvent {}
@@ -354,11 +321,10 @@ impl SignatureEventTrait for SignBidirectionalEvent {
                 key_version: self.key_version,
             },
             chain: Chain::Solana,
-            timestamp_sign_queue: Some(Instant::now()),
+            timestamp_sign_queue: Instant::now(),
             unix_timestamp_indexed: crate::util::current_unix_timestamp(),
             total_timeout,
             sign_request_type: SignRequestType::SignBidirectional(self.clone()),
-            participants: None,
         })
     }
 }
@@ -370,6 +336,8 @@ pub async fn run(
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     node_near_account_id: AccountId,
     backlog: Backlog,
+    near_client: crate::rpc::NearClient,
+    contract_watcher: crate::rpc::ContractStateWatcher,
 ) {
     let Some(sol) = sol else {
         tracing::warn!("solana indexer is disabled");
@@ -382,6 +350,7 @@ pub async fn run(
         return;
     };
 
+    backlog.recover(&near_client, &[Chain::Solana]).await;
     let keypair = Keypair::from_base58_string(&sol.account_sk);
     let cluster = Cluster::Custom(sol.rpc_http_url.clone(), sol.rpc_ws_url.clone());
     let client =
@@ -395,6 +364,12 @@ pub async fn run(
     );
 
     let total_timeout = Duration::from_secs(sol.total_timeout);
+
+    // Clone sol for respond events subscription
+    let sol_for_respond = sol.clone();
+    let backlog_for_respond = backlog.clone();
+    let contract_watcher_for_respond = contract_watcher.clone();
+
     tokio::spawn(subscribe_and_process_sign_events(
         program_id,
         sol.rpc_http_url.clone(),
@@ -402,8 +377,27 @@ pub async fn run(
         sign_tx.clone(),
         node_near_account_id.clone(),
         total_timeout,
-        backlog,
+        backlog.clone(),
+        near_client.clone(),
     ));
+
+    // Subscribe to respond bidirectional events
+    tokio::spawn(async move {
+        loop {
+            if let Err(err) = subscribe_to_program_respond_events(
+                program_id,
+                &sol_for_respond.rpc_http_url,
+                &sol_for_respond.rpc_ws_url,
+                backlog_for_respond.clone(),
+                contract_watcher_for_respond.clone(),
+            )
+            .await
+            {
+                tracing::warn!("Failed to subscribe to solana respond events: {:?}", err);
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    });
 
     // Subscribe to non-CPI sign events
     loop {
@@ -417,6 +411,7 @@ pub async fn run(
             sign_tx.clone(),
             node_near_account_id.clone(),
             total_timeout,
+            backlog.clone(),
         )
         .await;
         if let Err(err) = unsub {
@@ -434,6 +429,7 @@ async fn subscribe_to_program_non_cpi_events<C: Deref<Target = Keypair> + Clone>
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     node_near_account_id: AccountId,
     total_timeout: Duration,
+    backlog: Backlog,
 ) -> anyhow::Result<anchor_client::EventUnsubscriber<'_>> {
     tracing::info!("Subscribing to program events");
     let (sender, mut receiver) = mpsc::unbounded_channel();
@@ -455,6 +451,7 @@ async fn subscribe_to_program_non_cpi_events<C: Deref<Target = Keypair> + Clone>
             sign_tx.clone(),
             node_near_account_id.clone(),
             total_timeout,
+            backlog.clone(),
         )
         .await
         {
@@ -471,8 +468,38 @@ async fn process_anchor_sign_event(
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     node_near_account_id: AccountId,
     total_timeout: Duration,
+    backlog: Backlog,
 ) -> anyhow::Result<()> {
     let sign_request = sign_event.generate_sign_request(tx_sig, total_timeout)?;
+
+    // Insert the transaction into the backlog when we first see the sign request
+    let sign_id = sign_request.id;
+    let sign_request_type = sign_request.sign_request_type.clone();
+
+    // Create the appropriate BacklogTransaction based on the sign request type
+    let backlog_tx = match &sign_request_type {
+        SignRequestType::Sign => BacklogTransaction::Sign(SignTx {
+            request_id: sign_id.request_id,
+            source_chain: Chain::Solana,
+            key_version: sign_request.args.key_version,
+            status: PendingRequestStatus::AwaitingResponse,
+        }),
+        SignRequestType::SignBidirectional(_event) => {
+            // For bidirectional requests, start with a Sign transaction
+            // The protocol will advance it to Bidirectional after generating the signature
+            BacklogTransaction::Sign(SignTx {
+                request_id: sign_id.request_id,
+                source_chain: Chain::Solana,
+                key_version: sign_request.args.key_version,
+                status: PendingRequestStatus::AwaitingResponse,
+            })
+        }
+        _ => anyhow::bail!("Unexpected sign request type"),
+    };
+
+    backlog
+        .insert(Chain::Solana, sign_id, backlog_tx, sign_request_type)
+        .await;
 
     if let Err(err) = sign_tx.send(sign_request).await {
         // TODO: handle error to ensure 100% success rate
@@ -487,6 +514,7 @@ async fn process_anchor_sign_event(
 }
 
 // Reference: https://github.com/solana-foundation/anchor/blob/a5df519319ac39cff21191f2b09d54eda42c5716/client/src/lib.rs#L31
+#[allow(clippy::too_many_arguments)]
 async fn subscribe_and_process_sign_events(
     program_id: Pubkey,
     rpc_url: String,
@@ -495,22 +523,26 @@ async fn subscribe_and_process_sign_events(
     node_near_account_id: AccountId,
     total_timeout: Duration,
     backlog: Backlog,
+    near_client: crate::rpc::NearClient,
 ) {
     loop {
         let sign_tx_clone = sign_tx.clone();
         let node_near_account_id_clone = node_near_account_id.clone();
+        let backlog = backlog.clone();
 
         let result = subscribe_to_program_cpi_events(
             program_id,
             &rpc_url,
             &ws_url,
             backlog.clone(),
-            move |event, signature, _slot| {
+            near_client.clone(),
+            move |event, signature: solana_sdk::signature::Signature, _slot| {
                 tracing::info!("got event: {:?}", event);
                 let tx_sig: Vec<u8> = signature.as_ref().to_vec();
 
                 let sign_tx_inner = sign_tx_clone.clone();
                 let node_near_account_id_inner = node_near_account_id_clone.clone();
+                let backlog = backlog.clone();
 
                 tokio::spawn(async move {
                     if let Err(err) = process_anchor_sign_event(
@@ -519,6 +551,7 @@ async fn subscribe_and_process_sign_events(
                         sign_tx_inner,
                         node_near_account_id_inner,
                         total_timeout,
+                        backlog,
                     )
                     .await
                     {
@@ -640,6 +673,7 @@ async fn subscribe_to_program_cpi_events<F>(
     rpc_url: &str,
     ws_url: &str,
     backlog: Backlog,
+    near_client: crate::rpc::NearClient,
     mut event_handler: F,
 ) -> Result<()>
 where
@@ -689,9 +723,30 @@ where
             }
         }
 
-        backlog
+        // Submit checkpoint if one was created at this slot
+        if let Some(checkpoint) = backlog
             .set_processed_block(Chain::Solana, response.context.slot)
-            .await;
+            .await
+        {
+            tracing::info!(slot = response.context.slot, "submitting Solana checkpoint");
+            match near_client.vote_checkpoint(Chain::Solana, checkpoint).await {
+                Ok(true) => {
+                    tracing::info!(
+                        slot = response.context.slot,
+                        "Solana checkpoint threshold reached"
+                    );
+                }
+                Ok(false) => {
+                    tracing::debug!(
+                        slot = response.context.slot,
+                        "Solana checkpoint vote recorded"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(slot = response.context.slot, %e, "failed to vote for Solana checkpoint");
+                }
+            }
+        }
     }
 
     Ok(())
@@ -704,4 +759,318 @@ fn looks_like_cpi_sign_event(logs: &[String]) -> bool {
 
 fn has_log_starts_with(logs: &[String], start_with: &str) -> bool {
     logs.iter().any(|l| l.starts_with(start_with))
+}
+
+async fn parse_cpi_respond_events(
+    rpc_client: &RpcClient,
+    signature: &Signature,
+    target_program_id: &Pubkey,
+) -> Result<(Vec<RespondBidirectionalEvent>, Vec<SignatureRespondedEvent>)> {
+    use solana_transaction_status::{UiInstruction, UiParsedInstruction};
+
+    let tx = rpc_client
+        .get_transaction_with_config(
+            signature,
+            solana_client::rpc_config::RpcTransactionConfig {
+                encoding: Some(solana_transaction_status::UiTransactionEncoding::JsonParsed),
+                commitment: Some(CommitmentConfig::confirmed()),
+                max_supported_transaction_version: Some(0),
+            },
+        )
+        .await?;
+
+    let Some(meta) = tx.transaction.meta else {
+        return Ok((Vec::new(), Vec::new()));
+    };
+
+    let target_program_str = target_program_id.to_string();
+    let mut respond_bidirectional_events = Vec::<RespondBidirectionalEvent>::new();
+    let mut signature_responded_events = Vec::<SignatureRespondedEvent>::new();
+
+    // Helper closure to try decoding RespondBidirectionalEvent and SignatureRespondedEvent from raw data
+    let try_parse_respond_event =
+        |data: &str| -> Result<(Vec<RespondBidirectionalEvent>, Vec<SignatureRespondedEvent>)> {
+            let Ok(ix_data) = solana_sdk::bs58::decode(data).into_vec() else {
+                tracing::warn!("Failed to decode instruction data for target program");
+                return Ok((Vec::new(), Vec::new()));
+            };
+
+            // Ensure this is an Anchor event instruction
+            if !ix_data.starts_with(anchor_lang::event::EVENT_IX_TAG_LE) {
+                return Ok((Vec::new(), Vec::new()));
+            }
+
+            let event_discriminator = &ix_data[8..16];
+            let event_data = &ix_data[16..];
+
+            let mut respond_bdx = Vec::new();
+            let mut sig_resp = Vec::new();
+
+            // Handle RespondBidirectionalEvent
+            if event_discriminator == RespondBidirectionalEvent::DISCRIMINATOR {
+                match RespondBidirectionalEvent::deserialize(&mut &event_data[..]) {
+                    Ok(ev) => respond_bdx.push(ev),
+                    Err(e) => {
+                        tracing::warn!("Failed to deserialize RespondBidirectionalEvent: {e}")
+                    }
+                }
+            }
+
+            // Handle SignatureRespondedEvent
+            if event_discriminator == SignatureRespondedEvent::DISCRIMINATOR {
+                match SignatureRespondedEvent::deserialize(&mut &event_data[..]) {
+                    Ok(ev) => sig_resp.push(ev),
+                    Err(e) => {
+                        tracing::warn!("Failed to deserialize SignatureRespondedEvent: {e}")
+                    }
+                }
+            }
+
+            Ok((respond_bdx, sig_resp))
+        };
+
+    // Look into inner instructions for CPI calls
+    let inner_ixs = match meta.inner_instructions {
+        solana_transaction_status::option_serializer::OptionSerializer::Some(ixs) => ixs,
+        _ => return Ok((Vec::new(), Vec::new())),
+    };
+
+    for (set_idx, inner_ix_set) in inner_ixs.iter().enumerate() {
+        for (ix_idx, instruction) in inner_ix_set.instructions.iter().enumerate() {
+            if let UiInstruction::Parsed(UiParsedInstruction::PartiallyDecoded(ui)) = instruction {
+                if ui.program_id == target_program_str {
+                    match try_parse_respond_event(&ui.data) {
+                        Ok((mut r_bdx, mut s_resp)) => {
+                            if !r_bdx.is_empty() {
+                                tracing::info!(
+                                    "parsed {} RespondBidirectionalEvent(s) from {}.{}",
+                                    r_bdx.len(),
+                                    set_idx,
+                                    ix_idx
+                                );
+                            }
+                            if !s_resp.is_empty() {
+                                tracing::info!(
+                                    "parsed {} SignatureRespondedEvent(s) from {}.{}",
+                                    s_resp.len(),
+                                    set_idx,
+                                    ix_idx
+                                );
+                            }
+                            respond_bidirectional_events.append(&mut r_bdx);
+                            signature_responded_events.append(&mut s_resp);
+                        }
+                        Err(e) => tracing::warn!(
+                            "Error processing inner instruction {}.{}: {}",
+                            set_idx,
+                            ix_idx,
+                            e
+                        ),
+                    }
+                }
+            }
+        }
+    }
+
+    Ok((respond_bidirectional_events, signature_responded_events))
+}
+
+async fn subscribe_to_program_respond_events(
+    program_id: Pubkey,
+    rpc_url: &str,
+    ws_url: &str,
+    backlog: Backlog,
+    mut contract_watcher: crate::rpc::ContractStateWatcher,
+) -> Result<()> {
+    let rpc_client = RpcClient::new(rpc_url.to_string());
+    let pubsub_client = PubsubClient::new(ws_url).await?;
+
+    let filter = RpcTransactionLogsFilter::Mentions(vec![program_id.to_string()]);
+    let config = RpcTransactionLogsConfig {
+        commitment: Some(CommitmentConfig::confirmed()),
+    };
+
+    let (mut stream, _unsubscriber) = pubsub_client.logs_subscribe(filter, config).await?;
+
+    // Simple TTL cache to avoid multiple getTransaction calls for the same signature
+    let mut seen: HashMap<Signature, Instant> = HashMap::new();
+    let ttl = Duration::from_secs(30);
+
+    let program_invoke_log = format!("Program {program_id} invoke [");
+    while let Some(response) = stream.next().await {
+        if response.value.err.is_some() {
+            continue;
+        }
+
+        let logs = &response.value.logs;
+        if !has_log_starts_with(logs, &program_invoke_log) {
+            continue;
+        }
+
+        let Ok(signature) = Signature::from_str(&response.value.signature) else {
+            tracing::warn!("Invalid signature format");
+            continue;
+        };
+        let now = Instant::now();
+        // Periodic cleanup of expired entries in the TTL cache
+        seen.retain(|_, &mut timestamp| now.duration_since(timestamp) < ttl);
+        if seen.contains_key(&signature) {
+            continue;
+        }
+        seen.insert(signature, now);
+
+        let Ok((respond_bidirectional_events, respond_events)) =
+            parse_cpi_respond_events(&rpc_client, &signature, &program_id).await
+        else {
+            continue;
+        };
+        for ev in respond_bidirectional_events {
+            let sign_id = SignId::new(ev.request_id);
+            tracing::info!(?sign_id, "processing RespondBidirectionalEvent");
+            if backlog.remove(Chain::Solana, &sign_id).await.is_some() {
+                tracing::info!(?sign_id, "bidirectional tx completed");
+            } else {
+                tracing::warn!(?sign_id, "bidirectional tx not found on completion");
+            }
+        }
+
+        for ev in respond_events {
+            let sign_id = SignId::new(ev.request_id);
+
+            let Some(sign_type) = backlog.sign_type(Chain::Solana, &sign_id).await else {
+                tracing::warn!(
+                    ?sign_id,
+                    "sign type not found for respond event (may have already been processed)"
+                );
+                continue;
+            };
+            let event = match sign_type {
+                SignRequestType::SignBidirectional(event) => event,
+                SignRequestType::Sign => {
+                    tracing::info!(?sign_id, "sign request completed successfully");
+                    backlog.remove(Chain::Solana, &sign_id).await;
+                    continue;
+                }
+                SignRequestType::RespondBidirectional(_) => {
+                    tracing::warn!(?sign_id, "RespondBidirectional received respond event?");
+                    continue;
+                }
+            };
+
+            tracing::info!(?sign_id, "bidirectional processing initial respond event");
+            let Ok(target_chain) = Chain::from_str(&event.dest).inspect_err(|err| {
+                tracing::warn!(?sign_id, %err, "unable to parse target chain from dest");
+            }) else {
+                continue;
+            };
+
+            let Some(BacklogTransaction::Sign(_)) = backlog.get(Chain::Solana, &sign_id).await
+            else {
+                tracing::warn!(?sign_id, "bidirectional tx not found for advancement");
+                continue;
+            };
+
+            // Create a 65-byte uncompressed point representation (0x04 || x || y)
+            let mut big_r = [0u8; 65];
+            big_r[0] = 0x04;
+            big_r[1..33].copy_from_slice(&ev.signature.big_r.x);
+            big_r[33..65].copy_from_slice(&ev.signature.big_r.y);
+
+            let Ok(big_r) = k256::EncodedPoint::from_bytes(big_r).inspect_err(|err| {
+                tracing::warn!(?sign_id, %err, "unable to parse big_r for encoded point");
+            }) else {
+                continue;
+            };
+            let big_r_ct_opt = AffinePoint::from_encoded_point(&big_r);
+            let big_r = if bool::from(big_r_ct_opt.is_some()) {
+                big_r_ct_opt.unwrap()
+            } else {
+                tracing::warn!(?sign_id, "failed to create AffinePoint from encoded point");
+                continue;
+            };
+
+            let Some(s) = Scalar::from_bytes(ev.signature.s) else {
+                tracing::warn!(?sign_id, "failed to create Scalar from s bytes");
+                continue;
+            };
+
+            let mpc_sig = mpc_primitives::Signature {
+                big_r,
+                s,
+                recovery_id: ev.signature.recovery_id,
+            };
+
+            // Sign and hash the transaction to get the correct tx_id and nonce
+            let (signed_tx_hash, nonce) = crate::sign_bidirectional::sign_and_hash_transaction(
+                &event.serialized_transaction,
+                mpc_sig,
+            )?;
+
+            let tx_id = BidirectionalTxId(signed_tx_hash.into());
+
+            // Get the MPC public key and derive the from_address
+            let root_public_key = contract_watcher.wait_public_key().await;
+            let epsilon = mpc_crypto::kdf::derive_epsilon_sol(
+                event.key_version,
+                &ev.responder.to_string(),
+                &event.path,
+            );
+            let from_address =
+                crate::sign_bidirectional::derive_user_address(root_public_key, epsilon);
+
+            let bidirectional_tx = BidirectionalTx {
+                id: tx_id,
+                sender: ev.responder,
+                serialized_transaction: event.serialized_transaction,
+                source_chain: Chain::Solana,
+                target_chain,
+                caip2_id: event.caip2_id,
+                key_version: event.key_version,
+                deposit: event.deposit,
+                path: event.path.clone(),
+                algo: event.algo.clone(),
+                dest: event.dest.clone(),
+                params: event.params.clone(),
+                output_deserialization_schema: event.output_deserialization_schema.clone(),
+                respond_serialization_schema: event.respond_serialization_schema.clone(),
+                request_id: ev.request_id,
+                from_address,
+                nonce,
+                status: PendingRequestStatus::AwaitingResponse,
+            };
+
+            tracing::info!(
+                ?sign_id,
+                ?tx_id,
+                nonce = ?bidirectional_tx.nonce,
+                from_address = ?bidirectional_tx.from_address,
+                "bidirectional tx details before advancement",
+            );
+
+            match backlog
+                .advance(Chain::Solana, sign_id, bidirectional_tx)
+                .await
+            {
+                Ok(_) => {
+                    tracing::info!(
+                        ?sign_id,
+                        ?tx_id,
+                        ?target_chain,
+                        "advance bidirectional tx to execution successful"
+                    );
+                }
+                Err(err) => {
+                    tracing::error!(
+                        ?sign_id,
+                        ?tx_id,
+                        ?target_chain,
+                        ?err,
+                        "advance bidirectional tx to execution failed"
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -1,8 +1,12 @@
 use crate::backlog::{Backlog, BacklogTransaction, SignTx};
+use crate::mesh::{wait_threshold_active, MeshState};
+use crate::node_client::NodeClient;
 use crate::protocol::{Chain, IndexedSignRequest, SignRequestType};
+use crate::rpc::ContractStateWatcher;
 use crate::sign_bidirectional::{
     hash_rlp_data, BidirectionalTx, BidirectionalTxId, PendingRequestStatus,
 };
+
 use alloy_sol_types::SolValue;
 use anchor_client::anchor_lang::AnchorDeserialize;
 use anchor_client::{Client, Cluster, Program};
@@ -35,7 +39,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::time::{Duration, Instant};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 
 pub(crate) static MAX_SECP256K1_SCALAR: LazyLock<Scalar> = LazyLock::new(|| {
     Scalar::from_bytes(
@@ -336,8 +340,9 @@ pub async fn run(
     sign_tx: mpsc::Sender<IndexedSignRequest>,
     node_near_account_id: AccountId,
     backlog: Backlog,
-    near_client: crate::rpc::NearClient,
-    contract_watcher: crate::rpc::ContractStateWatcher,
+    mut contract_watcher: ContractStateWatcher,
+    mut mesh_state: watch::Receiver<MeshState>,
+    node_client: NodeClient,
 ) {
     let Some(sol) = sol else {
         tracing::warn!("solana indexer is disabled");
@@ -350,7 +355,15 @@ pub async fn run(
         return;
     };
 
-    backlog.recover(&near_client, &[Chain::Solana]).await;
+    // Wait for threshold to be available
+    let threshold = contract_watcher.wait_threshold().await;
+    if threshold > 0 {
+        wait_threshold_active(&mut mesh_state, threshold).await;
+        let mesh_state = mesh_state.borrow().clone();
+        backlog
+            .recover(&mesh_state, &node_client, threshold, &[Chain::Solana])
+            .await;
+    }
     let keypair = Keypair::from_base58_string(&sol.account_sk);
     let cluster = Cluster::Custom(sol.rpc_http_url.clone(), sol.rpc_ws_url.clone());
     let client =
@@ -378,7 +391,6 @@ pub async fn run(
         node_near_account_id.clone(),
         total_timeout,
         backlog.clone(),
-        near_client.clone(),
     ));
 
     // Subscribe to respond bidirectional events
@@ -523,7 +535,6 @@ async fn subscribe_and_process_sign_events(
     node_near_account_id: AccountId,
     total_timeout: Duration,
     backlog: Backlog,
-    near_client: crate::rpc::NearClient,
 ) {
     loop {
         let sign_tx_clone = sign_tx.clone();
@@ -535,7 +546,6 @@ async fn subscribe_and_process_sign_events(
             &rpc_url,
             &ws_url,
             backlog.clone(),
-            near_client.clone(),
             move |event, signature: solana_sdk::signature::Signature, _slot| {
                 tracing::info!("got event: {:?}", event);
                 let tx_sig: Vec<u8> = signature.as_ref().to_vec();
@@ -673,7 +683,6 @@ async fn subscribe_to_program_cpi_events<F>(
     rpc_url: &str,
     ws_url: &str,
     backlog: Backlog,
-    near_client: crate::rpc::NearClient,
     mut event_handler: F,
 ) -> Result<()>
 where
@@ -723,29 +732,16 @@ where
             }
         }
 
-        // Submit checkpoint if one was created at this slot
+        // Create checkpoint if one was created at this slot
         if let Some(checkpoint) = backlog
             .set_processed_block(Chain::Solana, response.context.slot)
             .await
         {
-            tracing::info!(slot = response.context.slot, "submitting Solana checkpoint");
-            match near_client.vote_checkpoint(Chain::Solana, checkpoint).await {
-                Ok(true) => {
-                    tracing::info!(
-                        slot = response.context.slot,
-                        "Solana checkpoint threshold reached"
-                    );
-                }
-                Ok(false) => {
-                    tracing::debug!(
-                        slot = response.context.slot,
-                        "Solana checkpoint vote recorded"
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(slot = response.context.slot, %e, "failed to vote for Solana checkpoint");
-                }
-            }
+            tracing::info!(
+                slot = response.context.slot,
+                ?checkpoint,
+                "created Solana checkpoint"
+            );
         }
     }
 
@@ -880,7 +876,7 @@ async fn subscribe_to_program_respond_events(
     rpc_url: &str,
     ws_url: &str,
     backlog: Backlog,
-    mut contract_watcher: crate::rpc::ContractStateWatcher,
+    mut contract_watcher: ContractStateWatcher,
 ) -> Result<()> {
     let rpc_client = RpcClient::new(rpc_url.to_string());
     let pubsub_client = PubsubClient::new(ws_url).await?;

--- a/chain-signatures/node/src/lib.rs
+++ b/chain-signatures/node/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod backlog;
+pub mod checkpoint_consensus;
 pub mod cli;
 pub mod config;
 pub mod gcp;

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -178,6 +178,15 @@ impl Mesh {
     }
 }
 
+pub async fn wait_threshold_active(mesh_state: &mut watch::Receiver<MeshState>, threshold: usize) {
+    loop {
+        if mesh_state.borrow().active.len() >= threshold {
+            return;
+        }
+        let _ = mesh_state.changed().await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;

--- a/chain-signatures/node/src/node_client.rs
+++ b/chain-signatures/node/src/node_client.rs
@@ -1,15 +1,20 @@
+use crate::backlog::Checkpoint;
 use crate::protocol::message::cbor_to_bytes;
 use crate::protocol::state::NodeStatus;
 use crate::protocol::sync::SyncUpdate;
+use crate::protocol::Chain;
 use crate::web::StateView;
+
 use hyper::StatusCode;
 use mpc_keys::hpke::Ciphered;
 use reqwest::IntoUrl;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use url::Url;
+
+use std::collections::HashMap;
 use std::str::Utf8Error;
 use std::time::Duration;
-use url::Url;
 
 #[derive(Debug, Clone, clap::Parser)]
 #[group(id = "message_options")]
@@ -166,5 +171,31 @@ impl NodeClient {
         url.set_path("sync");
 
         self.post_cbor(&url, update).await
+    }
+
+    pub async fn checkpoint(
+        &self,
+        base: impl IntoUrl,
+    ) -> Result<HashMap<Chain, Checkpoint>, RequestError> {
+        let mut url = base.into_url()?;
+        url.set_path("checkpoint");
+
+        let resp = self
+            .http
+            .get(url)
+            .timeout(Duration::from_secs(15))
+            .send()
+            .await?;
+
+        let status = resp.status();
+        let body = resp.bytes().await.map_err(RequestError::MalformedBody)?;
+
+        if status.is_success() {
+            ciborium::from_reader(body.as_ref())
+                .map_err(|err| RequestError::Conversion(err.to_string()))
+        } else {
+            let resp = std::str::from_utf8(&body).map_err(RequestError::MalformedResponse)?;
+            Err(RequestError::Unsuccessful(status, resp.into()))
+        }
     }
 }

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -17,12 +17,13 @@ pub use contract::primitives::ParticipantInfo;
 pub use contract::ProtocolState;
 pub use cryptography::CryptographicError;
 pub use message::{Message, MessageChannel};
+pub use mpc_primitives::Chain;
 pub use signature::{IndexedSignRequest, SignQueue};
+use signet_program::SignBidirectionalEvent;
 pub use state::{Node, NodeState};
 
 use crate::backlog::Backlog;
 use crate::config::Config;
-use crate::indexer_sol::SignBidirectionalEvent;
 use crate::mesh::MeshState;
 use crate::protocol::consensus::ConsensusProtocol;
 use crate::protocol::cryptography::CryptographicProtocol;
@@ -35,8 +36,6 @@ use crate::storage::triple_storage::TripleStorage;
 
 use near_account_id::AccountId;
 use semver::Version;
-use serde::{Deserialize, Serialize};
-use std::fmt;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -227,48 +226,12 @@ pub async fn spawn_system_metrics(node_account_id: &str) -> tokio::task::JoinHan
     })
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum Chain {
-    NEAR,
-    Ethereum,
-    Solana,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[allow(clippy::large_enum_variant)]
 pub enum SignRequestType {
     Sign,
     SignBidirectional(SignBidirectionalEvent),
     RespondBidirectional(RespondBidirectionalTx),
-}
-
-impl Chain {
-    pub const fn as_str(&self) -> &'static str {
-        match self {
-            Chain::NEAR => "NEAR",
-            Chain::Ethereum => "Ethereum",
-            Chain::Solana => "Solana",
-        }
-    }
-}
-
-impl std::str::FromStr for Chain {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "NEAR" | "Near" | "near" => Ok(Chain::NEAR),
-            "Ethereum" | "ethereum" | "eth" => Ok(Chain::Ethereum),
-            "Solana" | "solana" | "sol" => Ok(Chain::Solana),
-            _ => Err(format!("unknown or unsupported chain {s}")),
-        }
-    }
-}
-
-impl fmt::Display for Chain {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
 }
 
 #[cfg(test)]

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -10,7 +10,6 @@ use crate::protocol::posit::{PositAction, PositInternalAction, Positor, Posits};
 use crate::protocol::presignature::PresignatureId;
 use crate::protocol::Chain;
 use crate::rpc::{ContractStateWatcher, RpcChannel};
-use crate::sign_bidirectional::{BidirectionalTx, SignBidirectionalSignature};
 use crate::storage::presignature_storage::{PresignatureTaken, PresignatureTakenDropper};
 use crate::storage::PresignatureStorage;
 use crate::types::SignatureProtocol;
@@ -46,10 +45,9 @@ pub struct IndexedSignRequest {
     pub args: SignArgs,
     pub chain: Chain,
     pub unix_timestamp_indexed: u64,
-    pub timestamp_sign_queue: Option<Instant>,
+    pub timestamp_sign_queue: Instant,
     pub total_timeout: Duration,
     pub sign_request_type: SignRequestType,
-    pub participants: Option<Vec<Participant>>,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -171,11 +169,7 @@ impl SignQueue {
     ) -> SignRequest {
         let sign_id = indexed.id;
         let reorganize = initial_round > 0;
-        let mut participants = if indexed.participants.is_some() {
-            indexed.participants.clone().unwrap()
-        } else {
-            participants.keys().cloned().collect()
-        };
+        let mut participants = participants.keys().copied().collect::<Vec<_>>();
         participants.sort();
 
         // Simple round-robin selection of the proposer, using only inputs that
@@ -339,9 +333,8 @@ impl SignQueue {
 
     pub fn expire(&mut self, cfg: &ProtocolConfig) {
         self.requests.retain(|_, request| {
-            request.indexed.timestamp_sign_queue.is_none_or(|t| {
-                t.elapsed() < Duration::from_millis(cfg.signature.generation_timeout_total)
-            })
+            request.indexed.timestamp_sign_queue.elapsed()
+                < Duration::from_millis(cfg.signature.generation_timeout_total)
         });
         self.my_requests.retain(|id| {
             let Some(request) = self.requests.get(id) else {
@@ -389,6 +382,10 @@ struct SignatureGenerator {
     inbox: mpsc::Receiver<SignatureMessage>,
     msg: MessageChannel,
     rpc: RpcChannel,
+
+    // TODO: will be used in the future when we move requests channels
+    // into the backlog.
+    #[allow(dead_code)]
     backlog: Backlog,
 
     #[cfg(feature = "debug-page")]
@@ -476,13 +473,7 @@ impl SignatureGenerator {
     }
 
     fn timeout_total(&self) -> bool {
-        let timestamp = self
-            .request
-            .indexed
-            .timestamp_sign_queue
-            .as_ref()
-            .unwrap_or(&self.created);
-        timestamp.elapsed() >= self.timeout_total
+        self.request.indexed.timestamp_sign_queue.elapsed() >= self.timeout_total
     }
 
     /// Receive the next message for the signature protocol; error out on the timeout being reached
@@ -654,60 +645,16 @@ impl SignatureGenerator {
                         &self.request.indexed.sign_request_type
                     {
                         let source_chain = self.request.indexed.chain;
-                        let dest = event.dest.clone();
-                        let expected_public_key = mpc_crypto::derive_key(
-                            self.public_key,
-                            self.request.indexed.args.epsilon,
+
+                        // Note: The promotion to Bidirectional will happen when we receive the
+                        // SignatureRespondedEvent in the Solana indexer, which has the signature data.
+                        // For now, we just complete the signature generation. The indexer will handle the promotion.
+                        tracing::debug!(
+                            ?sign_id,
+                            ?source_chain,
+                            ?event.dest,
+                            "generated signature for bidirectional request, awaiting indexer to process"
                         );
-
-                        let signature = match crate::kdf::into_eth_sig(
-                            &expected_public_key,
-                            &big_r,
-                            &s,
-                            self.request.indexed.args.payload,
-                        ) {
-                            Ok(sig) => sig,
-                            Err(err) => {
-                                tracing::error!(
-                                    ?sign_id,
-                                    ?source_chain,
-                                    target_chain = ?dest,
-                                    ?err,
-                                    "failed to generate a valid signature"
-                                );
-                                break Ok(());
-                            }
-                        };
-
-                        let signature = SignBidirectionalSignature {
-                            public_key: self.public_key,
-                            request: self.request.clone(),
-                            signature,
-                            participants: self.participants.clone(),
-                        };
-
-                        match BidirectionalTx::new(signature) {
-                            Ok(tx) => {
-                                let target_chain = tx.target_chain;
-                                let source_chain = tx.source_chain;
-                                self.backlog.insert(target_chain, sign_id, tx).await;
-                                tracing::info!(
-                                    ?sign_id,
-                                    ?source_chain,
-                                    ?target_chain,
-                                    "inserted SignRespond tx into backlog with Pending status"
-                                );
-                            }
-                            Err(err) => {
-                                tracing::error!(
-                                    ?sign_id,
-                                    ?source_chain,
-                                    target_chain = ?dest,
-                                    ?err,
-                                    "failed to create SignRespondTx",
-                                );
-                            }
-                        }
                     }
 
                     break Ok(());

--- a/chain-signatures/node/src/respond_bidirectional.rs
+++ b/chain-signatures/node/src/respond_bidirectional.rs
@@ -1,4 +1,3 @@
-use crate::backlog::Backlog;
 use crate::protocol::{Chain, IndexedSignRequest};
 use crate::sign_bidirectional::BidirectionalTx;
 use crate::sign_bidirectional::BidirectionalTxId;
@@ -20,7 +19,6 @@ use helios::ethereum::EthereumClient;
 use k256::Scalar;
 use mpc_crypto::ScalarExt;
 use mpc_primitives::{SignArgs, SignId};
-use tokio::sync::mpsc;
 use tokio::time::Duration;
 
 const MAGIC_ERROR_PREFIX: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
@@ -239,7 +237,7 @@ impl CompletedTx {
                 key_version: self.tx.key_version,
             },
             unix_timestamp_indexed: crate::util::current_unix_timestamp(),
-            timestamp_sign_queue: None,
+            timestamp_sign_queue: std::time::Instant::now(),
             total_timeout: signature_generation_total_timeout,
             sign_request_type: crate::protocol::SignRequestType::RespondBidirectional(
                 RespondBidirectionalTx {
@@ -247,7 +245,6 @@ impl CompletedTx {
                     output: serialized_output,
                 },
             ),
-            participants: Some(self.tx.participants.clone()),
         })
     }
 
@@ -358,54 +355,6 @@ async fn fetch_tx_from_helios(
                 tracing::warn!("Failed to fecth tx from helios: {err:?}, retrying...");
                 attempts += 1;
                 tokio::time::sleep(Duration::from_millis(100)).await;
-            }
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct RespondBidirectionalTxChannel {
-    tx: mpsc::Sender<(Chain, SignId)>,
-}
-
-impl RespondBidirectionalTxChannel {
-    pub fn send(&self, chain: Chain, sign_id: SignId) {
-        let tx = self.tx.clone();
-        tokio::spawn(async move {
-            if let Err(err) = tx.send((chain, sign_id)).await {
-                tracing::error!(%err, "failed to send respond bidirectional tx id");
-            }
-        });
-    }
-}
-
-pub struct RespondBidirectionalTxProcessor {
-    rx: mpsc::Receiver<(Chain, SignId)>,
-}
-
-const MAX_CONCURRENT_RESPOND_BIDIRECTIONAL_TX_REQUESTS: usize = 1024;
-
-impl RespondBidirectionalTxProcessor {
-    pub fn new() -> (RespondBidirectionalTxChannel, Self) {
-        let (tx, rx) = mpsc::channel(MAX_CONCURRENT_RESPOND_BIDIRECTIONAL_TX_REQUESTS);
-        (RespondBidirectionalTxChannel { tx }, Self { rx })
-    }
-
-    pub async fn run(mut self, backlog: Backlog, max_attempts: u8) {
-        while let Some((chain, sign_id)) = self.rx.recv().await {
-            for attempt in 1..=max_attempts {
-                if backlog.remove(chain, &sign_id).await.is_some() {
-                    tracing::info!(?sign_id, ?chain, "removed bidirectional tx from backlog");
-                    break;
-                } else if attempt == max_attempts {
-                    tracing::error!(
-                        ?sign_id,
-                        ?chain,
-                        "failed to remove bidirectional tx from backlog after {max_attempts} attempts"
-                    );
-                } else {
-                    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-                }
             }
         }
     }

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -1,4 +1,4 @@
-use crate::backlog::{Backlog, Checkpoint};
+use crate::backlog::Backlog;
 use crate::config::{Config, ContractConfig, NetworkConfig};
 use crate::indexer_eth::EthConfig;
 use crate::indexer_sol::SolConfig;
@@ -226,6 +226,16 @@ impl ContractStateWatcher {
             ProtocolState::Initializing(_) => None,
             ProtocolState::Running(state) => Some(state.threshold),
             ProtocolState::Resharing(state) => Some(state.threshold),
+        }
+    }
+
+    /// Wait until the MPC threshold is available and return it
+    pub async fn wait_threshold(&mut self) -> usize {
+        loop {
+            if let Some(threshold) = self.threshold().await {
+                return threshold;
+            }
+            let _ = self.contract_state.changed().await;
         }
     }
 
@@ -525,75 +535,6 @@ impl NearClient {
             .json()?;
 
         Ok(result)
-    }
-
-    pub async fn vote_checkpoint(
-        &self,
-        chain: Chain,
-        checkpoint: Checkpoint,
-    ) -> anyhow::Result<bool> {
-        tracing::info!(
-            ?chain,
-            block_height = checkpoint.block_height,
-            signer_id = %self.signer.account_id,
-            "voting for checkpoint"
-        );
-
-        // Serialize the checkpoint to JSON for the contract call
-        let checkpoint_json = serde_json::to_value(&checkpoint)
-            .map_err(|e| anyhow::anyhow!("failed to serialize checkpoint: {}", e))?;
-
-        let result = self
-            .client
-            .call(&self.signer, &self.contract_id, "vote_checkpoint")
-            .args_json(json!({
-                "chain": chain,
-                "checkpoint": checkpoint_json
-            }))
-            .max_gas()
-            .retry_exponential(10, 5)
-            .transact()
-            .await
-            .inspect_err(|err| {
-                tracing::warn!(%err, ?chain, block_height = checkpoint.block_height, "failed to vote for checkpoint");
-            })?
-            .json()?;
-
-        Ok(result)
-    }
-
-    pub async fn fetch_latest_checkpoint(
-        &self,
-        chain: Chain,
-    ) -> anyhow::Result<Option<crate::backlog::Checkpoint>> {
-        tracing::debug!(?chain, "fetching latest checkpoint from contract");
-
-        let result: Option<mpc_contract::primitives::Checkpoint> = self
-            .client
-            .view(&self.contract_id, "latest_checkpoint")
-            .args_json(json!({
-                "chain": chain
-            }))
-            .await
-            .inspect_err(|err| {
-                tracing::warn!(%err, ?chain, "failed to fetch latest checkpoint");
-            })?
-            .json()?;
-
-        match result {
-            Some(checkpoint) => {
-                tracing::info!(
-                    ?chain,
-                    block_height = checkpoint.block_height,
-                    "successfully fetched latest checkpoint"
-                );
-                Ok(Some(checkpoint))
-            }
-            None => {
-                tracing::debug!(?chain, "no checkpoint found for chain");
-                Ok(None)
-            }
-        }
     }
 
     pub async fn propose_join(&self) -> anyhow::Result<()> {

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -1,4 +1,4 @@
-use crate::backlog::Backlog;
+use crate::backlog::{Backlog, Checkpoint};
 use crate::config::{Config, ContractConfig, NetworkConfig};
 use crate::indexer_eth::EthConfig;
 use crate::indexer_sol::SolConfig;
@@ -6,7 +6,6 @@ use crate::protocol::contract::primitives::{ParticipantMap, Participants};
 use crate::protocol::contract::RunningContractState;
 use crate::protocol::signature::SignRequest;
 use crate::protocol::{Chain, Governance, ProtocolState, SignRequestType};
-use crate::respond_bidirectional::RespondBidirectionalTxChannel;
 use crate::util::AffinePointExt as _;
 
 use solana_sdk::commitment_config::CommitmentConfig;
@@ -223,15 +222,33 @@ impl ContractStateWatcher {
     }
 
     pub async fn threshold(&self) -> Option<usize> {
-        match self.state().clone()? {
+        match self.state()? {
             ProtocolState::Initializing(_) => None,
             ProtocolState::Running(state) => Some(state.threshold),
             ProtocolState::Resharing(state) => Some(state.threshold),
         }
     }
 
+    pub async fn public_key(&self) -> Option<AffinePoint> {
+        match self.borrow_state().as_ref()? {
+            ProtocolState::Initializing(_) => None,
+            ProtocolState::Running(state) => Some(state.public_key),
+            ProtocolState::Resharing(_) => None,
+        }
+    }
+
+    /// Wait until the public key is available and return it
+    pub async fn wait_public_key(&mut self) -> AffinePoint {
+        loop {
+            if let Some(pk) = self.public_key().await {
+                return pk;
+            }
+            let _ = self.contract_state.changed().await;
+        }
+    }
+
     pub async fn info(&self) -> Option<(usize, Participant)> {
-        match self.state().clone()? {
+        match self.state()? {
             ProtocolState::Initializing(_) => None,
             ProtocolState::Running(state) => Some((
                 state.threshold,
@@ -313,7 +330,6 @@ impl RpcExecutor {
         mut self,
         contract: watch::Sender<Option<ProtocolState>>,
         config: watch::Sender<Config>,
-        respond_bidirectional_tx_channel: RespondBidirectionalTxChannel,
     ) {
         // spin up update task for updating contract state and config
         let near = self.near.clone();
@@ -353,18 +369,10 @@ impl RpcExecutor {
             let eth_rpc_tx = eth_rpc_tx.clone(); // clone for task use
             let backlog = self.backlog.clone();
 
-            let respond_bidirectional_tx_channel_clone = respond_bidirectional_tx_channel.clone();
             tokio::spawn(async move {
                 match chain {
                     Chain::NEAR | Chain::Solana => {
-                        execute_publish(
-                            client,
-                            action,
-                            near_account_id,
-                            backlog,
-                            respond_bidirectional_tx_channel_clone,
-                        )
-                        .await;
+                        execute_publish(client, action, near_account_id, backlog).await;
                     }
                     Chain::Ethereum => {
                         if let Err(err) = eth_rpc_tx.send(action).await {
@@ -519,6 +527,75 @@ impl NearClient {
         Ok(result)
     }
 
+    pub async fn vote_checkpoint(
+        &self,
+        chain: Chain,
+        checkpoint: Checkpoint,
+    ) -> anyhow::Result<bool> {
+        tracing::info!(
+            ?chain,
+            block_height = checkpoint.block_height,
+            signer_id = %self.signer.account_id,
+            "voting for checkpoint"
+        );
+
+        // Serialize the checkpoint to JSON for the contract call
+        let checkpoint_json = serde_json::to_value(&checkpoint)
+            .map_err(|e| anyhow::anyhow!("failed to serialize checkpoint: {}", e))?;
+
+        let result = self
+            .client
+            .call(&self.signer, &self.contract_id, "vote_checkpoint")
+            .args_json(json!({
+                "chain": chain,
+                "checkpoint": checkpoint_json
+            }))
+            .max_gas()
+            .retry_exponential(10, 5)
+            .transact()
+            .await
+            .inspect_err(|err| {
+                tracing::warn!(%err, ?chain, block_height = checkpoint.block_height, "failed to vote for checkpoint");
+            })?
+            .json()?;
+
+        Ok(result)
+    }
+
+    pub async fn fetch_latest_checkpoint(
+        &self,
+        chain: Chain,
+    ) -> anyhow::Result<Option<crate::backlog::Checkpoint>> {
+        tracing::debug!(?chain, "fetching latest checkpoint from contract");
+
+        let result: Option<mpc_contract::primitives::Checkpoint> = self
+            .client
+            .view(&self.contract_id, "latest_checkpoint")
+            .args_json(json!({
+                "chain": chain
+            }))
+            .await
+            .inspect_err(|err| {
+                tracing::warn!(%err, ?chain, "failed to fetch latest checkpoint");
+            })?
+            .json()?;
+
+        match result {
+            Some(checkpoint) => {
+                tracing::info!(
+                    ?chain,
+                    block_height = checkpoint.block_height,
+                    "successfully fetched latest checkpoint"
+                );
+                Ok(Some(checkpoint))
+            }
+            None => {
+                tracing::debug!(?chain, "no checkpoint found for chain");
+                Ok(None)
+            }
+        }
+    }
+
     pub async fn propose_join(&self) -> anyhow::Result<()> {
         tracing::info!(signer_id = %self.signer.account_id, "joining the protocol");
         self.client
@@ -658,7 +735,6 @@ async fn execute_publish(
     mut action: PublishAction,
     near_account_id: AccountId,
     backlog: Backlog,
-    respond_bidirectional_tx_channel: RespondBidirectionalTxChannel,
 ) {
     let chain = action.request.indexed.chain;
     let sign_id = action.request.indexed.id;
@@ -708,7 +784,6 @@ async fn execute_publish(
                 &action.timestamp,
                 &signature,
                 &near_account_id,
-                respond_bidirectional_tx_channel.clone(),
             )
             .await
             .map_err(|_| ()),
@@ -827,23 +902,20 @@ async fn try_publish_near(
         "published signature sucessfully",
     );
 
+    let elapsed = action.request.indexed.timestamp_sign_queue.elapsed();
     crate::metrics::NUM_SIGN_SUCCESS
         .with_label_values(&[chain.as_str(), near.my_account_id.as_str()])
         .inc();
-    if let Some(timestamp_sign_queue) = action.request.indexed.timestamp_sign_queue {
-        crate::metrics::SIGN_TOTAL_LATENCY
-            .with_label_values(&[chain.as_str(), near.my_account_id.as_str()])
-            .observe(timestamp_sign_queue.elapsed().as_secs_f64());
-    }
+    crate::metrics::SIGN_TOTAL_LATENCY
+        .with_label_values(&[chain.as_str(), near.my_account_id.as_str()])
+        .observe(elapsed.as_secs_f64());
     crate::metrics::SIGN_RESPOND_LATENCY
         .with_label_values(&[chain.as_str(), near.my_account_id.as_str()])
         .observe(timestamp.elapsed().as_secs_f64());
-    if let Some(timestamp_sign_queue) = action.request.indexed.timestamp_sign_queue {
-        if timestamp_sign_queue.elapsed().as_secs() <= 30 {
-            crate::metrics::NUM_SIGN_SUCCESS_30S
-                .with_label_values(&[chain.as_str(), near.my_account_id.as_str()])
-                .inc();
-        }
+    if elapsed.as_secs() <= 30 {
+        crate::metrics::NUM_SIGN_SUCCESS_30S
+            .with_label_values(&[chain.as_str(), near.my_account_id.as_str()])
+            .inc();
     }
 
     Ok(())
@@ -1123,15 +1195,14 @@ async fn try_publish_eth(
     crate::metrics::NUM_SIGN_SUCCESS
         .with_label_values(&[chain.as_str(), near_account_id.as_str()])
         .inc();
-    if let Some(timestamp_sign_queue) = action.request.indexed.timestamp_sign_queue {
-        crate::metrics::SIGN_TOTAL_LATENCY
+    let elapsed = action.request.indexed.timestamp_sign_queue.elapsed();
+    crate::metrics::SIGN_TOTAL_LATENCY
+        .with_label_values(&[chain.as_str(), near_account_id.as_str()])
+        .observe(elapsed.as_secs_f64());
+    if elapsed.as_secs() <= 30 {
+        crate::metrics::NUM_SIGN_SUCCESS_30S
             .with_label_values(&[chain.as_str(), near_account_id.as_str()])
-            .observe(timestamp_sign_queue.elapsed().as_secs_f64());
-        if timestamp_sign_queue.elapsed().as_secs() <= 30 {
-            crate::metrics::NUM_SIGN_SUCCESS_30S
-                .with_label_values(&[chain.as_str(), near_account_id.as_str()])
-                .inc();
-        }
+            .inc();
     }
 
     crate::metrics::SIGN_RESPOND_LATENCY
@@ -1229,15 +1300,14 @@ async fn try_batch_publish_eth(
         .with_label_values(&[chain.as_str(), near_account_id.as_str()])
         .inc_by(num_requests as f64);
     for action in actions {
-        if let Some(timestamp_sign_queue) = action.request.indexed.timestamp_sign_queue {
-            crate::metrics::SIGN_TOTAL_LATENCY
+        let elapsed = action.request.indexed.timestamp_sign_queue.elapsed();
+        crate::metrics::SIGN_TOTAL_LATENCY
+            .with_label_values(&[chain.as_str(), near_account_id.as_str()])
+            .observe(elapsed.as_secs_f64());
+        if elapsed.as_secs() <= 30 {
+            crate::metrics::NUM_SIGN_SUCCESS_30S
                 .with_label_values(&[chain.as_str(), near_account_id.as_str()])
-                .observe(timestamp_sign_queue.elapsed().as_secs_f64());
-            if timestamp_sign_queue.elapsed().as_secs() <= 30 {
-                crate::metrics::NUM_SIGN_SUCCESS_30S
-                    .with_label_values(&[chain.as_str(), near_account_id.as_str()])
-                    .inc();
-            }
+                .inc();
         }
     }
     crate::metrics::SIGN_RESPOND_LATENCY
@@ -1325,7 +1395,6 @@ async fn try_publish_sol(
     timestamp: &Instant,
     signature: &Signature,
     near_account_id: &AccountId,
-    respond_bidirectional_tx_channel: RespondBidirectionalTxChannel,
 ) -> Result<(), ()> {
     let chain = action.request.indexed.chain;
     let program = sol.client.program(sol.program_id).map_err(|_| ())?;
@@ -1421,7 +1490,6 @@ async fn try_publish_sol(
                 elapsed = ?timestamp.elapsed(),
                 "published respond bidirectional solana signature successfully"
             );
-            respond_bidirectional_tx_channel.send(chain, action.request.indexed.id);
         }
     }
 

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -6,7 +6,6 @@ use alloy::primitives::{keccak256, Address, Bytes, B256, I256, U256};
 use alloy_dyn_abi::{DynSolType, DynSolValue};
 use anchor_lang::prelude::Pubkey;
 use borsh::BorshSerialize;
-use cait_sith::protocol::Participant;
 use k256::elliptic_curve::point::AffineCoordinates;
 use k256::{AffinePoint, Scalar};
 use mpc_crypto::derive_key;
@@ -36,10 +35,14 @@ struct AbiField {
     typ: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum PendingRequestStatus {
+    /// Request has been received on the source chain and is waiting for a `respond`
+    /// transaction to be observed.
+    AwaitingResponse,
+    /// Request has been responded to and the derived transaction is now waiting to
+    /// execute on the destination chain.
     PendingExecution,
-    PendingPublish,
     Failed,
     Success,
 }
@@ -63,7 +66,6 @@ pub struct BidirectionalTx {
     pub request_id: [u8; 32],
     pub from_address: Address,
     pub nonce: u64,
-    pub participants: Vec<Participant>,
     pub status: PendingRequestStatus,
 }
 
@@ -112,8 +114,7 @@ impl BidirectionalTx {
             request_id: signature.request.indexed.id.request_id,
             from_address,
             nonce,
-            participants: signature.participants,
-            status: PendingRequestStatus::PendingExecution,
+            status: PendingRequestStatus::AwaitingResponse,
         })
     }
 }
@@ -266,7 +267,18 @@ pub fn sign_and_hash_transaction(
     if is_eip1559(unsigned_rlp) {
         sign_and_hash_eip1559_from_unsigned(unsigned_rlp, &r, &s, y_parity)
     } else {
-        sign_and_hash_legacy_from_unsigned(unsigned_rlp, Some(60), &r, &s, y_parity)
+        // Extract chain_id from the unsigned RLP (it's the 7th field in legacy transactions)
+        // In legacy Ethereum transactions with EIP-155, there are 9 fields:
+        // [nonce, gasPrice, gasLimit, to, value, data, chain_id, 0, 0]
+        // The chain_id is the 7th field (index 6, 0-based).
+        // We check for at least 9 fields to ensure chain_id is present.
+        let rlp = Rlp::new(unsigned_rlp);
+        let chain_id = if rlp.item_count().unwrap_or(0) >= 9 {
+            rlp.val_at::<u64>(6).ok()
+        } else {
+            None
+        };
+        sign_and_hash_legacy_from_unsigned(unsigned_rlp, chain_id, &r, &s, y_parity)
     }
 }
 
@@ -514,5 +526,4 @@ pub struct SignBidirectionalSignature {
     pub public_key: mpc_crypto::PublicKey,
     pub request: SignRequest,
     pub signature: Signature,
-    pub participants: Vec<Participant>,
 }

--- a/chain-signatures/node/src/web/error.rs
+++ b/chain-signatures/node/src/web/error.rs
@@ -21,6 +21,8 @@ pub enum Error {
     Message(#[from] MessageError),
     #[error(transparent)]
     Rpc(#[from] near_fetch::Error),
+    #[error("invalid parameters: {0}")]
+    InvalidParameters(String),
 }
 
 impl Error {
@@ -31,6 +33,7 @@ impl Error {
             Error::Cryptography(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::Message(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::Rpc(_) => StatusCode::BAD_REQUEST,
+            Error::InvalidParameters(_) => StatusCode::BAD_REQUEST,
         }
     }
 }

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -7,17 +7,18 @@ pub mod mock;
 pub mod debug;
 
 use self::error::Error;
+use crate::backlog::{Backlog, Checkpoint};
 use crate::indexer::NearIndexer;
 use crate::metrics::WEB_ENDPOINT_LATENCY;
 use crate::protocol::state::{NodeStateWatcher, NodeStatus, ResharingStatus};
 use crate::protocol::sync::{SyncChannel, SyncUpdate};
-use crate::protocol::MessageChannel;
+use crate::protocol::{Chain, MessageChannel};
 use crate::storage::{PresignatureStorage, TripleStorage};
 use crate::web::cbor::Cbor;
 use crate::web::error::Result;
 
 use anyhow::Context;
-use axum::extract::DefaultBodyLimit;
+use axum::extract::{DefaultBodyLimit, Query};
 use axum::http::StatusCode;
 use axum::routing::{get, post};
 use axum::{Extension, Json, Router};
@@ -28,6 +29,7 @@ use near_account_id::AccountId;
 use near_primitives::types::BlockHeight;
 use prometheus::{Encoder, TextEncoder};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -39,6 +41,7 @@ struct AxumState {
     sync_channel: SyncChannel,
     msg_channel: MessageChannel,
     my_account_id: AccountId,
+    backlog: Backlog,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -51,6 +54,7 @@ pub async fn run(
     presignature_storage: PresignatureStorage,
     sync_channel: SyncChannel,
     my_account_id: AccountId,
+    backlog: Backlog,
 ) {
     tracing::info!("starting web server");
     let axum_state = AxumState {
@@ -61,6 +65,7 @@ pub async fn run(
         presignature_storage,
         sync_channel,
         my_account_id,
+        backlog,
     };
 
     // Sync can be a large payload, so we set a higher limit for payload.
@@ -81,6 +86,7 @@ pub async fn run(
         .route("/state", get(state))
         .route("/status", get(status))
         .route("/metrics", get(metrics))
+        .route("/checkpoint", get(checkpoint))
         .route("/debug", get(debug::page))
         .merge(sync);
 
@@ -267,6 +273,65 @@ async fn sync(
         .with_label_values(&["sync", state.my_account_id.as_str()])
         .observe(start.elapsed().as_millis() as f64);
     Ok(Json(()))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ChainsParam {
+    One(String),
+    Many(Vec<String>),
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CheckpointQuery {
+    #[serde(default)]
+    chains: Option<ChainsParam>,
+}
+
+#[tracing::instrument(level = "debug", skip_all)]
+async fn checkpoint(
+    Extension(state): Extension<Arc<AxumState>>,
+    Query(query): Query<CheckpointQuery>,
+) -> Result<Json<HashMap<Chain, Checkpoint>>> {
+    let start = Instant::now();
+    let chains_to_fetch: Vec<Chain> = match query.chains {
+        Some(chains_param) => {
+            let chain_strs = match chains_param {
+                ChainsParam::One(chain) => vec![chain],
+                ChainsParam::Many(chains) => chains,
+            };
+
+            let mut errs = Vec::with_capacity(chain_strs.len());
+            let mut chains = Vec::with_capacity(chain_strs.len());
+            for chain_str in chain_strs {
+                match chain_str.parse::<Chain>() {
+                    Ok(chain) => chains.push(chain),
+                    Err(err) => {
+                        errs.push(err);
+                        continue;
+                    }
+                }
+            }
+            if !errs.is_empty() {
+                return Err(Error::InvalidParameters(errs.join(", ")));
+            }
+
+            chains
+        }
+        None => vec![Chain::NEAR, Chain::Ethereum, Chain::Solana],
+    };
+
+    let mut resp = HashMap::new();
+    for chain in chains_to_fetch {
+        let checkpoint = state.backlog.checkpoint(chain).await;
+        resp.insert(chain, checkpoint);
+    }
+
+    WEB_ENDPOINT_LATENCY
+        .with_label_values(&["checkpoint", state.my_account_id.as_str()])
+        .observe(start.elapsed().as_millis() as f64);
+
+    Ok(Json(resp))
 }
 
 #[cfg(not(feature = "debug-page"))]

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -276,54 +276,88 @@ async fn sync(
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum ChainsParam {
-    One(String),
-    Many(Vec<String>),
+pub struct CheckpointQuery {
+    /// Combined chain selection and hash filter. Entries are separated by commas.
+    /// Examples:
+    /// - "Ethereum" -> latest Ethereum checkpoint
+    /// - "Solana:1234" -> specific Solana checkpoint by hash
+    /// - "Solana:1234,Ethereum" -> mix of filters
+    #[serde(default)]
+    query: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct CheckpointQuery {
-    #[serde(default)]
-    chains: Option<ChainsParam>,
+impl CheckpointQuery {
+    #[allow(clippy::result_large_err)]
+    fn parse(self) -> Result<Vec<(Chain, Option<u64>)>, Error> {
+        let Some(query) = self.query else {
+            return Ok(Chain::iter()
+                .into_iter()
+                .map(|chain| (chain, None))
+                .collect());
+        };
+
+        let mut selections = Vec::new();
+        for entry in query.split(',') {
+            let entry = entry.trim();
+            if entry.is_empty() {
+                return Err(Error::InvalidParameters(
+                    "query parameter contains an empty segment".to_string(),
+                ));
+            }
+
+            let mut parts = entry.splitn(2, ':');
+            let chain_part = parts
+                .next()
+                .expect("splitn(2) always returns at least one part")
+                .trim();
+            let chain = chain_part.parse::<Chain>().map_err(|e| {
+                Error::InvalidParameters(format!("Invalid chain '{}': {}", chain_part, e))
+            })?;
+
+            let hash = match parts.next() {
+                Some(hash_part) => {
+                    let hash_part = hash_part.trim();
+                    if hash_part.is_empty() {
+                        return Err(Error::InvalidParameters(format!(
+                            "Invalid hash format for '{}'. Expected 'chain:hash'",
+                            chain_part
+                        )));
+                    }
+
+                    Some(hash_part.parse::<u64>().map_err(|e| {
+                        Error::InvalidParameters(format!("Invalid hash '{}': {}", hash_part, e))
+                    })?)
+                }
+                None => None,
+            };
+
+            selections.push((chain, hash));
+        }
+
+        Ok(selections)
+    }
 }
 
 #[tracing::instrument(level = "debug", skip_all)]
 async fn checkpoint(
     Extension(state): Extension<Arc<AxumState>>,
     Query(query): Query<CheckpointQuery>,
-) -> Result<Json<HashMap<Chain, Checkpoint>>> {
+) -> Result<Cbor<HashMap<Chain, Checkpoint>>> {
     let start = Instant::now();
-    let chains_to_fetch: Vec<Chain> = match query.chains {
-        Some(chains_param) => {
-            let chain_strs = match chains_param {
-                ChainsParam::One(chain) => vec![chain],
-                ChainsParam::Many(chains) => chains,
-            };
-
-            let mut errs = Vec::with_capacity(chain_strs.len());
-            let mut chains = Vec::with_capacity(chain_strs.len());
-            for chain_str in chain_strs {
-                match chain_str.parse::<Chain>() {
-                    Ok(chain) => chains.push(chain),
-                    Err(err) => {
-                        errs.push(err);
-                        continue;
-                    }
-                }
-            }
-            if !errs.is_empty() {
-                return Err(Error::InvalidParameters(errs.join(", ")));
-            }
-
-            chains
-        }
-        None => vec![Chain::NEAR, Chain::Ethereum, Chain::Solana],
-    };
-
+    let selections = query.parse()?;
     let mut resp = HashMap::new();
-    for chain in chains_to_fetch {
-        let checkpoint = state.backlog.checkpoint(chain).await;
+    for (chain, hash) in selections {
+        let checkpoint = if let Some(hash) = hash {
+            state.backlog.find_checkpoint_by_hash(chain, hash).await
+        } else {
+            state.backlog.latest_checkpoint(chain).await
+        };
+
+        let Some(checkpoint) = checkpoint else {
+            tracing::warn!(?chain, ?hash, "unable to find checkpoint");
+            continue;
+        };
+
         resp.insert(chain, checkpoint);
     }
 
@@ -331,7 +365,7 @@ async fn checkpoint(
         .with_label_values(&["checkpoint", state.my_account_id.as_str()])
         .observe(start.elapsed().as_millis() as f64);
 
-    Ok(Json(resp))
+    Ok(Cbor(resp))
 }
 
 #[cfg(not(feature = "debug-page"))]

--- a/chain-signatures/primitives/src/lib.rs
+++ b/chain-signatures/primitives/src/lib.rs
@@ -135,6 +135,32 @@ impl Chain {
             Chain::Solana => "Solana",
         }
     }
+
+    pub const fn iter() -> [Chain; 3] {
+        [Chain::NEAR, Chain::Ethereum, Chain::Solana]
+    }
+
+    // TODO: maybe need an interface for this in the future for more chains.
+    pub fn checkpoint_interval(&self) -> Option<u64> {
+        let (key, default) = match self {
+            Chain::NEAR => return None,
+            Chain::Ethereum => ("CHECKPOINT_INTERVAL_ETHEREUM", 20),
+            Chain::Solana => ("CHECKPOINT_INTERVAL_SOLANA", 120),
+        };
+
+        let interval = std::env::var(key)
+            .map(|param| param.parse::<u64>().unwrap_or(default))
+            .unwrap_or(default);
+
+        Some(interval)
+    }
+
+    pub fn checkpoint_env_vars() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("CHECKPOINT_INTERVAL_ETHEREUM", "2"),
+            ("CHECKPOINT_INTERVAL_SOLANA", "5"),
+        ]
+    }
 }
 
 impl fmt::Display for Chain {
@@ -162,7 +188,6 @@ impl FromStr for Chain {
     BorshSerialize,
     Serialize,
     Deserialize,
-    Debug,
     Clone,
     PartialEq,
     Eq,
@@ -175,6 +200,14 @@ pub struct PendingTx {
     pub sign_id: SignId,
     #[serde(with = "serde_bytes")]
     pub transaction: Vec<u8>,
+}
+
+impl fmt::Debug for PendingTx {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PendingTx")
+            .field("sign_id", &self.sign_id)
+            .finish()
+    }
 }
 
 /// A checkpoint represents the backlog state at a specific block height.

--- a/chain-signatures/primitives/src/lib.rs
+++ b/chain-signatures/primitives/src/lib.rs
@@ -5,6 +5,7 @@ use near_account_id::AccountId;
 use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
 use sha3::Digest;
+use std::{fmt, str::FromStr};
 
 use crate::bytes::cbor_scalar;
 
@@ -100,6 +101,109 @@ impl Signature {
             big_r,
             s,
             recovery_id,
+        }
+    }
+}
+
+/// Supported blockchain networks for checkpoints.
+#[derive(
+    BorshDeserialize,
+    BorshSerialize,
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+)]
+#[borsh(crate = "near_sdk::borsh")]
+pub enum Chain {
+    NEAR,
+    Ethereum,
+    Solana,
+}
+
+impl Chain {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Chain::NEAR => "NEAR",
+            Chain::Ethereum => "Ethereum",
+            Chain::Solana => "Solana",
+        }
+    }
+}
+
+impl fmt::Display for Chain {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl FromStr for Chain {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "near" => Ok(Chain::NEAR),
+            "ethereum" | "eth" => Ok(Chain::Ethereum),
+            "solana" | "sol" => Ok(Chain::Solana),
+            other => Err(format!("unknown or unsupported chain {other}")),
+        }
+    }
+}
+
+/// Transaction information tracked across checkpoints.
+#[derive(
+    BorshDeserialize,
+    BorshSerialize,
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+)]
+#[borsh(crate = "near_sdk::borsh")]
+pub struct PendingTx {
+    pub sign_id: SignId,
+    #[serde(with = "serde_bytes")]
+    pub transaction: Vec<u8>,
+}
+
+/// A checkpoint represents the backlog state at a specific block height.
+#[derive(
+    BorshDeserialize,
+    BorshSerialize,
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+)]
+#[borsh(crate = "near_sdk::borsh")]
+pub struct Checkpoint {
+    pub chain: Chain,
+    pub block_height: u64,
+    pub pending_requests: Vec<PendingTx>,
+}
+
+impl Checkpoint {
+    pub fn empty(chain: Chain) -> Self {
+        Self {
+            chain,
+            block_height: 0,
+            pending_requests: Vec::new(),
         }
     }
 }

--- a/chain-signatures/primitives/src/lib.rs
+++ b/chain-signatures/primitives/src/lib.rs
@@ -140,7 +140,6 @@ impl Chain {
         [Chain::NEAR, Chain::Ethereum, Chain::Solana]
     }
 
-    // TODO: maybe need an interface for this in the future for more chains.
     pub fn checkpoint_interval(&self) -> Option<u64> {
         let (key, default) = match self {
             Chain::NEAR => return None,

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -13,6 +13,7 @@ backon = "0.4"
 bollard = "0.17.0"
 borsh.workspace = true
 bs58 = "0.5.1"
+ciborium.workspace = true
 clap.workspace = true
 deadpool-redis.workspace = true
 futures = "0.3"

--- a/integration-tests/src/actions/wait.rs
+++ b/integration-tests/src/actions/wait.rs
@@ -1,15 +1,18 @@
 use std::future::{Future, IntoFuture};
+use std::time::Duration;
 
 use anyhow::Context;
 use backon::{ConstantBuilder, Retryable};
 use mpc_contract::{ProtocolContractState, RunningContractState};
 use mpc_node::web::StateView;
+use mpc_primitives::{Chain, Checkpoint};
 use near_account_id::AccountId;
 
 use crate::cluster::Cluster;
 
 type Epoch = u64;
 type Present = bool;
+type BlockHeight = u64;
 
 enum ContractState {
     Candidate(AccountId, Present),
@@ -31,6 +34,7 @@ enum WaitActions {
     Signable(usize),
     NodeState(NodeState, usize),
     ContractState(ContractState),
+    Checkpoint(usize, Chain, BlockHeight),
 }
 
 pub struct WaitAction<'a, R> {
@@ -127,6 +131,21 @@ impl<'a, R> WaitAction<'a, R> {
         self
     }
 
+    pub fn node_checkpoint(
+        mut self,
+        id: usize,
+        chain: Chain,
+        block_height: BlockHeight,
+    ) -> WaitAction<'a, Checkpoint> {
+        self.actions
+            .push(WaitActions::Checkpoint(id, chain, block_height));
+        WaitAction {
+            nodes: self.nodes,
+            actions: self.actions,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
     pub fn candidate_present(mut self, candidate: &AccountId) -> Self {
         self.actions
             .push(WaitActions::ContractState(ContractState::Candidate(
@@ -183,6 +202,9 @@ impl<'a, R> WaitAction<'a, R> {
                 }
                 WaitActions::ContractState(state) => {
                     require_contract_state(self.nodes, state).await?;
+                }
+                WaitActions::Checkpoint(id, chain, block_height) => {
+                    require_checkpoint(self.nodes, id, chain, block_height).await?;
                 }
             }
         }
@@ -399,4 +421,26 @@ pub async fn require_triples(
     })?;
 
     Ok(state_views)
+}
+
+async fn require_checkpoint(
+    nodes: &Cluster,
+    id: usize,
+    chain: Chain,
+    block_height: u64,
+) -> anyhow::Result<Checkpoint> {
+    tokio::time::timeout(Duration::from_secs(10), async move {
+        loop {
+            let checkpoints = nodes.fetch_checkpoints(id).await?;
+            if let Some(checkpoint) = checkpoints.get(&chain) {
+                if checkpoint.block_height >= block_height {
+                    return Ok(checkpoint.clone());
+                }
+            }
+
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    })
+    .await
+    .unwrap()
 }

--- a/integration-tests/src/cluster/mod.rs
+++ b/integration-tests/src/cluster/mod.rs
@@ -1,9 +1,10 @@
 pub mod spawner;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use mpc_contract::primitives::Participants;
 use mpc_node::storage::{PresignatureStorage, TripleStorage};
+use mpc_primitives::{Chain, Checkpoint};
 use near_workspaces::network::Sandbox;
 use near_workspaces::types::{Finality, NearToken};
 use near_workspaces::{Account, AccountId, Contract, Worker};
@@ -22,7 +23,7 @@ use mpc_node::web::{BenchMetrics, StateView};
 use anyhow::Context;
 use url::Url;
 
-const CURRENT_CONTRACT_DEPLOY_DEPOSIT: NearToken = NearToken::from_millinear(9000);
+const CURRENT_CONTRACT_DEPLOY_DEPOSIT: NearToken = NearToken::from_millinear(10000);
 const CURRENT_CONTRACT_FILE_PATH: &str =
     "../target/wasm32-unknown-unknown/release/mpc_contract.wasm";
 
@@ -335,5 +336,9 @@ impl Cluster {
             .min_mine_presignatures(self.cfg.protocol.presignature.min_presignatures as usize)
             .await
             .unwrap();
+    }
+
+    pub async fn fetch_checkpoints(&self, id: usize) -> anyhow::Result<HashMap<Chain, Checkpoint>> {
+        self.nodes.fetch_checkpoints(id).await
     }
 }

--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -92,6 +92,8 @@ impl Node {
     }
 
     pub async fn kill(self) -> NodeEnvConfig {
+        // Give the container a brief moment to clean up connections gracefully
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         self.container.stop().await.unwrap();
         NodeEnvConfig {
             web_port: Self::CONTAINER_PORT,

--- a/integration-tests/src/execute.rs
+++ b/integration-tests/src/execute.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use async_process::Child;
+use mpc_primitives::Chain;
 
 pub(crate) const PACKAGE_MULTICHAIN: &str = "mpc-node";
 
@@ -43,6 +44,7 @@ pub fn spawn_multichain(
     async_process::Command::new(&executable)
         .args(cli.into_str_args())
         .env("RUST_LOG", "info,workspaces=warn")
+        .envs(Chain::checkpoint_env_vars())
         .envs(std::env::vars())
         .stdout(async_process::Stdio::inherit())
         .stderr(async_process::Stdio::inherit())

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -246,12 +246,17 @@ impl Nodes {
     }
 
     pub async fn fetch_checkpoint(&self, id: usize, chain: Chain) -> anyhow::Result<Checkpoint> {
-        let url = format!("{}/checkpoint?chains={chain}", self.url(id));
+        let url = format!("{}/checkpoint?query={chain}", self.url(id));
         let response = reqwest::get(&url).await?;
         let status = response.status();
-        let body = response.text().await?;
-        tracing::info!(?status, raw_body = %body, "checkpoint response body");
-        let mut value: HashMap<Chain, Checkpoint> = serde_json::from_str(&body)?;
+        let body = response.bytes().await?;
+        let mut value: HashMap<Chain, Checkpoint> =
+            ciborium::from_reader(body.as_ref()).context("failed to decode checkpoint CBOR")?;
+        if let Ok(pretty) = serde_json::to_string(&value) {
+            tracing::info!(?status, raw_body = %pretty, "checkpoint response body");
+        } else {
+            tracing::info!(?status, raw_body = %hex::encode(&body), "checkpoint response body");
+        }
         value
             .remove(&chain)
             .context("checkpoint not found for chain")
@@ -261,9 +266,14 @@ impl Nodes {
         let url = format!("{}/checkpoint", self.url(id));
         let response = reqwest::get(&url).await?;
         let status = response.status();
-        let body = response.text().await?;
-        tracing::info!(?status, raw_body = %body, "checkpoint response body");
-        let value = serde_json::from_str(&body)?;
+        let body = response.bytes().await?;
+        let value: HashMap<Chain, Checkpoint> =
+            ciborium::from_reader(body.as_ref()).context("failed to decode checkpoint CBOR")?;
+        if let Ok(pretty) = serde_json::to_string(&value) {
+            tracing::info!(?status, raw_body = %pretty, "checkpoint response body");
+        } else {
+            tracing::info!(?status, raw_body = %hex::encode(&body), "checkpoint response body");
+        }
         Ok(value)
     }
 }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -7,22 +7,24 @@ pub mod local;
 pub mod mpc_fixture;
 pub mod utils;
 
-use cluster::spawner::ClusterSpawner;
-use deadpool_redis::Pool;
-use mpc_node::indexer_eth::EthConfig;
-use mpc_node::indexer_sol::SolConfig;
 use std::collections::HashMap;
 use std::time::Duration;
 
 use self::local::NodeEnvConfig;
 use crate::containers::DockerClient;
+
 use anyhow::Context as _;
+use cluster::spawner::ClusterSpawner;
+use deadpool_redis::Pool;
 use ethers::types::{Address, U256};
 use mpc_contract::config::{PresignatureConfig, ProtocolConfig, TripleConfig};
 use mpc_contract::primitives::CandidateInfo;
 use mpc_node::gcp::GcpService;
+use mpc_node::indexer_eth::EthConfig;
+use mpc_node::indexer_sol::SolConfig;
 use mpc_node::storage::triple_storage::TripleStorage;
 use mpc_node::{logs, mesh, node_client, storage};
+use mpc_primitives::{Chain, Checkpoint};
 use near_workspaces::network::Sandbox;
 use near_workspaces::types::{KeyType, SecretKey};
 use near_workspaces::{Account, AccountId, Contract, Worker};
@@ -241,6 +243,28 @@ impl Nodes {
 
     pub fn contract(&self) -> &Contract {
         &self.ctx().mpc_contract
+    }
+
+    pub async fn fetch_checkpoint(&self, id: usize, chain: Chain) -> anyhow::Result<Checkpoint> {
+        let url = format!("{}/checkpoint?chains={chain}", self.url(id));
+        let response = reqwest::get(&url).await?;
+        let status = response.status();
+        let body = response.text().await?;
+        tracing::info!(?status, raw_body = %body, "checkpoint response body");
+        let mut value: HashMap<Chain, Checkpoint> = serde_json::from_str(&body)?;
+        value
+            .remove(&chain)
+            .context("checkpoint not found for chain")
+    }
+
+    pub async fn fetch_checkpoints(&self, id: usize) -> anyhow::Result<HashMap<Chain, Checkpoint>> {
+        let url = format!("{}/checkpoint", self.url(id));
+        let response = reqwest::get(&url).await?;
+        let status = response.status();
+        let body = response.text().await?;
+        tracing::info!(?status, raw_body = %body, "checkpoint response body");
+        let value = serde_json::from_str(&body)?;
+        Ok(value)
     }
 }
 

--- a/integration-tests/src/local.rs
+++ b/integration-tests/src/local.rs
@@ -210,6 +210,10 @@ impl Node {
 
 impl Drop for Node {
     fn drop(&mut self) {
+        // Give the process a brief moment to clean up connections gracefully
+        // before we forcefully kill it. This reduces flaky test failures
+        // during teardown when nodes are trying to write to Redis.
+        std::thread::sleep(std::time::Duration::from_millis(100));
         self.process.kill().unwrap();
     }
 }

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -13,6 +13,7 @@ use mpc_contract::primitives::{
     CandidateInfo, Candidates as CandidatesById, ParticipantInfo, Participants as ParticipantsById,
 };
 use mpc_keys::hpke::{self, Ciphered};
+use mpc_node::backlog::Backlog;
 use mpc_node::config::{Config, LocalConfig, NetworkConfig};
 use mpc_node::mesh::MeshState;
 use mpc_node::protocol::contract::primitives::{Candidates, Participants, PkVotes, Votes};
@@ -483,6 +484,7 @@ impl MpcFixtureNodeBuilder {
             msg_channel: self.messaging.channel,
             triple_storage,
             presignature_storage,
+            backlog: Backlog::new(),
             web_handle: None,
         };
 

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -3,6 +3,7 @@
 
 use crate::containers::Redis;
 use cait_sith::protocol::Participant;
+use mpc_node::backlog::Backlog;
 use mpc_node::config::Config;
 use mpc_node::mesh::MeshState;
 use mpc_node::protocol::state::NodeStateWatcher;
@@ -34,6 +35,7 @@ pub struct MpcFixtureNode {
 
     pub triple_storage: TripleStorage,
     pub presignature_storage: PresignatureStorage,
+    pub backlog: Backlog,
 
     pub web_handle: Option<tokio::task::JoinHandle<()>>,
 }
@@ -106,6 +108,7 @@ impl MpcFixtureNode {
             // unused but needed to call the web interface
             SyncChannel::new().1,
             account_id,
+            self.backlog.clone(),
         );
         self.web_handle = Some(tokio::spawn(task));
     }

--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -1,12 +1,14 @@
 use anyhow::{anyhow, Context, Result};
 use ethers::types::{BlockNumber, U256};
+use integration_tests::cluster::Cluster;
 use integration_tests::{actions, cluster, eth};
 use k256::ecdsa::VerifyingKey;
 use k256::elliptic_curve::sec1::FromEncodedPoint;
 use k256::{AffinePoint, EncodedPoint, FieldBytes, PublicKey as K256PublicKey};
 use mpc_crypto::derive_key;
 use mpc_crypto::kdf::derive_epsilon_eth;
-use mpc_primitives::LATEST_MPC_KEY_VERSION;
+use mpc_primitives::{Chain, Checkpoint, LATEST_MPC_KEY_VERSION};
+use near_workspaces::types::Finality;
 use test_log::test;
 use tokio::time::{sleep, Duration};
 
@@ -129,4 +131,322 @@ async fn test_signature_ethereum() -> Result<()> {
     );
 
     Ok(())
+}
+
+/// Test that checkpoints are properly cleaned up after responses are observed
+#[test(tokio::test)]
+async fn test_proper_indexer_checkpoint() -> Result<()> {
+    let cluster = cluster::spawn().disable_prestockpile().ethereum().await?;
+    cluster.wait().signable().await?;
+
+    let ctx = cluster.nodes.ctx();
+    let eth_ctx = ctx
+        .ethereum
+        .as_ref()
+        .context("ethereum sandbox not initialized")?;
+    let endpoint = eth_ctx.sandbox.external_http_endpoint.clone();
+    let secret_key = eth_ctx.sandbox.secret_key.clone();
+    let chain_id = eth_ctx.sandbox.chain_id;
+    let contract_address = eth_ctx.contract_address;
+
+    let (client, requester) = eth::client(&endpoint, &secret_key, chain_id)?;
+    let contract = eth::ChainSignaturesContract::new(contract_address, client.clone());
+
+    // Get initial checkpoint state
+    let node_idx = 0;
+    let initial_checkpoint = cluster.nodes.fetch_checkpoints(node_idx).await?;
+
+    tracing::info!(
+        ?initial_checkpoint,
+        "initial checkpoint state before request"
+    );
+
+    // Submit a signature request
+    let payload = [42u8; 32];
+    let path = "test";
+    let algo = "secp256k1";
+    let dest = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
+    let params = "{}";
+
+    let request = eth::SignRequest {
+        payload,
+        path: path.to_string(),
+        key_version: LATEST_MPC_KEY_VERSION,
+        algo: algo.to_string(),
+        dest: dest.to_string(),
+        params: params.to_string(),
+    };
+
+    let call = contract.sign(request).value(U256::from(1_u64));
+    let pending = call.send().await?;
+    let receipt = pending.await?.context("sign transaction failed")?;
+    let from_block = BlockNumber::Number(
+        receipt
+            .block_number
+            .context("missing block number in receipt")?,
+    );
+
+    let expected_request_id = eth::compute_request_id(
+        requester,
+        payload,
+        path,
+        LATEST_MPC_KEY_VERSION,
+        U256::from(chain_id),
+        algo,
+        dest,
+        params,
+    );
+
+    tracing::info!(?expected_request_id, "submitted signature request");
+
+    // Wait a bit for the request to be indexed and added to backlog
+    sleep(Duration::from_secs(3)).await;
+
+    // Check checkpoint - request should be in the pending transactions
+    let checkpoints = cluster.fetch_checkpoints(node_idx).await?;
+    tracing::info!(?checkpoints, "checkpoint after request submitted");
+
+    let checkpoint = checkpoints
+        .get(&Chain::Ethereum)
+        .expect("checkpoint not found for eth");
+    tracing::info!(
+        pending_count = checkpoint.pending_requests.len(),
+        "pending transactions in checkpoint"
+    );
+
+    // Wait for the signature response
+    let mut matching_event = None;
+    for _ in 0..30 {
+        let events = contract
+            .event::<eth::SignatureRespondedFilter>()
+            .from_block(from_block)
+            .query()
+            .await?;
+        if let Some(event) = events.into_iter().find(|event| {
+            event.request_id == expected_request_id[..] && event.responder == requester
+        }) {
+            matching_event = Some(event);
+            break;
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+
+    let _event =
+        matching_event.ok_or_else(|| anyhow!("did not observe signature response on ethereum"))?;
+
+    tracing::info!("signature response observed on-chain");
+
+    // Wait for indexer to process the response event and remove from backlog
+    // The indexer polls every few seconds, so we give it time
+    sleep(Duration::from_secs(10)).await;
+
+    // Check checkpoint again - request should be removed
+    let checkpoints = cluster.fetch_checkpoints(node_idx).await?;
+    tracing::info!(?checkpoints, "checkpoint after response observed");
+
+    let checkpoint = checkpoints
+        .get(&Chain::Ethereum)
+        .expect("checkpoint not found for eth");
+    tracing::info!(
+        pending_count = checkpoint.pending_requests.len(),
+        "pending transactions count after response"
+    );
+
+    let expected_request_bytes = expected_request_id.as_bytes();
+    let request_still_present = checkpoint
+        .pending_requests
+        .iter()
+        .any(|tx| tx.sign_id.request_id == *expected_request_bytes);
+
+    assert!(
+        !request_still_present,
+        "request should be removed from checkpoint after response is observed"
+    );
+
+    tracing::info!("request successfully removed from checkpoint after response");
+
+    Ok(())
+}
+
+/// Test that a node can recover from a checkpoint after being offline
+#[test(tokio::test)]
+async fn test_checkpoint_recovery_after_offline() -> anyhow::Result<()> {
+    let mut cluster = cluster::spawn().disable_prestockpile().ethereum().await?;
+    cluster.wait().signable().await?;
+
+    let contract = cluster.contract().clone();
+    let ctx = cluster.nodes.ctx();
+    let eth_ctx = ctx
+        .ethereum
+        .as_ref()
+        .context("ethereum sandbox not initialized")?;
+    let (eth_client, _requester) = eth::client(
+        &eth_ctx.sandbox.external_http_endpoint,
+        &eth_ctx.sandbox.secret_key,
+        eth_ctx.sandbox.chain_id,
+    )?;
+    let eth_contract = eth::ChainSignaturesContract::new(eth_ctx.contract_address, eth_client);
+
+    // Produce a few sign requests up front so the contract stores an initial checkpoint
+    for i in 0..5 {
+        submit_eth_sign_request(&eth_contract, i).await?;
+    }
+
+    let initial_checkpoint =
+        wait_contract_checkpoint(&contract, Chain::Ethereum, 1, Duration::from_secs(10)).await?;
+
+    let target_account = cluster.account_id(0).clone();
+    let offline_idx = 0usize;
+    let active_idx = 1usize;
+
+    tracing::info!(%target_account, "taking node offline for checkpoint recovery test");
+    let offline_config = cluster.kill_node(&target_account).await;
+
+    // Keep the node offline while the remaining nodes continue operating and sign requests
+    // are being processed alongside new checkpoints being created.
+    let offline_duration = Duration::from_secs(10);
+    let mut elapsed = Duration::default();
+    let mut seed = 100usize;
+    while elapsed < offline_duration {
+        submit_eth_sign_request(&eth_contract, seed).await?;
+        seed += 1;
+        sleep(Duration::from_secs(2)).await;
+        elapsed += Duration::from_secs(2);
+    }
+
+    let contract_checkpoint = wait_contract_checkpoint(
+        &contract,
+        Chain::Ethereum,
+        initial_checkpoint.block_height + 1,
+        Duration::from_secs(10),
+    )
+    .await?;
+
+    let node_active_checkpoint = wait_node_checkpoint(
+        &cluster,
+        active_idx,
+        Chain::Ethereum,
+        contract_checkpoint.block_height,
+        Duration::from_secs(10),
+    )
+    .await?;
+
+    assert_eq!(
+        contract_checkpoint, node_active_checkpoint,
+        "active node should match contract checkpoint while peer is offline"
+    );
+
+    tracing::info!("bringing offline node back online");
+    cluster.restart_node(offline_config).await?;
+    cluster.wait().signable().await?;
+
+    let node_recovered_checkpoint = wait_node_checkpoint(
+        &cluster,
+        offline_idx,
+        Chain::Ethereum,
+        contract_checkpoint.block_height,
+        Duration::from_secs(10),
+    )
+    .await?;
+
+    assert_eq!(
+        contract_checkpoint, node_recovered_checkpoint,
+        "restarted node should recover to contract checkpoint"
+    );
+
+    let active_checkpoint_after_restart = wait_node_checkpoint(
+        &cluster,
+        active_idx,
+        Chain::Ethereum,
+        contract_checkpoint.block_height,
+        Duration::from_secs(10),
+    )
+    .await?;
+
+    assert_eq!(
+        contract_checkpoint, active_checkpoint_after_restart,
+        "active node checkpoint should remain aligned after peer recovery"
+    );
+
+    Ok(())
+}
+
+async fn submit_eth_sign_request(
+    contract: &eth::ChainSignaturesContract<eth::SandboxMiddleware>,
+    seed: usize,
+) -> anyhow::Result<()> {
+    let payload = [seed as u8; 32];
+    let request = eth::SignRequest {
+        payload,
+        path: format!("offline_test_{seed}"),
+        key_version: LATEST_MPC_KEY_VERSION,
+        algo: "secp256k1".to_string(),
+        dest: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1".to_string(),
+        params: "{}".to_string(),
+    };
+
+    contract
+        .sign(request)
+        .value(U256::from(1_u64))
+        .send()
+        .await?
+        .await?
+        .context("sign transaction failed")?;
+
+    Ok(())
+}
+
+async fn wait_contract_checkpoint(
+    contract: &near_workspaces::Contract,
+    chain: Chain,
+    min_block_height: u64,
+    timeout: Duration,
+) -> anyhow::Result<Checkpoint> {
+    tokio::time::timeout(timeout, async {
+        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        loop {
+            interval.tick().await;
+
+            let latest: Option<Checkpoint> = contract
+                .view("latest_checkpoint")
+                .args_json(serde_json::json!({ "chain": chain }))
+                .finality(Finality::Final)
+                .await?
+                .json()?;
+
+            if let Some(checkpoint) = latest {
+                if checkpoint.block_height >= min_block_height {
+                    return Ok(checkpoint);
+                }
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timeout waiting for contract checkpoint >= {min_block_height}"))
+}
+
+async fn wait_node_checkpoint(
+    nodes: &Cluster,
+    node_idx: usize,
+    chain: Chain,
+    min_block_height: u64,
+    timeout: Duration,
+) -> anyhow::Result<Checkpoint> {
+    tokio::time::timeout(timeout, async {
+        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        loop {
+            interval.tick().await;
+
+            let checkpoints = nodes.fetch_checkpoints(node_idx).await?;
+            if let Some(checkpoint) = checkpoints.get(&chain) {
+                if checkpoint.block_height >= min_block_height {
+                    return Ok(checkpoint.clone());
+                }
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!("timed out waiting for node {node_idx} checkpoint >= {min_block_height}")
+    })
 }

--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -8,9 +8,8 @@ use k256::{AffinePoint, EncodedPoint, FieldBytes, PublicKey as K256PublicKey};
 use mpc_crypto::derive_key;
 use mpc_crypto::kdf::derive_epsilon_eth;
 use mpc_primitives::{Chain, Checkpoint, LATEST_MPC_KEY_VERSION};
-use near_workspaces::types::Finality;
 use test_log::test;
-use tokio::time::{sleep, Duration};
+use tokio::time::Duration;
 
 #[test(tokio::test)]
 async fn test_signature_ethereum() -> Result<()> {
@@ -78,7 +77,7 @@ async fn test_signature_ethereum() -> Result<()> {
             matching_event = Some(event);
             break;
         }
-        sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(Duration::from_secs(1)).await;
     }
 
     let event =
@@ -200,7 +199,7 @@ async fn test_proper_indexer_checkpoint() -> Result<()> {
     tracing::info!(?expected_request_id, "submitted signature request");
 
     // Wait a bit for the request to be indexed and added to backlog
-    sleep(Duration::from_secs(3)).await;
+    tokio::time::sleep(Duration::from_secs(10)).await;
 
     // Check checkpoint - request should be in the pending transactions
     let checkpoints = cluster.fetch_checkpoints(node_idx).await?;
@@ -228,7 +227,7 @@ async fn test_proper_indexer_checkpoint() -> Result<()> {
             matching_event = Some(event);
             break;
         }
-        sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(Duration::from_secs(1)).await;
     }
 
     let _event =
@@ -238,7 +237,7 @@ async fn test_proper_indexer_checkpoint() -> Result<()> {
 
     // Wait for indexer to process the response event and remove from backlog
     // The indexer polls every few seconds, so we give it time
-    sleep(Duration::from_secs(10)).await;
+    tokio::time::sleep(Duration::from_secs(10)).await;
 
     // Check checkpoint again - request should be removed
     let checkpoints = cluster.fetch_checkpoints(node_idx).await?;
@@ -274,7 +273,6 @@ async fn test_checkpoint_recovery_after_offline() -> anyhow::Result<()> {
     let mut cluster = cluster::spawn().disable_prestockpile().ethereum().await?;
     cluster.wait().signable().await?;
 
-    let contract = cluster.contract().clone();
     let ctx = cluster.nodes.ctx();
     let eth_ctx = ctx
         .ethereum
@@ -287,19 +285,25 @@ async fn test_checkpoint_recovery_after_offline() -> anyhow::Result<()> {
     )?;
     let eth_contract = eth::ChainSignaturesContract::new(eth_ctx.contract_address, eth_client);
 
-    // Produce a few sign requests up front so the contract stores an initial checkpoint
+    // Produce a few sign requests up front so nodes create initial checkpoints
     for i in 0..5 {
         submit_eth_sign_request(&eth_contract, i).await?;
     }
 
-    let initial_checkpoint =
-        wait_contract_checkpoint(&contract, Chain::Ethereum, 1, Duration::from_secs(10)).await?;
+    let active_idx = 1usize;
+    let initial_checkpoint = wait_node_checkpoint(
+        &cluster,
+        active_idx,
+        Chain::Ethereum,
+        1,
+        Duration::from_secs(10),
+    )
+    .await?;
 
     let target_account = cluster.account_id(0).clone();
     let offline_idx = 0usize;
-    let active_idx = 1usize;
 
-    tracing::info!(%target_account, "taking node offline for checkpoint recovery test");
+    tracing::info!(%target_account, ?initial_checkpoint, "taking node offline for checkpoint recovery test");
     let offline_config = cluster.kill_node(&target_account).await;
 
     // Keep the node offline while the remaining nodes continue operating and sign requests
@@ -310,61 +314,61 @@ async fn test_checkpoint_recovery_after_offline() -> anyhow::Result<()> {
     while elapsed < offline_duration {
         submit_eth_sign_request(&eth_contract, seed).await?;
         seed += 1;
-        sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
         elapsed += Duration::from_secs(2);
     }
 
-    let contract_checkpoint = wait_contract_checkpoint(
-        &contract,
+    // Wait for active node to create a new checkpoint beyond the initial one
+    let node_active_checkpoint = wait_node_checkpoint(
+        &cluster,
+        active_idx,
         Chain::Ethereum,
         initial_checkpoint.block_height + 1,
         Duration::from_secs(10),
     )
     .await?;
 
-    let node_active_checkpoint = wait_node_checkpoint(
-        &cluster,
-        active_idx,
-        Chain::Ethereum,
-        contract_checkpoint.block_height,
-        Duration::from_secs(10),
-    )
-    .await?;
-
-    assert_eq!(
-        contract_checkpoint, node_active_checkpoint,
-        "active node should match contract checkpoint while peer is offline"
+    tracing::info!(
+        block_height = node_active_checkpoint.block_height,
+        "active node created new checkpoint while peer is offline"
     );
 
     tracing::info!("bringing offline node back online");
     cluster.restart_node(offline_config).await?;
     cluster.wait().signable().await?;
 
+    // Verify the restarted node recovers to the same checkpoint via node consensus
     let node_recovered_checkpoint = wait_node_checkpoint(
         &cluster,
         offline_idx,
         Chain::Ethereum,
-        contract_checkpoint.block_height,
+        node_active_checkpoint.block_height,
         Duration::from_secs(10),
     )
     .await?;
 
+    tracing::info!(
+        ?node_active_checkpoint,
+        ?node_recovered_checkpoint,
+        "offline node has restarted and checkpoint recovery complete",
+    );
+
     assert_eq!(
-        contract_checkpoint, node_recovered_checkpoint,
-        "restarted node should recover to contract checkpoint"
+        node_active_checkpoint, node_recovered_checkpoint,
+        "restarted node should recover to same checkpoint as active node via consensus"
     );
 
     let active_checkpoint_after_restart = wait_node_checkpoint(
         &cluster,
         active_idx,
         Chain::Ethereum,
-        contract_checkpoint.block_height,
+        node_active_checkpoint.block_height,
         Duration::from_secs(10),
     )
     .await?;
 
     assert_eq!(
-        contract_checkpoint, active_checkpoint_after_restart,
+        node_active_checkpoint, active_checkpoint_after_restart,
         "active node checkpoint should remain aligned after peer recovery"
     );
 
@@ -394,35 +398,6 @@ async fn submit_eth_sign_request(
         .context("sign transaction failed")?;
 
     Ok(())
-}
-
-async fn wait_contract_checkpoint(
-    contract: &near_workspaces::Contract,
-    chain: Chain,
-    min_block_height: u64,
-    timeout: Duration,
-) -> anyhow::Result<Checkpoint> {
-    tokio::time::timeout(timeout, async {
-        let mut interval = tokio::time::interval(Duration::from_secs(1));
-        loop {
-            interval.tick().await;
-
-            let latest: Option<Checkpoint> = contract
-                .view("latest_checkpoint")
-                .args_json(serde_json::json!({ "chain": chain }))
-                .finality(Finality::Final)
-                .await?
-                .json()?;
-
-            if let Some(checkpoint) = latest {
-                if checkpoint.block_height >= min_block_height {
-                    return Ok(checkpoint);
-                }
-            }
-        }
-    })
-    .await
-    .unwrap_or_else(|_| panic!("timeout waiting for contract checkpoint >= {min_block_height}"))
 }
 
 async fn wait_node_checkpoint(

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -197,9 +197,8 @@ fn sign_request(seed: u8) -> IndexedSignRequest {
         args: sign_arg(seed),
         chain: Chain::NEAR,
         unix_timestamp_indexed: 0,
-        timestamp_sign_queue: None,
+        timestamp_sign_queue: std::time::Instant::now(),
         total_timeout: Duration::from_secs(45),
-        participants: None,
         sign_request_type: SignRequestType::Sign,
     }
 }


### PR DESCRIPTION
This adds in checkpoint creation and recovery from backlog:

- create checkpoints every block interval (hardcoded to ~5~ 20 for eth and ~10~ 120 for sol for now)
- recover from checkpoint on restart (there's a test for this)
- ~checkpoints are rudimentarily uploaded to the contract for now (will be removed in the future once stored in redis since I didn't want to snowball redis into this PR).~ A query of the latest checkpoint for every other node is done on recovery.
- indexers now follow the simpler approach I mentioned in https://github.com/sig-net/mpc/issues/499#issuecomment-3487754525
  - backlog.insert request on indexing Sign or SignBidirectional
  - backlog.watch execution on indexing Respond for SignBidirectional request
  - backlog.remove on Respond for Sign, RespondBidirectional for SignBidirectional requests.

Note the SignRequestType and the BacklogTransaction has a lot of duplicate information and some sporadic clones are about. Will clean up in a future PR.