### PR TITLE
chore: remove unnecessary deps in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,6 @@ RUN npx hardhat compile
 FROM rust:latest AS node-builder
 RUN rustc --version --verbose
 WORKDIR /usr/src/app
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive \
-    apt-get install --no-install-recommends --assume-yes \
-    protobuf-compiler libprotobuf-dev
-
 COPY chain-signatures/ ./chain-signatures
 COPY integration-tests/ ./integration-tests
 COPY Cargo.toml .


### PR DESCRIPTION
for some reason we have protobuf in our docker builds that we never really use