### PR TITLE
feat: improve integration test times

### DIFF
--- a/integration-tests/src/actions/wait.rs
+++ b/integration-tests/src/actions/wait.rs
@@ -230,8 +230,8 @@ async fn require_node_state(nodes: &Cluster, state: NodeState, id: usize) -> any
     };
 
     let strategy = ConstantBuilder::default()
-        .with_delay(std::time::Duration::from_secs(3))
-        .with_max_times(20);
+        .with_delay(std::time::Duration::from_millis(500))
+        .with_max_times(30);
 
     let state = is_ready
         .retry(&strategy)
@@ -240,7 +240,7 @@ async fn require_node_state(nodes: &Cluster, state: NodeState, id: usize) -> any
 
     if matches!(state, NodeState::Joining) {
         // wait a bit longer for voting to join
-        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     }
 
     Ok(())
@@ -267,8 +267,8 @@ async fn require_contract_state(nodes: &Cluster, state: ContractState) -> anyhow
     };
 
     let strategy = ConstantBuilder::default()
-        .with_delay(std::time::Duration::from_secs(3))
-        .with_max_times(20);
+        .with_delay(std::time::Duration::from_millis(500))
+        .with_max_times(30);
 
     is_ready
         .retry(&strategy)
@@ -296,8 +296,8 @@ pub async fn running_mpc(
     };
 
     let strategy = ConstantBuilder::default()
-        .with_delay(std::time::Duration::from_secs(3))
-        .with_max_times(50);
+        .with_delay(std::time::Duration::from_millis(500))
+        .with_max_times(40);
 
     is_running.retry(&strategy).await.with_context(|| {
         format!(
@@ -346,7 +346,7 @@ pub async fn require_presignatures(
     };
 
     let strategy = ConstantBuilder::default()
-        .with_delay(std::time::Duration::from_secs(5))
+        .with_delay(std::time::Duration::from_secs(1))
         .with_max_times(expected * 100);
 
     let state_views = is_enough.retry(&strategy).await.with_context(|| {
@@ -391,7 +391,7 @@ pub async fn require_triples(
     };
 
     let strategy = ConstantBuilder::default()
-        .with_delay(std::time::Duration::from_secs(5))
+        .with_delay(std::time::Duration::from_secs(1))
         .with_max_times(expected * 100);
 
     let state_views = is_enough.retry(&strategy).await.with_context(|| {

--- a/integration-tests/src/actions/wait_for.rs
+++ b/integration-tests/src/actions/wait_for.rs
@@ -67,8 +67,8 @@ pub async fn signature_responded(
     };
 
     let strategy = ConstantBuilder::default()
-        .with_delay(Duration::from_secs(20))
-        .with_max_times(10);
+        .with_delay(Duration::from_millis(500))
+        .with_max_times(120);
 
     match is_tx_ready.retry(&strategy).await? {
         Outcome::Signature(signature) => Ok(signature),
@@ -121,9 +121,10 @@ pub async fn rogue_message_responded(status: AsyncTransactionStatus) -> anyhow::
         Ok(err_msg.clone())
     };
 
+    // Poll every 1 second to detect completion faster
     let strategy = ConstantBuilder::default()
-        .with_delay(Duration::from_secs(20))
-        .with_max_times(5);
+        .with_delay(Duration::from_secs(1))
+        .with_max_times(30); // 30 seconds max total wait time
 
     let signature = is_tx_ready
         .retry(&strategy)
@@ -209,8 +210,8 @@ pub async fn batch_signature_responded(
     };
 
     let strategy = ConstantBuilder::default()
-        .with_delay(Duration::from_secs(20))
-        .with_max_times(5);
+        .with_delay(Duration::from_millis(500))
+        .with_max_times(120);
 
     match is_tx_ready.retry(&strategy).await? {
         Outcome::Signature(_) => Err(WaitForError::Signature(SignatureError::Failed(

--- a/integration-tests/src/cluster/mod.rs
+++ b/integration-tests/src/cluster/mod.rs
@@ -320,7 +320,7 @@ impl Cluster {
             "did not successfully vote for update"
         );
 
-        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     }
 
     pub async fn prestockpile(&self, prestockpile: Prestockpile) {

--- a/integration-tests/src/cluster/spawner.rs
+++ b/integration-tests/src/cluster/spawner.rs
@@ -1,9 +1,11 @@
 use cait_sith::protocol::Participant;
 use mpc_contract::config::ProtocolConfig;
+use mpc_node::protocol::state::NodeKeyInfo;
 use near_account_id::AccountId;
 use near_workspaces::network::Sandbox;
 use near_workspaces::{Account, Worker};
 
+use std::collections::BTreeMap;
 use std::future::{Future, IntoFuture};
 use std::path::PathBuf;
 
@@ -16,6 +18,89 @@ use crate::cluster::Cluster;
 const DOCKER_NETWORK: &str = "mpc_it_network";
 const GCP_PROJECT_ID: &str = "multichain-integration";
 const ENV: &str = "integration-tests";
+
+/// Configuration for pregenerated keys to skip the 20+ second key generation phase.
+///
+/// When enabled, uses hardcoded key shares from fixture data to start nodes in
+/// Running state immediately, avoiding the expensive MPC key generation protocol.
+#[derive(Clone)]
+pub enum PregeneratedKeys {
+    /// Generate keys fresh during cluster setup (slow but tests full protocol)
+    Disabled,
+    /// Use pregenerated keys from fixture data (fast, skips keygen)
+    Enabled {
+        /// Key shares for each participant, indexed by participant ID
+        keys: BTreeMap<Participant, NodeKeyInfo>,
+        /// The shared public key for all participants
+        public_key: mpc_crypto::PublicKey,
+    },
+}
+
+impl PregeneratedKeys {
+    /// Load pregenerated keys for the given number of nodes from fixture data
+    pub fn load(num_nodes: usize) -> Option<Self> {
+        let data = match num_nodes {
+            3 => include_str!("../mpc_fixture/3_nodes.json"),
+            5 => include_str!("../mpc_fixture/5_nodes.json"),
+            other => {
+                tracing::warn!("No pregenerated keys for {other} nodes available");
+                return None;
+            }
+        };
+
+        #[derive(serde::Deserialize)]
+        struct FixtureData {
+            keys: BTreeMap<Participant, NodeKeyInfo>,
+        }
+
+        let fixture: FixtureData = serde_json::from_str(data)
+            .expect("Failed to parse pregenerated keys from fixture data");
+
+        let public_key = fixture
+            .keys
+            .values()
+            .next()
+            .expect("No keys in fixture data")
+            .public_key;
+
+        Some(Self::Enabled {
+            keys: fixture.keys,
+            public_key,
+        })
+    }
+
+    /// Check if keys are enabled
+    pub fn is_enabled(&self) -> bool {
+        matches!(self, Self::Enabled { .. })
+    }
+
+    /// Get the key info for a specific participant
+    pub fn get(&self, participant: &Participant) -> Option<&NodeKeyInfo> {
+        match self {
+            Self::Disabled => None,
+            Self::Enabled { keys, .. } => keys.get(participant),
+        }
+    }
+
+    /// Get the public key
+    pub fn public_key(&self) -> Option<mpc_crypto::PublicKey> {
+        match self {
+            Self::Disabled => None,
+            Self::Enabled { public_key, .. } => Some(*public_key),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Disabled => 0,
+            Self::Enabled { keys, .. } => keys.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
 
 pub struct Prestockpile {
     /// Multiplier to increase the stockpile such that stockpiling presignatures does not trigger
@@ -40,6 +125,7 @@ pub struct ClusterSpawner {
     pub solana: Option<containers::Solana>,
     pub program_address: Option<String>,
     prestockpile: Option<Prestockpile>,
+    pub pregenerated_keys: PregeneratedKeys,
     pub use_ethereum: bool,
 }
 
@@ -48,8 +134,9 @@ impl Default for ClusterSpawner {
         let mut tmp_dir = execute::target_dir().expect("unable to locate target dir");
         tmp_dir.push("tmp");
 
+        let nodes = 3;
         let cfg = NodeConfig {
-            nodes: 3,
+            nodes,
             threshold: 2,
             ..Default::default()
         };
@@ -70,6 +157,7 @@ impl Default for ClusterSpawner {
             solana: None,
             program_address: None,
             prestockpile: Some(Prestockpile { multiplier: 4 }),
+            pregenerated_keys: PregeneratedKeys::load(nodes).unwrap(),
             use_ethereum: false,
         }
     }
@@ -119,6 +207,21 @@ impl ClusterSpawner {
 
     pub fn prestockpile(mut self, multiplier: u32) -> Self {
         self.prestockpile = Some(Prestockpile { multiplier });
+        self
+    }
+
+    /// Disable pregenerated keys and generate keys fresh.
+    /// This is slower but tests the full key generation protocol.
+    pub fn without_pregenerated_keys(mut self) -> Self {
+        self.pregenerated_keys = PregeneratedKeys::Disabled;
+        self
+    }
+
+    fn load_pregenerated_keys(mut self) -> Self {
+        if self.pregenerated_keys.is_enabled() && self.pregenerated_keys.len() != self.cfg.nodes {
+            self.pregenerated_keys =
+                PregeneratedKeys::load(self.cfg.nodes).unwrap_or(PregeneratedKeys::Disabled);
+        }
         self
     }
 
@@ -263,7 +366,7 @@ impl IntoFuture for ClusterSpawner {
 
     fn into_future(mut self) -> Self::IntoFuture {
         Box::pin(async move {
-            self = self.init_network().await?;
+            self = self.load_pregenerated_keys().init_network().await?;
 
             // Check if Solana is enabled and spawn if needed
             if self.cfg.sol.is_some() {

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -12,6 +12,7 @@ use deadpool_redis::Pool;
 use mpc_node::indexer_eth::EthConfig;
 use mpc_node::indexer_sol::SolConfig;
 use std::collections::HashMap;
+use std::time::Duration;
 
 use self::local::NodeEnvConfig;
 use crate::containers::DockerClient;
@@ -162,7 +163,7 @@ impl Nodes {
         };
 
         // wait for the node to be removed from the network
-        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        tokio::time::sleep(Duration::from_secs(3)).await;
 
         killed_node_config
     }
@@ -203,7 +204,7 @@ impl Nodes {
             }
         }
         // wait for the node to be added to the network
-        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
 
         Ok(())
     }
@@ -284,6 +285,7 @@ pub async fn setup(spawner: &mut ClusterSpawner) -> anyhow::Result<Context> {
     tracing::info!(contract_id = %mpc_contract.id(), "deployed mpc contract");
 
     let redis = spawner.take_redis().await;
+
     let sk_share_local_path = spawner.tmp_dir.join("secrets");
     std::fs::create_dir_all(&sk_share_local_path).expect("could not create secrets dir");
     let sk_share_local_path = sk_share_local_path.to_string_lossy().to_string();
@@ -345,6 +347,35 @@ pub async fn setup(spawner: &mut ClusterSpawner) -> anyhow::Result<Context> {
         state_timeout: 1000,
     };
 
+    // If using pregenerated keys, inject them into storage before nodes start
+    if spawner.pregenerated_keys.is_enabled() {
+        tracing::info!("injecting pregenerated keyshares into storage...");
+        for (i, account) in spawner.accounts.iter().enumerate() {
+            let participant = cait_sith::protocol::Participant::from(i as u32);
+            if let Some(key_info) = spawner.pregenerated_keys.get(&participant) {
+                let mut secret_storage = storage::secret_storage::init(
+                    None, // No GCP service for tests
+                    &storage_options,
+                    account.id(),
+                );
+
+                let persistent_data = mpc_node::protocol::state::PersistentNodeData {
+                    epoch: 0,
+                    private_share: key_info.private_share,
+                    public_key: key_info.public_key,
+                };
+
+                let account_id = account.id().to_string();
+                if let Err(err) = secret_storage.store(&persistent_data).await {
+                    tracing::error!(?err, "failed to store pregenerated key");
+                    continue;
+                }
+
+                tracing::info!(?account_id, "stored key share for participant");
+            }
+        }
+    }
+
     Ok(Context {
         docker_client: spawner.docker.clone(),
         docker_network: spawner.network.clone(),
@@ -388,15 +419,44 @@ pub async fn docker(spawner: &mut ClusterSpawner) -> anyhow::Result<Nodes> {
             )
         })
         .collect();
-    ctx.mpc_contract
-        .call("init")
-        .args_json(json!({
-            "threshold": cfg.threshold,
-            "candidates": candidates
-        }))
-        .transact()
-        .await?
-        .into_result()?;
+
+    if let Some(public_key) = spawner.pregenerated_keys.public_key() {
+        // Use init_running to skip key generation
+        let participants =
+            mpc_contract::primitives::Participants::from(mpc_contract::primitives::Candidates {
+                candidates: candidates.clone().into_iter().collect(),
+            });
+        use k256::elliptic_curve::sec1::ToEncodedPoint;
+        let near_pk = near_crypto::PublicKey::SECP256K1(
+            near_crypto::Secp256K1PublicKey::try_from(
+                &public_key.to_encoded_point(false).as_bytes()[1..65],
+            )
+            .unwrap(),
+        );
+        ctx.mpc_contract
+            .call("init_running")
+            .args_json(json!({
+                "epoch": 0,
+                "participants": participants,
+                "threshold": cfg.threshold,
+                "public_key": near_pk,
+            }))
+            .transact()
+            .await?
+            .into_result()?;
+        tracing::info!("contract initialized with pregenerated keys (skipped keygen)");
+    } else {
+        ctx.mpc_contract
+            .call("init")
+            .args_json(json!({
+                "threshold": cfg.threshold,
+                "candidates": candidates
+            }))
+            .transact()
+            .await?
+            .into_result()?;
+        tracing::info!("contract initialized, will generate keys...");
+    }
 
     Ok(Nodes::Docker {
         next_id: nodes.len(),
@@ -455,9 +515,13 @@ pub async fn dry_host(spawner: &mut ClusterSpawner) -> anyhow::Result<Context> {
 }
 
 pub async fn host(spawner: &mut ClusterSpawner) -> anyhow::Result<Nodes> {
+    let setup_start = std::time::Instant::now();
     let ctx = setup(spawner).await?;
+    tracing::info!("⏱️  setup (total) took: {:?}", setup_start.elapsed());
+
     let cfg = &spawner.cfg;
 
+    let spawn_nodes_start = std::time::Instant::now();
     let node_futures = spawner
         .accounts
         .iter()
@@ -466,6 +530,10 @@ pub async fn host(spawner: &mut ClusterSpawner) -> anyhow::Result<Nodes> {
         .await
         .into_iter()
         .collect::<Result<Vec<_>, _>>()?;
+    tracing::info!(
+        elapsed = ?spawn_nodes_start.elapsed(),
+        "all mpc nodes have been spawned",
+    );
     let candidates: HashMap<AccountId, CandidateInfo> = spawner
         .accounts
         .iter()
@@ -482,15 +550,51 @@ pub async fn host(spawner: &mut ClusterSpawner) -> anyhow::Result<Nodes> {
             )
         })
         .collect();
-    ctx.mpc_contract
-        .call("init")
-        .args_json(json!({
-            "threshold": cfg.threshold,
-            "candidates": candidates
-        }))
-        .transact()
-        .await?
-        .into_result()?;
+
+    // Initialize contract based on whether we're using pregenerated keys
+    let init_contract_start = std::time::Instant::now();
+    if let Some(public_key) = spawner.pregenerated_keys.public_key() {
+        // Use init_running to skip key generation
+        let candidates_struct = mpc_contract::primitives::Candidates {
+            candidates: candidates.clone().into_iter().collect(),
+        };
+        let participants = mpc_contract::primitives::Participants::from(candidates_struct);
+        // Convert secp256k1 public key to NEAR public key format (secp256k1)
+        use k256::elliptic_curve::sec1::ToEncodedPoint;
+        let near_pk = near_crypto::PublicKey::SECP256K1(
+            near_crypto::Secp256K1PublicKey::try_from(
+                &public_key.to_encoded_point(false).as_bytes()[1..65],
+            )
+            .unwrap(),
+        );
+        ctx.mpc_contract
+            .call("init_running")
+            .args_json(json!({
+                "epoch": 0,
+                "participants": participants,
+                "threshold": cfg.threshold,
+                "public_key": near_pk,
+            }))
+            .transact()
+            .await?
+            .into_result()?;
+        tracing::info!("contract initialized with pregenerated keys (skipped keygen)");
+    } else {
+        // Standard init - will trigger key generation
+        ctx.mpc_contract
+            .call("init")
+            .args_json(json!({
+                "threshold": cfg.threshold,
+                "candidates": candidates
+            }))
+            .transact()
+            .await?
+            .into_result()?;
+    }
+    tracing::info!(
+        elapsed = ?init_contract_start.elapsed(),
+        "governance contract initialized"
+    );
 
     Ok(Nodes::Local {
         next_id: nodes.len(),


### PR DESCRIPTION
This makes our integration tests more performant.

- reduces the querying wait times since some were pretty big (sign had a 20s interval between queries).
- add in `PregeneratedKeys` which takes @jakmeier work on mpc fixture over for integration tests. This reduces our setup time by about 20s which is pretty good.
- our `test_signature_basic` went from 55-60s to now 30s from my measurement.