### PR TITLE
feat: Singular task SignTask for organizing + posit + generation

### DIFF
--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -6,10 +6,11 @@ use crate::node_client::{self, NodeClient};
 use crate::protocol::message::MessageChannel;
 use crate::protocol::state::Node;
 use crate::protocol::sync::SyncTask;
-use crate::protocol::{spawn_system_metrics, MpcSignProtocol, SignQueue};
+use crate::protocol::{spawn_system_metrics, MpcSignProtocol};
 use crate::rpc::{ContractStateWatcher, NearClient, RpcExecutor};
 use crate::storage::app_data_storage;
 use crate::{indexer, indexer_eth, indexer_sol, logs, mesh, storage, web};
+
 use clap::Parser;
 use deadpool_redis::Runtime;
 use k256::sha2::Sha256;
@@ -200,7 +201,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 .with_label_values(&[account_id.as_str()])
                 .set(digest);
 
-            let (sign_tx, sign_rx) = SignQueue::channel();
+            let (sign_tx, sign_rx) = tokio::sync::mpsc::channel(1024);
 
             let gcp_service = GcpService::init(&account_id, &storage_options).await?;
 

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -6,7 +6,7 @@ use crate::node_client::{self, NodeClient};
 use crate::protocol::message::MessageChannel;
 use crate::protocol::state::Node;
 use crate::protocol::sync::SyncTask;
-use crate::protocol::{spawn_system_metrics, MpcSignProtocol};
+use crate::protocol::{spawn_system_metrics, MpcSignProtocol, Sign};
 use crate::rpc::{ContractStateWatcher, NearClient, RpcExecutor};
 use crate::storage::app_data_storage;
 use crate::{indexer, indexer_eth, indexer_sol, logs, mesh, storage, web};
@@ -201,7 +201,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 .with_label_values(&[account_id.as_str()])
                 .set(digest);
 
-            let (sign_tx, sign_rx) = tokio::sync::mpsc::channel(1024);
+            let (sign_tx, sign_rx) = tokio::sync::mpsc::channel::<Sign>(1024);
 
             let gcp_service = GcpService::init(&account_id, &storage_options).await?;
 
@@ -228,8 +228,8 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
 
             // NEAR Indexer is only used for integration tests
             // TODO: Remove this once we have integration tests built on other chains
-            let indexer = if storage_options.env == "integration-tests" {
-                let (_handle, indexer) = indexer::run(
+            if storage_options.env == "integration-tests" {
+                indexer::run(
                     &indexer_options,
                     &mpc_contract_id,
                     &account_id,
@@ -237,10 +237,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                     rpc_client.clone(),
                     backlog.clone(),
                 )?;
-                Some(indexer)
-            } else {
-                None
-            };
+            }
 
             let web_port = web_port.unwrap_or(DEFAULT_WEB_PORT);
 
@@ -340,7 +337,6 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 web_port,
                 msg_channel,
                 node_watcher,
-                indexer,
                 triple_storage,
                 presignature_storage,
                 sync_channel,

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -6,7 +6,7 @@ use crate::node_client::{self, NodeClient};
 use crate::protocol::message::MessageChannel;
 use crate::protocol::state::Node;
 use crate::protocol::sync::SyncTask;
-use crate::protocol::{spawn_system_metrics, MpcSignProtocol, Sign};
+use crate::protocol::{spawn_system_metrics, MpcSignProtocol};
 use crate::rpc::{ContractStateWatcher, NearClient, RpcExecutor};
 use crate::storage::app_data_storage;
 use crate::{indexer, indexer_eth, indexer_sol, logs, mesh, storage, web};
@@ -19,7 +19,7 @@ use near_account_id::AccountId;
 use near_crypto::{InMemorySigner, PublicKey, SecretKey};
 use sha3::Digest;
 use std::sync::Arc;
-use tokio::sync::{watch, RwLock};
+use tokio::sync::{mpsc, watch, RwLock};
 use url::Url;
 
 use mpc_keys::hpke;
@@ -201,7 +201,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 .with_label_values(&[account_id.as_str()])
                 .set(digest);
 
-            let (sign_tx, sign_rx) = tokio::sync::mpsc::channel::<Sign>(1024);
+            let (sign_tx, sign_rx) = mpsc::channel(1024);
 
             let gcp_service = GcpService::init(&account_id, &storage_options).await?;
 

--- a/chain-signatures/node/src/indexer.rs
+++ b/chain-signatures/node/src/indexer.rs
@@ -1,14 +1,11 @@
 use crate::backlog::Backlog;
-use crate::protocol::Chain;
-use crate::protocol::IndexedSignRequest;
+use crate::protocol::{Chain, IndexedSignRequest, Sign};
 use mpc_contract::primitives::PendingRequest;
 use mpc_primitives::{SignArgs, SignId};
 use near_account_id::AccountId;
-use near_primitives::types::BlockHeight;
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
 /// Configures indexer.
@@ -29,46 +26,57 @@ impl Options {
     }
 }
 
-#[derive(Clone)]
 pub struct NearIndexer {
-    last_updated_timestamp: Arc<RwLock<Instant>>,
+    last_updated_timestamp: Instant,
     running_threshold: Duration,
-    processed_requests: Arc<RwLock<HashMap<SignId, Instant>>>,
+    processed_requests: HashMap<SignId, Instant>,
 }
 
 impl NearIndexer {
     fn new(options: &Options) -> Self {
         Self {
-            last_updated_timestamp: Arc::new(RwLock::new(Instant::now())),
+            last_updated_timestamp: Instant::now(),
             running_threshold: Duration::from_secs(options.running_threshold),
-            processed_requests: Arc::new(RwLock::new(HashMap::new())),
+            processed_requests: HashMap::new(),
         }
     }
 
     /// Check whether the indexer is on track with polling.
-    pub async fn is_running(&self) -> bool {
-        self.last_updated_timestamp.read().await.elapsed() <= self.running_threshold
+    pub fn is_running(&self) -> bool {
+        self.last_updated_timestamp.elapsed() <= self.running_threshold
     }
 
-    async fn update_timestamp(&self) {
-        *self.last_updated_timestamp.write().await = Instant::now();
+    fn update_timestamp(&mut self) {
+        self.last_updated_timestamp = Instant::now();
     }
 
-    async fn seen_request(&self, sign_id: &SignId) -> bool {
-        self.processed_requests.read().await.contains_key(sign_id)
+    fn seen_request(&self, sign_id: &SignId) -> bool {
+        self.processed_requests.contains_key(sign_id)
     }
 
-    async fn mark_request_seen(&self, sign_id: SignId) {
-        self.processed_requests
-            .write()
-            .await
-            .insert(sign_id, Instant::now());
+    fn mark_request_seen(&mut self, sign_id: SignId) {
+        self.processed_requests.insert(sign_id, Instant::now());
     }
 
-    async fn cleanup_old_requests(&self) {
-        let mut processed = self.processed_requests.write().await;
+    async fn cleanup_old_requests(&mut self) {
         let cutoff = Instant::now() - Duration::from_secs(3600); // Keep for 1 hour
-        processed.retain(|_, timestamp| *timestamp > cutoff);
+        self.processed_requests
+            .retain(|_, timestamp| *timestamp > cutoff);
+    }
+
+    fn completed_requests(&mut self, currently_pending: &HashSet<SignId>) -> Vec<SignId> {
+        let mut completed = Vec::new();
+
+        self.processed_requests.retain(|sign_id, _| {
+            if currently_pending.contains(sign_id) {
+                true
+            } else {
+                completed.push(*sign_id);
+                false
+            }
+        });
+
+        completed
     }
 
     /// Fetch pending requests from the smart contract
@@ -125,26 +133,18 @@ impl NearIndexer {
         hasher.update(format!("{:?}", sign_id).as_bytes());
         hasher.finalize().into()
     }
-
-    /// Compatibility method for web module
-    pub async fn last_processed_block(&self) -> Option<BlockHeight> {
-        // Since we're no longer tracking block heights in the polling approach,
-        // we return a default value. The web module uses this for status reporting.
-        Some(0)
-    }
 }
 
-#[derive(Clone)]
 struct Context {
     mpc_contract_id: AccountId,
     node_account_id: AccountId,
-    sign_tx: mpsc::Sender<IndexedSignRequest>,
+    sign_tx: mpsc::Sender<Sign>,
     indexer: NearIndexer,
     rpc_client: near_fetch::Client,
     backlog: Backlog,
 }
 
-async fn poll_pending_requests(ctx: &Context) -> anyhow::Result<()> {
+async fn poll_pending_requests(ctx: &mut Context) -> anyhow::Result<()> {
     let latest_block = ctx.rpc_client.view_block().await?;
     let latest_height = latest_block.header.height;
 
@@ -155,9 +155,12 @@ async fn poll_pending_requests(ctx: &Context) -> anyhow::Result<()> {
         .await?;
 
     let mut new_requests = Vec::new();
+    let mut current_pending = HashSet::new();
 
     for (sign_id, pending_request) in pending_requests.into_iter() {
-        if ctx.indexer.seen_request(&sign_id).await {
+        current_pending.insert(sign_id);
+
+        if ctx.indexer.seen_request(&sign_id) {
             continue;
         }
 
@@ -174,11 +177,13 @@ async fn poll_pending_requests(ctx: &Context) -> anyhow::Result<()> {
         );
 
         new_requests.push(indexed_request);
-        ctx.indexer.mark_request_seen(sign_id).await;
+        ctx.indexer.mark_request_seen(sign_id);
     }
 
+    let completed_requests = ctx.indexer.completed_requests(&current_pending);
+
     // Update timestamp to indicate we're still running
-    ctx.indexer.update_timestamp().await;
+    ctx.indexer.update_timestamp();
 
     // Update metrics
     crate::metrics::LATEST_BLOCK_NUMBER
@@ -191,12 +196,23 @@ async fn poll_pending_requests(ctx: &Context) -> anyhow::Result<()> {
             sign_id = ?request.id,
             "sending new sign request to processing queue"
         );
-        if let Err(err) = ctx.sign_tx.send(request).await {
+        if let Err(err) = ctx.sign_tx.send(Sign::Request(request)).await {
             tracing::error!(?err, "failed to send the sign request into sign queue");
         } else {
             crate::metrics::NUM_SIGN_REQUESTS
                 .with_label_values(&[Chain::NEAR.as_str(), ctx.node_account_id.as_str()])
                 .inc();
+        }
+    }
+
+    for sign_id in completed_requests {
+        tracing::info!(?sign_id, "detected completed NEAR sign request");
+        if let Err(err) = ctx.sign_tx.send(Sign::Completion(sign_id)).await {
+            tracing::error!(
+                ?err,
+                ?sign_id,
+                "failed to send completion event into sign queue"
+            );
         }
     }
 
@@ -214,10 +230,10 @@ pub fn run(
     options: &Options,
     mpc_contract_id: &AccountId,
     node_account_id: &AccountId,
-    sign_tx: mpsc::Sender<IndexedSignRequest>,
+    sign_tx: mpsc::Sender<Sign>,
     rpc_client: near_fetch::Client,
     backlog: Backlog,
-) -> anyhow::Result<(JoinHandle<anyhow::Result<()>>, NearIndexer)> {
+) -> anyhow::Result<JoinHandle<anyhow::Result<()>>> {
     tracing::info!(
         %mpc_contract_id,
         %node_account_id,
@@ -225,27 +241,24 @@ pub fn run(
     );
 
     let indexer = NearIndexer::new(options);
-    let context = Context {
+    let mut context = Context {
         mpc_contract_id: mpc_contract_id.clone(),
         node_account_id: node_account_id.clone(),
         sign_tx,
-        indexer: indexer.clone(),
+        indexer,
         rpc_client,
         backlog,
     };
 
-    let join_handle = tokio::spawn(run_polling_loop(context));
-    Ok((join_handle, indexer))
-}
+    Ok(tokio::spawn(async move {
+        tracing::info!("starting polling loop for pending requests");
 
-async fn run_polling_loop(context: Context) -> anyhow::Result<()> {
-    tracing::info!("starting polling loop for pending requests");
-
-    let mut interval = tokio::time::interval(Duration::from_secs(3));
-    loop {
-        interval.tick().await;
-        if let Err(err) = poll_pending_requests(&context).await {
-            tracing::error!(%err, "failed to poll pending requests");
+        let mut interval = tokio::time::interval(Duration::from_millis(750));
+        loop {
+            interval.tick().await;
+            if let Err(err) = poll_pending_requests(&mut context).await {
+                tracing::error!(%err, "failed to poll pending requests");
+            }
         }
-    }
+    }))
 }

--- a/chain-signatures/node/src/indexer_eth.rs
+++ b/chain-signatures/node/src/indexer_eth.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use crate::backlog::Backlog;
 use crate::mesh::{wait_threshold_active, MeshState};
 use crate::node_client::NodeClient;
-use crate::protocol::{Chain, IndexedSignRequest, SignRequestType};
+use crate::protocol::{Chain, IndexedSignRequest, Sign, SignRequestType};
 use crate::rpc::ContractStateWatcher;
 #[cfg(not(feature = "light_client"))]
 use crate::sign_bidirectional::BidirectionalTx;
@@ -488,7 +488,7 @@ fn finalized_block_channel() -> (mpsc::Sender<BlockNumber>, mpsc::Receiver<Block
 #[cfg(feature = "light_client")]
 pub async fn run(
     eth: Option<EthConfig>,
-    sign_tx: mpsc::Sender<IndexedSignRequest>,
+    sign_tx: mpsc::Sender<Sign>,
     app_data_storage: AppDataStorage,
     node_near_account_id: AccountId,
     backlog: Backlog,
@@ -615,6 +615,7 @@ pub async fn run(
         eth_contract_addr,
         node_near_account_id.clone(),
         requests_indexed_send.clone(),
+        sign_tx.clone(),
         total_timeout,
         backlog.clone(),
     ));
@@ -673,6 +674,7 @@ pub async fn run(
             eth_contract_addr,
             node_near_account_id.clone(),
             requests_indexed_send_clone.clone(),
+            sign_tx.clone(),
             total_timeout,
             backlog.clone(),
             &near_client,
@@ -705,6 +707,7 @@ async fn retry_failed_blocks(
     eth_contract_addr: Address,
     node_near_account_id: AccountId,
     requests_indexed: mpsc::Sender<BlockAndRequests>,
+    sign_tx: mpsc::Sender<Sign>,
     total_timeout: Duration,
     backlog: Backlog,
 ) {
@@ -720,6 +723,7 @@ async fn retry_failed_blocks(
             eth_contract_addr,
             node_near_account_id.clone(),
             requests_indexed.clone(),
+            sign_tx.clone(),
             total_timeout,
             backlog.clone(),
             &near_client,
@@ -929,6 +933,7 @@ async fn process_block(
     eth_contract_addr: Address,
     node_near_account_id: AccountId,
     requests_indexed: mpsc::Sender<BlockAndRequests>,
+    sign_tx: mpsc::Sender<Sign>,
     total_timeout: Duration,
     backlog: Backlog,
     near_client: &NearClient,
@@ -1078,7 +1083,7 @@ async fn process_block(
         });
 
     if !respond_logs.is_empty() {
-        process_respond_events(&respond_logs, &backlog).await;
+        process_respond_events(&respond_logs, &backlog, &sign_tx).await;
     }
 
     let request_logs: Vec<Log> = potential_request_logs
@@ -1142,7 +1147,7 @@ async fn send_requests_when_final(
     helios_client: Arc<EthereumClient>,
     mut requests_indexed: mpsc::Receiver<BlockAndRequests>,
     mut finalized_block_rx: mpsc::Receiver<BlockNumber>,
-    sign_tx: mpsc::Sender<IndexedSignRequest>,
+    sign_tx: mpsc::Sender<Sign>,
     app_data_storage: AppDataStorage,
     node_near_account_id: AccountId,
     optimistic_requests: bool,
@@ -1240,9 +1245,17 @@ fn parse_filtered_logs(logs: Vec<Log>, total_timeout: Duration) -> Vec<IndexedSi
     indexed_requests
 }
 
-async fn process_respond_events(logs: &[Log], backlog: &Backlog) {
+async fn process_respond_events(logs: &[Log], backlog: &Backlog, sign_tx: &mpsc::Sender<Sign>) {
     for log in logs {
         if let Some(sign_id) = sign_id_from_signature_responded_log(log) {
+            if let Err(err) = sign_tx.send(Sign::Completion(sign_id)).await {
+                tracing::error!(
+                    ?sign_id,
+                    ?err,
+                    "failed to send completion for respond event"
+                );
+            }
+
             // Check the sign request type to determine if it's a bidirectional request
             if let Some(sign_type) = backlog.sign_type(Chain::Ethereum, &sign_id).await {
                 match sign_type {
@@ -1295,14 +1308,14 @@ fn sign_id_from_signature_responded_log(log: &Log) -> Option<SignId> {
 
 fn send_indexed_requests(
     requests: Vec<IndexedSignRequest>,
-    sign_tx: mpsc::Sender<IndexedSignRequest>,
+    sign_tx: mpsc::Sender<Sign>,
     node_near_account_id: AccountId,
 ) {
     for request in requests {
         let sign_tx = sign_tx.clone();
         let node_near_account_id = node_near_account_id.clone();
         tokio::spawn(async move {
-            match sign_tx.send(request).await {
+            match sign_tx.send(Sign::Request(request)).await {
                 Ok(_) => {
                     crate::metrics::NUM_SIGN_REQUESTS
                         .with_label_values(&[
@@ -1357,7 +1370,7 @@ impl SignatureRequestedEvent {
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     eth: Option<EthConfig>,
-    sign_tx: mpsc::Sender<IndexedSignRequest>,
+    sign_tx: mpsc::Sender<Sign>,
     app_data_storage: AppDataStorage,
     node_near_account_id: AccountId,
     backlog: Backlog,
@@ -1476,7 +1489,7 @@ async fn process_block(
     block_number: u64,
     contract_address: Address,
     node_near_account_id: AccountId,
-    sign_tx: mpsc::Sender<IndexedSignRequest>,
+    sign_tx: mpsc::Sender<Sign>,
     total_timeout: Duration,
     backlog: &Backlog,
 ) -> anyhow::Result<()> {
@@ -1503,7 +1516,7 @@ async fn process_block(
         });
 
     if !respond_logs.is_empty() {
-        process_respond_events(&respond_logs, backlog).await;
+        process_respond_events(&respond_logs, backlog, &sign_tx).await;
     }
 
     let request_logs: Vec<Log> = potential_request_logs

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -1,7 +1,7 @@
 use crate::backlog::{Backlog, BacklogTransaction, SignTx};
 use crate::mesh::{wait_threshold_active, MeshState};
 use crate::node_client::NodeClient;
-use crate::protocol::{Chain, IndexedSignRequest, SignRequestType};
+use crate::protocol::{Chain, IndexedSignRequest, Sign, SignRequestType};
 use crate::rpc::ContractStateWatcher;
 use crate::sign_bidirectional::{
     hash_rlp_data, BidirectionalTx, BidirectionalTxId, PendingRequestStatus,
@@ -337,7 +337,7 @@ type Result<T> = anyhow::Result<T>;
 
 pub async fn run(
     sol: Option<SolConfig>,
-    sign_tx: mpsc::Sender<IndexedSignRequest>,
+    sign_tx: mpsc::Sender<Sign>,
     node_near_account_id: AccountId,
     backlog: Backlog,
     mut contract_watcher: ContractStateWatcher,
@@ -382,6 +382,7 @@ pub async fn run(
     let sol_for_respond = sol.clone();
     let backlog_for_respond = backlog.clone();
     let contract_watcher_for_respond = contract_watcher.clone();
+    let sign_tx_for_respond = sign_tx.clone();
 
     tokio::spawn(subscribe_and_process_sign_events(
         program_id,
@@ -402,6 +403,7 @@ pub async fn run(
                 &sol_for_respond.rpc_ws_url,
                 backlog_for_respond.clone(),
                 contract_watcher_for_respond.clone(),
+                sign_tx_for_respond.clone(),
             )
             .await
             {
@@ -438,7 +440,7 @@ pub async fn run(
 
 async fn subscribe_to_program_non_cpi_events<C: Deref<Target = Keypair> + Clone>(
     program: &Program<C>,
-    sign_tx: mpsc::Sender<IndexedSignRequest>,
+    sign_tx: mpsc::Sender<Sign>,
     node_near_account_id: AccountId,
     total_timeout: Duration,
     backlog: Backlog,
@@ -477,7 +479,7 @@ async fn subscribe_to_program_non_cpi_events<C: Deref<Target = Keypair> + Clone>
 async fn process_anchor_sign_event(
     sign_event: SignatureEventBox,
     tx_sig: Vec<u8>,
-    sign_tx: mpsc::Sender<IndexedSignRequest>,
+    sign_tx: mpsc::Sender<Sign>,
     node_near_account_id: AccountId,
     total_timeout: Duration,
     backlog: Backlog,
@@ -513,7 +515,7 @@ async fn process_anchor_sign_event(
         .insert(Chain::Solana, sign_id, backlog_tx, sign_request_type)
         .await;
 
-    if let Err(err) = sign_tx.send(sign_request).await {
+    if let Err(err) = sign_tx.send(Sign::Request(sign_request)).await {
         // TODO: handle error to ensure 100% success rate
         tracing::error!(?err, "Failed to send Solana sign request into queue");
     } else {
@@ -531,7 +533,7 @@ async fn subscribe_and_process_sign_events(
     program_id: Pubkey,
     rpc_url: String,
     ws_url: String,
-    sign_tx: mpsc::Sender<IndexedSignRequest>,
+    sign_tx: mpsc::Sender<Sign>,
     node_near_account_id: AccountId,
     total_timeout: Duration,
     backlog: Backlog,
@@ -877,6 +879,7 @@ async fn subscribe_to_program_respond_events(
     ws_url: &str,
     backlog: Backlog,
     mut contract_watcher: ContractStateWatcher,
+    sign_tx: mpsc::Sender<Sign>,
 ) -> Result<()> {
     let rpc_client = RpcClient::new(rpc_url.to_string());
     let pubsub_client = PubsubClient::new(ws_url).await?;
@@ -928,6 +931,14 @@ async fn subscribe_to_program_respond_events(
             } else {
                 tracing::warn!(?sign_id, "bidirectional tx not found on completion");
             }
+
+            if let Err(err) = sign_tx.send(Sign::Completion(sign_id)).await {
+                tracing::error!(
+                    ?sign_id,
+                    ?err,
+                    "failed to send completion for respond bidirectional"
+                );
+            }
         }
 
         for ev in respond_events {
@@ -945,6 +956,13 @@ async fn subscribe_to_program_respond_events(
                 SignRequestType::Sign => {
                     tracing::info!(?sign_id, "sign request completed successfully");
                     backlog.remove(Chain::Solana, &sign_id).await;
+                    if let Err(err) = sign_tx.send(Sign::Completion(sign_id)).await {
+                        tracing::error!(
+                            ?sign_id,
+                            ?err,
+                            "failed to send completion for respond event"
+                        );
+                    }
                     continue;
                 }
                 SignRequestType::RespondBidirectional(_) => {

--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -109,15 +109,6 @@ pub(crate) static REDIS_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
     .unwrap()
 });
 
-pub(crate) static SIGN_QUEUE_MINE_SIZE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
-    try_create_int_gauge_vec(
-        "multichain_sign_queue_mine_size",
-        "number of my requests in sign queue",
-        &["node_account_id"],
-    )
-    .unwrap()
-});
-
 pub(crate) static NUM_TRIPLE_GENERATORS_INTRODUCED: LazyLock<IntGaugeVec> = LazyLock::new(|| {
     try_create_int_gauge_vec(
         "multichain_num_triple_generators_introduced",
@@ -379,15 +370,6 @@ pub(crate) static PRESIGNATURE_GENERATOR_FAILURES: LazyLock<CounterVec> = LazyLo
     try_create_counter_vec(
         "multichain_presignature_generator_failures",
         "total presignature generator failures",
-        &["node_account_id"],
-    )
-    .unwrap()
-});
-
-pub(crate) static SIGNATURE_FAILURES: LazyLock<CounterVec> = LazyLock::new(|| {
-    try_create_counter_vec(
-        "multichain_signature_failures",
-        "total signature failures",
         &["node_account_id"],
     )
     .unwrap()

--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -2,8 +2,10 @@ mod filter;
 mod sub;
 mod types;
 
+pub use sub::Subscriber;
+
 use crate::protocol::message::sub::{
-    SubscribeId, SubscribeRequest, SubscribeRequestAction, SubscribeResponse, Subscriber,
+    SubscribeId, SubscribeRequest, SubscribeRequestAction, SubscribeResponse,
 };
 pub use crate::protocol::message::types::{
     GeneratingMessage, Message, MessageError, MessageFilterId, PositMessage, PositProtocolId,

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -18,7 +18,7 @@ pub use contract::ProtocolState;
 pub use cryptography::CryptographicError;
 pub use message::{Message, MessageChannel};
 pub use mpc_primitives::Chain;
-pub use signature::{IndexedSignRequest, SignQueue};
+pub use signature::IndexedSignRequest;
 use signet_program::SignBidirectionalEvent;
 pub use state::{Node, NodeState};
 

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -18,7 +18,7 @@ pub use contract::ProtocolState;
 pub use cryptography::CryptographicError;
 pub use message::{Message, MessageChannel};
 pub use mpc_primitives::Chain;
-pub use signature::IndexedSignRequest;
+pub use signature::{IndexedSignRequest, Sign};
 use signet_program::SignBidirectionalEvent;
 pub use state::{Node, NodeState};
 
@@ -48,7 +48,7 @@ pub struct MpcSignProtocol {
     pub(crate) secret_storage: SecretNodeStorageBox,
     pub(crate) triple_storage: TripleStorage,
     pub(crate) presignature_storage: PresignatureStorage,
-    pub(crate) sign_rx: Arc<RwLock<mpsc::Receiver<IndexedSignRequest>>>,
+    pub(crate) sign_rx: Arc<RwLock<mpsc::Receiver<Sign>>>,
     pub(crate) generating: mpsc::Receiver<GeneratingMessage>,
     pub(crate) resharing: mpsc::Receiver<ResharingMessage>,
     pub(crate) ready: mpsc::Receiver<ReadyMessage>,

--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -354,6 +354,54 @@ impl<Id: Copy + Hash + Eq + fmt::Debug, S> Posits<Id, S> {
     }
 }
 
+/// A single posit counter that tracks participants accepting/rejecting a proposal.
+/// This is used by individual signature tasks instead of the global Posits mapping.
+pub struct SinglePositCounter {
+    participants: HashSet<Participant>,
+    rejects: HashSet<Participant>,
+    pub accepts: HashSet<Participant>,
+}
+
+impl SinglePositCounter {
+    pub fn new(me: Participant, participants: &[Participant]) -> Self {
+        let mut accepts = HashSet::new();
+        accepts.insert(me);
+        Self {
+            participants: participants.iter().copied().collect(),
+            rejects: HashSet::new(),
+            accepts,
+        }
+    }
+
+    pub fn enough_accepts(&self, threshold: usize) -> bool {
+        self.accepts.len() >= threshold
+    }
+
+    pub fn enough_rejects(&self, threshold: usize) -> bool {
+        self.rejects.len() > self.participants.len() - threshold
+    }
+
+    pub fn meets_totality(&self) -> bool {
+        self.accepts.len() + self.rejects.len() == self.participants.len()
+    }
+
+    pub fn process_action(&mut self, from: Participant, action: &PositAction) -> bool {
+        if !self.participants.contains(&from) {
+            return false;
+        }
+        match action {
+            PositAction::Accept => {
+                self.accepts.insert(from);
+            }
+            PositAction::Reject => {
+                self.rejects.insert(from);
+            }
+            _ => return false,
+        }
+        true
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -679,13 +679,16 @@ impl PresignatureSpawner {
 
     async fn run(
         mut self,
-        mesh_state: watch::Receiver<MeshState>,
-        config: watch::Receiver<Config>,
+        mut mesh_state: watch::Receiver<MeshState>,
+        mut cfg: watch::Receiver<Config>,
         ongoing_gen_tx: watch::Sender<usize>,
     ) {
         let mut stockpile_interval = time::interval(Duration::from_millis(100));
         let mut expiration_interval = tokio::time::interval(Duration::from_secs(20));
         let mut posits = self.msg.subscribe_presignature_posit().await;
+
+        let mut protocol = cfg.borrow().protocol.clone();
+        let mut active = mesh_state.borrow().active.keys_vec();
 
         loop {
             tokio::select! {
@@ -698,13 +701,13 @@ impl PresignatureSpawner {
                             );
                             continue;
                         };
-                        let timeout = config.borrow().protocol.presignature.generation_timeout;
-                        self.start_generation(id, positor, participants, Duration::from_millis(timeout)).await;
+                        let timeout = Duration::from_millis(protocol.presignature.generation_timeout);
+                        self.start_generation(id, positor, participants, timeout).await;
                     }
                 }
                 Some((id, from, action)) = posits.recv() => {
-                    let timeout = config.borrow().protocol.presignature.generation_timeout;
-                    self.process_posit(id, from, action, Duration::from_millis(timeout)).await;
+                    let timeout = Duration::from_millis(protocol.presignature.generation_timeout);
+                    self.process_posit(id, from, action, timeout).await;
                 }
                 // `join_next` returns None on the set being empty, so don't handle that case
                 Some(result) = self.ongoing.join_next(), if !self.ongoing.is_empty() => {
@@ -718,10 +721,8 @@ impl PresignatureSpawner {
                     self.ongoing_owned.remove(&id);
                     let _ = ongoing_gen_tx.send(self.ongoing.len());
                 }
-                _ = stockpile_interval.tick() => {
-                    let active = mesh_state.borrow().active.keys_vec();
-                    let protocol_cfg = config.borrow().protocol.clone();
-                    self.stockpile(&active, &protocol_cfg).await;
+                _ = stockpile_interval.tick(), if active.len() >= self.threshold => {
+                    self.stockpile(&active, &protocol).await;
                     let _ = ongoing_gen_tx.send(self.ongoing.len());
 
                     crate::metrics::NUM_PRESIGNATURES_MINE
@@ -733,6 +734,12 @@ impl PresignatureSpawner {
                     crate::metrics::NUM_PRESIGNATURE_GENERATORS_TOTAL
                         .with_label_values(&[self.my_account_id.as_str()])
                         .set(self.len_potential().await as i64 - self.len_generated().await as i64);
+                }
+                Ok(()) = cfg.changed() => {
+                    protocol = cfg.borrow().protocol.clone();
+                }
+                Ok(()) = mesh_state.changed() => {
+                    active = mesh_state.borrow().active.keys_vec();
                 }
             }
         }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -336,7 +336,6 @@ impl SignPositor {
 
                     break *presignature_id;
                 } else {
-                    // reject
                     tracing::warn!(
                         ?sign_id,
                         ?from,
@@ -408,9 +407,6 @@ impl SignPositor {
         let is_proposer = proposer == ctx.me;
         let is_deliberator = !is_proposer;
 
-        // GUARANTEE: at least threshold participants from organizing phase.
-        let posit_participants = stable.iter().copied().collect::<Vec<_>>();
-
         // Get the presignature participants - only these nodes participated in generating it
         let presignature_participants = if let Some(ref taken) = presignature {
             taken.presignature.participants.clone()
@@ -441,6 +437,8 @@ impl SignPositor {
             }
         }
 
+        // GUARANTEE: at least threshold participants from organizing phase.
+        let posit_participants = stable.iter().copied().collect::<Vec<_>>();
         let mut counter = SinglePositCounter::new(ctx.me, &posit_participants);
 
         let posit_timeout = Duration::from_secs(60);
@@ -1102,8 +1100,11 @@ impl SignatureSpawner {
             Sign::Request(indexed) => {
                 let sign_id = indexed.id;
 
-                // Skip if we've already seen this request
-                if self.inboxes.contains_key(&sign_id) {
+                // Skip if we already have a task handling this request.
+                // Use tasks instead of inbox map since it may already contain buffered messages
+                // (e.g. a Propose arriving before the indexer notifies us), so we must only look
+                // at the task map to decide whether the request is truly a duplicate.
+                if self.tasks.contains_key(&sign_id) {
                     tracing::info!(?sign_id, "skipping duplicate sign request");
                     return;
                 }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -3,7 +3,9 @@ use crate::backlog::Backlog;
 use crate::config::Config;
 use crate::kdf::derive_delta;
 use crate::mesh::MeshState;
-use crate::protocol::message::{MessageChannel, PositMessage, PositProtocolId, SignatureMessage};
+use crate::protocol::message::{
+    MessageChannel, PositMessage, PositProtocolId, SignatureMessage, Subscriber,
+};
 use crate::protocol::posit::{PositAction, SinglePositCounter};
 use crate::protocol::presignature::PresignatureId;
 use crate::protocol::Chain;
@@ -1013,11 +1015,9 @@ impl SignTask {
                 }
             }
 
-            match phase.advance(&self, &mut state, &mut task_rx).await {
+            phase = match phase.advance(&self, &mut state, &mut task_rx).await {
                 SignPhase::Complete(result) => return result,
-                other => {
-                    phase = other;
-                }
+                other => other,
             }
         }
     }
@@ -1041,11 +1041,8 @@ pub struct SignatureSpawner {
     seen_requests: HashSet<SignId>,
     /// Consolidated signature tasks - one per sign_id, each task is an async task handling complete lifecycle
     tasks: JoinMap<SignId, Result<(), SignError>>,
-    /// Channels to send messages to running tasks
-    task_channels: HashMap<SignId, mpsc::Sender<SignTaskMessage>>,
-    /// Buffer for posit messages that arrived before the task was created
-    /// Maps sign_id -> list of (presignature_id, from, action)
-    pending_posit_messages: HashMap<SignId, Vec<(PresignatureId, Participant, PositAction)>>,
+    /// Buffered inboxes for posit messages, allowing us to queue before tasks spawn
+    inboxes: HashMap<SignId, Subscriber<SignTaskMessage>>,
     /// Watch channel for stable participants (needed for task reorganization)
     mesh_state: watch::Receiver<MeshState>,
 
@@ -1081,8 +1078,7 @@ impl SignatureSpawner {
             sign_rx,
             seen_requests: HashSet::new(),
             tasks: JoinMap::new(),
-            task_channels: HashMap::new(),
-            pending_posit_messages: HashMap::new(),
+            inboxes: HashMap::new(),
             mesh_state,
             me,
             my_account_id: my_account_id.clone(),
@@ -1107,27 +1103,12 @@ impl SignatureSpawner {
         let sign_id = indexed.id;
         tracing::info!(?sign_id, "spawning signature task");
 
-        // Create channel for task communication
-        let (tx, rx) = mpsc::channel(256);
-        self.task_channels.insert(sign_id, tx.clone());
-
-        // Process any pending posit messages
-        if let Some(pending_messages) = self.pending_posit_messages.remove(&sign_id) {
-            tracing::debug!(
-                ?sign_id,
-                count = pending_messages.len(),
-                "sending pending posit messages to task"
-            );
-            for (msg_presignature_id, msg_from, msg_action) in pending_messages {
-                let _ = tx
-                    .send(SignTaskMessage::PositMessage {
-                        presignature_id: msg_presignature_id,
-                        from: msg_from,
-                        action: msg_action,
-                    })
-                    .await;
-            }
-        }
+        // Subscribe to (or create) the posit inbox for this sign request
+        let rx = self
+            .inboxes
+            .entry(sign_id)
+            .or_insert_with(Subscriber::unsubscribed)
+            .subscribe();
 
         let task = SignTask {
             me: self.me,
@@ -1164,22 +1145,18 @@ impl SignatureSpawner {
         }
 
         // If task channel exists, forward message to it
-        if let Some(ch) = self.task_channels.get(&sign_id) {
-            let _ = ch
-                .send(SignTaskMessage::PositMessage {
-                    presignature_id,
-                    from,
-                    action,
-                })
-                .await;
-        } else {
-            // No task yet - buffer message for when task is created
-            tracing::trace!(?sign_id, ?from, ?action, "buffering message - no task yet");
-            self.pending_posit_messages
-                .entry(sign_id)
-                .or_default()
-                .push((presignature_id, from, action));
-        }
+        let inbox = self
+            .inboxes
+            .entry(sign_id)
+            .or_insert_with(Subscriber::unsubscribed);
+
+        let _ = inbox
+            .send(SignTaskMessage::PositMessage {
+                presignature_id,
+                from,
+                action,
+            })
+            .await;
     }
 
     fn handle_completion(&mut self, sign_id: SignId) {
@@ -1190,8 +1167,7 @@ impl SignatureSpawner {
             tracing::info!(?sign_id, "task already completed or unable to be aborted");
         }
 
-        self.task_channels.remove(&sign_id);
-        self.pending_posit_messages.remove(&sign_id);
+        self.inboxes.remove(&sign_id);
 
         if !request_seen {
             tracing::debug!(
@@ -1272,7 +1248,6 @@ impl SignatureSpawner {
     async fn run(mut self, contract: ContractStateWatcher, cfg: watch::Receiver<Config>) {
         let mut check_requests_interval = tokio::time::interval(Duration::from_millis(100));
         let mut posits = self.msg.subscribe_signature_posit().await;
-        let _current_epoch = self.epoch;
 
         loop {
             tokio::select! {
@@ -1284,13 +1259,13 @@ impl SignatureSpawner {
                         Ok(outcome) => outcome,
                         Err(sign_id) => {
                             tracing::warn!(?sign_id, "signature task interrupted");
-                            self.task_channels.remove(&sign_id);
+                            self.inboxes.remove(&sign_id);
                             continue;
                         }
                     };
 
                     // Clean up channel
-                    self.task_channels.remove(&sign_id);
+                    self.inboxes.remove(&sign_id);
 
                     match result {
                         Ok(()) => {

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -26,7 +26,7 @@ use mpc_primitives::{SignArgs, SignId};
 use rand::rngs::StdRng;
 use rand::seq::IteratorRandom;
 use rand::SeedableRng;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::error::TryRecvError;
@@ -47,7 +47,6 @@ pub struct IndexedSignRequest {
     pub sign_request_type: SignRequestType,
 }
 
-/// Message types that can be sent over the sign processing channel.
 #[derive(Debug, Clone, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum Sign {
@@ -174,8 +173,7 @@ impl SignOrganizer {
                 once = false;
             }
 
-            if let Err(err) = state.mesh_state.changed().await {
-                tracing::error!(?sign_id, ?err, "mesh state watch channel closed");
+            if state.mesh_state.changed().await.is_err() {
                 return BTreeSet::new();
             }
         }
@@ -232,9 +230,7 @@ impl SignOrganizer {
             (stable, proposer)
         };
 
-        // let posit_participants = stable.iter().copied().collect::<Vec<_>>();
         let is_proposer = proposer == ctx.me;
-
         let (presignature_id, presignature) = if is_proposer {
             tracing::info!(?sign_id, round = ?state.round, "proposer waiting for presignature");
             let fetch = tokio::time::timeout(Duration::from_secs(30), async {
@@ -761,7 +757,6 @@ impl SignGenerator {
     }
 
     /// Receive the next message for the signature protocol; error out on the timeout being reached
-    /// or the channel having been closed (aborted).
     async fn recv(&mut self) -> Result<SignatureMessage, SignError> {
         let sign_id = self.request.indexed.id;
         let presignature_id = self.dropper.id;
@@ -1037,13 +1032,10 @@ pub struct SignatureSpawner {
     presignatures: PresignatureStorage,
     /// Receiver for incoming sign requests from indexer
     sign_rx: Arc<RwLock<mpsc::Receiver<Sign>>>,
-    /// Track which sign requests we've seen and spawned tasks for
-    seen_requests: HashSet<SignId>,
     /// Consolidated signature tasks - one per sign_id, each task is an async task handling complete lifecycle
     tasks: JoinMap<SignId, Result<(), SignError>>,
     /// Buffered inboxes for posit messages, allowing us to queue before tasks spawn
     inboxes: HashMap<SignId, Subscriber<SignTaskMessage>>,
-    /// Watch channel for stable participants (needed for task reorganization)
     mesh_state: watch::Receiver<MeshState>,
 
     me: Participant,
@@ -1070,11 +1062,7 @@ impl SignatureSpawner {
         tracing::info!(?sign_id, "spawning signature task");
 
         // Subscribe to (or create) the posit inbox for this sign request
-        let rx = self
-            .inboxes
-            .entry(sign_id)
-            .or_insert_with(Subscriber::unsubscribed)
-            .subscribe();
+        let rx = self.inboxes.entry(sign_id).or_default().subscribe();
 
         let task = SignTask {
             me: self.me,
@@ -1122,20 +1110,11 @@ impl SignatureSpawner {
     }
 
     fn handle_completion(&mut self, sign_id: SignId) {
-        let request_seen = self.seen_requests.remove(&sign_id);
+        self.inboxes.remove(&sign_id);
         if self.tasks.abort(sign_id) {
             tracing::info!(?sign_id, "aborting signature task due to completion event");
         } else {
             tracing::info!(?sign_id, "task already completed or unable to be aborted");
-        }
-
-        self.inboxes.remove(&sign_id);
-
-        if !request_seen {
-            tracing::debug!(
-                ?sign_id,
-                "received completion event for unknown sign request"
-            );
         }
     }
 
@@ -1162,10 +1141,7 @@ impl SignatureSpawner {
 
         while let Ok(sign) = {
             match sign_rx.try_recv() {
-                err @ Err(TryRecvError::Disconnected) => {
-                    tracing::error!("sign request channel disconnected");
-                    err
-                }
+                err @ Err(TryRecvError::Disconnected) => err,
                 other => other,
             }
         } {
@@ -1177,12 +1153,11 @@ impl SignatureSpawner {
                     let sign_id = indexed.id;
 
                     // Skip if we've already seen this request
-                    if self.seen_requests.contains(&sign_id) {
-                        tracing::debug!(?sign_id, "skipping duplicate sign request");
+                    if self.inboxes.contains_key(&sign_id) {
+                        tracing::info!(?sign_id, "skipping duplicate sign request");
                         continue;
                     }
 
-                    self.seen_requests.insert(sign_id);
                     crate::metrics::NUM_UNIQUE_SIGN_REQUESTS
                         .with_label_values(&[indexed.chain.as_str(), self.my_account_id.as_str()])
                         .inc();
@@ -1206,7 +1181,7 @@ impl SignatureSpawner {
         // Update metrics
         crate::metrics::SIGN_QUEUE_SIZE
             .with_label_values(&[self.my_account_id.as_str()])
-            .set(self.seen_requests.len() as i64);
+            .set(self.tasks.len() as i64);
     }
 
     async fn run(mut self, mut contract: ContractStateWatcher, cfg: watch::Receiver<Config>) {
@@ -1227,15 +1202,11 @@ impl SignatureSpawner {
                         Err(sign_id) => {
                             tracing::warn!(?sign_id, "signature task interrupted");
                             self.inboxes.remove(&sign_id);
-                            self.seen_requests.remove(&sign_id);
                             continue;
                         }
                     };
 
-                    // Clean up channel
                     self.inboxes.remove(&sign_id);
-                    self.seen_requests.remove(&sign_id);
-
                     match result {
                         Ok(()) => {
                             tracing::info!(?sign_id, "signature task completed successfully");
@@ -1276,7 +1247,6 @@ impl SignatureSpawnerTask {
     ) -> Self {
         let spawner = SignatureSpawner {
             me,
-            seen_requests: HashSet::new(),
             tasks: JoinMap::new(),
             inboxes: HashMap::new(),
             my_account_id: ctx.my_account_id.clone(),
@@ -1332,7 +1302,7 @@ impl PendingPresignature {
 
         let presignature = tokio::time::timeout(timeout, async {
             // TODO: we can make storage wait for presignature to be available instead of here
-            let mut interval = tokio::time::interval(Duration::from_millis(50));
+            let mut interval = tokio::time::interval(Duration::from_millis(250));
             loop {
                 interval.tick().await;
                 if let Some(presignature) = storage.take(id, owner, me).await {

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -112,7 +112,7 @@ impl SignPhase {
         self,
         ctx: &SignTask,
         state: &mut SignState,
-        task_rx: &mut mpsc::Receiver<SignatureTaskMessage>,
+        task_rx: &mut mpsc::Receiver<SignTaskMessage>,
     ) -> SignPhase {
         match self {
             SignPhase::Organizing(phase) => phase.advance(ctx, state).await,
@@ -222,7 +222,7 @@ impl SignOrganizer {
             (stable, proposer)
         };
 
-        let posit_participants = stable.iter().copied().collect::<Vec<_>>();
+        // let posit_participants = stable.iter().copied().collect::<Vec<_>>();
         let is_proposer = proposer == ctx.me;
 
         let (presignature_id, presignature) = if is_proposer {
@@ -253,7 +253,8 @@ impl SignOrganizer {
             let presignature_id = taken.presignature.id;
             tracing::info!(?sign_id, presignature_id, "proposer got presignature");
 
-            for &p in &posit_participants {
+            // broadcast to stable and let them reject if they don't have the presignature.
+            for &p in &stable {
                 if p == ctx.me {
                     continue;
                 }
@@ -289,24 +290,17 @@ impl SignPositor {
     async fn wait_propose(
         ctx: &SignTask,
         state: &mut SignState,
-        task_rx: &mut mpsc::Receiver<SignatureTaskMessage>,
+        task_rx: &mut mpsc::Receiver<SignTaskMessage>,
         proposer: Participant,
     ) -> Result<PresignatureId, SignPhase> {
         let sign_id = ctx.sign_id;
         let round = state.round;
-
-        tracing::info!(
-            ?sign_id,
-            ?round,
-            ?proposer,
-            "deliberator waiting for Propose"
-        );
         let outcome = tokio::time::timeout(Duration::from_secs(30), async {
             loop {
                 let Some(task_msg) = task_rx.recv().await else {
                     continue;
                 };
-                let SignatureTaskMessage::PositMessage {
+                let SignTaskMessage::PositMessage {
                     presignature_id,
                     from,
                     action,
@@ -323,6 +317,28 @@ impl SignPositor {
                         ?from,
                         "deliberator received Propose"
                     );
+
+                    // Check if we have access to this presignature (in storage or generating)
+                    if !ctx.presignatures.contains(*presignature_id).await {
+                        tracing::warn!(
+                            ?sign_id,
+                            presignature_id,
+                            "deliberator does not have access to proposed presignature, rejecting"
+                        );
+                        ctx.msg
+                            .send(
+                                ctx.me,
+                                proposer,
+                                PositMessage {
+                                    id: PositProtocolId::Signature(sign_id, *presignature_id),
+                                    from: ctx.me,
+                                    action: PositAction::Reject,
+                                },
+                            )
+                            .await;
+                        continue;
+                    }
+
                     break *presignature_id;
                 } else {
                     // reject
@@ -383,7 +399,7 @@ impl SignPositor {
         self,
         ctx: &SignTask,
         state: &mut SignState,
-        task_rx: &mut mpsc::Receiver<SignatureTaskMessage>,
+        task_rx: &mut mpsc::Receiver<SignTaskMessage>,
     ) -> SignPhase {
         let SignPositor {
             proposer,
@@ -397,6 +413,14 @@ impl SignPositor {
         let is_proposer = proposer == ctx.me;
         let is_deliberator = !is_proposer;
         let posit_participants = stable.iter().copied().collect::<Vec<_>>();
+
+        // Get the presignature participants - only these nodes participated in generating it
+        let presignature_participants = if let Some(ref taken) = presignature {
+            taken.presignature.participants.clone()
+        } else {
+            // Deliberators don't have the presignature yet, will verify when they receive Propose
+            Vec::new()
+        };
 
         tracing::info!(
             ?sign_id,
@@ -417,6 +441,13 @@ impl SignPositor {
         }
 
         if is_deliberator {
+            tracing::info!(
+                ?sign_id,
+                ?round,
+                ?proposer,
+                "deliberator waiting for Propose"
+            );
+
             presignature_id = match Self::wait_propose(ctx, state, task_rx, proposer).await {
                 Ok(id) => id,
                 Err(phase) => return phase,
@@ -432,8 +463,8 @@ impl SignPositor {
         let accepted_participants = loop {
             tokio::select! {
                 Some(task_msg) = task_rx.recv() => {
-                    let SignatureTaskMessage::PositMessage { presignature_id: _, from, action } = task_msg;
-                    if !is_proposer {
+                    let SignTaskMessage::PositMessage { presignature_id: _, from, action } = task_msg;
+                    if is_deliberator {
                         if let PositAction::Start(participants) = action {
                             if from != proposer {
                                 tracing::warn!(?sign_id, ?from, ?proposer, "received Start from non-proposer, ignoring");
@@ -454,7 +485,25 @@ impl SignPositor {
                         }
 
                         if counter.meets_totality() {
-                            let participants = counter.accepts.iter().copied().collect::<Vec<_>>();
+                            // Only include participants who both accepted AND were part of the presignature generation
+                            let mut participants = counter.accepts.iter().copied().collect::<Vec<_>>();
+                            if !presignature_participants.is_empty() {
+                                participants.retain(|p| presignature_participants.contains(p));
+                            }
+
+                            if participants.len() < ctx.threshold {
+                                tracing::warn!(
+                                    ?sign_id,
+                                    presig_participants = ?presignature_participants,
+                                    accepts = ?counter.accepts,
+                                    filtered_participants = ?participants,
+                                    threshold = ctx.threshold,
+                                    "not enough presignature participants accepted, reorganizing"
+                                );
+                                state.bump_round();
+                                return SignPhase::Organizing(SignOrganizer);
+                            }
+
                             tracing::info!(?sign_id, me = ?ctx.me, ?participants, "proposer broadcasting Start");
                             for &p in &participants {
                                 if p == ctx.me {
@@ -479,7 +528,25 @@ impl SignPositor {
                 _ = &mut posit_deadline => {
                     if is_proposer {
                         if counter.enough_accepts(ctx.threshold) {
-                            let participants = counter.accepts.iter().copied().collect::<Vec<_>>();
+                            // Only include participants who both accepted AND were part of the presignature generation
+                            let mut participants = counter.accepts.iter().copied().collect::<Vec<_>>();
+                            if !presignature_participants.is_empty() {
+                                participants.retain(|p| presignature_participants.contains(p));
+                            }
+
+                            if participants.len() < ctx.threshold {
+                                tracing::warn!(
+                                    ?sign_id,
+                                    presig_participants = ?presignature_participants,
+                                    accepts = ?counter.accepts,
+                                    filtered_participants = ?participants,
+                                    threshold = ctx.threshold,
+                                    "posit timeout: not enough presignature participants accepted, reorganizing"
+                                );
+                                state.bump_round();
+                                return SignPhase::Organizing(SignOrganizer);
+                            }
+
                             tracing::info!(?sign_id, "posit timeout with enough accepts, broadcasting Start");
                             for &p in &participants {
                                 if p == ctx.me {
@@ -889,6 +956,7 @@ struct SignTask {
     backlog: Backlog,
 
     cfg: ProtocolConfig,
+    contract: ContractStateWatcher,
 }
 
 impl SignTask {
@@ -896,12 +964,14 @@ impl SignTask {
         self,
         indexed: IndexedSignRequest,
         mesh_state: watch::Receiver<MeshState>,
-        mut task_rx: mpsc::Receiver<SignatureTaskMessage>,
+        mut task_rx: mpsc::Receiver<SignTaskMessage>,
     ) -> Result<(), SignError> {
         let sign_id = self.sign_id;
+        let task_epoch = self.epoch;
         tracing::info!(
             ?sign_id,
             me = ?self.me,
+            epoch = task_epoch,
             "signature task starting with organizing loop"
         );
 
@@ -909,6 +979,32 @@ impl SignTask {
         let mut phase = SignPhase::Organizing(SignOrganizer);
 
         loop {
+            // Check if we should abort due to resharing or epoch change
+            if let Some(contract_state) = self.contract.state() {
+                match contract_state {
+                    crate::protocol::ProtocolState::Resharing(_) => {
+                        tracing::info!(
+                            ?sign_id,
+                            epoch = task_epoch,
+                            "signature task interrupted: contract is resharing"
+                        );
+                        return Err(SignError::Aborted);
+                    }
+                    crate::protocol::ProtocolState::Running(running)
+                        if running.epoch != task_epoch =>
+                    {
+                        tracing::info!(
+                            ?sign_id,
+                            old_epoch = task_epoch,
+                            new_epoch = running.epoch,
+                            "signature task interrupted: epoch changed"
+                        );
+                        return Err(SignError::Aborted);
+                    }
+                    _ => {}
+                }
+            }
+
             match phase.advance(&self, &mut state, &mut task_rx).await {
                 SignPhase::Complete(result) => return result,
                 other => {
@@ -920,7 +1016,7 @@ impl SignTask {
 }
 
 /// Message types that can be sent to a running signature task
-enum SignatureTaskMessage {
+enum SignTaskMessage {
     PositMessage {
         presignature_id: PresignatureId,
         from: Participant,
@@ -938,7 +1034,7 @@ pub struct SignatureSpawner {
     /// Consolidated signature tasks - one per sign_id, each task is an async task handling complete lifecycle
     tasks: JoinMap<SignId, Result<(), SignError>>,
     /// Channels to send messages to running tasks
-    task_channels: HashMap<SignId, mpsc::Sender<SignatureTaskMessage>>,
+    task_channels: HashMap<SignId, mpsc::Sender<SignTaskMessage>>,
     /// Buffer for posit messages that arrived before the task was created
     /// Maps sign_id -> list of (presignature_id, from, action)
     pending_posit_messages: HashMap<SignId, Vec<(PresignatureId, Participant, PositAction)>>,
@@ -953,6 +1049,7 @@ pub struct SignatureSpawner {
     msg: MessageChannel,
     rpc: RpcChannel,
     backlog: Backlog,
+    contract: ContractStateWatcher,
 }
 
 impl SignatureSpawner {
@@ -969,6 +1066,7 @@ impl SignatureSpawner {
         msg: MessageChannel,
         rpc: RpcChannel,
         backlog: Backlog,
+        contract: ContractStateWatcher,
     ) -> Self {
         Self {
             presignatures: presignatures.clone(),
@@ -986,6 +1084,7 @@ impl SignatureSpawner {
             msg,
             rpc,
             backlog,
+            contract,
         }
     }
 
@@ -1013,7 +1112,7 @@ impl SignatureSpawner {
             );
             for (msg_presignature_id, msg_from, msg_action) in pending_messages {
                 let _ = tx
-                    .send(SignatureTaskMessage::PositMessage {
+                    .send(SignTaskMessage::PositMessage {
                         presignature_id: msg_presignature_id,
                         from: msg_from,
                         action: msg_action,
@@ -1035,6 +1134,7 @@ impl SignatureSpawner {
             rpc: self.rpc.clone(),
             backlog: self.backlog.clone(),
             cfg: cfg.clone(),
+            contract: self.contract.clone(),
         };
 
         // Spawn the async task with organizing loop
@@ -1058,7 +1158,7 @@ impl SignatureSpawner {
         // If task channel exists, forward message to it
         if let Some(ch) = self.task_channels.get(&sign_id) {
             let _ = ch
-                .send(SignatureTaskMessage::PositMessage {
+                .send(SignTaskMessage::PositMessage {
                     presignature_id,
                     from,
                     action,
@@ -1133,13 +1233,43 @@ impl SignatureSpawner {
     async fn run(mut self, contract: ContractStateWatcher, cfg: watch::Receiver<Config>) {
         let mut check_requests_interval = tokio::time::interval(Duration::from_millis(100));
         let mut posits = self.msg.subscribe_signature_posit().await;
+        let current_epoch = self.epoch;
 
         loop {
             tokio::select! {
                 Some((sign_id, presignature_id, from, action)) = posits.recv() => {
+                    // Check if epoch has changed or we're resharing - abort all tasks
+                    // if let Some(state) = contract.state() {
+                    //     match state {
+                    //         crate::protocol::ProtocolState::Resharing(_) => {
+                    //             tracing::info!("contract is resharing, aborting all signature tasks");
+                    //             return;
+                    //         }
+                    //         crate::protocol::ProtocolState::Running(running) if running.epoch != current_epoch => {
+                    //             tracing::info!(old_epoch = current_epoch, new_epoch = running.epoch, "epoch changed, aborting all signature tasks");
+                    //             return;
+                    //         }
+                    //         _ => {}
+                    //     }
+                    // }
                     self.handle_posit(sign_id, presignature_id, from, action).await;
                 }
                 Some(result) = self.tasks.join_next(), if !self.tasks.is_empty() => {
+                    // // Check if epoch has changed or we're resharing - abort all tasks
+                    // if let Some(state) = contract.state() {
+                    //     match state {
+                    //         crate::protocol::ProtocolState::Resharing(_) => {
+                    //             tracing::info!("contract is resharing, aborting all signature tasks");
+                    //             return;
+                    //         }
+                    //         crate::protocol::ProtocolState::Running(running) if running.epoch != current_epoch => {
+                    //             tracing::info!(old_epoch = current_epoch, new_epoch = running.epoch, "epoch changed, aborting all signature tasks");
+                    //             return;
+                    //         }
+                    //         _ => {}
+                    //     }
+                    // }
+
                     let (sign_id, result) = match result {
                         Ok(outcome) => outcome,
                         Err(sign_id) => {
@@ -1164,6 +1294,21 @@ impl SignatureSpawner {
                     }
                 }
                 _ = check_requests_interval.tick() => {
+                    // // Check if epoch has changed or we're resharing - abort all tasks
+                    // if let Some(state) = contract.state() {
+                    //     match state {
+                    //         crate::protocol::ProtocolState::Resharing(_) => {
+                    //             tracing::info!("contract is resharing, aborting all signature tasks");
+                    //             return;
+                    //         }
+                    //         crate::protocol::ProtocolState::Running(running) if running.epoch != current_epoch => {
+                    //             tracing::info!(old_epoch = current_epoch, new_epoch = running.epoch, "epoch changed, aborting all signature tasks");
+                    //             return;
+                    //         }
+                    //         _ => {}
+                    //     }
+                    // }
+
                     // Don't process requests until contract has participants
                     let Some(participants) = contract.participants() else {
                         continue;
@@ -1210,6 +1355,7 @@ impl SignatureSpawnerTask {
             ctx.msg_channel.clone(),
             ctx.rpc_channel.clone(),
             ctx.backlog.clone(),
+            ctx.contract.clone(),
         );
 
         Self {

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -45,6 +45,14 @@ pub struct IndexedSignRequest {
     pub sign_request_type: SignRequestType,
 }
 
+/// Message types that can be sent over the sign processing channel.
+#[derive(Debug, Clone, PartialEq)]
+#[allow(clippy::large_enum_variant)]
+pub enum Sign {
+    Request(IndexedSignRequest),
+    Completion(SignId),
+}
+
 /// The sign request for the node to process. This contains relevant info for the node
 /// to generate a signature such as what has been indexed and what the node needs to maintain
 /// metadata-wise to generate the signature.
@@ -1028,7 +1036,7 @@ pub struct SignatureSpawner {
     /// Presignature storage that maintains all presignatures.
     presignatures: PresignatureStorage,
     /// Receiver for incoming sign requests from indexer
-    sign_rx: Arc<RwLock<mpsc::Receiver<IndexedSignRequest>>>,
+    sign_rx: Arc<RwLock<mpsc::Receiver<Sign>>>,
     /// Track which sign requests we've seen and spawned tasks for
     seen_requests: HashSet<SignId>,
     /// Consolidated signature tasks - one per sign_id, each task is an async task handling complete lifecycle
@@ -1060,7 +1068,7 @@ impl SignatureSpawner {
         threshold: usize,
         public_key: PublicKey,
         epoch: u64,
-        sign_rx: Arc<RwLock<mpsc::Receiver<IndexedSignRequest>>>,
+        sign_rx: Arc<RwLock<mpsc::Receiver<Sign>>>,
         presignatures: &PresignatureStorage,
         mesh_state: watch::Receiver<MeshState>,
         msg: MessageChannel,
@@ -1174,6 +1182,25 @@ impl SignatureSpawner {
         }
     }
 
+    fn handle_completion(&mut self, sign_id: SignId) {
+        let request_seen = self.seen_requests.remove(&sign_id);
+        if self.tasks.abort(sign_id) {
+            tracing::info!(?sign_id, "aborting signature task due to completion event");
+        } else {
+            tracing::info!(?sign_id, "task already completed or unable to be aborted");
+        }
+
+        self.task_channels.remove(&sign_id);
+        self.pending_posit_messages.remove(&sign_id);
+
+        if !request_seen {
+            tracing::debug!(
+                ?sign_id,
+                "received completion event for unknown sign request"
+            );
+        }
+    }
+
     async fn handle_requests(
         &mut self,
         stable: &BTreeSet<Participant>,
@@ -1192,8 +1219,9 @@ impl SignatureSpawner {
         // Receive new sign requests from indexer
         let mut sign_rx = self.sign_rx.write().await;
         let mut new_requests = Vec::new();
+        let mut completions = Vec::new();
 
-        while let Ok(indexed) = {
+        while let Ok(sign) = {
             match sign_rx.try_recv() {
                 err @ Err(TryRecvError::Disconnected) => {
                     tracing::error!("sign request channel disconnected");
@@ -1202,22 +1230,33 @@ impl SignatureSpawner {
                 other => other,
             }
         } {
-            let sign_id = indexed.id;
+            match sign {
+                Sign::Completion(sign_id) => {
+                    completions.push(sign_id);
+                }
+                Sign::Request(indexed) => {
+                    let sign_id = indexed.id;
 
-            // Skip if we've already seen this request
-            if self.seen_requests.contains(&sign_id) {
-                tracing::debug!(?sign_id, "skipping duplicate sign request");
-                continue;
+                    // Skip if we've already seen this request
+                    if self.seen_requests.contains(&sign_id) {
+                        tracing::debug!(?sign_id, "skipping duplicate sign request");
+                        continue;
+                    }
+
+                    self.seen_requests.insert(sign_id);
+                    crate::metrics::NUM_UNIQUE_SIGN_REQUESTS
+                        .with_label_values(&[indexed.chain.as_str(), self.my_account_id.as_str()])
+                        .inc();
+
+                    new_requests.push(indexed);
+                }
             }
-
-            self.seen_requests.insert(sign_id);
-            crate::metrics::NUM_UNIQUE_SIGN_REQUESTS
-                .with_label_values(&[indexed.chain.as_str(), self.my_account_id.as_str()])
-                .inc();
-
-            new_requests.push(indexed);
         }
         drop(sign_rx);
+
+        for sign_id in completions {
+            self.handle_completion(sign_id);
+        }
 
         // Create tasks for all new requests
         for indexed in new_requests {
@@ -1233,43 +1272,14 @@ impl SignatureSpawner {
     async fn run(mut self, contract: ContractStateWatcher, cfg: watch::Receiver<Config>) {
         let mut check_requests_interval = tokio::time::interval(Duration::from_millis(100));
         let mut posits = self.msg.subscribe_signature_posit().await;
-        let current_epoch = self.epoch;
+        let _current_epoch = self.epoch;
 
         loop {
             tokio::select! {
                 Some((sign_id, presignature_id, from, action)) = posits.recv() => {
-                    // Check if epoch has changed or we're resharing - abort all tasks
-                    // if let Some(state) = contract.state() {
-                    //     match state {
-                    //         crate::protocol::ProtocolState::Resharing(_) => {
-                    //             tracing::info!("contract is resharing, aborting all signature tasks");
-                    //             return;
-                    //         }
-                    //         crate::protocol::ProtocolState::Running(running) if running.epoch != current_epoch => {
-                    //             tracing::info!(old_epoch = current_epoch, new_epoch = running.epoch, "epoch changed, aborting all signature tasks");
-                    //             return;
-                    //         }
-                    //         _ => {}
-                    //     }
-                    // }
                     self.handle_posit(sign_id, presignature_id, from, action).await;
                 }
                 Some(result) = self.tasks.join_next(), if !self.tasks.is_empty() => {
-                    // // Check if epoch has changed or we're resharing - abort all tasks
-                    // if let Some(state) = contract.state() {
-                    //     match state {
-                    //         crate::protocol::ProtocolState::Resharing(_) => {
-                    //             tracing::info!("contract is resharing, aborting all signature tasks");
-                    //             return;
-                    //         }
-                    //         crate::protocol::ProtocolState::Running(running) if running.epoch != current_epoch => {
-                    //             tracing::info!(old_epoch = current_epoch, new_epoch = running.epoch, "epoch changed, aborting all signature tasks");
-                    //             return;
-                    //         }
-                    //         _ => {}
-                    //     }
-                    // }
-
                     let (sign_id, result) = match result {
                         Ok(outcome) => outcome,
                         Err(sign_id) => {
@@ -1294,27 +1304,11 @@ impl SignatureSpawner {
                     }
                 }
                 _ = check_requests_interval.tick() => {
-                    // // Check if epoch has changed or we're resharing - abort all tasks
-                    // if let Some(state) = contract.state() {
-                    //     match state {
-                    //         crate::protocol::ProtocolState::Resharing(_) => {
-                    //             tracing::info!("contract is resharing, aborting all signature tasks");
-                    //             return;
-                    //         }
-                    //         crate::protocol::ProtocolState::Running(running) if running.epoch != current_epoch => {
-                    //             tracing::info!(old_epoch = current_epoch, new_epoch = running.epoch, "epoch changed, aborting all signature tasks");
-                    //             return;
-                    //         }
-                    //         _ => {}
-                    //     }
-                    // }
-
                     // Don't process requests until contract has participants
                     let Some(participants) = contract.participants() else {
                         continue;
                     };
-                    let participants = participants.keys().cloned().collect::<BTreeSet<_>>();
-
+                    let participants = participants.keys().cloned().collect();
                     let stable = self.mesh_state.borrow().stable.clone();
                     let protocol = cfg.borrow().protocol.clone();
                     self.handle_requests(&stable, &protocol, &participants).await;

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -1,12 +1,10 @@
-use super::contract::primitives::intersect_vec;
 use super::MpcSignProtocol;
 use crate::backlog::Backlog;
 use crate::config::Config;
 use crate::kdf::derive_delta;
 use crate::mesh::MeshState;
-use crate::protocol::contract::primitives::Participants;
 use crate::protocol::message::{MessageChannel, PositMessage, PositProtocolId, SignatureMessage};
-use crate::protocol::posit::{PositAction, PositInternalAction, Positor, Posits};
+use crate::protocol::posit::{PositAction, SinglePositCounter};
 use crate::protocol::presignature::PresignatureId;
 use crate::protocol::Chain;
 use crate::rpc::{ContractStateWatcher, RpcChannel};
@@ -26,17 +24,14 @@ use mpc_primitives::{SignArgs, SignId};
 use rand::rngs::StdRng;
 use rand::seq::IteratorRandom;
 use rand::SeedableRng;
-use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::error::TryRecvError;
-use tokio::sync::{mpsc, oneshot, watch, RwLock};
-use tokio::task::{JoinHandle, JoinSet};
+use tokio::sync::{mpsc, watch, RwLock};
+use tokio::task::JoinHandle;
 
 use near_account_id::AccountId;
-
-/// This is the maximum amount of sign requests that we can accept in the network.
-const MAX_SIGN_REQUESTS: usize = 1024;
 
 /// All relevant info pertaining to an Indexed sign request from an indexer.
 #[derive(Debug, Clone, PartialEq)]
@@ -50,47 +45,6 @@ pub struct IndexedSignRequest {
     pub sign_request_type: SignRequestType,
 }
 
-#[allow(clippy::large_enum_variant)]
-pub enum PendingRequest {
-    Available(SignRequest),
-    Pending(SignId, oneshot::Receiver<SignRequest>),
-}
-
-impl PendingRequest {
-    fn id(&self) -> SignId {
-        match self {
-            Self::Available(request) => request.indexed.id,
-            Self::Pending(id, _) => *id,
-        }
-    }
-
-    async fn fetch(self, timeout: Duration) -> Option<SignRequest> {
-        match self {
-            PendingRequest::Available(request) => Some(request),
-            PendingRequest::Pending(sign_id, channel) => {
-                match tokio::time::timeout(timeout, channel).await {
-                    Ok(Ok(request)) => Some(request),
-                    Ok(Err(_)) => {
-                        tracing::warn!(
-                            ?sign_id,
-                            "pending sign request channel closed before receiving request"
-                        );
-                        None
-                    }
-                    Err(_) => {
-                        tracing::warn!(
-                            ?sign_id,
-                            ?timeout,
-                            "timeout waiting for pending sign request"
-                        );
-                        None
-                    }
-                }
-            }
-        }
-    }
-}
-
 /// The sign request for the node to process. This contains relevant info for the node
 /// to generate a signature such as what has been indexed and what the node needs to maintain
 /// metadata-wise to generate the signature.
@@ -102,322 +56,583 @@ pub struct SignRequest {
     pub round: usize,
 }
 
-pub struct SignQueue {
-    me: Participant,
-    sign_rx: Arc<RwLock<mpsc::Receiver<IndexedSignRequest>>>,
-    /// The requests that belong to us where we will the propose the signature to the chain.
-    my_requests: VecDeque<SignId>,
-    /// Set of requests that failed to be processed during signature generation and need to
-    /// be reorganized with a potentially newer set of stable participants.
-    failed_requests: VecDeque<SignId>,
-    /// The pool of requests that we are about to process or are currently processing. Only
-    /// to be removed when fully timing out or when the request is completed.
-    requests: HashMap<SignId, SignRequest>,
-    /// The set of pending request listeners that are waiting for a sign request to be indexed.
-    /// They will be notified when a sign request is available.
-    pending: HashMap<SignId, oneshot::Sender<SignRequest>>,
-}
-
-impl SignQueue {
-    pub fn channel() -> (
-        mpsc::Sender<IndexedSignRequest>,
-        mpsc::Receiver<IndexedSignRequest>,
-    ) {
-        mpsc::channel(MAX_SIGN_REQUESTS)
-    }
-
-    pub fn new(me: Participant, sign_rx: Arc<RwLock<mpsc::Receiver<IndexedSignRequest>>>) -> Self {
-        Self {
-            me,
-            sign_rx,
-            my_requests: VecDeque::new(),
-            requests: HashMap::new(),
-            failed_requests: VecDeque::new(),
-            pending: HashMap::new(),
-        }
-    }
-
-    pub fn len_mine(&self) -> usize {
-        self.my_requests.len()
-    }
-
-    pub fn is_empty_mine(&self) -> bool {
-        self.len_mine() == 0
-    }
-
-    /// Length of requests that are currently in the sign queue. This includes all requests that
-    /// our node has observed, which means this does not include pending requests.
-    pub fn len(&self) -> usize {
-        self.requests.len()
-    }
-
-    /// Returns true if the sign queue is empty. Excludes pending requests.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    fn contains(&self, sign_id: &SignId) -> bool {
-        self.requests.contains_key(sign_id)
-    }
-
-    fn organize_request(
-        &self,
-        stable: &BTreeSet<Participant>,
-        participants: &Participants,
-        indexed: IndexedSignRequest,
-        initial_round: usize,
-    ) -> SignRequest {
-        let sign_id = indexed.id;
-        let reorganize = initial_round > 0;
-        let mut participants = participants.keys().copied().collect::<Vec<_>>();
-        participants.sort();
-
-        // Simple round-robin selection of the proposer, using only inputs that
-        // are guaranteed to be the same on all nodes.
-        fn proposer_per_round(
-            round: usize,
-            participants: &[Participant],
-            entropy: &[u8; 32],
-        ) -> Participant {
-            // if entropy is random, using one byte is as good as using all
-            let index = entropy[0] as usize + round;
-            participants[index % participants.len()]
-        }
-
-        let max_rounds = initial_round + 512;
-        // Use the smallest round that selects a stable proposer.
-        let (round, proposer) = (initial_round..max_rounds)
-            .map(|round| {
-                (
-                    round,
-                    proposer_per_round(round, &participants, &indexed.args.entropy),
-                )
-            })
-            .find(|(_, potential_proposer)| stable.contains(potential_proposer))
-            // on exhausting all rounds, just pick one at random and have posits error out.
-            .unwrap_or_else(|| {
-                (
-                    max_rounds,
-                    *stable
-                        .iter()
-                        .choose(&mut StdRng::from_seed(indexed.args.entropy))
-                        .unwrap(),
-                )
-            });
-
-        let is_mine = proposer == self.me;
-        tracing::info!(
-            ?stable,
-            ?sign_id,
-            ?proposer,
-            me = ?self.me,
-            is_mine,
-            "sign queue: {}organizing request",
-            if reorganize { "re" } else { "" },
-        );
-
-        SignRequest {
-            indexed,
-            proposer,
-            stable: stable.clone(),
-            round,
-        }
-    }
-
-    pub async fn organize(
-        &mut self,
-        stable: &BTreeSet<Participant>,
-        participants: &Participants,
-        my_account_id: &AccountId,
-    ) {
-        // Reorganize the failed requests with a potentially newer list of stable participants.
-        self.organize_failed(stable, participants, my_account_id);
-
-        // try and organize the new incoming requests.
-        let mut sign_rx = self.sign_rx.write().await;
-        while let Ok(indexed) = {
-            match sign_rx.try_recv() {
-                err @ Err(TryRecvError::Disconnected) => {
-                    tracing::error!("sign queue channel disconnected");
-                    err
-                }
-                other => other,
-            }
-        } {
-            let sign_id = indexed.id;
-            if self.contains(&sign_id) {
-                tracing::info!(?sign_id, "skipping sign request: already in the sign queue");
-                continue;
-            }
-            crate::metrics::NUM_UNIQUE_SIGN_REQUESTS
-                .with_label_values(&[indexed.chain.as_str(), my_account_id.as_str()])
-                .inc();
-
-            let request = self.organize_request(stable, participants, indexed, 0);
-            let is_mine = request.proposer == self.me;
-            if is_mine {
-                self.my_requests.push_back(sign_id);
-                crate::metrics::NUM_SIGN_REQUESTS_MINE
-                    .with_label_values(&[my_account_id.as_str()])
-                    .inc();
-            }
-            if let Some(pending) = self.pending.remove(&sign_id) {
-                tracing::info!(?sign_id, proposer = ?request.proposer, "sign queue received pending request");
-                if pending.send(request.clone()).is_err() {
-                    tracing::warn!(
-                        ?sign_id,
-                        "pending sign request channel closed before able to send request"
-                    );
-                }
-            }
-
-            self.requests.insert(sign_id, request);
-        }
-    }
-
-    fn organize_failed(
-        &mut self,
-        stable: &BTreeSet<Participant>,
-        participants: &Participants,
-        my_account_id: &AccountId,
-    ) {
-        while let Some(id) = self.failed_requests.pop_front() {
-            let Some(request) = self.requests.remove(&id) else {
-                continue;
-            };
-
-            let (reorganized, request) = if &request.stable == stable {
-                // just use the same request if the participants are the same
-                (false, request)
-            } else {
-                let request =
-                    self.organize_request(stable, participants, request.indexed, request.round);
-                (true, request)
-            };
-
-            // NOTE: this prioritizes old requests first then tries to do new ones if there's enough presignatures.
-            // TODO: we need to decide how to prioritize certain requests over others such as with gas or time of
-            // when the request made it into the NEAR network.
-            // issue: https://github.com/near/mpc-recovery/issues/596
-            if request.proposer == self.me {
-                self.my_requests.push_front(request.indexed.id);
-                if reorganized {
-                    crate::metrics::NUM_SIGN_REQUESTS_MINE
-                        .with_label_values(&[my_account_id.as_str()])
-                        .inc();
-                }
-            }
-
-            self.requests.insert(request.indexed.id, request);
-        }
-    }
-
-    pub fn push_failed(&mut self, sign_id: SignId) {
-        self.failed_requests.push_back(sign_id);
-    }
-
-    pub fn take_mine(&mut self) -> Option<SignRequest> {
-        let id = self.my_requests.pop_front()?;
-        self.requests.get(&id).cloned()
-    }
-
-    pub fn get_or_pending(&mut self, id: &SignId) -> PendingRequest {
-        if let Some(request) = self.requests.get(id) {
-            PendingRequest::Available(request.clone())
-        } else {
-            let (tx, rx) = oneshot::channel();
-            self.pending.insert(*id, tx);
-            PendingRequest::Pending(*id, rx)
-        }
-    }
-
-    pub fn expire(&mut self, cfg: &ProtocolConfig) {
-        self.requests.retain(|_, request| {
-            request.indexed.timestamp_sign_queue.elapsed()
-                < Duration::from_millis(cfg.signature.generation_timeout_total)
-        });
-        self.my_requests.retain(|id| {
-            let Some(request) = self.requests.get(id) else {
-                // if we are unable to find the corresponding request, we can remove it.
-                return false;
-            };
-            crate::util::duration_between_unix(
-                request.indexed.unix_timestamp_indexed,
-                crate::util::current_unix_timestamp(),
-            ) < request.indexed.total_timeout
-        });
-        self.failed_requests.retain(|id| {
-            let Some(request) = self.requests.get(id) else {
-                // if we are unable to find the corresponding request, we can remove it.
-                return false;
-            };
-            crate::util::duration_between_unix(
-                request.indexed.unix_timestamp_indexed,
-                crate::util::current_unix_timestamp(),
-            ) < request.indexed.total_timeout
-        });
-    }
-
-    pub fn remove(&mut self, sign_id: SignId) -> Option<SignRequest> {
-        self.requests.remove(&sign_id)
-    }
-}
-
+#[derive(Debug, Clone, Copy)]
 enum SignError {
-    Retry,
-    TotalTimeout,
     Aborted,
 }
 
+struct SignState {
+    round: usize,
+    indexed: IndexedSignRequest,
+    mesh_state: watch::Receiver<MeshState>,
+}
+
+impl SignState {
+    fn new(indexed: IndexedSignRequest, mesh_state: watch::Receiver<MeshState>) -> Self {
+        Self {
+            round: 0,
+            indexed,
+            mesh_state,
+        }
+    }
+
+    fn indexed(&self) -> &IndexedSignRequest {
+        &self.indexed
+    }
+
+    fn bump_round(&mut self) {
+        self.round += 1;
+    }
+}
+
+struct SignPositor {
+    proposer: Participant,
+    stable: BTreeSet<Participant>,
+    presignature_id: PresignatureId,
+    presignature: Option<PresignatureTaken>,
+}
+
+struct SignGenerating {
+    proposer: Participant,
+    stable: BTreeSet<Participant>,
+    presignature_id: PresignatureId,
+    presignature: Option<PresignatureTaken>,
+    accepted_participants: Vec<Participant>,
+}
+
+enum SignPhase {
+    Organizing(SignOrganizer),
+    Posit(SignPositor),
+    Generating(SignGenerating),
+    Complete(Result<(), SignError>),
+}
+
+impl SignPhase {
+    async fn advance(
+        self,
+        ctx: &SignTask,
+        state: &mut SignState,
+        task_rx: &mut mpsc::Receiver<SignatureTaskMessage>,
+    ) -> SignPhase {
+        match self {
+            SignPhase::Organizing(phase) => phase.advance(ctx, state).await,
+            SignPhase::Posit(phase) => phase.advance(ctx, state, task_rx).await,
+            SignPhase::Generating(phase) => phase.advance(ctx, state).await,
+            SignPhase::Complete(result) => SignPhase::Complete(result),
+        }
+    }
+}
+
+struct SignOrganizer;
+
+impl SignOrganizer {
+    fn proposer_per_round(
+        round: usize,
+        participants: &[Participant],
+        entropy: &[u8; 32],
+    ) -> Participant {
+        let index = entropy[0] as usize + round;
+        participants[index % participants.len()]
+    }
+
+    /// Waits for threshold stable participants to be present.
+    async fn wait_stable(
+        &self,
+        ctx: &SignTask,
+        state: &mut SignState,
+        threshold: usize,
+    ) -> BTreeSet<Participant> {
+        let sign_id = ctx.sign_id;
+        let mut once = true;
+
+        loop {
+            let stable_count = {
+                let stable = &state.mesh_state.borrow().stable;
+                if stable.len() >= threshold {
+                    return stable.clone();
+                }
+                stable.len()
+            };
+
+            if once {
+                tracing::info!(
+                    ?sign_id,
+                    stable_count,
+                    ?threshold,
+                    "waiting for enough stable participants"
+                );
+                once = false;
+            }
+
+            if let Err(err) = state.mesh_state.changed().await {
+                tracing::error!(?sign_id, ?err, "mesh state watch channel closed");
+                return BTreeSet::new();
+            }
+        }
+    }
+
+    async fn advance(self, ctx: &SignTask, state: &mut SignState) -> SignPhase {
+        let sign_id = ctx.sign_id;
+        let threshold = ctx.threshold;
+        let me = ctx.me;
+        let entropy = state.indexed.args.entropy;
+        let participants = ctx.participants.iter().copied().collect::<Vec<_>>();
+
+        tracing::info!(?sign_id, round = ?state.round, "entering organizing phase");
+        let (stable, proposer) = {
+            let stable = self.wait_stable(ctx, state, threshold).await;
+            if stable.is_empty() {
+                tracing::warn!(?sign_id, round = ?state.round, "no stable participants, reorganizing");
+                state.bump_round();
+                return SignPhase::Organizing(self);
+            }
+
+            let max_rounds = state.round + 512;
+            let (selected_round, proposer) = (state.round..max_rounds)
+                .map(|r| (r, Self::proposer_per_round(r, &participants, &entropy)))
+                .find(|(_, potential_proposer)| stable.contains(potential_proposer))
+                .unwrap_or_else(|| {
+                    (
+                        max_rounds,
+                        *stable
+                            .iter()
+                            .choose(&mut StdRng::from_seed(entropy))
+                            .unwrap(),
+                    )
+                });
+
+            let is_mine = proposer == me;
+
+            tracing::info!(
+                ?sign_id,
+                round = selected_round,
+                ?proposer,
+                ?me,
+                is_mine,
+                stable_count = stable.len(),
+                "organized: selected proposer"
+            );
+
+            if is_mine && state.round == 0 {
+                crate::metrics::NUM_SIGN_REQUESTS_MINE
+                    .with_label_values(&[ctx.my_account_id.as_str()])
+                    .inc();
+            }
+
+            (stable, proposer)
+        };
+
+        let posit_participants = stable.iter().copied().collect::<Vec<_>>();
+        let is_proposer = proposer == ctx.me;
+
+        let (presignature_id, presignature) = if is_proposer {
+            tracing::info!(?sign_id, round = ?state.round, "proposer waiting for presignature");
+            let fetch = tokio::time::timeout(Duration::from_secs(30), async {
+                loop {
+                    if let Some(taken) = ctx.presignatures.take_mine(ctx.me).await {
+                        break taken;
+                    }
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                }
+            })
+            .await;
+
+            let taken = match fetch {
+                Ok(taken) => taken,
+                Err(_) => {
+                    tracing::warn!(
+                        ?sign_id,
+                        round = ?state.round,
+                        "proposer timeout waiting for presignature, reorganizing"
+                    );
+                    state.bump_round();
+                    return SignPhase::Organizing(self);
+                }
+            };
+
+            let presignature_id = taken.presignature.id;
+            tracing::info!(?sign_id, presignature_id, "proposer got presignature");
+
+            for &p in &posit_participants {
+                if p == ctx.me {
+                    continue;
+                }
+                ctx.msg
+                    .send(
+                        ctx.me,
+                        p,
+                        PositMessage {
+                            id: PositProtocolId::Signature(sign_id, presignature_id),
+                            from: ctx.me,
+                            action: PositAction::Propose,
+                        },
+                    )
+                    .await;
+            }
+
+            (presignature_id, Some(taken))
+        } else {
+            (PresignatureId::default(), None)
+        };
+
+        SignPhase::Posit(SignPositor {
+            proposer,
+            stable,
+            presignature_id,
+            presignature,
+        })
+    }
+}
+
+impl SignPositor {
+    /// Deliberator waits for the proposer to send a Propose message with a presignature_id.
+    async fn wait_propose(
+        ctx: &SignTask,
+        state: &mut SignState,
+        task_rx: &mut mpsc::Receiver<SignatureTaskMessage>,
+        proposer: Participant,
+    ) -> Result<PresignatureId, SignPhase> {
+        let sign_id = ctx.sign_id;
+        let round = state.round;
+
+        tracing::info!(
+            ?sign_id,
+            ?round,
+            ?proposer,
+            "deliberator waiting for Propose"
+        );
+        let outcome = tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                let Some(task_msg) = task_rx.recv().await else {
+                    continue;
+                };
+                let SignatureTaskMessage::PositMessage {
+                    presignature_id,
+                    from,
+                    action,
+                } = &task_msg;
+
+                if !matches!(action, PositAction::Propose) {
+                    continue;
+                }
+
+                if from == &proposer {
+                    tracing::info!(
+                        ?sign_id,
+                        presignature_id,
+                        ?from,
+                        "deliberator received Propose"
+                    );
+                    break *presignature_id;
+                } else {
+                    // reject
+                    tracing::warn!(
+                        ?sign_id,
+                        ?from,
+                        ?proposer,
+                        "received Propose from non-proposer, rejecting"
+                    );
+
+                    ctx.msg
+                        .send(
+                            ctx.me,
+                            *from,
+                            PositMessage {
+                                id: PositProtocolId::Signature(sign_id, *presignature_id),
+                                from: ctx.me,
+                                action: PositAction::Reject,
+                            },
+                        )
+                        .await;
+                }
+            }
+        })
+        .await;
+
+        let presignature_id = match outcome {
+            Ok(id) => id,
+            Err(_) => {
+                tracing::warn!(
+                    ?sign_id,
+                    ?round,
+                    ?proposer,
+                    "deliberator timeout waiting for Propose, reorganizing"
+                );
+                state.bump_round();
+                return Err(SignPhase::Organizing(SignOrganizer));
+            }
+        };
+
+        // received propose, send Accept
+        ctx.msg
+            .send(
+                ctx.me,
+                proposer,
+                PositMessage {
+                    id: PositProtocolId::Signature(sign_id, presignature_id),
+                    from: ctx.me,
+                    action: PositAction::Accept,
+                },
+            )
+            .await;
+
+        Ok(presignature_id)
+    }
+
+    async fn advance(
+        self,
+        ctx: &SignTask,
+        state: &mut SignState,
+        task_rx: &mut mpsc::Receiver<SignatureTaskMessage>,
+    ) -> SignPhase {
+        let SignPositor {
+            proposer,
+            stable,
+            mut presignature_id,
+            presignature,
+        } = self;
+
+        let sign_id = ctx.sign_id;
+        let round = state.round;
+        let is_proposer = proposer == ctx.me;
+        let is_deliberator = !is_proposer;
+        let posit_participants = stable.iter().copied().collect::<Vec<_>>();
+
+        tracing::info!(
+            ?sign_id,
+            ?presignature_id,
+            ?round,
+            is_proposer,
+            "entering posit phase"
+        );
+
+        if posit_participants.is_empty() {
+            tracing::warn!(
+                ?sign_id,
+                ?round,
+                "posit phase has no participants, reorganizing"
+            );
+            state.bump_round();
+            return SignPhase::Organizing(SignOrganizer);
+        }
+
+        if is_deliberator {
+            presignature_id = match Self::wait_propose(ctx, state, task_rx, proposer).await {
+                Ok(id) => id,
+                Err(phase) => return phase,
+            }
+        }
+
+        let mut counter = SinglePositCounter::new(ctx.me, &posit_participants);
+
+        let posit_timeout = Duration::from_secs(60);
+        let posit_deadline = tokio::time::sleep(posit_timeout);
+        tokio::pin!(posit_deadline);
+
+        let accepted_participants = loop {
+            tokio::select! {
+                Some(task_msg) = task_rx.recv() => {
+                    let SignatureTaskMessage::PositMessage { presignature_id: _, from, action } = task_msg;
+                    if !is_proposer {
+                        if let PositAction::Start(participants) = action {
+                            if from != proposer {
+                                tracing::warn!(?sign_id, ?from, ?proposer, "received Start from non-proposer, ignoring");
+                                continue;
+                            }
+                            tracing::info!(?sign_id, participant = ?ctx.me, ?participants, "deliberator received Start");
+                            break participants;
+                        }
+                    } else {
+                        if !counter.process_action(from, &action) {
+                            continue;
+                        }
+
+                        if counter.enough_rejects(ctx.threshold) {
+                            tracing::warn!(?sign_id, ?from, "received enough REJECTs, reorganizing");
+                            state.bump_round();
+                            return SignPhase::Organizing(SignOrganizer);
+                        }
+
+                        if counter.meets_totality() {
+                            let participants = counter.accepts.iter().copied().collect::<Vec<_>>();
+                            tracing::info!(?sign_id, me = ?ctx.me, ?participants, "proposer broadcasting Start");
+                            for &p in &participants {
+                                if p == ctx.me {
+                                    continue;
+                                }
+                                ctx.msg
+                                    .send(
+                                        ctx.me,
+                                        p,
+                                        PositMessage {
+                                            id: PositProtocolId::Signature(sign_id, presignature_id),
+                                            from: ctx.me,
+                                            action: PositAction::Start(participants.clone()),
+                                        },
+                                    )
+                                    .await;
+                            }
+                            break participants;
+                        }
+                    }
+                }
+                _ = &mut posit_deadline => {
+                    if is_proposer {
+                        if counter.enough_accepts(ctx.threshold) {
+                            let participants = counter.accepts.iter().copied().collect::<Vec<_>>();
+                            tracing::info!(?sign_id, "posit timeout with enough accepts, broadcasting Start");
+                            for &p in &participants {
+                                if p == ctx.me {
+                                    continue;
+                                }
+                                ctx.msg
+                                    .send(
+                                        ctx.me,
+                                        p,
+                                        PositMessage {
+                                            id: PositProtocolId::Signature(sign_id, presignature_id),
+                                            from: ctx.me,
+                                            action: PositAction::Start(participants.clone()),
+                                        },
+                                    )
+                                    .await;
+                            }
+                            break participants;
+                        } else {
+                            tracing::warn!(?sign_id, "posit timeout without enough accepts, reorganizing");
+                            state.bump_round();
+                            return SignPhase::Organizing(SignOrganizer);
+                        }
+                    } else {
+                        tracing::warn!(?sign_id, "deliberator posit timeout waiting for Start, reorganizing");
+                        state.bump_round();
+                        return SignPhase::Organizing(SignOrganizer);
+                    }
+                }
+            }
+        };
+
+        if accepted_participants.is_empty() {
+            tracing::warn!(
+                ?sign_id,
+                ?round,
+                "no accepted participants after posit, reorganizing"
+            );
+            state.bump_round();
+            return SignPhase::Organizing(SignOrganizer);
+        }
+
+        SignPhase::Generating(SignGenerating {
+            proposer,
+            stable,
+            presignature_id,
+            presignature,
+            accepted_participants,
+        })
+    }
+}
+
+impl SignGenerating {
+    async fn advance(mut self, ctx: &SignTask, state: &mut SignState) -> SignPhase {
+        let sign_id = ctx.sign_id;
+        let round = state.round;
+
+        tracing::info!(
+            ?sign_id,
+            presignature_id = ?self.presignature_id,
+            participants = ?self.accepted_participants,
+            "posit complete, starting generation"
+        );
+
+        let presignature_pending = if let Some(taken) = self.presignature.take() {
+            PendingPresignature::Available(taken)
+        } else {
+            PendingPresignature::InStorage(
+                self.presignature_id,
+                self.proposer,
+                ctx.presignatures.clone(),
+            )
+        };
+
+        let request = SignRequest {
+            indexed: state.indexed().clone(),
+            proposer: self.proposer,
+            stable: self.stable.clone(),
+            round,
+        };
+
+        let participants = self.accepted_participants.clone();
+
+        let generator = match SignGenerator::new(
+            ctx,
+            request,
+            presignature_pending,
+            participants.clone(),
+        )
+        .await
+        {
+            Ok(gen) => gen,
+            Err(err) => {
+                tracing::warn!(
+                    ?sign_id,
+                    ?round,
+                    ?err,
+                    "failed to create generator, reorganizing"
+                );
+                state.bump_round();
+                return SignPhase::Organizing(SignOrganizer);
+            }
+        };
+
+        // Track that we've created a generator
+        crate::metrics::NUM_TOTAL_HISTORICAL_SIGNATURE_GENERATORS
+            .with_label_values(&[ctx.my_account_id.as_str()])
+            .inc();
+
+        match generator.run(ctx).await {
+            Ok(()) => SignPhase::Complete(Ok(())),
+            Err(err) => {
+                tracing::warn!(
+                    ?sign_id,
+                    ?round,
+                    ?err,
+                    "signature generation failed, reorganizing"
+                );
+                state.bump_round();
+                SignPhase::Organizing(SignOrganizer)
+            }
+        }
+    }
+}
+
 /// An ongoing signature generator.
-struct SignatureGenerator {
+struct SignGenerator {
     protocol: SignatureProtocol,
     dropper: PresignatureTakenDropper,
     participants: Vec<Participant>,
     request: SignRequest,
-    public_key: PublicKey,
     created: Instant,
     timeout: Duration,
-    timeout_total: Duration,
     inbox: mpsc::Receiver<SignatureMessage>,
-    msg: MessageChannel,
-    rpc: RpcChannel,
-
-    // TODO: will be used in the future when we move requests channels
-    // into the backlog.
-    #[allow(dead_code)]
-    backlog: Backlog,
+    msg: MessageChannel, // Needed for Drop
 
     #[cfg(feature = "debug-page")]
     debug_view: crate::web::debug::DebugPageTaskHandle,
 }
 
-impl SignatureGenerator {
-    #[allow(clippy::too_many_arguments)]
+impl SignGenerator {
     async fn new(
-        me: Participant,
-        request: PendingRequest,
+        ctx: &SignTask,
+        request: SignRequest,
         presignature: PendingPresignature,
         participants: Vec<Participant>,
-        public_key: PublicKey,
-        cfg: ProtocolConfig,
-        msg: MessageChannel,
-        rpc: RpcChannel,
-        backlog: Backlog,
-        _my_account_id: &AccountId,
     ) -> Result<Self, InitializationError> {
-        let sign_id = request.id();
-        let request = request
-            .fetch(Duration::from_millis(cfg.signature.generation_timeout))
-            .await
-            .ok_or_else(|| {
-                InitializationError::BadParameters(format!(
-                    "sign request {sign_id:?} not found or timeout"
-                ))
-            })?;
         let presignature_id = presignature.id();
         let taken = presignature
-            .fetch(me, Duration::from_millis(cfg.signature.generation_timeout))
+            .fetch(
+                ctx.me,
+                Duration::from_millis(ctx.cfg.signature.generation_timeout),
+            )
             .await
             .ok_or_else(|| {
                 InitializationError::BadParameters(format!(
@@ -428,7 +643,7 @@ impl SignatureGenerator {
         let indexed = &request.indexed;
         let sign_id = indexed.id;
         tracing::info!(
-            ?me,
+            me = ?ctx.me,
             ?sign_id,
             presignature_id,
             "starting protocol to generate a new signature",
@@ -445,35 +660,27 @@ impl SignatureGenerator {
         };
         let protocol = Box::new(cait_sith::sign(
             &participants,
-            me,
-            derive_key(public_key, indexed.args.epsilon),
+            ctx.me,
+            derive_key(ctx.public_key, indexed.args.epsilon),
             output,
             indexed.args.payload,
         )?);
-        let inbox = msg.subscribe_signature(sign_id, presignature_id).await;
+        let inbox = ctx.msg.subscribe_signature(sign_id, presignature_id).await;
         Ok(Self {
             protocol,
             dropper,
             participants,
             request,
-            public_key,
             created: Instant::now(),
-            timeout: Duration::from_millis(cfg.signature.generation_timeout),
-            timeout_total: Duration::from_millis(cfg.signature.generation_timeout_total),
+            timeout: Duration::from_millis(ctx.cfg.signature.generation_timeout),
             inbox,
-            msg,
-            rpc,
-            backlog,
+            msg: ctx.msg.clone(),
             #[cfg(feature = "debug-page")]
             debug_view: crate::web::debug::register_task(
-                _my_account_id.to_string(),
+                ctx.my_account_id.to_string(),
                 format!("SignatureGenerator {sign_id:#?}"),
             ),
         })
-    }
-
-    fn timeout_total(&self) -> bool {
-        self.request.indexed.timestamp_sign_queue.elapsed() >= self.timeout_total
     }
 
     /// Receive the next message for the signature protocol; error out on the timeout being reached
@@ -493,30 +700,23 @@ impl SignatureGenerator {
                 Err(SignError::Aborted)
             }
             Err(_err) => {
-                tracing::warn!(
-                    ?sign_id,
-                    presignature_id,
-                    "signature generation timeout, retrying..."
-                );
-                Err(SignError::Retry)
+                tracing::warn!(?sign_id, presignature_id, "signature generation timeout");
+                Err(SignError::Aborted)
             }
         }
     }
 
-    async fn run(
-        mut self,
-        me: Participant,
-        epoch: u64,
-        my_account_id: AccountId,
-    ) -> Result<(), SignError> {
+    async fn run(mut self, ctx: &SignTask) -> Result<(), SignError> {
+        let my_account_id = &ctx.my_account_id;
+        let me = ctx.me;
+        let epoch = ctx.epoch;
+
         let accrued_wait_delay = crate::metrics::SIGNATURE_ACCRUED_WAIT_DELAY
             .with_label_values(&[my_account_id.as_str()]);
         let poke_counts =
             crate::metrics::SIGNATURE_POKES_CNT.with_label_values(&[my_account_id.as_str()]);
         let signature_generator_failures_metric = crate::metrics::SIGNATURE_GENERATOR_FAILURES
             .with_label_values(&[my_account_id.as_str()]);
-        let signature_failures_metric =
-            crate::metrics::SIGNATURE_FAILURES.with_label_values(&[my_account_id.as_str()]);
         let poke_latency =
             crate::metrics::SIGNATURE_POKE_CPU_TIME.with_label_values(&[my_account_id.as_str()]);
 
@@ -531,19 +731,6 @@ impl SignatureGenerator {
             .observe(self.created.elapsed().as_millis() as f64);
 
         loop {
-            if self.timeout_total() {
-                tracing::warn!(
-                    ?sign_id,
-                    presignature_id,
-                    "signature generation timeout, exhausted all attempts"
-                );
-                if self.request.proposer == me {
-                    signature_generator_failures_metric.inc();
-                    signature_failures_metric.inc();
-                }
-                break Err(SignError::TotalTimeout);
-            }
-
             let poke_start_time = Instant::now();
             let action = match self.protocol.poke() {
                 Ok(action) => action,
@@ -553,7 +740,7 @@ impl SignatureGenerator {
                         ?err,
                         "signature generation failed on protocol advancement",
                     );
-                    break Err(SignError::Retry);
+                    break Err(SignError::Aborted);
                 }
             };
 
@@ -579,7 +766,7 @@ impl SignatureGenerator {
                         if to == me {
                             continue;
                         }
-                        self.msg
+                        ctx.msg
                             .send(
                                 me,
                                 to,
@@ -597,7 +784,7 @@ impl SignatureGenerator {
                     }
                 }
                 Action::SendPrivate(to, data) => {
-                    self.msg
+                    ctx.msg
                         .send(
                             me,
                             to,
@@ -633,8 +820,8 @@ impl SignatureGenerator {
                         .observe(self.created.elapsed().as_secs_f64());
 
                     if self.request.proposer == me {
-                        self.rpc.publish(
-                            self.public_key,
+                        ctx.rpc.publish(
+                            ctx.public_key,
                             self.request.clone(),
                             output,
                             self.participants.clone(),
@@ -672,7 +859,7 @@ impl SignatureGenerator {
     }
 }
 
-impl Drop for SignatureGenerator {
+impl Drop for SignGenerator {
     fn drop(&mut self) {
         let msg = self.msg.clone();
         let sign_id = self.request.indexed.id;
@@ -684,15 +871,79 @@ impl Drop for SignatureGenerator {
     }
 }
 
+struct SignTask {
+    me: Participant,
+    participants: BTreeSet<Participant>,
+    sign_id: SignId,
+    threshold: usize,
+    public_key: PublicKey,
+    epoch: u64,
+    my_account_id: AccountId,
+    presignatures: PresignatureStorage,
+    msg: MessageChannel,
+    rpc: RpcChannel,
+
+    // TODO: will be used in the future when we move requests channels
+    // into the backlog.
+    #[allow(dead_code)]
+    backlog: Backlog,
+
+    cfg: ProtocolConfig,
+}
+
+impl SignTask {
+    async fn run(
+        self,
+        indexed: IndexedSignRequest,
+        mesh_state: watch::Receiver<MeshState>,
+        mut task_rx: mpsc::Receiver<SignatureTaskMessage>,
+    ) -> Result<(), SignError> {
+        let sign_id = self.sign_id;
+        tracing::info!(
+            ?sign_id,
+            me = ?self.me,
+            "signature task starting with organizing loop"
+        );
+
+        let mut state = SignState::new(indexed, mesh_state);
+        let mut phase = SignPhase::Organizing(SignOrganizer);
+
+        loop {
+            match phase.advance(&self, &mut state, &mut task_rx).await {
+                SignPhase::Complete(result) => return result,
+                other => {
+                    phase = other;
+                }
+            }
+        }
+    }
+}
+
+/// Message types that can be sent to a running signature task
+enum SignatureTaskMessage {
+    PositMessage {
+        presignature_id: PresignatureId,
+        from: Participant,
+        action: PositAction,
+    },
+}
+
 pub struct SignatureSpawner {
     /// Presignature storage that maintains all presignatures.
     presignatures: PresignatureStorage,
-    /// Ongoing signature generation protocols.
-    ongoing: JoinMap<(SignId, PresignatureId), Result<(), SignError>>,
-    /// Sign queue that maintains all requests coming in from indexer.
-    sign_queue: SignQueue,
-    /// The protocol posits that are currently in progress.
-    posits: Posits<(SignId, PresignatureId), PresignatureTaken>,
+    /// Receiver for incoming sign requests from indexer
+    sign_rx: Arc<RwLock<mpsc::Receiver<IndexedSignRequest>>>,
+    /// Track which sign requests we've seen and spawned tasks for
+    seen_requests: HashSet<SignId>,
+    /// Consolidated signature tasks - one per sign_id, each task is an async task handling complete lifecycle
+    tasks: JoinMap<SignId, Result<(), SignError>>,
+    /// Channels to send messages to running tasks
+    task_channels: HashMap<SignId, mpsc::Sender<SignatureTaskMessage>>,
+    /// Buffer for posit messages that arrived before the task was created
+    /// Maps sign_id -> list of (presignature_id, from, action)
+    pending_posit_messages: HashMap<SignId, Vec<(PresignatureId, Participant, PositAction)>>,
+    /// Watch channel for stable participants (needed for task reorganization)
+    mesh_state: watch::Receiver<MeshState>,
 
     me: Participant,
     my_account_id: AccountId,
@@ -714,15 +965,19 @@ impl SignatureSpawner {
         epoch: u64,
         sign_rx: Arc<RwLock<mpsc::Receiver<IndexedSignRequest>>>,
         presignatures: &PresignatureStorage,
+        mesh_state: watch::Receiver<MeshState>,
         msg: MessageChannel,
         rpc: RpcChannel,
         backlog: Backlog,
     ) -> Self {
         Self {
             presignatures: presignatures.clone(),
-            ongoing: JoinMap::new(),
-            sign_queue: SignQueue::new(me, sign_rx),
-            posits: Posits::new(me),
+            sign_rx,
+            seen_requests: HashSet::new(),
+            tasks: JoinMap::new(),
+            task_channels: HashMap::new(),
+            pending_posit_messages: HashMap::new(),
+            mesh_state,
             me,
             my_account_id: my_account_id.clone(),
             threshold,
@@ -734,228 +989,96 @@ impl SignatureSpawner {
         }
     }
 
-    /// Starts a new signature generation protocol.
-    async fn propose_posit(
+    /// Creates a signature task for a new sign request
+    /// The task will handle organizing, posit, and generation internally
+    async fn spawn_task(
         &mut self,
-        request: &SignRequest,
-        taken: PresignatureTaken,
-        participants: &[Participant],
+        indexed: IndexedSignRequest,
+        participants: BTreeSet<Participant>,
+        cfg: &ProtocolConfig,
     ) {
-        let sign_id = request.indexed.id;
-        let presignature_id = taken.presignature.id;
-        tracing::info!(
-            ?sign_id,
-            presignature_id,
-            "proposing protocol to generate a new signature"
-        );
+        let sign_id = indexed.id;
+        tracing::info!(?sign_id, "spawning signature task");
 
-        self.posits
-            .propose((sign_id, presignature_id), taken, participants);
-        for &p in participants.iter() {
-            if p == self.me {
-                continue;
+        // Create channel for task communication
+        let (tx, rx) = mpsc::channel(256);
+        self.task_channels.insert(sign_id, tx.clone());
+
+        // Process any pending posit messages
+        if let Some(pending_messages) = self.pending_posit_messages.remove(&sign_id) {
+            tracing::debug!(
+                ?sign_id,
+                count = pending_messages.len(),
+                "sending pending posit messages to task"
+            );
+            for (msg_presignature_id, msg_from, msg_action) in pending_messages {
+                let _ = tx
+                    .send(SignatureTaskMessage::PositMessage {
+                        presignature_id: msg_presignature_id,
+                        from: msg_from,
+                        action: msg_action,
+                    })
+                    .await;
             }
-
-            self.msg
-                .send(
-                    self.me,
-                    p,
-                    PositMessage {
-                        id: PositProtocolId::Signature(sign_id, presignature_id),
-                        from: self.me,
-                        action: PositAction::Propose,
-                    },
-                )
-                .await;
         }
+
+        let task = SignTask {
+            me: self.me,
+            participants,
+            sign_id,
+            threshold: self.threshold,
+            public_key: self.public_key,
+            epoch: self.epoch,
+            my_account_id: self.my_account_id.clone(),
+            presignatures: self.presignatures.clone(),
+            msg: self.msg.clone(),
+            rpc: self.rpc.clone(),
+            backlog: self.backlog.clone(),
+            cfg: cfg.clone(),
+        };
+
+        // Spawn the async task with organizing loop
+        self.tasks
+            .spawn(sign_id, task.run(indexed, self.mesh_state.clone(), rx));
     }
 
-    // TODO: we really need to refactor how posits are handled since the dependencies are being waited upon
-    // in a different places vs the `process_posit` function. This will be hard to read and tract down where
-    // things are being handled.
-    async fn process_posit(
+    /// Handle a posit message - routes to existing task or buffers if task not yet created
+    async fn handle_posit(
         &mut self,
         sign_id: SignId,
         presignature_id: PresignatureId,
-        mut request: Option<SignRequest>,
         from: Participant,
         action: PositAction,
-        cfg: ProtocolConfig,
     ) {
-        let internal_action = if self.ongoing.contains_key(&(sign_id, presignature_id)) {
-            tracing::warn!(
-                ?sign_id,
-                presignature_id,
-                "signature is already in the ongoing generation"
-            );
-            PositInternalAction::Reply(PositAction::Reject)
-        } else if matches!(action, PositAction::Propose) {
-            match request.take() {
-                Some(req) => {
-                    if req.proposer == from {
-                        self.posits
-                            .act((sign_id, presignature_id), from, self.threshold, &action)
-                    } else {
-                        tracing::warn!(
-                            ?sign_id,
-                            presignature_id,
-                            expected_proposer = ?req.proposer,
-                            actual_proposer = ?from,
-                            "rejecting signature posit: proposer mismatch",
-                        );
-                        PositInternalAction::Reply(PositAction::Reject)
-                    }
-                }
-                None => {
-                    tracing::warn!(
-                        ?sign_id,
-                        presignature_id,
-                        ?from,
-                        "rejecting signature posit: sign request not yet available locally",
-                    );
-                    PositInternalAction::Reply(PositAction::Reject)
-                }
-            }
-        } else {
-            self.posits
-                .act((sign_id, presignature_id), from, self.threshold, &action)
-        };
+        // Ignore messages from ourselves
+        if from == self.me {
+            return;
+        }
 
-        match internal_action {
-            PositInternalAction::None => {}
-            PositInternalAction::Abort => {
-                tracing::warn!(
-                    ?sign_id,
+        // If task channel exists, forward message to it
+        if let Some(ch) = self.task_channels.get(&sign_id) {
+            let _ = ch
+                .send(SignatureTaskMessage::PositMessage {
                     presignature_id,
-                    from = ?from,
-                    "signature posit action was rejected"
-                );
-                self.sign_queue.push_failed(sign_id);
-            }
-            PositInternalAction::Reply(action) => {
-                if matches!(action, PositAction::Reject) {
-                    // proposer can potentially be wrong, let's reorder our participants for this sign request:
-                    self.sign_queue.push_failed(sign_id);
-                }
-
-                self.msg
-                    .send(
-                        self.me,
-                        from,
-                        PositMessage {
-                            id: PositProtocolId::Signature(sign_id, presignature_id),
-                            from: self.me,
-                            action,
-                        },
-                    )
-                    .await;
-            }
-            PositInternalAction::StartProtocol(participants, positor) => {
-                self.start_generation(positor, sign_id, presignature_id, participants, cfg)
-                    .await;
-            }
+                    from,
+                    action,
+                })
+                .await;
+        } else {
+            // No task yet - buffer message for when task is created
+            tracing::trace!(?sign_id, ?from, ?action, "buffering message - no task yet");
+            self.pending_posit_messages
+                .entry(sign_id)
+                .or_default()
+                .push((presignature_id, from, action));
         }
-    }
-
-    /// Starts a new presignature generation protocol.
-    async fn generate(
-        &mut self,
-        request: PendingRequest,
-        presignature: PendingPresignature,
-        participants: Vec<Participant>,
-        cfg: ProtocolConfig,
-    ) {
-        let me = self.me;
-        let epoch = self.epoch;
-        let public_key = self.public_key;
-        let sign_id = request.id();
-        let presignature_id = presignature.id();
-        let my_account_id = self.my_account_id.clone();
-        let msg = self.msg.clone();
-        let rpc = self.rpc.clone();
-        let backlog = self.backlog.clone();
-        let task = async move {
-            let generator = match SignatureGenerator::new(
-                me,
-                request,
-                presignature,
-                participants,
-                public_key,
-                cfg,
-                msg,
-                rpc,
-                backlog,
-                &my_account_id,
-            )
-            .await
-            {
-                Ok(generator) => generator,
-                Err(InitializationError::BadParameters(err)) => {
-                    tracing::warn!(
-                        ?sign_id,
-                        presignature_id,
-                        ?err,
-                        "unable to start signature generation on START"
-                    );
-                    return Err(SignError::Retry);
-                }
-            };
-
-            crate::metrics::NUM_TOTAL_HISTORICAL_SIGNATURE_GENERATORS
-                .with_label_values(&[my_account_id.as_str()])
-                .inc();
-
-            generator.run(me, epoch, my_account_id).await
-        };
-
-        self.ongoing.spawn((sign_id, presignature_id), task);
-    }
-
-    async fn start_generation(
-        &mut self,
-        positor: Positor<PresignatureTaken>,
-        sign_id: SignId,
-        presignature_id: PresignatureId,
-        participants: Vec<Participant>,
-        cfg: ProtocolConfig,
-    ) {
-        if positor.is_proposer() {
-            for &p in &participants {
-                if p == self.me {
-                    continue;
-                }
-                self.msg
-                    .send(
-                        self.me,
-                        p,
-                        PositMessage {
-                            id: PositProtocolId::Signature(sign_id, presignature_id),
-                            from: self.me,
-                            action: PositAction::Start(participants.clone()),
-                        },
-                    )
-                    .await;
-            }
-        }
-
-        let request = self.sign_queue.get_or_pending(&sign_id);
-        let presignature = match positor {
-            Positor::Proposer(_proposer, taken) => PendingPresignature::Available(taken),
-            Positor::Deliberator(proposer) => PendingPresignature::InStorage(
-                presignature_id,
-                proposer,
-                self.presignatures.clone(),
-            ),
-        };
-        self.generate(request, presignature, participants, cfg)
-            .await;
     }
 
     async fn handle_requests(
         &mut self,
         stable: &BTreeSet<Participant>,
-        participants: &Participants,
         cfg: &ProtocolConfig,
+        participants: &BTreeSet<Participant>,
     ) {
         if stable.len() < self.threshold {
             tracing::warn!(
@@ -966,137 +1089,90 @@ impl SignatureSpawner {
             return;
         }
 
-        self.sign_queue.expire(cfg);
-        self.sign_queue
-            .organize(stable, participants, &self.my_account_id)
-            .await;
-        crate::metrics::SIGN_QUEUE_SIZE
-            .with_label_values(&[self.my_account_id.as_str()])
-            .set(self.sign_queue.len() as i64);
-        crate::metrics::SIGN_QUEUE_MINE_SIZE
-            .with_label_values(&[self.my_account_id.as_str()])
-            .set(self.sign_queue.len_mine() as i64);
+        // Receive new sign requests from indexer
+        let mut sign_rx = self.sign_rx.write().await;
+        let mut new_requests = Vec::new();
 
-        let mut retry = Vec::new();
-        while let Some(taken) = {
-            if self.sign_queue.is_empty_mine() {
-                None
-            } else {
-                self.presignatures.take_mine(self.me).await
+        while let Ok(indexed) = {
+            match sign_rx.try_recv() {
+                err @ Err(TryRecvError::Disconnected) => {
+                    tracing::error!("sign request channel disconnected");
+                    err
+                }
+                other => other,
             }
         } {
-            let Some(my_request) = self.sign_queue.take_mine() else {
-                tracing::warn!(
-                    presignature = ?taken.presignature,
-                    "unexpected, no more requests to handle. presignature will be removed",
-                );
-                continue;
-            };
+            let sign_id = indexed.id;
 
-            let stable = stable.iter().copied().collect::<Vec<_>>();
-            let participants = intersect_vec(&[&stable, &taken.presignature.participants]);
-            if participants.len() < self.threshold {
-                tracing::warn!(
-                    sign_id = ?my_request.indexed.id,
-                    presignature_id = ?taken.presignature.id,
-                    ?participants,
-                    "intersection < threshold, trashing presignature"
-                );
-                retry.push(my_request.indexed.id);
+            // Skip if we've already seen this request
+            if self.seen_requests.contains(&sign_id) {
+                tracing::debug!(?sign_id, "skipping duplicate sign request");
                 continue;
             }
 
-            self.propose_posit(&my_request, taken, &participants).await;
+            self.seen_requests.insert(sign_id);
+            crate::metrics::NUM_UNIQUE_SIGN_REQUESTS
+                .with_label_values(&[indexed.chain.as_str(), self.my_account_id.as_str()])
+                .inc();
+
+            new_requests.push(indexed);
+        }
+        drop(sign_rx);
+
+        // Create tasks for all new requests
+        for indexed in new_requests {
+            self.spawn_task(indexed, participants.clone(), cfg).await;
         }
 
-        for sign_id in retry {
-            self.sign_queue.push_failed(sign_id);
-        }
+        // Update metrics
+        crate::metrics::SIGN_QUEUE_SIZE
+            .with_label_values(&[self.my_account_id.as_str()])
+            .set(self.seen_requests.len() as i64);
     }
 
-    async fn run(
-        mut self,
-        contract: ContractStateWatcher,
-        mesh_state: watch::Receiver<MeshState>,
-        cfg: watch::Receiver<Config>,
-    ) {
-        // NOTE: signatures should only use stable and not active participants. The difference here is that
-        // stable participants utilizes more than the online status of a node, such as whether or not their
-        // block height is up to date, such that they too can process signature requests. If they cannot
-        // then they are considered unstable and should not be a part of signature generation this round.
-
+    async fn run(mut self, contract: ContractStateWatcher, cfg: watch::Receiver<Config>) {
         let mut check_requests_interval = tokio::time::interval(Duration::from_millis(100));
-        let mut expiration_interval = tokio::time::interval(Duration::from_secs(20));
         let mut posits = self.msg.subscribe_signature_posit().await;
-        let mut pending_posits = JoinSet::new();
 
         loop {
             tokio::select! {
-                _ = expiration_interval.tick() => {
-                    for ((sign_id, presignature_id), action) in self.posits.expire_and_start(self.threshold, Duration::from_secs(60)) {
-                        let (participants, positor) = match action {
-                            PositInternalAction::StartProtocol(participants, positor) => (participants, positor),
-                            PositInternalAction::Abort => {
-                                tracing::warn!(
-                                    ?sign_id,
-                                    presignature_id,
-                                    "signature posit aborting on expiration, retrying..."
-                                );
-                                self.sign_queue.push_failed(sign_id);
-                                continue;
-                            },
-                            _ => continue,
-                        };
-                        let protocol = cfg.borrow().protocol.clone();
-                        self.start_generation(positor, sign_id, presignature_id, participants, protocol).await;
-                    }
-                }
                 Some((sign_id, presignature_id, from, action)) = posits.recv() => {
-                    let request = self.sign_queue.get_or_pending(&sign_id);
-                    let timeout = Duration::from_millis(cfg.borrow().protocol.signature.generation_timeout);
-                    pending_posits.spawn(async move {
-                        let request = request.fetch(timeout).await;
-                        (sign_id, presignature_id, request, from, action)
-                    });
+                    self.handle_posit(sign_id, presignature_id, from, action).await;
                 }
-                Some(pending_posit) = pending_posits.join_next() => {
-                    let (sign_id, presignature_id, request, from, action) = match pending_posit {
-                        Ok(posit) => posit,
-                        Err(_) => {
-                            tracing::warn!("signature posit fetching request interrupted");
-                            continue;
-                        },
-                    };
-
-                    let protocol = cfg.borrow().protocol.clone();
-                    self.process_posit(sign_id, presignature_id, request, from, action, protocol).await;
-                }
-                // `join_next` returns None on the set being empty, so don't handle that case
-                Some(result) = self.ongoing.join_next(), if !self.ongoing.is_empty() => {
-                    let ((sign_id, _presignature_id), result) = match result {
+                Some(result) = self.tasks.join_next(), if !self.tasks.is_empty() => {
+                    let (sign_id, result) = match result {
                         Ok(outcome) => outcome,
-                        Err((sign_id, presignature_id)) => {
-                            tracing::warn!(?sign_id, presignature_id, "signature generation task interrupted");
+                        Err(sign_id) => {
+                            tracing::warn!(?sign_id, "signature task interrupted");
+                            self.task_channels.remove(&sign_id);
                             continue;
                         }
                     };
+
+                    // Clean up channel
+                    self.task_channels.remove(&sign_id);
 
                     match result {
-                        Err(SignError::Retry) => {
-                            self.sign_queue.push_failed(sign_id);
+                        Ok(()) => {
+                            tracing::info!(?sign_id, "signature task completed successfully");
+                            self.seen_requests.remove(&sign_id);
                         }
-                        Ok(()) | Err(SignError::TotalTimeout) | Err(SignError::Aborted) => {
-                            self.sign_queue.remove(sign_id);
+                        Err(SignError::Aborted) => {
+                            tracing::warn!(?sign_id, ?result, "signature task terminated");
+                            self.seen_requests.remove(&sign_id);
                         }
                     }
                 }
                 _ = check_requests_interval.tick() => {
+                    // Don't process requests until contract has participants
                     let Some(participants) = contract.participants() else {
                         continue;
                     };
-                    let stable = mesh_state.borrow().stable.clone();
+                    let participants = participants.keys().cloned().collect::<BTreeSet<_>>();
+
+                    let stable = self.mesh_state.borrow().stable.clone();
                     let protocol = cfg.borrow().protocol.clone();
-                    self.handle_requests(&stable, &participants, &protocol).await;
+                    self.handle_requests(&stable, &protocol, &participants).await;
                 }
             }
         }
@@ -1130,17 +1206,14 @@ impl SignatureSpawnerTask {
             epoch,
             ctx.sign_rx.clone(),
             &ctx.presignature_storage,
+            ctx.mesh_state.clone(),
             ctx.msg_channel.clone(),
             ctx.rpc_channel.clone(),
             ctx.backlog.clone(),
         );
 
         Self {
-            handle: tokio::spawn(spawner.run(
-                ctx.contract.clone(),
-                ctx.mesh_state.clone(),
-                ctx.config.clone(),
-            )),
+            handle: tokio::spawn(spawner.run(ctx.contract.clone(), ctx.config.clone())),
         }
     }
 

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -29,7 +29,6 @@ use rand::SeedableRng;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::{mpsc, watch, RwLock};
 use tokio::task::JoinHandle;
 
@@ -1030,8 +1029,6 @@ enum SignTaskMessage {
 pub struct SignatureSpawner {
     /// Presignature storage that maintains all presignatures.
     presignatures: PresignatureStorage,
-    /// Receiver for incoming sign requests from indexer
-    sign_rx: Arc<RwLock<mpsc::Receiver<Sign>>>,
     /// Consolidated signature tasks - one per sign_id, each task is an async task handling complete lifecycle
     tasks: JoinMap<SignId, Result<(), SignError>>,
     /// Buffered inboxes for posit messages, allowing us to queue before tasks spawn
@@ -1056,7 +1053,7 @@ impl SignatureSpawner {
         indexed: IndexedSignRequest,
         participants: BTreeSet<Participant>,
         contract: ContractStateWatcher,
-        cfg: &ProtocolConfig,
+        cfg: ProtocolConfig,
     ) {
         let sign_id = indexed.id;
         tracing::info!(?sign_id, "spawning signature task");
@@ -1076,7 +1073,7 @@ impl SignatureSpawner {
             msg: self.msg.clone(),
             rpc: self.rpc.clone(),
             backlog: self.backlog.clone(),
-            cfg: cfg.clone(),
+            cfg,
             contract,
         };
 
@@ -1118,64 +1115,33 @@ impl SignatureSpawner {
         }
     }
 
-    async fn handle_requests(
+    async fn handle_request(
         &mut self,
-        stable: &BTreeSet<Participant>,
+        sign: Sign,
         cfg: &ProtocolConfig,
         participants: &BTreeSet<Participant>,
         contract: &ContractStateWatcher,
     ) {
-        if stable.len() < self.threshold {
-            tracing::warn!(
-                ?stable,
-                threshold = self.threshold,
-                "not enough stable participants to handle requests"
-            );
-            return;
-        }
-
-        // Receive new sign requests from indexer
-        let mut sign_rx = self.sign_rx.write().await;
-        let mut new_requests = Vec::new();
-        let mut completions = Vec::new();
-
-        while let Ok(sign) = {
-            match sign_rx.try_recv() {
-                err @ Err(TryRecvError::Disconnected) => err,
-                other => other,
+        match sign {
+            Sign::Completion(sign_id) => {
+                self.handle_completion(sign_id);
             }
-        } {
-            match sign {
-                Sign::Completion(sign_id) => {
-                    completions.push(sign_id);
+            Sign::Request(indexed) => {
+                let sign_id = indexed.id;
+
+                // Skip if we've already seen this request
+                if self.inboxes.contains_key(&sign_id) {
+                    tracing::info!(?sign_id, "skipping duplicate sign request");
+                    return;
                 }
-                Sign::Request(indexed) => {
-                    let sign_id = indexed.id;
 
-                    // Skip if we've already seen this request
-                    if self.inboxes.contains_key(&sign_id) {
-                        tracing::info!(?sign_id, "skipping duplicate sign request");
-                        continue;
-                    }
+                crate::metrics::NUM_UNIQUE_SIGN_REQUESTS
+                    .with_label_values(&[indexed.chain.as_str(), self.my_account_id.as_str()])
+                    .inc();
 
-                    crate::metrics::NUM_UNIQUE_SIGN_REQUESTS
-                        .with_label_values(&[indexed.chain.as_str(), self.my_account_id.as_str()])
-                        .inc();
-
-                    new_requests.push(indexed);
-                }
+                self.spawn_task(indexed, participants.clone(), contract.clone(), cfg.clone())
+                    .await;
             }
-        }
-        drop(sign_rx);
-
-        for sign_id in completions {
-            self.handle_completion(sign_id);
-        }
-
-        // Create tasks for all new requests
-        for indexed in new_requests {
-            self.spawn_task(indexed, participants.clone(), contract.clone(), cfg)
-                .await;
         }
 
         // Update metrics
@@ -1184,15 +1150,31 @@ impl SignatureSpawner {
             .set(self.tasks.len() as i64);
     }
 
-    async fn run(mut self, mut contract: ContractStateWatcher, cfg: watch::Receiver<Config>) {
-        let mut check_requests_interval = tokio::time::interval(Duration::from_millis(100));
+    async fn run(
+        mut self,
+        sign_rx: Arc<RwLock<mpsc::Receiver<Sign>>>,
+        mut contract: ContractStateWatcher,
+        mut cfg: watch::Receiver<Config>,
+    ) {
         let mut posits = self.msg.subscribe_signature_posit().await;
 
         let running = contract.wait_running().await;
         let all_participants = running.participants.keys().copied().collect();
+        let mut protocol = cfg.borrow().protocol.clone();
+
+        // we acquire the lock but since this is a tokio lock, aborting the task while holding
+        // the lock is safe and will not deadlock other tasks trying to acquire the lock
+        let mut sign_rx = sign_rx.write().await;
 
         loop {
             tokio::select! {
+                sign = sign_rx.recv() => {
+                    let Some(sign) = sign else {
+                        tracing::warn!("signature spawner sign_rx closed, terminating");
+                        break;
+                    };
+                    self.handle_request(sign, &protocol, &all_participants, &contract).await;
+                }
                 Some((sign_id, presignature_id, from, action)) = posits.recv() => {
                     self.handle_posit(sign_id, presignature_id, from, action).await;
                 }
@@ -1216,10 +1198,8 @@ impl SignatureSpawner {
                         }
                     }
                 }
-                _ = check_requests_interval.tick() => {
-                    let stable = self.mesh_state.borrow().stable.clone();
-                    let protocol = cfg.borrow().protocol.clone();
-                    self.handle_requests(&stable, &protocol, &all_participants, &contract).await;
+                Ok(()) = cfg.changed() => {
+                    protocol = cfg.borrow().protocol.clone();
                 }
             }
         }
@@ -1253,7 +1233,6 @@ impl SignatureSpawnerTask {
             threshold,
             public_key,
             epoch,
-            sign_rx: ctx.sign_rx.clone(),
             presignatures: ctx.presignature_storage.clone(),
             mesh_state: ctx.mesh_state.clone(),
             msg: ctx.msg_channel.clone(),
@@ -1262,7 +1241,11 @@ impl SignatureSpawnerTask {
         };
 
         Self {
-            handle: tokio::spawn(spawner.run(ctx.contract.clone(), ctx.config.clone())),
+            handle: tokio::spawn(spawner.run(
+                ctx.sign_rx.clone(),
+                ctx.contract.clone(),
+                ctx.config.clone(),
+            )),
         }
     }
 

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -34,6 +34,9 @@ use tokio::task::JoinHandle;
 
 use near_account_id::AccountId;
 
+/// The round interval to search for a proposer in the organizing phase.
+const ROUND_INTERVAL: usize = 512;
+
 /// All relevant info pertaining to an Indexed sign request from an indexer.
 #[derive(Debug, Clone, PartialEq)]
 pub struct IndexedSignRequest {
@@ -51,17 +54,6 @@ pub struct IndexedSignRequest {
 pub enum Sign {
     Request(IndexedSignRequest),
     Completion(SignId),
-}
-
-/// The sign request for the node to process. This contains relevant info for the node
-/// to generate a signature such as what has been indexed and what the node needs to maintain
-/// metadata-wise to generate the signature.
-#[derive(Debug, Clone, PartialEq)]
-pub struct SignRequest {
-    pub indexed: IndexedSignRequest,
-    pub proposer: Participant,
-    pub stable: BTreeSet<Participant>,
-    pub round: usize,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -102,7 +94,6 @@ struct SignPositor {
 
 struct SignGenerating {
     proposer: Participant,
-    stable: BTreeSet<Participant>,
     presignature_id: PresignatureId,
     presignature: Option<PresignatureTaken>,
     accepted_participants: Vec<Participant>,
@@ -149,7 +140,7 @@ impl SignOrganizer {
         ctx: &SignTask,
         state: &mut SignState,
         threshold: usize,
-    ) -> BTreeSet<Participant> {
+    ) -> Option<BTreeSet<Participant>> {
         let sign_id = ctx.sign_id;
         let mut once = true;
 
@@ -157,7 +148,7 @@ impl SignOrganizer {
             let stable_count = {
                 let stable = &state.mesh_state.borrow().stable;
                 if stable.len() >= threshold {
-                    return stable.clone();
+                    return Some(stable.clone());
                 }
                 stable.len()
             };
@@ -173,7 +164,7 @@ impl SignOrganizer {
             }
 
             if state.mesh_state.changed().await.is_err() {
-                return BTreeSet::new();
+                return None;
             }
         }
     }
@@ -187,14 +178,13 @@ impl SignOrganizer {
 
         tracing::info!(?sign_id, round = ?state.round, "entering organizing phase");
         let (stable, proposer) = {
-            let stable = self.wait_stable(ctx, state, threshold).await;
-            if stable.is_empty() {
+            let Some(stable) = self.wait_stable(ctx, state, threshold).await else {
                 tracing::warn!(?sign_id, round = ?state.round, "no stable participants, reorganizing");
                 state.bump_round();
                 return SignPhase::Organizing(self);
-            }
+            };
 
-            let max_rounds = state.round + 512;
+            let max_rounds = state.round + ROUND_INTERVAL;
             let (selected_round, proposer) = (state.round..max_rounds)
                 .map(|r| (r, Self::proposer_per_round(r, &participants, &entropy)))
                 .find(|(_, potential_proposer)| stable.contains(potential_proposer))
@@ -417,6 +407,8 @@ impl SignPositor {
         let round = state.round;
         let is_proposer = proposer == ctx.me;
         let is_deliberator = !is_proposer;
+
+        // GUARANTEE: at least threshold participants from organizing phase.
         let posit_participants = stable.iter().copied().collect::<Vec<_>>();
 
         // Get the presignature participants - only these nodes participated in generating it
@@ -434,16 +426,6 @@ impl SignPositor {
             is_proposer,
             "entering posit phase"
         );
-
-        if posit_participants.is_empty() {
-            tracing::warn!(
-                ?sign_id,
-                ?round,
-                "posit phase has no participants, reorganizing"
-            );
-            state.bump_round();
-            return SignPhase::Organizing(SignOrganizer);
-        }
 
         if is_deliberator {
             tracing::info!(
@@ -596,7 +578,6 @@ impl SignPositor {
 
         SignPhase::Generating(SignGenerating {
             proposer,
-            stable,
             presignature_id,
             presignature,
             accepted_participants,
@@ -626,20 +607,12 @@ impl SignGenerating {
             )
         };
 
-        let request = SignRequest {
-            indexed: state.indexed().clone(),
-            proposer: self.proposer,
-            stable: self.stable.clone(),
-            round,
-        };
-
-        let participants = self.accepted_participants.clone();
-
         let generator = match SignGenerator::new(
             ctx,
-            request,
+            self.proposer,
+            state.indexed().clone(),
             presignature_pending,
-            participants.clone(),
+            self.accepted_participants.clone(),
         )
         .await
         {
@@ -682,7 +655,8 @@ struct SignGenerator {
     protocol: SignatureProtocol,
     dropper: PresignatureTakenDropper,
     participants: Vec<Participant>,
-    request: SignRequest,
+    proposer: Participant,
+    indexed: IndexedSignRequest,
     created: Instant,
     timeout: Duration,
     inbox: mpsc::Receiver<SignatureMessage>,
@@ -695,7 +669,8 @@ struct SignGenerator {
 impl SignGenerator {
     async fn new(
         ctx: &SignTask,
-        request: SignRequest,
+        proposer: Participant,
+        indexed: IndexedSignRequest,
         presignature: PendingPresignature,
         participants: Vec<Participant>,
     ) -> Result<Self, InitializationError> {
@@ -712,7 +687,6 @@ impl SignGenerator {
                 ))
             })?;
 
-        let indexed = &request.indexed;
         let sign_id = indexed.id;
         tracing::info!(
             me = ?ctx.me,
@@ -742,7 +716,8 @@ impl SignGenerator {
             protocol,
             dropper,
             participants,
-            request,
+            proposer,
+            indexed,
             created: Instant::now(),
             timeout: Duration::from_millis(ctx.cfg.signature.generation_timeout),
             inbox,
@@ -757,7 +732,7 @@ impl SignGenerator {
 
     /// Receive the next message for the signature protocol; error out on the timeout being reached
     async fn recv(&mut self) -> Result<SignatureMessage, SignError> {
-        let sign_id = self.request.indexed.id;
+        let sign_id = self.indexed.id;
         let presignature_id = self.dropper.id;
         match tokio::time::timeout(
             self.timeout.saturating_sub(self.created.elapsed()),
@@ -791,7 +766,7 @@ impl SignGenerator {
         let poke_latency =
             crate::metrics::SIGNATURE_POKE_CPU_TIME.with_label_values(&[my_account_id.as_str()]);
 
-        let sign_id = self.request.indexed.id;
+        let sign_id = self.indexed.id;
         let presignature_id = self.dropper.id;
 
         let mut total_wait = Duration::from_millis(0);
@@ -826,7 +801,7 @@ impl SignGenerator {
                 Action::Wait => {
                     // Wait for the next set of messages to arrive.
                     let msg = self.recv().await.inspect_err(|_| {
-                        if self.request.proposer == me {
+                        if self.proposer == me {
                             signature_generator_failures_metric.inc();
                         }
                     })?;
@@ -843,7 +818,7 @@ impl SignGenerator {
                                 to,
                                 SignatureMessage {
                                     id: sign_id,
-                                    proposer: self.request.proposer,
+                                    proposer: self.proposer,
                                     presignature_id: self.dropper.id,
                                     epoch,
                                     from: me,
@@ -861,7 +836,7 @@ impl SignGenerator {
                             to,
                             SignatureMessage {
                                 id: sign_id,
-                                proposer: self.request.proposer,
+                                proposer: self.proposer,
                                 presignature_id,
                                 epoch,
                                 from: me,
@@ -890,27 +865,25 @@ impl SignGenerator {
                         .with_label_values(&[my_account_id.as_str()])
                         .observe(self.created.elapsed().as_secs_f64());
 
-                    if self.request.proposer == me {
+                    if self.proposer == me {
                         ctx.rpc.publish(
                             ctx.public_key,
-                            self.request.clone(),
+                            self.indexed.clone(),
                             output,
                             self.participants.clone(),
                         );
                     }
 
                     if let SignRequestType::SignBidirectional(event) =
-                        &self.request.indexed.sign_request_type
+                        &self.indexed.sign_request_type
                     {
-                        let source_chain = self.request.indexed.chain;
-
                         // Note: The promotion to Bidirectional will happen when we receive the
                         // SignatureRespondedEvent in the Solana indexer, which has the signature data.
                         // For now, we just complete the signature generation. The indexer will handle the promotion.
-                        tracing::debug!(
+                        tracing::info!(
                             ?sign_id,
-                            ?source_chain,
-                            ?event.dest,
+                            source_chain = ?self.indexed.chain,
+                            target_chain = ?event.dest,
                             "generated signature for bidirectional request, awaiting indexer to process"
                         );
                     }
@@ -933,7 +906,7 @@ impl SignGenerator {
 impl Drop for SignGenerator {
     fn drop(&mut self) {
         let msg = self.msg.clone();
-        let sign_id = self.request.indexed.id;
+        let sign_id = self.indexed.id;
         let presignature_id = self.dropper.id;
         tokio::spawn(async move {
             msg.unsubscribe_signature(sign_id, presignature_id).await;

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -1054,50 +1054,16 @@ pub struct SignatureSpawner {
     msg: MessageChannel,
     rpc: RpcChannel,
     backlog: Backlog,
-    contract: ContractStateWatcher,
 }
 
 impl SignatureSpawner {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        me: Participant,
-        my_account_id: &AccountId,
-        threshold: usize,
-        public_key: PublicKey,
-        epoch: u64,
-        sign_rx: Arc<RwLock<mpsc::Receiver<Sign>>>,
-        presignatures: &PresignatureStorage,
-        mesh_state: watch::Receiver<MeshState>,
-        msg: MessageChannel,
-        rpc: RpcChannel,
-        backlog: Backlog,
-        contract: ContractStateWatcher,
-    ) -> Self {
-        Self {
-            presignatures: presignatures.clone(),
-            sign_rx,
-            seen_requests: HashSet::new(),
-            tasks: JoinMap::new(),
-            inboxes: HashMap::new(),
-            mesh_state,
-            me,
-            my_account_id: my_account_id.clone(),
-            threshold,
-            public_key,
-            epoch,
-            msg,
-            rpc,
-            backlog,
-            contract,
-        }
-    }
-
     /// Creates a signature task for a new sign request
     /// The task will handle organizing, posit, and generation internally
     async fn spawn_task(
         &mut self,
         indexed: IndexedSignRequest,
         participants: BTreeSet<Participant>,
+        contract: ContractStateWatcher,
         cfg: &ProtocolConfig,
     ) {
         let sign_id = indexed.id;
@@ -1123,7 +1089,7 @@ impl SignatureSpawner {
             rpc: self.rpc.clone(),
             backlog: self.backlog.clone(),
             cfg: cfg.clone(),
-            contract: self.contract.clone(),
+            contract,
         };
 
         // Spawn the async task with organizing loop
@@ -1143,14 +1109,10 @@ impl SignatureSpawner {
         if from == self.me {
             return;
         }
-
-        // If task channel exists, forward message to it
-        let inbox = self
+        let _ = self
             .inboxes
             .entry(sign_id)
-            .or_insert_with(Subscriber::unsubscribed);
-
-        let _ = inbox
+            .or_default()
             .send(SignTaskMessage::PositMessage {
                 presignature_id,
                 from,
@@ -1182,6 +1144,7 @@ impl SignatureSpawner {
         stable: &BTreeSet<Participant>,
         cfg: &ProtocolConfig,
         participants: &BTreeSet<Participant>,
+        contract: &ContractStateWatcher,
     ) {
         if stable.len() < self.threshold {
             tracing::warn!(
@@ -1236,7 +1199,8 @@ impl SignatureSpawner {
 
         // Create tasks for all new requests
         for indexed in new_requests {
-            self.spawn_task(indexed, participants.clone(), cfg).await;
+            self.spawn_task(indexed, participants.clone(), contract.clone(), cfg)
+                .await;
         }
 
         // Update metrics
@@ -1245,9 +1209,12 @@ impl SignatureSpawner {
             .set(self.seen_requests.len() as i64);
     }
 
-    async fn run(mut self, contract: ContractStateWatcher, cfg: watch::Receiver<Config>) {
+    async fn run(mut self, mut contract: ContractStateWatcher, cfg: watch::Receiver<Config>) {
         let mut check_requests_interval = tokio::time::interval(Duration::from_millis(100));
         let mut posits = self.msg.subscribe_signature_posit().await;
+
+        let running = contract.wait_running().await;
+        let all_participants = running.participants.keys().copied().collect();
 
         loop {
             tokio::select! {
@@ -1260,33 +1227,28 @@ impl SignatureSpawner {
                         Err(sign_id) => {
                             tracing::warn!(?sign_id, "signature task interrupted");
                             self.inboxes.remove(&sign_id);
+                            self.seen_requests.remove(&sign_id);
                             continue;
                         }
                     };
 
                     // Clean up channel
                     self.inboxes.remove(&sign_id);
+                    self.seen_requests.remove(&sign_id);
 
                     match result {
                         Ok(()) => {
                             tracing::info!(?sign_id, "signature task completed successfully");
-                            self.seen_requests.remove(&sign_id);
                         }
                         Err(SignError::Aborted) => {
-                            tracing::warn!(?sign_id, ?result, "signature task terminated");
-                            self.seen_requests.remove(&sign_id);
+                            tracing::warn!(?sign_id, "signature task terminated");
                         }
                     }
                 }
                 _ = check_requests_interval.tick() => {
-                    // Don't process requests until contract has participants
-                    let Some(participants) = contract.participants() else {
-                        continue;
-                    };
-                    let participants = participants.keys().cloned().collect();
                     let stable = self.mesh_state.borrow().stable.clone();
                     let protocol = cfg.borrow().protocol.clone();
-                    self.handle_requests(&stable, &protocol, &participants).await;
+                    self.handle_requests(&stable, &protocol, &all_participants, &contract).await;
                 }
             }
         }
@@ -1312,20 +1274,22 @@ impl SignatureSpawnerTask {
         ctx: &MpcSignProtocol,
         public_key: PublicKey,
     ) -> Self {
-        let spawner = SignatureSpawner::new(
+        let spawner = SignatureSpawner {
             me,
-            &ctx.my_account_id,
+            seen_requests: HashSet::new(),
+            tasks: JoinMap::new(),
+            inboxes: HashMap::new(),
+            my_account_id: ctx.my_account_id.clone(),
             threshold,
             public_key,
             epoch,
-            ctx.sign_rx.clone(),
-            &ctx.presignature_storage,
-            ctx.mesh_state.clone(),
-            ctx.msg_channel.clone(),
-            ctx.rpc_channel.clone(),
-            ctx.backlog.clone(),
-            ctx.contract.clone(),
-        );
+            sign_rx: ctx.sign_rx.clone(),
+            presignatures: ctx.presignature_storage.clone(),
+            mesh_state: ctx.mesh_state.clone(),
+            msg: ctx.msg_channel.clone(),
+            rpc: ctx.rpc_channel.clone(),
+            backlog: ctx.backlog.clone(),
+        };
 
         Self {
             handle: tokio::spawn(spawner.run(ctx.contract.clone(), ctx.config.clone())),

--- a/chain-signatures/node/src/protocol/test_setup.rs
+++ b/chain-signatures/node/src/protocol/test_setup.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::backlog::Backlog;
 use crate::config::Config;
 use crate::mesh::MeshState;
-use crate::protocol::{IndexedSignRequest, MessageChannel, MpcSignProtocol};
+use crate::protocol::{MessageChannel, MpcSignProtocol, Sign};
 use crate::rpc::{ContractStateWatcher, RpcChannel};
 use crate::storage::secret_storage::SecretNodeStorageBox;
 use crate::storage::{PresignatureStorage, TripleStorage};
@@ -17,7 +17,7 @@ pub struct TestProtocolStorage {
 }
 
 pub struct TestProtocolChannels {
-    pub sign_rx: Arc<RwLock<mpsc::Receiver<IndexedSignRequest>>>,
+    pub sign_rx: Arc<RwLock<mpsc::Receiver<Sign>>>,
     pub msg_channel: MessageChannel,
     pub rpc_channel: RpcChannel,
     pub config: watch::Receiver<Config>,

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -538,13 +538,16 @@ impl TripleSpawner {
 
     async fn run(
         mut self,
-        mesh_state: watch::Receiver<MeshState>,
-        config: watch::Receiver<Config>,
+        mut mesh_state: watch::Receiver<MeshState>,
+        mut cfg: watch::Receiver<Config>,
         ongoing_gen_tx: watch::Sender<usize>,
     ) {
         let mut stockpile_interval = tokio::time::interval(Duration::from_millis(100));
         let mut expiration_interval = tokio::time::interval(Duration::from_secs(60));
         let mut posits = self.msg.subscribe_triple_posit().await;
+
+        let mut active = mesh_state.borrow().active.keys_vec();
+        let mut protocol = cfg.borrow().protocol.clone();
 
         loop {
             tokio::select! {
@@ -553,13 +556,13 @@ impl TripleSpawner {
                         let (id, PositInternalAction::StartProtocol(participants, positor)) = action else {
                             continue;
                         };
-                        let timeout = config.borrow().protocol.triple.generation_timeout;
-                        self.start_generation(id, participants, positor, Duration::from_millis(timeout)).await;
+                        let timeout = Duration::from_millis(protocol.triple.generation_timeout);
+                        self.start_generation(id, participants, positor, timeout).await;
                     }
                 }
                 Some((id, from, action)) = posits.recv() => {
-                    let timeout = config.borrow().protocol.triple.generation_timeout;
-                    self.process_posit(id, from, action, Duration::from_millis(timeout)).await;
+                    let timeout = Duration::from_millis(protocol.triple.generation_timeout);
+                    self.process_posit(id, from, action, timeout).await;
                 }
                 // `join_next` returns None on the set being empty, so don't handle that case
                 Some(result) = self.ongoing.join_next(), if !self.ongoing.is_empty() => {
@@ -573,12 +576,7 @@ impl TripleSpawner {
                     self.ongoing_introduced.remove(&id);
                     let _ = ongoing_gen_tx.send(self.ongoing.len());
                 }
-                _ = stockpile_interval.tick() => {
-                    // TODO: eventually we should use all participants, and let nodes replying with
-                    // accept/reject determine who is a participant. The messaging layer should
-                    // rely more on active.
-                    let active = mesh_state.borrow().active.keys_vec();
-                    let protocol = config.borrow().protocol.clone();
+                _ = stockpile_interval.tick(), if active.len() >= self.threshold => {
                     self.stockpile(&active, &protocol).await;
                     let _ = ongoing_gen_tx.send(self.ongoing.len());
 
@@ -594,6 +592,12 @@ impl TripleSpawner {
                     crate::metrics::NUM_TRIPLE_GENERATORS_TOTAL
                         .with_label_values(&[self.my_account_id.as_str()])
                         .set(self.len_ongoing() as i64);
+                }
+                Ok(()) = cfg.changed() => {
+                    protocol = cfg.borrow().protocol.clone();
+                }
+                Ok(()) = mesh_state.changed() => {
+                    active = mesh_state.borrow().active.keys_vec();
                 }
             }
         }

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -288,6 +288,16 @@ impl ContractStateWatcher {
         }
     }
 
+    /// Waits till the contract is in the running state.
+    pub async fn wait_running(&mut self) -> RunningContractState {
+        loop {
+            if let Some(ProtocolState::Running(state)) = self.borrow_state().as_ref() {
+                return state.clone();
+            }
+            let _ = self.contract_state.changed().await;
+        }
+    }
+
     /// Create a list of contract states that share a single channel but use different account ids.
     #[cfg(feature = "test-feature")]
     pub fn test_batch(

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -4,8 +4,7 @@ use crate::indexer_eth::EthConfig;
 use crate::indexer_sol::SolConfig;
 use crate::protocol::contract::primitives::{ParticipantMap, Participants};
 use crate::protocol::contract::RunningContractState;
-use crate::protocol::signature::SignRequest;
-use crate::protocol::{Chain, Governance, ProtocolState, SignRequestType};
+use crate::protocol::{Chain, Governance, IndexedSignRequest, ProtocolState, SignRequestType};
 use crate::util::AffinePointExt as _;
 
 use solana_sdk::commitment_config::CommitmentConfig;
@@ -80,7 +79,7 @@ type EthContractInstance = ContractInstance<EthContractFillProvider>;
 #[derive(Clone)]
 pub struct PublishAction {
     pub public_key: mpc_crypto::PublicKey,
-    pub request: SignRequest,
+    pub indexed: IndexedSignRequest,
     output: FullSignature<Secp256k1>,
     pub participants: Vec<Participant>,
     timestamp: Instant,
@@ -100,7 +99,7 @@ impl RpcChannel {
     pub fn publish(
         &self,
         public_key: mpc_crypto::PublicKey,
-        request: SignRequest,
+        indexed: IndexedSignRequest,
         output: FullSignature<Secp256k1>,
         participants: Vec<Participant>,
     ) {
@@ -110,7 +109,7 @@ impl RpcChannel {
                 .tx
                 .send(RpcAction::Publish(PublishAction {
                     public_key,
-                    request,
+                    indexed,
                     output,
                     participants,
                     timestamp: Instant::now(),
@@ -383,7 +382,7 @@ impl RpcExecutor {
                 return;
             };
 
-            let chain = action.request.indexed.chain;
+            let chain = action.indexed.chain;
             let client = self.client(&chain);
             let near_account_id = self.near.my_account_id.clone();
             let eth_rpc_tx = eth_rpc_tx.clone(); // clone for task use
@@ -687,8 +686,8 @@ async fn execute_publish(
     near_account_id: AccountId,
     backlog: Backlog,
 ) {
-    let chain = action.request.indexed.chain;
-    let sign_id = action.request.indexed.id;
+    let chain = action.indexed.chain;
+    let sign_id = action.indexed.id;
     tracing::info!(
         ?sign_id,
         ?chain,
@@ -696,17 +695,17 @@ async fn execute_publish(
         "trying to publish signature",
     );
     let expected_public_key =
-        mpc_crypto::derive_key(action.public_key, action.request.indexed.args.epsilon);
+        mpc_crypto::derive_key(action.public_key, action.indexed.args.epsilon);
 
     // We do this here, rather than on the client side, so we can use the ecrecover system function on NEAR to validate our signature
     let Ok(signature) = crate::kdf::into_eth_sig(
         &expected_public_key,
         &action.output.big_r,
         &action.output.s,
-        action.request.indexed.args.payload,
+        action.indexed.args.payload,
     ) else {
         tracing::error!(
-            sign_id = ?action.request.indexed.id,
+            ?sign_id,
             "failed to generate a recovery id; trashing publish request",
         );
         return;
@@ -751,14 +750,14 @@ async fn execute_publish(
         tokio::time::sleep(Duration::from_millis(100)).await;
         if action.retry_count >= MAX_PUBLISH_RETRY {
             tracing::info!(
-                sign_id = ?action.request.indexed.id,
+                ?sign_id,
                 elapsed = ?action.timestamp.elapsed(),
                 "exceeded max retries, trashing publish request",
             );
             break publish;
         } else {
             tracing::info!(
-                sign_id = ?action.request.indexed.id,
+                ?sign_id,
                 retry_count = action.retry_count,
                 elapsed = ?action.timestamp.elapsed(),
                 "failed to publish, retrying"
@@ -768,7 +767,7 @@ async fn execute_publish(
 
     // Mark completion in Backlog for SignBidirectional requests
     if matches!(
-        action.request.indexed.sign_request_type,
+        action.indexed.sign_request_type,
         SignRequestType::SignBidirectional(_)
     ) {
         let success = publish_result.is_ok();
@@ -818,13 +817,13 @@ async fn try_publish_near(
     timestamp: &Instant,
     signature: &Signature,
 ) -> Result<(), near_fetch::Error> {
-    let chain = action.request.indexed.chain;
+    let chain = action.indexed.chain;
     let outcome = near
-        .call_respond(&action.request.indexed.id, signature)
+        .call_respond(&action.indexed.id, signature)
         .await
         .inspect_err(|err| {
             tracing::error!(
-                sign_id = ?action.request.indexed.id,
+                sign_id = ?action.indexed.id,
                 ?err,
                 "failed to publish signature",
             );
@@ -835,7 +834,7 @@ async fn try_publish_near(
 
     let _: () = outcome.json().inspect_err(|err| {
         tracing::error!(
-            sign_id = ?action.request.indexed.id,
+            sign_id = ?action.indexed.id,
             big_r = signature.big_r.to_base58(),
             s = ?signature.s,
             ?err,
@@ -846,14 +845,14 @@ async fn try_publish_near(
             .inc();
     })?;
     tracing::info!(
-        sign_id = ?action.request.indexed.id,
+        sign_id = ?action.indexed.id,
         big_r = signature.big_r.to_base58(),
         s = ?signature.s,
         elapsed = ?timestamp.elapsed(),
         "published signature sucessfully",
     );
 
-    let elapsed = action.request.indexed.timestamp_sign_queue.elapsed();
+    let elapsed = action.indexed.timestamp_sign_queue.elapsed();
     crate::metrics::NUM_SIGN_SUCCESS
         .with_label_values(&[chain.as_str(), near.my_account_id.as_str()])
         .inc();
@@ -1086,8 +1085,10 @@ async fn try_publish_eth(
     signature: &Signature,
     near_account_id: &AccountId,
 ) -> Result<(), ()> {
+    let chain = action.indexed.chain;
+    let sign_id = action.indexed.id;
     let params = [DynSolValue::Array(vec![DynSolValue::Tuple(vec![
-        DynSolValue::FixedBytes(action.request.indexed.id.request_id.into(), 32),
+        DynSolValue::FixedBytes(action.indexed.id.request_id.into(), 32),
         DynSolValue::Tuple(vec![
             DynSolValue::Tuple(vec![
                 DynSolValue::from(U256::from_be_slice(&signature.big_r.x())),
@@ -1104,7 +1105,7 @@ async fn try_publish_eth(
         &eth.contract,
         &params,
         40000,
-        std::slice::from_ref(&action.request.indexed.id),
+        std::slice::from_ref(&action.indexed.id),
         near_account_id,
     )
     .await?;
@@ -1113,7 +1114,7 @@ async fn try_publish_eth(
         eth.contract.provider(),
         tx_hash,
         near_account_id,
-        vec![action.request.indexed.id],
+        vec![action.indexed.id],
         ETH_TX_RECEIPT_MAX_ATTEMPTS,
     )
     .await?;
@@ -1121,23 +1122,19 @@ async fn try_publish_eth(
     // Check if transaction was successful
     if !receipt.status() {
         tracing::error!(
-            sign_id = ?action.request.indexed.id,
+            ?sign_id,
             tx_hash = ?receipt.transaction_hash,
             "transaction failed"
         );
         crate::metrics::SIGNATURE_PUBLISH_FAILURES
-            .with_label_values(&[
-                action.request.indexed.chain.as_str(),
-                near_account_id.as_str(),
-            ])
+            .with_label_values(&[action.indexed.chain.as_str(), near_account_id.as_str()])
             .inc();
         return Err(());
     }
 
-    let chain = action.request.indexed.chain;
     let tx_hash = receipt.transaction_hash;
     tracing::info!(
-        sign_id = ?action.request.indexed.id,
+        ?sign_id,
         tx_hash = ?tx_hash,
         elapsed = ?timestamp.elapsed(),
         "published ethereum signature successfully"
@@ -1146,7 +1143,7 @@ async fn try_publish_eth(
     crate::metrics::NUM_SIGN_SUCCESS
         .with_label_values(&[chain.as_str(), near_account_id.as_str()])
         .inc();
-    let elapsed = action.request.indexed.timestamp_sign_queue.elapsed();
+    let elapsed = action.indexed.timestamp_sign_queue.elapsed();
     crate::metrics::SIGN_TOTAL_LATENCY
         .with_label_values(&[chain.as_str(), near_account_id.as_str()])
         .observe(elapsed.as_secs_f64());
@@ -1175,15 +1172,15 @@ async fn try_batch_publish_eth(
     let num_requests = actions.len();
     let sign_ids = actions
         .iter()
-        .map(|action| action.request.indexed.id)
+        .map(|action| action.indexed.id)
         .collect::<Vec<_>>();
     tracing::info!(?sign_ids, "will send eth batch tx");
     for action in actions {
         let signature = signatures
-            .get(&action.request.indexed.id)
+            .get(&action.indexed.id)
             .expect("signature not found in map");
         params_vec.push(DynSolValue::Tuple(vec![
-            DynSolValue::FixedBytes(action.request.indexed.id.request_id.into(), 32),
+            DynSolValue::FixedBytes(action.indexed.id.request_id.into(), 32),
             DynSolValue::Tuple(vec![
                 DynSolValue::Tuple(vec![
                     DynSolValue::from(U256::from_be_slice(&signature.big_r.x())),
@@ -1251,7 +1248,7 @@ async fn try_batch_publish_eth(
         .with_label_values(&[chain.as_str(), near_account_id.as_str()])
         .inc_by(num_requests as f64);
     for action in actions {
-        let elapsed = action.request.indexed.timestamp_sign_queue.elapsed();
+        let elapsed = action.indexed.timestamp_sign_queue.elapsed();
         crate::metrics::SIGN_TOTAL_LATENCY
             .with_label_values(&[chain.as_str(), near_account_id.as_str()])
             .observe(elapsed.as_secs_f64());
@@ -1278,21 +1275,22 @@ async fn execute_batch_publish(
 
     for action in actions.iter() {
         let expected_public_key =
-            mpc_crypto::derive_key(action.public_key, action.request.indexed.args.epsilon);
+            mpc_crypto::derive_key(action.public_key, action.indexed.args.epsilon);
 
+        let sign_id = action.indexed.id;
         let Ok(signature) = crate::kdf::into_eth_sig(
             &expected_public_key,
             &action.output.big_r,
             &action.output.s,
-            action.request.indexed.args.payload,
+            action.indexed.args.payload,
         ) else {
             tracing::error!(
-                sign_id = ?action.request.indexed.id,
+                ?sign_id,
                 "failed to generate a recovery id; trashing publish request",
             );
             return;
         };
-        signatures.insert(action.request.indexed.id, signature);
+        signatures.insert(sign_id, signature);
     }
 
     let mut retry_count = 0;
@@ -1347,10 +1345,11 @@ async fn try_publish_sol(
     signature: &Signature,
     near_account_id: &AccountId,
 ) -> Result<(), ()> {
-    let chain = action.request.indexed.chain;
+    let chain = action.indexed.chain;
     let program = sol.client.program(sol.program_id).map_err(|_| ())?;
 
-    let request_ids = vec![action.request.indexed.id.request_id];
+    let sign_id = action.indexed.id;
+    let request_ids = vec![action.indexed.id.request_id];
     let big_r = signature.big_r.to_encoded_point(false);
     let signature = SolanaContractSignature {
         big_r: SolanaContractAffinePoint {
@@ -1362,12 +1361,12 @@ async fn try_publish_sol(
     };
 
     tracing::debug!(
-        sign_id = ?action.request.indexed.id,
-        request_type = ?action.request.indexed.sign_request_type,
+        ?sign_id,
+        request_type = ?action.indexed.sign_request_type,
         "try_publish_sol: dispatching request"
     );
 
-    match &action.request.indexed.sign_request_type {
+    match &action.indexed.sign_request_type {
         SignRequestType::Sign | SignRequestType::SignBidirectional(_) => {
             let (event_authority, _) =
                 Pubkey::find_program_address(&[b"__event_authority"], &sol.program_id);
@@ -1387,7 +1386,7 @@ async fn try_publish_sol(
                 .await
                 .map_err(|err| {
                     tracing::error!(
-                        sign_id = ?action.request.indexed.id,
+                        sign_id = ?action.indexed.id,
                         error = ?err,
                         "failed to publish solana signature"
                     );
@@ -1397,7 +1396,7 @@ async fn try_publish_sol(
                 })?;
 
             tracing::info!(
-                sign_id = ?action.request.indexed.id,
+                ?sign_id,
                 tx_hash = ?tx,
                 elapsed = ?timestamp.elapsed(),
                 "published solana signature successfully"
@@ -1405,7 +1404,7 @@ async fn try_publish_sol(
         }
         SignRequestType::RespondBidirectional(respond_bidirectional_tx) => {
             tracing::debug!(
-                sign_id = ?action.request.indexed.id,
+                ?sign_id,
                 request_id = ?request_ids[0],
                 serialized_output_len = respond_bidirectional_tx.output.len(),
                 "try_publish_sol: entering RespondBidirectional arm"
@@ -1426,7 +1425,7 @@ async fn try_publish_sol(
                 .await
                 .map_err(|err| {
                     tracing::error!(
-                        sign_id = ?action.request.indexed.id,
+                        ?sign_id,
                         error = ?err,
                         "failed to publish respond bidirectional solana signature"
                     );
@@ -1436,7 +1435,7 @@ async fn try_publish_sol(
                 })?;
 
             tracing::info!(
-                sign_id = ?action.request.indexed.id,
+                ?sign_id,
                 tx_hash = ?tx,
                 elapsed = ?timestamp.elapsed(),
                 "published respond bidirectional solana signature successfully"
@@ -1448,7 +1447,7 @@ async fn try_publish_sol(
         .with_label_values(&[chain.as_str(), near_account_id.as_str()])
         .inc();
     let sign_latency_in_secs = crate::util::duration_between_unix(
-        action.request.indexed.unix_timestamp_indexed,
+        action.indexed.unix_timestamp_indexed,
         crate::util::current_unix_timestamp(),
     )
     .as_secs();

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -1,6 +1,4 @@
-use crate::protocol::signature::SignRequest;
-use crate::protocol::Chain;
-use crate::protocol::SignRequestType;
+use crate::protocol::{Chain, IndexedSignRequest, SignRequestType};
 use crate::respond_bidirectional::SerDeserFormat;
 use alloy::primitives::{keccak256, Address, Bytes, B256, I256, U256};
 use alloy_dyn_abi::{DynSolType, DynSolValue};
@@ -71,8 +69,7 @@ pub struct BidirectionalTx {
 
 impl BidirectionalTx {
     pub fn new(signature: SignBidirectionalSignature) -> anyhow::Result<Self> {
-        let SignRequestType::SignBidirectional(event) =
-            signature.request.indexed.sign_request_type.clone()
+        let SignRequestType::SignBidirectional(event) = signature.indexed.sign_request_type.clone()
         else {
             anyhow::bail!("sign request is not a sign bidirectional");
         };
@@ -84,7 +81,7 @@ impl BidirectionalTx {
                 event.dest
             )
         })?;
-        let source_chain = signature.request.indexed.chain;
+        let source_chain = signature.indexed.chain;
 
         let (signed_transaction_hash, nonce) =
             sign_and_hash_transaction(unsigned_rlp_data, signature.signature)?;
@@ -92,7 +89,7 @@ impl BidirectionalTx {
         tracing::info!(signed_transaction_hash = ?signed_transaction_hash, "signed_transaction_hash");
 
         let from_address =
-            derive_user_address(signature.public_key, signature.request.indexed.args.epsilon);
+            derive_user_address(signature.public_key, signature.indexed.args.epsilon);
 
         tracing::info!(from_address = ?from_address, "from_address");
 
@@ -111,7 +108,7 @@ impl BidirectionalTx {
             params: event.params,
             output_deserialization_schema: event.output_deserialization_schema,
             respond_serialization_schema: event.respond_serialization_schema,
-            request_id: signature.request.indexed.id.request_id,
+            request_id: signature.indexed.id.request_id,
             from_address,
             nonce,
             status: PendingRequestStatus::AwaitingResponse,
@@ -524,6 +521,6 @@ fn parse_borsh_schema_fields(schema_json_bytes: &[u8]) -> anyhow::Result<Vec<Abi
 #[derive(Clone)]
 pub struct SignBidirectionalSignature {
     pub public_key: mpc_crypto::PublicKey,
-    pub request: SignRequest,
+    pub indexed: IndexedSignRequest,
     pub signature: Signature,
 }

--- a/chain-signatures/node/src/util.rs
+++ b/chain-signatures/node/src/util.rs
@@ -124,13 +124,7 @@ impl<T, U> JoinMap<T, U> {
             tasks: JoinSet::new(),
         }
     }
-}
 
-impl<T, U> JoinMap<T, U>
-where
-    T: Copy + Hash + Eq,
-    U: Send + 'static,
-{
     pub fn len(&self) -> usize {
         self.mapping.len()
     }
@@ -138,7 +132,13 @@ where
     pub fn is_empty(&self) -> bool {
         self.mapping.is_empty()
     }
+}
 
+impl<T, U> JoinMap<T, U>
+where
+    T: Copy + Hash + Eq,
+    U: Send + 'static,
+{
     pub fn contains_key(&self, key: &T) -> bool {
         self.mapping.contains_key(key)
     }
@@ -148,6 +148,24 @@ where
         let task_id = handle.id();
         self.mapping.insert(key, handle);
         self.mapping_id.insert(task_id, key);
+    }
+
+    pub fn abort(&mut self, key: T) -> bool {
+        if let Some(handle) = self.mapping.remove(&key) {
+            handle.abort();
+
+            if let Some(task_id) = self
+                .mapping_id
+                .iter()
+                .find_map(|(id, mapped_key)| (*mapped_key == key).then_some(*id))
+            {
+                self.mapping_id.remove(&task_id);
+            }
+
+            true
+        } else {
+            false
+        }
     }
 
     pub async fn join_next(&mut self) -> Option<Result<(T, U), T>> {

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -8,7 +8,6 @@ pub mod debug;
 
 use self::error::Error;
 use crate::backlog::{Backlog, Checkpoint};
-use crate::indexer::NearIndexer;
 use crate::metrics::WEB_ENDPOINT_LATENCY;
 use crate::protocol::state::{NodeStateWatcher, NodeStatus, ResharingStatus};
 use crate::protocol::sync::{SyncChannel, SyncUpdate};
@@ -35,7 +34,6 @@ use std::time::Instant;
 
 struct AxumState {
     node: NodeStateWatcher,
-    indexer: Option<NearIndexer>,
     triple_storage: TripleStorage,
     presignature_storage: PresignatureStorage,
     sync_channel: SyncChannel,
@@ -49,7 +47,6 @@ pub async fn run(
     port: u16,
     msg_channel: MessageChannel,
     node: NodeStateWatcher,
-    indexer: Option<NearIndexer>,
     triple_storage: TripleStorage,
     presignature_storage: PresignatureStorage,
     sync_channel: SyncChannel,
@@ -60,7 +57,6 @@ pub async fn run(
     let axum_state = AxumState {
         msg_channel,
         node,
-        indexer,
         triple_storage,
         presignature_storage,
         sync_channel,
@@ -154,12 +150,10 @@ async fn state(Extension(web): Extension<Arc<AxumState>>) -> Result<Json<StateVi
     let start = Instant::now();
     tracing::debug!("fetching state");
 
-    // TODO: remove once we have integration tests built using other chains
-    let latest_block_height = if let Some(indexer) = &web.indexer {
-        indexer.last_processed_block().await.unwrap_or(0)
-    } else {
-        0
-    };
+    // TODO: decide whether to keep latest_block_height in /state or not. We could use it for showing
+    // whatever block height our governance chain is on but with multiple chains, it doesn't have much
+    // of a use.
+    let latest_block_height = 0;
 
     let result = match web.node.status() {
         NodeStatus::Running {

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -21,7 +21,7 @@ use mpc_node::protocol::contract::{InitializingContractState, RunningContractSta
 use mpc_node::protocol::message::{MessageInbox, MessageOutbox};
 use mpc_node::protocol::state::NodeKeyInfo;
 use mpc_node::protocol::triple::Triple;
-use mpc_node::protocol::{self, MessageChannel, MpcSignProtocol, ProtocolState, SignQueue};
+use mpc_node::protocol::{self, MessageChannel, MpcSignProtocol, ProtocolState};
 use mpc_node::rpc::ContractStateWatcher;
 use mpc_node::rpc::RpcChannel;
 use mpc_node::storage::{
@@ -30,7 +30,7 @@ use mpc_node::storage::{
 use near_sdk::AccountId;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::{self, Sender};
 use tokio::sync::watch;
 use tokio::sync::RwLock;
 
@@ -417,9 +417,9 @@ impl MpcFixtureNodeBuilder {
         let presignature_storage = storage.presignature_storage.clone();
 
         // prepare all channels for the node
-        let (sign_tx, sign_rx) = SignQueue::channel();
+        let (sign_tx, sign_rx) = mpsc::channel(1024);
         const MAX_CONCURRENT_RPC_REQUESTS: usize = 1024;
-        let (rpc_tx, rpc_rx) = tokio::sync::mpsc::channel(MAX_CONCURRENT_RPC_REQUESTS);
+        let (rpc_tx, rpc_rx) = mpsc::channel(MAX_CONCURRENT_RPC_REQUESTS);
         let rpc_channel = RpcChannel { tx: rpc_tx };
         let (mesh_tx, mesh_rx) = watch::channel(context.init_mesh.clone());
         let (config_tx, config_rx) = watch::channel(self.config);

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -21,7 +21,7 @@ use mpc_node::protocol::contract::{InitializingContractState, RunningContractSta
 use mpc_node::protocol::message::{MessageInbox, MessageOutbox};
 use mpc_node::protocol::state::NodeKeyInfo;
 use mpc_node::protocol::triple::Triple;
-use mpc_node::protocol::{self, MessageChannel, MpcSignProtocol, ProtocolState, Sign};
+use mpc_node::protocol::{self, MessageChannel, MpcSignProtocol, ProtocolState};
 use mpc_node::rpc::ContractStateWatcher;
 use mpc_node::rpc::RpcChannel;
 use mpc_node::storage::{
@@ -417,7 +417,7 @@ impl MpcFixtureNodeBuilder {
         let presignature_storage = storage.presignature_storage.clone();
 
         // prepare all channels for the node
-        let (sign_tx, sign_rx) = mpsc::channel::<Sign>(1024);
+        let (sign_tx, sign_rx) = mpsc::channel(1024);
         const MAX_CONCURRENT_RPC_REQUESTS: usize = 1024;
         let (rpc_tx, rpc_rx) = mpsc::channel(MAX_CONCURRENT_RPC_REQUESTS);
         let rpc_channel = RpcChannel { tx: rpc_tx };

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -21,7 +21,7 @@ use mpc_node::protocol::contract::{InitializingContractState, RunningContractSta
 use mpc_node::protocol::message::{MessageInbox, MessageOutbox};
 use mpc_node::protocol::state::NodeKeyInfo;
 use mpc_node::protocol::triple::Triple;
-use mpc_node::protocol::{self, MessageChannel, MpcSignProtocol, ProtocolState};
+use mpc_node::protocol::{self, MessageChannel, MpcSignProtocol, ProtocolState, Sign};
 use mpc_node::rpc::ContractStateWatcher;
 use mpc_node::rpc::RpcChannel;
 use mpc_node::storage::{
@@ -417,7 +417,7 @@ impl MpcFixtureNodeBuilder {
         let presignature_storage = storage.presignature_storage.clone();
 
         // prepare all channels for the node
-        let (sign_tx, sign_rx) = mpsc::channel(1024);
+        let (sign_tx, sign_rx) = mpsc::channel::<Sign>(1024);
         const MAX_CONCURRENT_RPC_REQUESTS: usize = 1024;
         let (rpc_tx, rpc_rx) = mpsc::channel(MAX_CONCURRENT_RPC_REQUESTS);
         let rpc_channel = RpcChannel { tx: rpc_tx };

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -14,7 +14,7 @@ use near_sdk::AccountId;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc;
 use tokio::sync::{watch, Mutex};
 
 pub struct MpcFixture {
@@ -30,7 +30,7 @@ pub struct MpcFixtureNode {
     pub mesh: watch::Sender<MeshState>,
     pub config: watch::Sender<Config>,
 
-    pub sign_tx: Sender<Sign>,
+    pub sign_tx: mpsc::Sender<Sign>,
     pub msg_channel: MessageChannel,
 
     pub triple_storage: TripleStorage,

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -8,7 +8,7 @@ use mpc_node::config::Config;
 use mpc_node::mesh::MeshState;
 use mpc_node::protocol::state::NodeStateWatcher;
 use mpc_node::protocol::sync::SyncChannel;
-use mpc_node::protocol::{IndexedSignRequest, MessageChannel, ProtocolState};
+use mpc_node::protocol::{MessageChannel, ProtocolState, Sign};
 use mpc_node::storage::{PresignatureStorage, TripleStorage};
 use near_sdk::AccountId;
 use std::collections::HashSet;
@@ -30,7 +30,7 @@ pub struct MpcFixtureNode {
     pub mesh: watch::Sender<MeshState>,
     pub config: watch::Sender<Config>,
 
-    pub sign_tx: Sender<IndexedSignRequest>,
+    pub sign_tx: Sender<Sign>,
     pub msg_channel: MessageChannel,
 
     pub triple_storage: TripleStorage,
@@ -102,7 +102,6 @@ impl MpcFixtureNode {
             8200 + u32::from(self.me) as u16,
             self.msg_channel.clone(),
             self.state.clone(),
-            None,
             self.triple_storage.clone(),
             self.presignature_storage.clone(),
             // unused but needed to call the web interface

--- a/integration-tests/src/mpc_fixture/fixture_tasks.rs
+++ b/integration-tests/src/mpc_fixture/fixture_tasks.rs
@@ -87,7 +87,7 @@ pub(super) fn test_mock_network(
                         RpcAction::Publish(publish_action) => {
                             format!(
                                 "RpcAction::Publish({:?})",
-                                publish_action.request,
+                                publish_action.indexed,
                             )
                         },
                     };

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -5,7 +5,7 @@ use integration_tests::mpc_fixture::MpcFixtureBuilder;
 use mpc_node::protocol::presignature::Presignature;
 use mpc_node::protocol::triple::Triple;
 use mpc_node::protocol::SignRequestType;
-use mpc_node::protocol::{Chain, IndexedSignRequest, ProtocolState};
+use mpc_node::protocol::{Chain, IndexedSignRequest, ProtocolState, Sign};
 use mpc_primitives::{SignArgs, SignId, LATEST_MPC_KEY_VERSION};
 use test_log::test;
 
@@ -173,9 +173,21 @@ async fn test_basic_sign() {
 
     tracing::info!("sending requests now");
     let request = sign_request(0);
-    network[0].sign_tx.send(request.clone()).await.unwrap();
-    network[1].sign_tx.send(request.clone()).await.unwrap();
-    network[2].sign_tx.send(request.clone()).await.unwrap();
+    network[0]
+        .sign_tx
+        .send(Sign::Request(request.clone()))
+        .await
+        .unwrap();
+    network[1]
+        .sign_tx
+        .send(Sign::Request(request.clone()))
+        .await
+        .unwrap();
+    network[2]
+        .sign_tx
+        .send(Sign::Request(request.clone()))
+        .await
+        .unwrap();
 
     let timeout = Duration::from_secs(10);
 


### PR DESCRIPTION
This resolves https://github.com/sig-net/mpc/issues/559 partially.

This makes signature organizing, positing and generating in signatures become a singular `SignTask` which goes through each of these phases sequentially and backtracks to organizing if something goes wrong.

No more `SignQueue` with this change. `SignSpawner` is now responsible for receiving messages `SignQueue` once processing, while the organizing that `SignQueue` did got moved to the `SignOrganizer` aka the organizing phase of `SignTask`.

Also no more `get_or_pending`. How a `SignTask` gets created is a one to one mapping with an `IndexedSignRequest`. Once we receive a request from indexer, we will immediately create the task. The task will then do all the work necessary for that request.

This is pretty flexible, so that we can later have the `SignTask` be a watchdog on timeout if the request never gets completed. This is one thing that is present in the previous version as well, we never tell the MPC signing that the request got completed via indexer, so it may try to reorganize and posit over and over again. This was and still is an issue, but will be resolved after checkpoints when we can observe that the respond/respond-bidirectional request made it, and thus we can go and cancel the `SignTask` at this point.