### PR TITLE
feat: triple pairs

### DIFF
--- a/chain-signatures/node/src/protocol/message/types.rs
+++ b/chain-signatures/node/src/protocol/message/types.rs
@@ -125,8 +125,7 @@ impl From<TripleMessage> for Message {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct PresignatureMessage {
     pub id: u64,
-    pub triple0: TripleId,
-    pub triple1: TripleId,
+    pub pair_id: TripleId,
     pub epoch: Epoch,
     pub from: Participant,
     #[serde(with = "serde_bytes")]

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -228,8 +228,7 @@ impl PresignatureGenerator {
                                 *to,
                                 PresignatureMessage {
                                     id: self.id,
-                                    triple0: self.dropper.id0,
-                                    triple1: self.dropper.id1,
+                                    pair_id: self.dropper.pair_id,
                                     epoch,
                                     from: me,
                                     data: data.clone(),
@@ -246,8 +245,7 @@ impl PresignatureGenerator {
                             to,
                             PresignatureMessage {
                                 id: self.id,
-                                triple0: self.dropper.id0,
-                                triple1: self.dropper.id1,
+                                pair_id: self.dropper.pair_id,
                                 epoch,
                                 from: me,
                                 data,
@@ -475,8 +473,7 @@ impl PresignatureSpawner {
             return;
         };
 
-        let t0 = triples.pair.triple0.id;
-        let t1 = triples.pair.triple1.id;
+        let pair_id = triples.pair.id;
         let participants = intersect_vec(&[
             active,
             &triples.pair.triple0.public.participants,
@@ -486,14 +483,15 @@ impl PresignatureSpawner {
             tracing::warn!(
                 intersection = ?participants,
                 ?participants,
-                triple0 = ?(t0, &triples.pair.triple0.public.participants),
-                triple1 = ?(t1, &triples.pair.triple1.public.participants),
+                pair_id,
+                triple0 = ?(&triples.pair.triple0.public.participants),
+                triple1 = ?(&triples.pair.triple1.public.participants),
                 "intersection < threshold, trashing two triples"
             );
             return;
         }
 
-        let id = FullPresignatureId::from_pair(t0);
+        let id = FullPresignatureId::from_pair(pair_id);
         tracing::info!(
             ?id,
             ?triples,

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -474,7 +474,7 @@ impl PresignatureSpawner {
         };
 
         let pair_id = triples.pair.id;
-        // note: only one of the pair's participants is need since they are the same.
+        // note: only one of the pair's participants is needed since they are the same.
         let participants = intersect_vec(&[active, &triples.pair.triple0.public.participants]);
         if participants.len() < self.threshold {
             tracing::warn!(

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -35,23 +35,22 @@ use near_account_id::AccountId;
 /// generation messages.
 pub type PresignatureId = u64;
 
-/// The full presignature id. This encompasses the presignature id and the two triples
-/// that were used to generate it.
+/// The full presignature id. This encompasses the presignature id and the triple pair
+/// that was used to generate it.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct FullPresignatureId {
     id: PresignatureId,
-    t0: TripleId,
-    t1: TripleId,
+    pair_id: TripleId,
 }
 
 impl FullPresignatureId {
-    pub fn from_triples(t0: TripleId, t1: TripleId) -> Self {
-        let id = hash_as_id(t0, t1);
-        Self { id, t0, t1 }
+    pub fn from_pair(pair_id: TripleId) -> Self {
+        let id = hash_as_id(pair_id);
+        Self { id, pair_id }
     }
 
     pub fn validate(&self) -> bool {
-        self.id == hash_as_id(self.t0, self.t1)
+        self.id == hash_as_id(self.pair_id)
     }
 }
 
@@ -426,9 +425,8 @@ impl PresignatureSpawner {
             // TODO: we can potentially wait for the triples to exist first to then be able to accept.
             // whereas we just blatantly reject here. The problem with waiting is that the other side
             // might expire their posit first.
-            (self.triples.contains_reserved(id.t0).await || self.triples.contains(id.t0).await)
-                && (self.triples.contains_reserved(id.t1).await
-                    || self.triples.contains(id.t1).await)
+            (self.triples.contains_reserved(id.pair_id).await
+                || self.triples.contains(id.pair_id).await)
         } {
             tracing::warn!(
                 ?id,
@@ -473,29 +471,29 @@ impl PresignatureSpawner {
         // to use the same triple as any other node.
         // TODO: have all this part be a separate task such that finding a pair of triples is done in parallel instead
         // of waiting for storage to respond here.
-        let Some(triples) = self.triples.take_two_mine(self.me).await else {
+        let Some(triples) = self.triples.take_mine(self.me).await else {
             return;
         };
 
-        let t0 = triples.triple0.id;
-        let t1 = triples.triple1.id;
+        let t0 = triples.pair.triple0.id;
+        let t1 = triples.pair.triple1.id;
         let participants = intersect_vec(&[
             active,
-            &triples.triple0.public.participants,
-            &triples.triple1.public.participants,
+            &triples.pair.triple0.public.participants,
+            &triples.pair.triple1.public.participants,
         ]);
         if participants.len() < self.threshold {
             tracing::warn!(
                 intersection = ?participants,
                 ?participants,
-                triple0 = ?(t0, &triples.triple0.public.participants),
-                triple1 = ?(t1, &triples.triple1.public.participants),
+                triple0 = ?(t0, &triples.pair.triple0.public.participants),
+                triple1 = ?(t1, &triples.pair.triple1.public.participants),
                 "intersection < threshold, trashing two triples"
             );
             return;
         }
 
-        let id = FullPresignatureId::from_triples(t0, t1);
+        let id = FullPresignatureId::from_pair(t0);
         tracing::info!(
             ?id,
             ?triples,
@@ -554,7 +552,7 @@ impl PresignatureSpawner {
             Positor::Proposer(proposer, triples) => (proposer, PendingTriples::Available(triples)),
             Positor::Deliberator(proposer) => (
                 proposer,
-                PendingTriples::InStorage(id.t0, id.t1, self.triples.clone()),
+                PendingTriples::InStorage(id.pair_id, self.triples.clone()),
             ),
         };
         tracing::info!(
@@ -587,7 +585,7 @@ impl PresignatureSpawner {
                 return;
             };
 
-            let (triple0, triple1, dropper) = triples.take();
+            let (pair, dropper) = triples.take();
             let protocol = match cait_sith::presign(
                 &participants,
                 me,
@@ -596,8 +594,8 @@ impl PresignatureSpawner {
                 &participants,
                 me,
                 PresignArguments {
-                    triple0: (triple0.share, triple0.public),
-                    triple1: (triple1.share, triple1.public),
+                    triple0: (pair.triple0.share, pair.triple0.public),
+                    triple1: (pair.triple1.share, pair.triple1.public),
                     keygen_out,
                     threshold,
                 },
@@ -755,10 +753,9 @@ impl Drop for PresignatureSpawner {
     }
 }
 
-pub fn hash_as_id(triple0: TripleId, triple1: TripleId) -> PresignatureId {
+pub fn hash_as_id(pair_id: TripleId) -> PresignatureId {
     let mut hasher = Sha3_256::new();
-    hasher.update(triple0.to_le_bytes());
-    hasher.update(triple1.to_le_bytes());
+    hasher.update(pair_id.to_le_bytes());
     let id: [u8; 32] = hasher.finalize().into();
     let id = u64::from_le_bytes(crate::util::first_8_bytes(id));
 
@@ -824,12 +821,12 @@ impl Drop for PresignatureSpawnerTask {
     }
 }
 
-/// Represents two triples that are either available immediately or will eventually be available within
+/// Represents a triple pair that is either available immediately or will eventually be available within
 /// the storage, in which case the `fetch` method will block until they are available alongside a timeout.
 #[allow(clippy::large_enum_variant)]
 enum PendingTriples {
     Available(TriplesTaken),
-    InStorage(TripleId, TripleId, TripleStorage),
+    InStorage(TripleId, TripleStorage),
 }
 
 impl PendingTriples {
@@ -839,8 +836,8 @@ impl PendingTriples {
         owner: Participant,
         timeout: Duration,
     ) -> Option<TriplesTaken> {
-        let (id0, id1, storage) = match self {
-            Self::InStorage(id0, id1, storage) => (id0, id1, storage),
+        let (pair_id, storage) = match self {
+            Self::InStorage(pair_id, storage) => (pair_id, storage),
             Self::Available(triples) => return Some(triples),
         };
 
@@ -848,7 +845,7 @@ impl PendingTriples {
             let mut interval = tokio::time::interval(Duration::from_millis(200));
             loop {
                 interval.tick().await;
-                if let Some(triples) = storage.take_two(id0, id1, owner, me).await {
+                if let Some(triples) = storage.take(pair_id, owner, me).await {
                     break triples;
                 };
             }
@@ -858,7 +855,7 @@ impl PendingTriples {
         match triples {
             Ok(triples) => Some(triples),
             Err(_) => {
-                tracing::warn!(id0, id1, "timeout waiting for triples to be available");
+                tracing::warn!(pair_id, "timeout waiting for triple pair to be available");
                 None
             }
         }

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -423,8 +423,8 @@ impl PresignatureSpawner {
             // TODO: we can potentially wait for the triples to exist first to then be able to accept.
             // whereas we just blatantly reject here. The problem with waiting is that the other side
             // might expire their posit first.
-            (self.triples.contains_reserved(id.pair_id).await
-                || self.triples.contains(id.pair_id).await)
+            self.triples.contains_reserved(id.pair_id).await
+                || self.triples.contains(id.pair_id).await
         } {
             tracing::warn!(
                 ?id,
@@ -474,19 +474,14 @@ impl PresignatureSpawner {
         };
 
         let pair_id = triples.pair.id;
-        let participants = intersect_vec(&[
-            active,
-            &triples.pair.triple0.public.participants,
-            &triples.pair.triple1.public.participants,
-        ]);
+        // note: only one of the pair's participants is need since they are the same.
+        let participants = intersect_vec(&[active, &triples.pair.triple0.public.participants]);
         if participants.len() < self.threshold {
             tracing::warn!(
-                intersection = ?participants,
-                ?participants,
                 pair_id,
-                triple0 = ?(&triples.pair.triple0.public.participants),
-                triple1 = ?(&triples.pair.triple1.public.participants),
-                "intersection < threshold, trashing two triples"
+                ?active,
+                ?participants,
+                "intersection < threshold, trashing triple pair"
             );
             return;
         }

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -33,7 +33,6 @@ pub type TripleId = u64;
 /// A completed triple.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Triple {
-    pub id: TripleId,
     pub share: TripleShare<Secp256k1>,
     pub public: TriplePub<Secp256k1>,
 }
@@ -207,12 +206,10 @@ impl TripleGenerator {
 
                     // Assuming outputs is Vec<(TripleShare, TriplePub)> with 2 elements
                     let triple0 = Triple {
-                        id: self.id,
                         share: outputs[0].0.clone(),
                         public: outputs[0].1.clone(),
                     };
                     let triple1 = Triple {
-                        id: self.id + 1,
                         share: outputs[1].0.clone(),
                         public: outputs[1].1.clone(),
                     };
@@ -242,7 +239,7 @@ impl TripleGenerator {
                         success_owned_counts.inc();
                     }
 
-                    let pair = TriplePair { triple0, triple1 };
+                    let pair = TriplePair { id: self.id, triple0, triple1 };
                     self.slot.insert(pair, triple_owner).await;
                     break;
                 }

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -4,7 +4,7 @@ use super::MpcSignProtocol;
 use crate::config::Config;
 use crate::mesh::MeshState;
 use crate::protocol::posit::Positor;
-use crate::storage::triple_storage::{TripleSlot, TripleStorage};
+use crate::storage::triple_storage::{TriplePair, TriplePairSlot, TripleStorage};
 use crate::types::TripleProtocol;
 use crate::util::{AffinePointExt, JoinMap};
 
@@ -31,7 +31,7 @@ use std::time::{Duration, Instant};
 pub type TripleId = u64;
 
 /// A completed triple.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Triple {
     pub id: TripleId,
     pub share: TripleShare<Secp256k1>,
@@ -44,7 +44,7 @@ struct TripleGenerator {
     participants: Vec<Participant>,
     protocol: TripleProtocol,
     timeout: Duration,
-    slot: TripleSlot,
+    slot: TriplePairSlot,
     created: Instant,
     inbox: mpsc::Receiver<TripleMessage>,
     msg: MessageChannel,
@@ -60,7 +60,7 @@ impl TripleGenerator {
         threshold: usize,
         participants: &[Participant],
         timeout: Duration,
-        slot: TripleSlot,
+        slot: TriplePairSlot,
         msg: &MessageChannel,
         _my_account_id: &AccountId,
     ) -> Result<Self, InitializationError> {
@@ -70,7 +70,7 @@ impl TripleGenerator {
         participants.sort();
 
         let protocol =
-            cait_sith::triples::generate_triple::<Secp256k1>(&participants, me, threshold)?;
+            cait_sith::triples::generate_triple_many::<Secp256k1, 2>(&participants, me, threshold)?;
 
         let inbox = msg.subscribe_triple(id).await;
         Ok(Self {
@@ -197,7 +197,7 @@ impl TripleGenerator {
                     };
                     self.msg.send(self.me, to, message).await;
                 }
-                Action::Return(output) => {
+                Action::Return(outputs) => {
                     success_total_counts.inc();
                     runtime_latency.observe(start_time.elapsed().as_secs_f64());
                     // this measures from generator creation to finishing. TRIPLE_LATENCY instead starts from the first poke() on the generator
@@ -205,47 +205,45 @@ impl TripleGenerator {
                     accrued_wait_delay.observe(total_wait.as_millis() as f64);
                     poke_counts.observe(total_pokes as f64);
 
-                    let triple = Triple {
+                    // Assuming outputs is Vec<(TripleShare, TriplePub)> with 2 elements
+                    let triple0 = Triple {
                         id: self.id,
-                        share: output.0,
-                        public: output.1,
+                        share: outputs[0].0.clone(),
+                        public: outputs[0].1.clone(),
+                    };
+                    let triple1 = Triple {
+                        id: self.id + 1,
+                        share: outputs[1].0.clone(),
+                        public: outputs[1].1.clone(),
                     };
 
-                    // After creation the triple is assigned to a random node, which is NOT necessarily the one that initiated it's creation
+                    // For simplicity, assign both triples to the same owner based on the first triple
                     let triple_owner = {
-                        // This is an entirely unpredictable value to all participants because it's a combination of big_c_i
-                        // It is the same value across all participants
-                        let big_c = triple.public.big_c;
-
-                        // We turn this into a u64 in a way not biased to the structure of the byte serialisation so we hash it
-                        // We use Highway Hash because the DefaultHasher doesn't guarantee a consistent output across versions
+                        let big_c = triple0.public.big_c;
                         let entropy = HighwayHasher::default().hash64(&big_c.to_bytes()) as usize;
-
                         let num_participants = self.participants.len();
-                        // This has a *tiny* bias towards lower indexed participants, they're up to (1 + num_participants / u64::MAX)^2 times more likely to be selected
-                        // This is acceptably small that it will likely never result in a biased selection happening
                         self.participants[entropy % num_participants]
                     };
-                    let triple_is_mine = triple_owner == self.me;
+                    let pair_is_mine = triple_owner == self.me;
 
                     tracing::debug!(
                         id = self.id,
                         me = ?self.me,
                         ?triple_owner,
-                        triple_is_mine,
+                        pair_is_mine,
                         participants = ?self.participants,
-                        big_a = ?triple.public.big_a.to_base58(),
-                        big_b = ?triple.public.big_b.to_base58(),
-                        big_c = ?triple.public.big_c.to_base58(),
+                        big_a0 = ?triple0.public.big_a.to_base58(),
+                        big_a1 = ?triple1.public.big_a.to_base58(),
                         elapsed = ?self.created.elapsed(),
-                        "completed triple generation"
+                        "completed triple pair generation"
                     );
 
-                    if triple_is_mine {
+                    if pair_is_mine {
                         success_owned_counts.inc();
                     }
 
-                    self.slot.insert(triple, triple_owner).await;
+                    let pair = TriplePair { triple0, triple1 };
+                    self.slot.insert(pair, triple_owner).await;
                     break;
                 }
             }
@@ -331,8 +329,8 @@ impl TripleSpawner {
         }
     }
 
-    async fn reserve(&self, id: TripleId) -> Option<TripleSlot> {
-        self.triple_storage.reserve(id).await
+    async fn reserve(&self, id: TripleId) -> Option<TriplePairSlot> {
+        self.triple_storage.reserve_pair(id).await
     }
 
     pub async fn contains(&self, id: TripleId) -> bool {
@@ -412,8 +410,10 @@ impl TripleSpawner {
 
     /// Propose a new triple generation protocol to the network.
     async fn propose_posit(&mut self, active: &[Participant]) {
-        let id = rand::random();
-        self.posits.propose(id, (), active);
+        let id0 = rand::random();
+        let id1 = rand::random();
+        self.posits.propose(id0, (), active);
+        self.posits.propose(id1, (), active);
         for &p in active.iter() {
             if p == self.me {
                 continue;
@@ -424,7 +424,18 @@ impl TripleSpawner {
                     self.me,
                     p,
                     PositMessage {
-                        id: PositProtocolId::Triple(id),
+                        id: PositProtocolId::Triple(id0),
+                        from: self.me,
+                        action: PositAction::Propose,
+                    },
+                )
+                .await;
+            self.msg
+                .send(
+                    self.me,
+                    p,
+                    PositMessage {
+                        id: PositProtocolId::Triple(id1),
                         from: self.me,
                         action: PositAction::Propose,
                     },
@@ -479,9 +490,9 @@ impl TripleSpawner {
         timeout: Duration,
     ) -> Result<(), InitializationError> {
         // Check if the `id` is already in the system. Error out and have the next cycle try again.
-        let Some(slot) = self.reserve(id).await else {
+        let Some(slot) = self.triple_storage.reserve_pair(id).await else {
             return Err(InitializationError::BadParameters(format!(
-                "id collision: triple_id={id}"
+                "id collision: pair_id={id}"
             )));
         };
 

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -239,7 +239,11 @@ impl TripleGenerator {
                         success_owned_counts.inc();
                     }
 
-                    let pair = TriplePair { id: self.id, triple0, triple1 };
+                    let pair = TriplePair {
+                        id: self.id,
+                        triple0,
+                        triple1,
+                    };
                     self.slot.insert(pair, triple_owner).await;
                     break;
                 }
@@ -324,10 +328,6 @@ impl TripleSpawner {
             my_account_id: my_account_id.clone(),
             msg,
         }
-    }
-
-    async fn reserve(&self, id: TripleId) -> Option<TriplePairSlot> {
-        self.triple_storage.reserve_pair(id).await
     }
 
     pub async fn contains(&self, id: TripleId) -> bool {
@@ -487,7 +487,7 @@ impl TripleSpawner {
         timeout: Duration,
     ) -> Result<(), InitializationError> {
         // Check if the `id` is already in the system. Error out and have the next cycle try again.
-        let Some(slot) = self.triple_storage.reserve_pair(id).await else {
+        let Some(slot) = self.triple_storage.reserve(id).await else {
             return Err(InitializationError::BadParameters(format!(
                 "id collision: pair_id={id}"
             )));

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -205,18 +205,26 @@ impl TripleGenerator {
                     poke_counts.observe(total_pokes as f64);
 
                     // Assuming outputs is Vec<(TripleShare, TriplePub)> with 2 elements
-                    let triple0 = Triple {
-                        share: outputs[0].0.clone(),
-                        public: outputs[0].1.clone(),
+                    let [first, second, ..] = &outputs[..] else {
+                        tracing::warn!(
+                            id = self.id,
+                            triples = outputs.len(),
+                            "unexpected, not enough triples to make pair"
+                        );
+                        break;
                     };
-                    let triple1 = Triple {
-                        share: outputs[1].0.clone(),
-                        public: outputs[1].1.clone(),
+                    let first = Triple {
+                        share: first.0.clone(),
+                        public: first.1.clone(),
+                    };
+                    let second = Triple {
+                        share: second.0.clone(),
+                        public: second.1.clone(),
                     };
 
                     // For simplicity, assign both triples to the same owner based on the first triple
                     let triple_owner = {
-                        let big_c = triple0.public.big_c;
+                        let big_c = first.public.big_c;
                         let entropy = HighwayHasher::default().hash64(&big_c.to_bytes()) as usize;
                         let num_participants = self.participants.len();
                         self.participants[entropy % num_participants]
@@ -229,8 +237,8 @@ impl TripleGenerator {
                         ?triple_owner,
                         pair_is_mine,
                         participants = ?self.participants,
-                        big_a0 = ?triple0.public.big_a.to_base58(),
-                        big_a1 = ?triple1.public.big_a.to_base58(),
+                        big_a0 = ?first.public.big_a.to_base58(),
+                        big_a1 = ?second.public.big_a.to_base58(),
                         elapsed = ?self.created.elapsed(),
                         "completed triple pair generation"
                     );
@@ -241,8 +249,8 @@ impl TripleGenerator {
 
                     let pair = TriplePair {
                         id: self.id,
-                        triple0,
-                        triple1,
+                        triple0: first,
+                        triple1: second,
                     };
                     self.slot.insert(pair, triple_owner).await;
                     break;
@@ -407,10 +415,8 @@ impl TripleSpawner {
 
     /// Propose a new triple generation protocol to the network.
     async fn propose_posit(&mut self, active: &[Participant]) {
-        let id0 = rand::random();
-        let id1 = rand::random();
-        self.posits.propose(id0, (), active);
-        self.posits.propose(id1, (), active);
+        let pair_id = rand::random();
+        self.posits.propose(pair_id, (), active);
         for &p in active.iter() {
             if p == self.me {
                 continue;
@@ -421,18 +427,7 @@ impl TripleSpawner {
                     self.me,
                     p,
                     PositMessage {
-                        id: PositProtocolId::Triple(id0),
-                        from: self.me,
-                        action: PositAction::Propose,
-                    },
-                )
-                .await;
-            self.msg
-                .send(
-                    self.me,
-                    p,
-                    PositMessage {
-                        id: PositProtocolId::Triple(id1),
+                        id: PositProtocolId::Triple(pair_id),
                         from: self.me,
                         action: PositAction::Propose,
                     },

--- a/chain-signatures/node/src/storage/mod.rs
+++ b/chain-signatures/node/src/storage/mod.rs
@@ -8,7 +8,7 @@ pub use presignature_storage::PresignatureStorage;
 pub use triple_storage::TripleStorage;
 
 // Can be used to "clear" redis storage in case of a breaking change
-pub const STORAGE_VERSION: &str = "v8";
+pub const STORAGE_VERSION: &str = "v9";
 
 /// Configures storage.
 #[derive(Debug, Clone, clap::Parser)]

--- a/chain-signatures/node/src/storage/triple_storage.rs
+++ b/chain-signatures/node/src/storage/triple_storage.rs
@@ -7,6 +7,7 @@ use cait_sith::protocol::Participant;
 use chrono::Duration;
 use deadpool_redis::{Connection, Pool};
 use redis::{AsyncCommands, FromRedisValue, RedisError, RedisWrite, ToRedisArgs};
+use serde::{Deserialize, Serialize};
 
 use near_account_id::AccountId;
 
@@ -14,85 +15,112 @@ use super::{owner_key, STORAGE_VERSION};
 
 const USED_EXPIRE_TIME: Duration = Duration::hours(24);
 
-/// A pre-reserved slot for a triple that will eventually be inserted.
-pub struct TripleSlot {
+/// A pair of completed triples.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TriplePair {
+    pub triple0: Triple,
+    pub triple1: Triple,
+}
+
+impl ToRedisArgs for TriplePair {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        match serde_json::to_string(self) {
+            Ok(json) => out.write_arg(json.as_bytes()),
+            Err(e) => {
+                tracing::error!("Failed to serialize TriplePair: {}", e);
+                out.write_arg("failed_to_serialize".as_bytes())
+            }
+        }
+    }
+}
+
+impl FromRedisValue for TriplePair {
+    fn from_redis_value(v: &redis::Value) -> redis::RedisResult<Self> {
+        let json = String::from_redis_value(v)?;
+
+        serde_json::from_str(&json).map_err(|e| {
+            RedisError::from((
+                redis::ErrorKind::TypeError,
+                "Failed to deserialize TriplePair",
+                e.to_string(),
+            ))
+        })
+    }
+}
+
+/// A pre-reserved slot for a triple pair that will eventually be inserted.
+pub struct TriplePairSlot {
     id: TripleId,
     storage: TripleStorage,
     stored: bool,
 }
 
-impl TripleSlot {
-    /// Inserts the triple into the storage, associating it with the given owner.
+impl TriplePairSlot {
+    /// Inserts the triple pair into the storage, associating it with the given owner.
     /// Returns true if the insertion was successful, false otherwise.
     // TODO: put inside a tokio task:
-    pub async fn insert(&mut self, triple: Triple, owner: Participant) -> bool {
-        self.stored = self.storage.insert(triple, owner).await;
+    pub async fn insert(&mut self, pair: TriplePair, owner: Participant) -> bool {
+        self.stored = self.storage.insert_pair(pair, owner).await;
         self.stored
     }
 
     pub async fn unreserve(&self) {
         if !self.stored {
-            self.storage.unreserve([self.id]).await;
+            self.storage.unreserve_pair([self.id]).await;
         }
     }
 }
 
-impl Drop for TripleSlot {
+impl Drop for TriplePairSlot {
     fn drop(&mut self) {
         if !self.stored {
             let storage = self.storage.clone();
             let id = self.id;
             // If the slot was not stored, we need to unreserve it.
             tokio::spawn(async move {
-                storage.unreserve([id]).await;
+                storage.unreserve_pair([id]).await;
             });
         }
     }
 }
 
 pub struct TriplesTaken {
-    pub triple0: Triple,
-    pub triple1: Triple,
+    pub pair: TriplePair,
     pub dropper: TriplesTakenDropper,
 }
 
 impl TriplesTaken {
-    pub fn owner(triple0: Triple, triple1: Triple, storage: TripleStorage) -> Self {
+    pub fn owner(pair: TriplePair, storage: TripleStorage) -> Self {
         let dropper = TriplesTakenDropper {
-            id0: triple0.id,
-            id1: triple1.id,
+            id0: pair.triple0.id,
+            id1: pair.triple1.id,
             storage: Some(storage),
         };
-        Self {
-            triple0,
-            triple1,
-            dropper,
-        }
+        Self { pair, dropper }
     }
 
-    pub fn foreigner(triple0: Triple, triple1: Triple) -> Self {
+    pub fn foreigner(pair: TriplePair) -> Self {
         let dropper = TriplesTakenDropper {
-            id0: triple0.id,
-            id1: triple1.id,
+            id0: pair.triple0.id,
+            id1: pair.triple1.id,
             storage: None,
         };
-        Self {
-            triple0,
-            triple1,
-            dropper,
-        }
+        Self { pair, dropper }
     }
 
-    pub fn take(self) -> (Triple, Triple, TriplesTakenDropper) {
-        (self.triple0, self.triple1, self.dropper)
+    pub fn take(self) -> (TriplePair, TriplesTakenDropper) {
+        (self.pair, self.dropper)
     }
 }
 
 impl fmt::Debug for TriplesTaken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("TriplesTaken")
-            .field(&self.triple0.id)
-            .field(&self.triple1.id)
+            .field(&self.pair.triple0.id)
+            .field(&self.pair.triple1.id)
             .finish()
     }
 }
@@ -106,10 +134,9 @@ pub struct TriplesTakenDropper {
 impl Drop for TriplesTakenDropper {
     fn drop(&mut self) {
         if let Some(storage) = self.storage.take() {
-            let id0 = self.id0;
-            let id1 = self.id1;
+            let pair_id = self.id0; // Pair is stored under id0
             tokio::spawn(async move {
-                storage.unreserve([id0, id1]).await;
+                storage.unreserve_pair([pair_id]).await;
             });
         }
     }
@@ -161,28 +188,28 @@ impl TripleStorage {
             .ok()
     }
 
-    pub async fn reserve(&self, id: TripleId) -> Option<TripleSlot> {
+    pub async fn reserve_pair(&self, id: TripleId) -> Option<TriplePairSlot> {
         let start = Instant::now();
 
         const SCRIPT: &str = r#"
             local triple_key = KEYS[1]
             local used_key = KEYS[2]
             local reserved_key = KEYS[3]
-            local triple_id = ARGV[1]
+            local pair_id = ARGV[1]
 
-            -- cannot reserve this triple if it already exists.
-            if redis.call("SADD", reserved_key, triple_id) == 0 then
-                return {err = "WARN triple " .. triple_id .. " has already been reserved"}
+            -- cannot reserve this pair if it already exists.
+            if redis.call("SADD", reserved_key, pair_id) == 0 then
+                return {err = "WARN pair " .. pair_id .. " has already been reserved"}
             end
 
-            -- cannot reserve this triple if its already in storage.
-            if redis.call("HEXISTS", triple_key, triple_id) == 1 then
-                return {err = "WARN triple " .. triple_id .. " has already been stored"}
+            -- cannot reserve this pair if its already in storage.
+            if redis.call("HEXISTS", triple_key, pair_id) == 1 then
+                return {err = "WARN pair " .. pair_id .. " has already been stored"}
             end
 
-            -- cannot reserve this triple if it has already been used.
-            if redis.call("HEXISTS", used_key, triple_id) == 1 then
-                return {err = "WARN triple " .. triple_id .. " has already been used"}
+            -- cannot reserve this pair if it has already been used.
+            if redis.call("HEXISTS", used_key, pair_id) == 1 then
+                return {err = "WARN pair " .. pair_id .. " has already been used"}
             end
         "#;
 
@@ -197,11 +224,11 @@ impl TripleStorage {
 
         let elapsed = start.elapsed();
         crate::metrics::REDIS_LATENCY
-            .with_label_values(&["triple", "reserve", self.account_id.as_str()])
+            .with_label_values(&["triple", "reserve_pair", self.account_id.as_str()])
             .observe(elapsed.as_millis() as f64);
 
         match result {
-            Ok(_) => Some(TripleSlot {
+            Ok(_) => Some(TriplePairSlot {
                 id,
                 storage: self.clone(),
                 stored: false,
@@ -210,7 +237,7 @@ impl TripleStorage {
                 tracing::warn!(
                     ?err,
                     elapsed_ms = elapsed.as_millis(),
-                    "failed to reserve triple"
+                    "failed to reserve pair"
                 );
                 None
             }
@@ -225,6 +252,10 @@ impl TripleStorage {
         if let Err(err) = outcome {
             tracing::warn!(?triples, ?err, "failed to unreserve triples");
         }
+    }
+
+    async fn unreserve_pair(&self, pairs: [TripleId; 1]) {
+        self.unreserve(pairs).await;
     }
 
     pub async fn remove_outdated(
@@ -327,7 +358,7 @@ impl TripleStorage {
             .unwrap_or_default()
     }
 
-    async fn insert(&self, triple: Triple, owner: Participant) -> bool {
+    async fn insert_pair(&self, pair: TriplePair, owner: Participant) -> bool {
         let start = Instant::now();
 
         const SCRIPT: &str = r#"
@@ -336,27 +367,27 @@ impl TripleStorage {
             local reserved_key = KEYS[3]
             local owner_keys = KEYS[4]
             local owner_key = KEYS[5]
-            local triple_id = ARGV[1]
-            local triple = ARGV[2]
+            local pair_id = ARGV[1]
+            local pair = ARGV[2]
 
-            -- if the triple has not been reserved, then something went wrong when acquiring the
-            -- reservation for it via triple slot.
-            if redis.call("SREM", reserved_key, triple_id) == 0 then
-                return {err = "WARN triple " .. triple_id .. " has NOT been reserved"}
+            -- if the pair has not been reserved, then something went wrong when acquiring the
+            -- reservation for it via triple pair slot.
+            if redis.call("SREM", reserved_key, pair_id) == 0 then
+                return {err = "WARN pair " .. pair_id .. " has NOT been reserved"}
             end
 
-            if redis.call("HEXISTS", used_key, triple_id) == 1 then
-                return {err = "WARN triple " .. triple_id .. " has already been used"}
+            if redis.call("HEXISTS", used_key, pair_id) == 1 then
+                return {err = "WARN pair " .. pair_id .. " has already been used"}
             end
 
-            redis.call("SADD", owner_key, triple_id)
+            redis.call("SADD", owner_key, pair_id)
             redis.call("SADD", owner_keys, owner_key)
-            redis.call("HSET", triple_key, triple_id, triple)
+            redis.call("HSET", triple_key, pair_id, pair)
         "#;
 
-        let id = triple.id;
+        let id = pair.triple0.id; // Use first triple's ID as pair ID
         let Some(mut conn) = self.connect().await else {
-            tracing::warn!(id, "failed to insert triple: connection failed");
+            tracing::warn!(id, "failed to insert pair: connection failed");
             return false;
         };
         let result: Result<(), _> = redis::Script::new(SCRIPT)
@@ -366,13 +397,13 @@ impl TripleStorage {
             .key(&self.owner_keys)
             .key(owner_key(&self.owner_keys, owner))
             .arg(id)
-            .arg(triple)
+            .arg(pair)
             .invoke_async(&mut conn)
             .await;
 
         let elapsed = start.elapsed();
         crate::metrics::REDIS_LATENCY
-            .with_label_values(&["triple", "insert", self.account_id.as_str()])
+            .with_label_values(&["triple", "insert_pair", self.account_id.as_str()])
             .observe(elapsed.as_millis() as f64);
 
         if let Err(err) = result {
@@ -380,7 +411,7 @@ impl TripleStorage {
                 id,
                 ?err,
                 elapsed_ms = elapsed.as_millis(),
-                "failed to insert triple into storage"
+                "failed to insert pair into storage"
             );
             false
         } else {
@@ -441,14 +472,12 @@ impl TripleStorage {
         }
     }
 
-    /// Take two unspent triple by theirs id with no way to return it. Only takes
-    /// if both of them are present.
-    /// It is very important to NOT reuse the same triple twice for two different
+    /// Take a triple pair by its id. Only takes if it is present.
+    /// It is very important to NOT reuse the same pair twice for two different
     /// protocols.
-    pub async fn take_two(
+    pub async fn take(
         &self,
-        id1: TripleId,
-        id2: TripleId,
+        id: TripleId,
         owner: Participant,
         me: Participant,
     ) -> Option<TriplesTaken> {
@@ -458,43 +487,38 @@ impl TripleStorage {
             local owner_key = KEYS[3]
             local mine_key = KEYS[4]
             local reserved_key = KEYS[5]
-            local id1 = ARGV[1]
-            local id2 = ARGV[2]
+            local pair_id = ARGV[1]
 
-            local reserved = redis.call("SMISMEMBER", reserved_key, id1, id2)
-            if reserved[1] == 1 or reserved[2] == 1 then
-                return {err = "WARN triple " .. id1 .. " or " .. id2 .. " is generating or taken"}
+            local reserved = redis.call("SMISMEMBER", reserved_key, pair_id)
+            if reserved[1] == 1 then
+                return {err = "WARN pair " .. pair_id .. " is generating or taken"}
             end
 
-            -- check if the given triple id belong to us, if so then we cannot take it as foreign
-            local check = redis.call("SMISMEMBER", mine_key, id1, id2)
-            if check[1] == 1 or check[2] == 1 then
-                return {err = "WARN triple " .. id1 .. " or " .. id2 .. " cannot be taken as foreign owned"}
+            -- check if the given pair id belong to us, if so then we cannot take it as foreign
+            local check = redis.call("SMISMEMBER", mine_key, pair_id)
+            if check[1] == 1 then
+                return {err = "WARN pair " .. pair_id .. " cannot be taken as foreign owned"}
             end
 
-            -- check if the given triple id belong to the owner, if not then error out
-            local check = redis.call("SMISMEMBER", owner_key, id1, id2)
-            if check[1] == 0 or check[2] == 0 then
-                return {err = "WARN triple " .. id1 .. " or " .. id2 .. " cannot be taken by incorrect owner " .. owner_key}
+            -- check if the given pair id belong to the owner, if not then error out
+            local check = redis.call("SMISMEMBER", owner_key, pair_id)
+            if check[1] == 0 then
+                return {err = "WARN pair " .. pair_id .. " cannot be taken by incorrect owner " .. owner_key}
             end
 
-            -- fetch the triples and delete them once successfully fetched
-            local triples = redis.call("HMGET", triple_key, id1, id2)
-            if not triples[1] then
-                return {err = "WARN unexpected, triple " .. id1 .. " is missing"}
+            -- fetch the pair and delete it once successfully fetched
+            local pair = redis.call("HGET", triple_key, pair_id)
+            if not pair then
+                return {err = "WARN unexpected, pair " .. pair_id .. " is missing"}
             end
-            if not triples[2] then
-                return {err = "WARN unexpected, triple " .. id2 .. " is missing"}
-            end
-            redis.call("HDEL", triple_key, id1, id2)
-            redis.call("SREM", owner_key, id1, id2)
+            redis.call("HDEL", triple_key, pair_id)
+            redis.call("SREM", owner_key, pair_id)
 
-            -- Add the triples to the used set and set expiration time. Note, HSET is used so
-            -- we can expire on each field instead of the whole hash set.
-            redis.call("HSET", used_key, id1, "1", id2, "1")
-            redis.call("HEXPIRE", used_key, ARGV[3], "FIELDS", 2, id1, id2)
+            -- Add the pair to the used set and set expiration time.
+            redis.call("HSET", used_key, pair_id, "1")
+            redis.call("HEXPIRE", used_key, ARGV[2], "FIELDS", 1, pair_id)
 
-            return triples
+            return pair
         "#;
 
         let start = Instant::now();
@@ -505,44 +529,37 @@ impl TripleStorage {
             .key(owner_key(&self.owner_keys, owner))
             .key(owner_key(&self.owner_keys, me))
             .key(&self.reserved_key)
-            .arg(id1)
-            .arg(id2)
+            .arg(id)
             .arg(USED_EXPIRE_TIME.num_seconds())
             .invoke_async(&mut conn)
             .await;
 
         let elapsed = start.elapsed();
         crate::metrics::REDIS_LATENCY
-            .with_label_values(&["triple", "take_two", self.account_id.as_str()])
+            .with_label_values(&["triple", "take", self.account_id.as_str()])
             .observe(elapsed.as_millis() as f64);
 
         match result {
-            Ok((triple0, triple1)) => {
-                tracing::debug!(
-                    id1,
-                    id2,
-                    elapsed_ms = elapsed.as_millis(),
-                    "took two triples"
-                );
-                Some(TriplesTaken::foreigner(triple0, triple1))
+            Ok(pair) => {
+                tracing::debug!(id, elapsed_ms = elapsed.as_millis(), "took pair");
+                Some(TriplesTaken::foreigner(pair))
             }
             Err(err) => {
                 tracing::warn!(
-                    id1,
-                    id2,
+                    id,
                     ?err,
                     elapsed_ms = elapsed.as_millis(),
-                    "failed to take two triples from storage"
+                    "failed to take pair from storage"
                 );
                 None
             }
         }
     }
 
-    /// Take two random unspent triple generated by this node. Either takes both or none.
-    /// It is very important to NOT reuse the same triple twice for two different
+    /// Take a random unspent triple pair generated by this node.
+    /// It is very important to NOT reuse the same pair twice for two different
     /// protocols.
-    pub async fn take_two_mine(&self, me: Participant) -> Option<TriplesTaken> {
+    pub async fn take_mine(&self, me: Participant) -> Option<TriplesTaken> {
         const SCRIPT: &str = r#"
             local triple_key = KEYS[1]
             local used_key = KEYS[2]
@@ -550,36 +567,32 @@ impl TripleStorage {
             local reserved_key = KEYS[4]
             local expire_time = ARGV[1]
 
-            if redis.call("SCARD", mine_key) < 2 then
+            if redis.call("SCARD", mine_key) < 1 then
                 return nil
             end
 
-            -- pop two triples from the self owner set and delete them once successfully fetched
-            local triple_ids = redis.call("SPOP", mine_key, 2)
-            local triples = redis.call("HMGET", triple_key, unpack(triple_ids))
-            if not triples[1] then
-                return {err = "WARN unexpected, triple " .. triple_ids[1] .. " is missing"}
-            end
-            if not triples[2] then
-                return {err = "WARN unexpected, triple " .. triple_ids[2] .. " is missing"}
+            -- pop one pair from the self owner set and delete it once successfully fetched
+            local pair_ids = redis.call("SPOP", mine_key, 1)
+            local pair = redis.call("HGET", triple_key, pair_ids[1])
+            if not pair then
+                return {err = "WARN unexpected, pair " .. pair_ids[1] .. " is missing"}
             end
 
-            -- reserve the triples again, since the owner is taking them here, and should
+            -- reserve the pair again, since the owner is taking it here, and should
             -- not invalidate the other nodes when syncing.
-            redis.call("SADD", reserved_key, unpack(triple_ids))
+            redis.call("SADD", reserved_key, pair_ids[1])
 
-            -- Delete the triples from the hash map
-            redis.call("HDEL", triple_key, unpack(triple_ids))
-            -- delete the triples from our self owner set
-            redis.call("SREM", mine_key, unpack(triple_ids))
+            -- Delete the pair from the hash map
+            redis.call("HDEL", triple_key, pair_ids[1])
+            -- delete the pair from our self owner set
+            redis.call("SREM", mine_key, pair_ids[1])
 
-            -- Add the triples to the used set and set expiration time. Note, HSET is used so
-            -- we can expire on each field instead of the whole hash set.
-            redis.call("HSET", used_key, triple_ids[1], "1", triple_ids[2], "1")
-            redis.call("HEXPIRE", used_key, expire_time, "FIELDS", 2, unpack(triple_ids))
+            -- Add the pair to the used set and set expiration time.
+            redis.call("HSET", used_key, pair_ids[1], "1")
+            redis.call("HEXPIRE", used_key, expire_time, "FIELDS", 1, pair_ids[1])
 
-            -- Return the triples as a response
-            return triples
+            -- Return the pair as a response
+            return pair
         "#;
 
         let start = Instant::now();
@@ -595,17 +608,16 @@ impl TripleStorage {
 
         let elapsed = start.elapsed();
         crate::metrics::REDIS_LATENCY
-            .with_label_values(&["triple", "take_two_mine", self.account_id.as_str()])
+            .with_label_values(&["triple", "take_mine", self.account_id.as_str()])
             .observe(elapsed.as_millis() as f64);
 
         match result {
-            Ok(Some((triple0, triple1))) => {
-                let taken = TriplesTaken::owner(triple0, triple1, self.clone());
+            Ok(Some(pair)) => {
+                let taken = TriplesTaken::owner(pair, self.clone());
                 tracing::debug!(
-                    id0 = taken.triple0.id,
-                    id1 = taken.triple1.id,
+                    id = taken.pair.triple0.id,
                     elapsed_ms = elapsed.as_millis(),
-                    "took two mine triples"
+                    "took mine pair"
                 );
                 Some(taken)
             }
@@ -614,7 +626,7 @@ impl TripleStorage {
                 tracing::warn!(
                     ?err,
                     elapsed_ms = elapsed.as_millis(),
-                    "failed to take two mine triples from storage"
+                    "failed to take mine pair from storage"
                 );
                 None
             }

--- a/chain-signatures/node/src/storage/triple_storage.rs
+++ b/chain-signatures/node/src/storage/triple_storage.rs
@@ -18,6 +18,7 @@ const USED_EXPIRE_TIME: Duration = Duration::hours(24);
 /// A pair of completed triples.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TriplePair {
+    pub id: TripleId,
     pub triple0: Triple,
     pub triple1: Triple,
 }
@@ -95,8 +96,7 @@ pub struct TriplesTaken {
 impl TriplesTaken {
     pub fn owner(pair: TriplePair, storage: TripleStorage) -> Self {
         let dropper = TriplesTakenDropper {
-            id0: pair.triple0.id,
-            id1: pair.triple1.id,
+            pair_id: pair.id,
             storage: Some(storage),
         };
         Self { pair, dropper }
@@ -104,8 +104,7 @@ impl TriplesTaken {
 
     pub fn foreigner(pair: TriplePair) -> Self {
         let dropper = TriplesTakenDropper {
-            id0: pair.triple0.id,
-            id1: pair.triple1.id,
+            pair_id: pair.id,
             storage: None,
         };
         Self { pair, dropper }
@@ -119,22 +118,20 @@ impl TriplesTaken {
 impl fmt::Debug for TriplesTaken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("TriplesTaken")
-            .field(&self.pair.triple0.id)
-            .field(&self.pair.triple1.id)
+            .field(&self.pair.id)
             .finish()
     }
 }
 
 pub struct TriplesTakenDropper {
-    pub id0: TripleId,
-    pub id1: TripleId,
+    pub pair_id: TripleId,
     storage: Option<TripleStorage>,
 }
 
 impl Drop for TriplesTakenDropper {
     fn drop(&mut self) {
         if let Some(storage) = self.storage.take() {
-            let pair_id = self.id0; // Pair is stored under id0
+            let pair_id = self.pair_id;
             tokio::spawn(async move {
                 storage.unreserve_pair([pair_id]).await;
             });
@@ -145,8 +142,7 @@ impl Drop for TriplesTakenDropper {
 impl fmt::Debug for TriplesTakenDropper {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("TriplesTakenDropper")
-            .field(&self.id0)
-            .field(&self.id1)
+            .field(&self.pair_id)
             .finish()
     }
 }
@@ -385,7 +381,7 @@ impl TripleStorage {
             redis.call("HSET", triple_key, pair_id, pair)
         "#;
 
-        let id = pair.triple0.id; // Use first triple's ID as pair ID
+        let id = pair.id;
         let Some(mut conn) = self.connect().await else {
             tracing::warn!(id, "failed to insert pair: connection failed");
             return false;
@@ -615,7 +611,7 @@ impl TripleStorage {
             Ok(Some(pair)) => {
                 let taken = TriplesTaken::owner(pair, self.clone());
                 tracing::debug!(
-                    id = taken.pair.triple0.id,
+                    id = taken.pair.id,
                     elapsed_ms = elapsed.as_millis(),
                     "took mine pair"
                 );

--- a/chain-signatures/node/src/storage/triple_storage.rs
+++ b/chain-signatures/node/src/storage/triple_storage.rs
@@ -117,9 +117,7 @@ impl TriplesTaken {
 
 impl fmt::Debug for TriplesTaken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("TriplesTaken")
-            .field(&self.pair.id)
-            .finish()
+        f.debug_tuple("TriplesTaken").field(&self.pair.id).finish()
     }
 }
 
@@ -184,7 +182,7 @@ impl TripleStorage {
             .ok()
     }
 
-    pub async fn reserve_pair(&self, id: TripleId) -> Option<TriplePairSlot> {
+    pub async fn reserve(&self, id: TripleId) -> Option<TriplePairSlot> {
         let start = Instant::now();
 
         const SCRIPT: &str = r#"

--- a/chain-signatures/node/src/types.rs
+++ b/chain-signatures/node/src/types.rs
@@ -1,5 +1,4 @@
 use cait_sith::protocol::{Action, InitializationError, MessageData, Participant, ProtocolError};
-use cait_sith::triples::TripleGenerationOutput;
 use cait_sith::{protocol::Protocol, KeygenOutput};
 use cait_sith::{FullSignature, PresignOutput};
 use k256::{elliptic_curve::CurveArithmetic, Secp256k1};

--- a/chain-signatures/node/src/types.rs
+++ b/chain-signatures/node/src/types.rs
@@ -7,8 +7,15 @@ use k256::{elliptic_curve::CurveArithmetic, Secp256k1};
 use crate::protocol::contract::ResharingContractState;
 
 pub type SecretKeyShare = <Secp256k1 as CurveArithmetic>::Scalar;
-pub type TripleProtocol =
-    Box<dyn Protocol<Output = TripleGenerationOutput<Secp256k1>> + Send + Sync>;
+pub type TripleProtocol = Box<
+    dyn Protocol<
+            Output = Vec<(
+                cait_sith::triples::TripleShare<Secp256k1>,
+                cait_sith::triples::TriplePub<Secp256k1>,
+            )>,
+        > + Send
+        + Sync,
+>;
 pub type PresignatureProtocol = Box<dyn Protocol<Output = PresignOutput<Secp256k1>> + Send + Sync>;
 pub type SignatureProtocol = Box<dyn Protocol<Output = FullSignature<Secp256k1>> + Send + Sync>;
 

--- a/integration-tests/benches/store.rs
+++ b/integration-tests/benches/store.rs
@@ -20,7 +20,7 @@ use mpc_node::{
         ParticipantInfo, ProtocolState,
     },
     rpc::ContractStateWatcher,
-    storage::{PresignatureStorage, TripleStorage},
+    storage::{triple_storage::TriplePair, PresignatureStorage, TripleStorage},
 };
 use near_account_id::AccountId;
 use tokio::{
@@ -156,7 +156,7 @@ fn bench_load_keys(c: &mut Criterion) {
         b.iter(|| {
             rt.block_on(async {
                 for i in 0..1000 {
-                    let t = dummy_triple(i);
+                    let t = dummy_pair(i);
                     env.triples
                         .reserve(t.id)
                         .await
@@ -226,10 +226,17 @@ fn dummy_presignature(id: u64) -> Presignature {
     }
 }
 
-// TODO: cleanup and move this to a common test utils module
-fn dummy_triple(id: u64) -> Triple {
-    Triple {
+fn dummy_pair(id: u64) -> TriplePair {
+    TriplePair {
         id,
+        triple0: dummy_triple(),
+        triple1: dummy_triple(),
+    }
+}
+
+// TODO: cleanup and move this to a common test utils module
+fn dummy_triple() -> Triple {
+    Triple {
         share: TripleShare {
             a: <Secp256k1 as CurveArithmetic>::Scalar::ZERO,
             b: <Secp256k1 as CurveArithmetic>::Scalar::ZERO,

--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -407,16 +407,10 @@ impl Redis {
             for _ in 0..(cfg.protocol.triple.min_triples * mul / 2) {
                 num_pairs += 1;
                 let pair_id = rand::random();
-                // Deal two triples for the pair
-                let (public0, shares0) =
-                    cait_sith::triples::deal(&mut OsRng, &participant_ids, cfg.threshold);
-                let (public1, shares1) =
-                    cait_sith::triples::deal(&mut OsRng, &participant_ids, cfg.threshold);
-
                 for ((me, triple0), triple1) in participant_ids
                     .iter()
-                    .zip(shares_to_triples(pair_id, &public0, &shares0))
-                    .zip(shares_to_triples(pair_id + 1, &public1, &shares1))
+                    .zip(shares_to_triples(pair_id, &public, &shares))
+                    .zip(shares_to_triples(pair_id + 1, &public, &shares))
                 {
                     let pair = TriplePair { triple0, triple1 };
                     storage

--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -409,10 +409,10 @@ impl Redis {
                 let pair_id = rand::random();
                 for ((me, triple0), triple1) in participant_ids
                     .iter()
-                    .zip(shares_to_triples(pair_id, &public, &shares))
-                    .zip(shares_to_triples(pair_id + 1, &public, &shares))
+                    .zip(shares_to_triples(&public, &shares))
+                    .zip(shares_to_triples(&public, &shares))
                 {
-                    let pair = TriplePair { triple0, triple1 };
+                    let pair = TriplePair { id: pair_id, triple0, triple1 };
                     storage
                         .get(me)
                         .unwrap()
@@ -559,14 +559,12 @@ fn derive_secret_key(mnemonic: &str) -> anyhow::Result<String> {
 }
 
 fn shares_to_triples(
-    id: u64,
     public: &TriplePub<Secp256k1>,
     shares: &[TripleShare<Secp256k1>],
 ) -> Vec<Triple> {
     shares
         .iter()
         .map(|share| Triple {
-            id,
             public: public.clone(),
             share: share.clone(),
         })

--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -25,6 +25,7 @@ use mpc_keys::hpke;
 use mpc_node::config::OverrideConfig;
 use mpc_node::indexer_eth::EthArgs;
 use mpc_node::protocol::triple::Triple;
+use mpc_node::storage::triple_storage::TriplePair;
 use near_account_id::AccountId;
 use near_workspaces::Account;
 use reqwest::Client;
@@ -396,33 +397,41 @@ impl Redis {
             .values()
             .map(|id| Participant::from(*id))
             .collect::<Vec<_>>();
-        let (public, shares) =
+        let (public, shares): (TriplePub<Secp256k1>, Vec<TripleShare<Secp256k1>>) =
             cait_sith::triples::deal(&mut OsRng, &participant_ids, cfg.threshold);
 
         // - first/second loop add at least min_triples per node
-        // - third loop: for each triple, store the shares individually per node
-        let mut num_triples = 0;
+        // - third loop: for each pair, store the shares as pairs per node
+        let mut num_pairs = 0;
         for owner in &participant_ids {
-            for _ in 0..(cfg.protocol.triple.min_triples * mul) {
-                num_triples += 1;
-                let triple_id = rand::random();
-                for (me, triple) in participant_ids
+            for _ in 0..(cfg.protocol.triple.min_triples * mul / 2) {
+                num_pairs += 1;
+                let pair_id = rand::random();
+                // Deal two triples for the pair
+                let (public0, shares0) =
+                    cait_sith::triples::deal(&mut OsRng, &participant_ids, cfg.threshold);
+                let (public1, shares1) =
+                    cait_sith::triples::deal(&mut OsRng, &participant_ids, cfg.threshold);
+
+                for ((me, triple0), triple1) in participant_ids
                     .iter()
-                    .zip(shares_to_triples(triple_id, &public, &shares))
+                    .zip(shares_to_triples(pair_id, &public0, &shares0))
+                    .zip(shares_to_triples(pair_id + 1, &public1, &shares1))
                 {
+                    let pair = TriplePair { triple0, triple1 };
                     storage
                         .get(me)
                         .unwrap()
-                        .reserve(triple.id)
+                        .reserve_pair(pair_id)
                         .await
                         .unwrap()
-                        .insert(triple, *owner)
+                        .insert(pair, *owner)
                         .await;
                 }
             }
         }
 
-        tracing::info!("stockpiled {num_triples} triples");
+        tracing::info!("stockpiled {num_pairs} triple pairs");
     }
 }
 

--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -412,11 +412,15 @@ impl Redis {
                     .zip(shares_to_triples(&public, &shares))
                     .zip(shares_to_triples(&public, &shares))
                 {
-                    let pair = TriplePair { id: pair_id, triple0, triple1 };
+                    let pair = TriplePair {
+                        id: pair_id,
+                        triple0,
+                        triple1,
+                    };
                     storage
                         .get(me)
                         .unwrap()
-                        .reserve_pair(pair_id)
+                        .reserve(pair_id)
                         .await
                         .unwrap()
                         .insert(pair, *owner)

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -19,10 +19,10 @@ use mpc_node::protocol::contract::primitives::{Candidates, Participants, PkVotes
 use mpc_node::protocol::contract::{InitializingContractState, RunningContractState};
 use mpc_node::protocol::message::{MessageInbox, MessageOutbox};
 use mpc_node::protocol::state::NodeKeyInfo;
+use mpc_node::protocol::triple::Triple;
 use mpc_node::protocol::{self, MessageChannel, MpcSignProtocol, ProtocolState, SignQueue};
 use mpc_node::rpc::ContractStateWatcher;
 use mpc_node::rpc::RpcChannel;
-use mpc_node::protocol::triple::Triple;
 use mpc_node::storage::{
     presignature_storage, secret_storage, triple_storage, triple_storage::TriplePair, Options,
 };
@@ -534,7 +534,7 @@ impl MpcFixtureNodeBuilder {
                             public: pair[1].public.clone(),
                         },
                     };
-                    let mut slot = triple_storage.reserve_pair(pair_id).await.unwrap();
+                    let mut slot = triple_storage.reserve(pair_id).await.unwrap();
                     slot.insert(pair, owner).await;
                 }
             }

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -521,8 +521,9 @@ impl MpcFixtureNodeBuilder {
             let my_shares = fixture_config.input.triples.remove(&self.me).unwrap();
             for (owner, triple_shares) in my_shares {
                 // Group triples into pairs
-                for (i, pair) in triple_shares.chunks_exact(2).enumerate() {
-                    let pair_id = i as u64; // Use index as pair ID
+                for pair in triple_shares.chunks_exact(2) {
+                    // Use the id from the fixture data as the pair ID
+                    let pair_id = pair[0].id;
                     let pair = TriplePair {
                         id: pair_id,
                         triple0: Triple {

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -22,6 +22,7 @@ use mpc_node::protocol::state::NodeKeyInfo;
 use mpc_node::protocol::{self, MessageChannel, MpcSignProtocol, ProtocolState, SignQueue};
 use mpc_node::rpc::ContractStateWatcher;
 use mpc_node::rpc::RpcChannel;
+use mpc_node::protocol::triple::Triple;
 use mpc_node::storage::{
     presignature_storage, secret_storage, triple_storage, triple_storage::TriplePair, Options,
 };
@@ -520,11 +521,18 @@ impl MpcFixtureNodeBuilder {
             let my_shares = fixture_config.input.triples.remove(&self.me).unwrap();
             for (owner, triple_shares) in my_shares {
                 // Group triples into pairs
-                for pair in triple_shares.chunks_exact(2) {
-                    let pair_id = pair[0].id; // Use first triple's ID as pair ID
+                for (i, pair) in triple_shares.chunks_exact(2).enumerate() {
+                    let pair_id = i as u64; // Use index as pair ID
                     let pair = TriplePair {
-                        triple0: pair[0].clone(),
-                        triple1: pair[1].clone(),
+                        id: pair_id,
+                        triple0: Triple {
+                            share: pair[0].share.clone(),
+                            public: pair[0].public.clone(),
+                        },
+                        triple1: Triple {
+                            share: pair[1].share.clone(),
+                            public: pair[1].public.clone(),
+                        },
                     };
                     let mut slot = triple_storage.reserve_pair(pair_id).await.unwrap();
                     slot.insert(pair, owner).await;

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -22,7 +22,9 @@ use mpc_node::protocol::state::NodeKeyInfo;
 use mpc_node::protocol::{self, MessageChannel, MpcSignProtocol, ProtocolState, SignQueue};
 use mpc_node::rpc::ContractStateWatcher;
 use mpc_node::rpc::RpcChannel;
-use mpc_node::storage::{presignature_storage, secret_storage, triple_storage, Options};
+use mpc_node::storage::{
+    presignature_storage, secret_storage, triple_storage, triple_storage::TriplePair, Options,
+};
 use near_sdk::AccountId;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -517,9 +519,15 @@ impl MpcFixtureNodeBuilder {
             // removing here because we can't clone a triple
             let my_shares = fixture_config.input.triples.remove(&self.me).unwrap();
             for (owner, triple_shares) in my_shares {
-                for triple_share in triple_shares {
-                    let mut slot = triple_storage.reserve(triple_share.id).await.unwrap();
-                    slot.insert(triple_share, owner).await;
+                // Group triples into pairs
+                for pair in triple_shares.chunks_exact(2) {
+                    let pair_id = pair[0].id; // Use first triple's ID as pair ID
+                    let pair = TriplePair {
+                        triple0: pair[0].clone(),
+                        triple1: pair[1].clone(),
+                    };
+                    let mut slot = triple_storage.reserve_pair(pair_id).await.unwrap();
+                    slot.insert(pair, owner).await;
                 }
             }
         }

--- a/integration-tests/src/mpc_fixture/input.rs
+++ b/integration-tests/src/mpc_fixture/input.rs
@@ -1,15 +1,33 @@
 use cait_sith::protocol::Participant;
+use cait_sith::triples::{TriplePub, TripleShare};
+use k256::Secp256k1;
 use mpc_node::protocol::presignature::Presignature;
 use mpc_node::protocol::state::NodeKeyInfo;
 use mpc_node::protocol::triple::Triple;
 use std::collections::BTreeMap;
 
 #[derive(serde::Deserialize, serde::Serialize)]
+pub struct FixtureTriple {
+    pub id: u64,
+    pub share: TripleShare<Secp256k1>,
+    pub public: TriplePub<Secp256k1>,
+}
+
+impl From<FixtureTriple> for Triple {
+    fn from(f: FixtureTriple) -> Self {
+        Triple {
+            share: f.share,
+            public: f.public,
+        }
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
 pub struct FixtureInput {
     /// Output of test_basic_generate_keys
     pub keys: BTreeMap<Participant, NodeKeyInfo>,
     /// Output of test_basic_generate_triples
-    pub triples: BTreeMap<Participant, BTreeMap<Participant, Vec<Triple>>>,
+    pub triples: BTreeMap<Participant, BTreeMap<Participant, Vec<FixtureTriple>>>,
     /// Output of test_basic_generate_presignature
     pub presignatures: BTreeMap<Participant, BTreeMap<Participant, Vec<Presignature>>>,
 }

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -1,5 +1,6 @@
 use deadpool_redis::redis::AsyncCommands;
 use integration_tests::mpc_fixture::fixture_tasks::MessageFilter;
+use integration_tests::mpc_fixture::input::FixtureTriple;
 use integration_tests::mpc_fixture::MpcFixtureBuilder;
 use mpc_node::protocol::presignature::Presignature;
 use mpc_node::protocol::triple::Triple;
@@ -91,7 +92,11 @@ async fn test_basic_generate_triples() {
                         .hget::<&str, u64, Triple>(node.triple_storage.triple_key(), triple_id)
                         .await;
                     if let Ok(t) = t {
-                        peer_triples.push(t);
+                        peer_triples.push(FixtureTriple {
+                            id: triple_id,
+                            share: t.share,
+                            public: t.public,
+                        });
                     } else {
                         tracing::error!("missing triple in redis {triple_id}");
                     }

--- a/integration-tests/tests/cases/store.rs
+++ b/integration-tests/tests/cases/store.rs
@@ -40,13 +40,13 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     assert_eq!(triple_spawner.len_potential().await, 0);
 
     triple_storage
-        .reserve_pair(triple_id1)
+        .reserve(triple_id1)
         .await
         .unwrap()
         .insert(dummy_pair(triple_id1), node1)
         .await;
     triple_storage
-        .reserve_pair(triple_id2)
+        .reserve(triple_id2)
         .await
         .unwrap()
         .insert(dummy_pair(triple_id2), node1)
@@ -75,8 +75,8 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     assert!(triple_storage.contains_used(triple_id2).await);
 
     // Attempt to re-reserve used triples and check that it cannot be reserved since it is used.
-    assert!(triple_storage.reserve_pair(triple_id1).await.is_none());
-    assert!(triple_storage.reserve_pair(triple_id2).await.is_none());
+    assert!(triple_storage.reserve(triple_id1).await.is_none());
+    assert!(triple_storage.reserve(triple_id2).await.is_none());
     assert!(!triple_spawner.contains(triple_id1).await);
     assert!(!triple_spawner.contains(triple_id2).await);
 
@@ -84,18 +84,18 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     let id4: u64 = 4;
 
     // check that reserve and unreserve works:
-    let slot = triple_storage.reserve_pair(id3).await.unwrap();
+    let slot = triple_storage.reserve(id3).await.unwrap();
     slot.unreserve().await;
 
     // Add mine triple and check that it is in the storage
     triple_storage
-        .reserve_pair(id3)
+        .reserve(id3)
         .await
         .unwrap()
         .insert(dummy_pair(id3), node0)
         .await;
     triple_storage
-        .reserve_pair(id4)
+        .reserve(id4)
         .await
         .unwrap()
         .insert(dummy_pair(id4), node0)
@@ -123,8 +123,8 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     assert!(triple_storage.contains_used(id4).await);
 
     // Attempt to re-insert used mine triples and check that it fails
-    assert!(triple_storage.reserve_pair(id3).await.is_none());
-    assert!(triple_storage.reserve_pair(id4).await.is_none());
+    assert!(triple_storage.reserve(id3).await.is_none());
+    assert!(triple_storage.reserve(id4).await.is_none());
     assert!(!triple_spawner.contains(id3).await);
     assert!(!triple_spawner.contains(id4).await);
 
@@ -132,7 +132,7 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     // Have our node0 observe shares for triples 10 to 15 where node1 is owner.
     for id in 10..=15 {
         triple_storage
-            .reserve_pair(id)
+            .reserve(id)
             .await
             .unwrap()
             .insert(dummy_pair(id), node1)
@@ -142,7 +142,7 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     // Have our node0 own 16 to 20
     for id in 16..=20 {
         triple_storage
-            .reserve_pair(id)
+            .reserve(id)
             .await
             .unwrap()
             .insert(dummy_pair(id), node0)

--- a/integration-tests/tests/cases/store.rs
+++ b/integration-tests/tests/cases/store.rs
@@ -316,14 +316,14 @@ fn dummy_presignature(id: u64) -> Presignature {
 
 fn dummy_pair(id: u64) -> TriplePair {
     TriplePair {
-        triple0: dummy_triple(id * 2),
-        triple1: dummy_triple(id * 2 + 1),
+        id,
+        triple0: dummy_triple(),
+        triple1: dummy_triple(),
     }
 }
 
-fn dummy_triple(id: u64) -> Triple {
+fn dummy_triple() -> Triple {
     Triple {
-        id,
         share: TripleShare {
             a: <Secp256k1 as CurveArithmetic>::Scalar::ZERO,
             b: <Secp256k1 as CurveArithmetic>::Scalar::ZERO,

--- a/integration-tests/tests/cases/store.rs
+++ b/integration-tests/tests/cases/store.rs
@@ -9,6 +9,7 @@ use mpc_crypto::PublicKey;
 use mpc_node::protocol::presignature::{Presignature, PresignatureSpawner};
 use mpc_node::protocol::triple::{Triple, TripleSpawner};
 use mpc_node::protocol::MessageChannel;
+use mpc_node::storage::triple_storage::TriplePair;
 use mpc_node::types::SecretKeyShare;
 use test_log::test;
 
@@ -39,16 +40,16 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     assert_eq!(triple_spawner.len_potential().await, 0);
 
     triple_storage
-        .reserve(triple_id1)
+        .reserve_pair(triple_id1)
         .await
         .unwrap()
-        .insert(dummy_triple(triple_id1), node1)
+        .insert(dummy_pair(triple_id1), node1)
         .await;
     triple_storage
-        .reserve(triple_id2)
+        .reserve_pair(triple_id2)
         .await
         .unwrap()
-        .insert(dummy_triple(triple_id2), node1)
+        .insert(dummy_pair(triple_id2), node1)
         .await;
 
     // Check that the storage contains the foreign triple
@@ -60,11 +61,9 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     assert_eq!(triple_storage.len_by_owner(node0).await, 0);
     assert_eq!(triple_spawner.len_potential().await, 2);
 
-    // Take triple and check that it is removed from the storage and added to used set
-    triple_storage
-        .take_two(triple_id1, triple_id2, node1, node0)
-        .await
-        .unwrap();
+    // Take triple pairs and check that they are removed from the storage and added to used set
+    triple_storage.take(triple_id1, node1, node0).await.unwrap();
+    triple_storage.take(triple_id2, node1, node0).await.unwrap();
     assert!(!triple_spawner.contains(triple_id1).await);
     assert!(!triple_spawner.contains(triple_id2).await);
     assert!(!triple_spawner.contains_mine(triple_id1).await);
@@ -76,8 +75,8 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     assert!(triple_storage.contains_used(triple_id2).await);
 
     // Attempt to re-reserve used triples and check that it cannot be reserved since it is used.
-    assert!(triple_storage.reserve(triple_id1).await.is_none());
-    assert!(triple_storage.reserve(triple_id2).await.is_none());
+    assert!(triple_storage.reserve_pair(triple_id1).await.is_none());
+    assert!(triple_storage.reserve_pair(triple_id2).await.is_none());
     assert!(!triple_spawner.contains(triple_id1).await);
     assert!(!triple_spawner.contains(triple_id2).await);
 
@@ -85,21 +84,21 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     let id4: u64 = 4;
 
     // check that reserve and unreserve works:
-    let slot = triple_storage.reserve(id3).await.unwrap();
+    let slot = triple_storage.reserve_pair(id3).await.unwrap();
     slot.unreserve().await;
 
     // Add mine triple and check that it is in the storage
     triple_storage
-        .reserve(id3)
+        .reserve_pair(id3)
         .await
         .unwrap()
-        .insert(dummy_triple(id3), node0)
+        .insert(dummy_pair(id3), node0)
         .await;
     triple_storage
-        .reserve(id4)
+        .reserve_pair(id4)
         .await
         .unwrap()
-        .insert(dummy_triple(id4), node0)
+        .insert(dummy_pair(id4), node0)
         .await;
     assert!(triple_spawner.contains(id3).await);
     assert!(triple_spawner.contains(id4).await);
@@ -109,8 +108,9 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     assert_eq!(triple_spawner.len_mine().await, 2);
     assert_eq!(triple_spawner.len_potential().await, 2);
 
-    // Take mine triple and check that it is removed from the storage and added to used set
-    triple_storage.take_two_mine(node0).await.unwrap();
+    // Take mine triple pairs and check that they are removed from the storage and added to used set
+    triple_storage.take_mine(node0).await.unwrap();
+    triple_storage.take_mine(node0).await.unwrap();
     assert!(!triple_spawner.contains(id3).await);
     assert!(!triple_spawner.contains(id4).await);
     assert!(!triple_spawner.contains_mine(id3).await);
@@ -123,8 +123,8 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     assert!(triple_storage.contains_used(id4).await);
 
     // Attempt to re-insert used mine triples and check that it fails
-    assert!(triple_storage.reserve(id3).await.is_none());
-    assert!(triple_storage.reserve(id4).await.is_none());
+    assert!(triple_storage.reserve_pair(id3).await.is_none());
+    assert!(triple_storage.reserve_pair(id4).await.is_none());
     assert!(!triple_spawner.contains(id3).await);
     assert!(!triple_spawner.contains(id4).await);
 
@@ -132,20 +132,20 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     // Have our node0 observe shares for triples 10 to 15 where node1 is owner.
     for id in 10..=15 {
         triple_storage
-            .reserve(id)
+            .reserve_pair(id)
             .await
             .unwrap()
-            .insert(dummy_triple(id), node1)
+            .insert(dummy_pair(id), node1)
             .await;
     }
 
     // Have our node0 own 16 to 20
     for id in 16..=20 {
         triple_storage
-            .reserve(id)
+            .reserve_pair(id)
             .await
             .unwrap()
-            .insert(dummy_triple(id), node0)
+            .insert(dummy_pair(id), node0)
             .await;
     }
 
@@ -311,6 +311,13 @@ fn dummy_presignature(id: u64) -> Presignature {
             sigma: <Secp256k1 as CurveArithmetic>::Scalar::ONE,
         },
         participants: vec![Participant::from(1), Participant::from(2)],
+    }
+}
+
+fn dummy_pair(id: u64) -> TriplePair {
+    TriplePair {
+        triple0: dummy_triple(id * 2),
+        triple1: dummy_triple(id * 2 + 1),
     }
 }
 

--- a/integration-tests/tests/cases/sync.rs
+++ b/integration-tests/tests/cases/sync.rs
@@ -17,7 +17,7 @@ use mpc_node::protocol::sync::{SyncTask, SyncUpdate};
 use mpc_node::protocol::triple::Triple;
 use mpc_node::protocol::{ParticipantInfo, ProtocolState};
 use mpc_node::rpc::ContractStateWatcher;
-use mpc_node::storage::{PresignatureStorage, TripleStorage};
+use mpc_node::storage::{triple_storage::TriplePair, PresignatureStorage, TripleStorage};
 
 #[test_log::test(tokio::test)]
 async fn test_state_sync_update() -> anyhow::Result<()> {
@@ -183,10 +183,10 @@ async fn insert_triples(
 ) {
     for id in range {
         triples
-            .reserve(id)
+            .reserve_pair(id)
             .await
             .unwrap()
-            .insert(dummy_triple(id), node)
+            .insert(dummy_pair(id), node)
             .await;
     }
 }
@@ -299,4 +299,11 @@ fn participants(num_nodes: usize) -> Participants {
         );
     }
     participants
+}
+
+fn dummy_pair(id: u64) -> TriplePair {
+    TriplePair {
+        triple0: dummy_triple(id * 2),
+        triple1: dummy_triple(id * 2 + 1),
+    }
 }

--- a/integration-tests/tests/cases/sync.rs
+++ b/integration-tests/tests/cases/sync.rs
@@ -183,7 +183,7 @@ async fn insert_triples(
 ) {
     for id in range {
         triples
-            .reserve_pair(id)
+            .reserve(id)
             .await
             .unwrap()
             .insert(dummy_pair(id), node)

--- a/integration-tests/tests/cases/sync.rs
+++ b/integration-tests/tests/cases/sync.rs
@@ -262,9 +262,8 @@ fn dummy_presignature(id: u64) -> Presignature {
 }
 
 // TODO: cleanup and move this to a common test utils module
-fn dummy_triple(id: u64) -> Triple {
+fn dummy_triple() -> Triple {
     Triple {
-        id,
         share: TripleShare {
             a: <Secp256k1 as CurveArithmetic>::Scalar::ZERO,
             b: <Secp256k1 as CurveArithmetic>::Scalar::ZERO,
@@ -303,7 +302,8 @@ fn participants(num_nodes: usize) -> Participants {
 
 fn dummy_pair(id: u64) -> TriplePair {
     TriplePair {
-        triple0: dummy_triple(id * 2),
-        triple1: dummy_triple(id * 2 + 1),
+        id,
+        triple0: dummy_triple(),
+        triple1: dummy_triple(),
     }
 }


### PR DESCRIPTION
cait sith has `generate_triple_many` which allows us to generate multiple triples at once. We switch to generating triple pairs in this PR.

By generating triple pairs, we have the same participants set for both, and thus we do not need to line up participants of similar intersection when generating the presignature.

This ends up simplifying the triple process a bit and leads to less trashed triples.