### PR TITLE
fix: guard against empty triples/presignatures on sync

### DIFF
--- a/chain-signatures/node/src/protocol/sync/mod.rs
+++ b/chain-signatures/node/src/protocol/sync/mod.rs
@@ -262,10 +262,18 @@ impl SyncUpdate {
     async fn process(self, triples: TripleStorage, presignatures: PresignatureStorage) {
         let start = Instant::now();
 
-        let outdated_triples = triples.remove_outdated(self.from, &self.triples).await;
-        let outdated_presignatures = presignatures
-            .remove_outdated(self.from, &self.presignatures)
-            .await;
+        let outdated_triples = if !self.triples.is_empty() {
+            triples.remove_outdated(self.from, &self.triples).await
+        } else {
+            Vec::new()
+        };
+        let outdated_presignatures = if !self.presignatures.is_empty() {
+            presignatures
+                .remove_outdated(self.from, &self.presignatures)
+                .await
+        } else {
+            Vec::new()
+        };
 
         if !outdated_triples.is_empty() || !outdated_presignatures.is_empty() {
             tracing::info!(


### PR DESCRIPTION
This guards against an empty set of triples and presignatures that may get synced in cases of redis connection error or some other redis related error when trying to fetch the list of owned triples/presignatures