### PR TITLE
feat: handle 100% signature guarantee on resharing

### DIFF
--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -25,8 +25,7 @@ use mpc_keys::hpke;
 use near_account_id::AccountId;
 use near_crypto::{InMemorySigner, PublicKey, SecretKey};
 use sha3::Digest;
-use std::sync::Arc;
-use tokio::sync::{mpsc, watch, RwLock};
+use tokio::sync::{mpsc, watch};
 use url::Url;
 
 const DEFAULT_WEB_PORT: u16 = 3000;
@@ -341,7 +340,6 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let msg_channel =
                 MessageChannel::spawn(client.clone(), config_rx.clone(), contract_watcher.clone())
                     .await;
-            let sign_rx = Arc::new(RwLock::new(sign_rx));
             let sign_task = SignatureSpawnerTask::run(
                 account_id.clone(),
                 sign_rx,

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -7,6 +7,7 @@ use crate::mesh::Mesh;
 use crate::node_client::{self, NodeClient};
 use crate::protocol::message::MessageChannel;
 use crate::protocol::presignature::Presignature;
+use crate::protocol::signature::SignatureSpawnerTask;
 use crate::protocol::state::Node;
 use crate::protocol::sync::SyncTask;
 use crate::protocol::{spawn_system_metrics, MpcSignProtocol};
@@ -340,21 +341,30 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let msg_channel =
                 MessageChannel::spawn(client.clone(), config_rx.clone(), contract_watcher.clone())
                     .await;
+            let sign_rx = Arc::new(RwLock::new(sign_rx));
+            let sign_task = SignatureSpawnerTask::run(
+                account_id.clone(),
+                sign_rx,
+                contract_watcher.clone(),
+                config_rx.clone(),
+                presignature_storage.clone(),
+                mesh_state.clone(),
+                msg_channel.clone(),
+                rpc_channel.clone(),
+                backlog.clone(),
+            );
             let protocol = MpcSignProtocol {
                 my_account_id: account_id.clone(),
-                rpc_channel,
                 msg_channel: msg_channel.clone(),
                 generating: msg_channel.subscribe_generation().await,
                 resharing: msg_channel.subscribe_resharing().await,
                 ready: msg_channel.subscribe_ready().await,
-                sign_rx: Arc::new(RwLock::new(sign_rx)),
+                sign_task,
                 secret_storage: key_storage,
                 triple_storage: triple_storage.clone(),
                 presignature_storage: presignature_storage.clone(),
-                contract: contract_watcher.clone(),
                 config: config_rx,
                 mesh_state: mesh_state.clone(),
-                backlog: backlog.clone(),
             };
 
             tracing::info!("protocol initialized");

--- a/chain-signatures/node/src/protocol/consensus.rs
+++ b/chain-signatures/node/src/protocol/consensus.rs
@@ -6,7 +6,6 @@ use super::state::{
 use super::MpcSignProtocol;
 use crate::protocol::contract::primitives::Participants;
 use crate::protocol::presignature::PresignatureSpawnerTask;
-use crate::protocol::signature::SignatureSpawnerTask;
 use crate::protocol::state::GeneratingState;
 use crate::protocol::triple::TripleSpawnerTask;
 use crate::protocol::Governance;
@@ -110,14 +109,6 @@ impl<G: Governance> ConsensusProtocol<G> for StartedState {
                                 &public_key,
                             );
 
-                            let sign_task = SignatureSpawnerTask::run(
-                                me,
-                                contract_state.threshold,
-                                epoch,
-                                ctx,
-                                public_key,
-                            );
-
                             NodeState::Running(RunningState {
                                 epoch,
                                 me,
@@ -127,7 +118,6 @@ impl<G: Governance> ConsensusProtocol<G> for StartedState {
                                 public_key,
                                 triple_task,
                                 presign_task,
-                                sign_task,
                             })
                         }
                     }
@@ -414,14 +404,6 @@ impl<G: Governance> ConsensusProtocol<G> for WaitingForConsensusState {
                         &self.private_share,
                         &self.public_key,
                     );
-                    let sign_task = SignatureSpawnerTask::run(
-                        me,
-                        self.threshold,
-                        self.epoch,
-                        ctx,
-                        self.public_key,
-                    );
-
                     NodeState::Running(RunningState {
                         epoch: self.epoch,
                         me,
@@ -431,7 +413,6 @@ impl<G: Governance> ConsensusProtocol<G> for WaitingForConsensusState {
                         public_key: self.public_key,
                         triple_task,
                         presign_task,
-                        sign_task,
                     })
                 }
             },

--- a/chain-signatures/node/src/protocol/contract/mod.rs
+++ b/chain-signatures/node/src/protocol/contract/mod.rs
@@ -116,6 +116,7 @@ impl ProtocolState {
                 epoch: state.epoch,
                 public_key: state.public_key,
                 participants: state.participants.keys().copied().collect(),
+                is_running: true,
             }),
             ProtocolState::Resharing(state) => Some(GovernanceInfo {
                 me: *state.new_participants.find_participant(account_id)?,
@@ -123,6 +124,7 @@ impl ProtocolState {
                 epoch: state.old_epoch + 1,
                 public_key: state.public_key,
                 participants: state.new_participants.keys().copied().collect(),
+                is_running: false,
             }),
             ProtocolState::Initializing(_) => None,
         }

--- a/chain-signatures/node/src/protocol/contract/mod.rs
+++ b/chain-signatures/node/src/protocol/contract/mod.rs
@@ -1,13 +1,13 @@
 pub mod primitives;
 
-use crate::util::NearPublicKeyExt;
+use self::primitives::{Candidates, Participants, PkVotes, Votes};
+use crate::{rpc::GovernanceInfo, util::NearPublicKeyExt as _};
+
 use mpc_contract::ProtocolContractState;
 use mpc_crypto::PublicKey;
 use near_account_id::AccountId;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, str::FromStr};
-
-use self::primitives::{Candidates, Participants, PkVotes, Votes};
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct InitializingContractState {
@@ -105,6 +105,26 @@ impl ProtocolState {
             ProtocolState::Initializing(InitializingContractState { threshold, .. }) => *threshold,
             ProtocolState::Running(RunningContractState { threshold, .. }) => *threshold,
             ProtocolState::Resharing(ResharingContractState { threshold, .. }) => *threshold,
+        }
+    }
+
+    pub fn governance(&self, account_id: &AccountId) -> Option<GovernanceInfo> {
+        match self {
+            ProtocolState::Running(state) => Some(GovernanceInfo {
+                me: *state.participants.find_participant(account_id)?,
+                threshold: state.threshold,
+                epoch: state.epoch,
+                public_key: state.public_key,
+                participants: state.participants.keys().copied().collect(),
+            }),
+            ProtocolState::Resharing(state) => Some(GovernanceInfo {
+                me: *state.new_participants.find_participant(account_id)?,
+                threshold: state.threshold,
+                epoch: state.old_epoch + 1,
+                public_key: state.public_key,
+                participants: state.new_participants.keys().copied().collect(),
+            }),
+            ProtocolState::Initializing(_) => None,
         }
     }
 }

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -21,14 +21,14 @@ pub use mpc_primitives::Chain;
 pub use signature::{IndexedSignRequest, Sign};
 pub use state::{Node, NodeState};
 
-use crate::backlog::Backlog;
 use crate::config::Config;
 use crate::mesh::MeshState;
 use crate::protocol::consensus::ConsensusProtocol;
 use crate::protocol::cryptography::CryptographicProtocol;
 use crate::protocol::message::{GeneratingMessage, ReadyMessage, ResharingMessage};
+use crate::protocol::signature::SignatureSpawnerTask;
 use crate::respond_bidirectional::RespondBidirectionalTx;
-use crate::rpc::{ContractStateWatcher, RpcChannel};
+use crate::rpc::ContractStateWatcher;
 use crate::storage::presignature_storage::PresignatureStorage;
 use crate::storage::secret_storage::SecretNodeStorageBox;
 use crate::storage::triple_storage::TripleStorage;
@@ -36,10 +36,8 @@ use crate::storage::triple_storage::TripleStorage;
 use near_account_id::AccountId;
 use semver::Version;
 use std::path::Path;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 use sysinfo::{CpuRefreshKind, Disks, RefreshKind, System};
-use tokio::sync::RwLock;
 use tokio::sync::{mpsc, watch};
 
 pub struct MpcSignProtocol {
@@ -47,16 +45,19 @@ pub struct MpcSignProtocol {
     pub(crate) secret_storage: SecretNodeStorageBox,
     pub(crate) triple_storage: TripleStorage,
     pub(crate) presignature_storage: PresignatureStorage,
-    pub(crate) sign_rx: Arc<RwLock<mpsc::Receiver<Sign>>>,
+    pub(crate) sign_task: SignatureSpawnerTask,
     pub(crate) generating: mpsc::Receiver<GeneratingMessage>,
     pub(crate) resharing: mpsc::Receiver<ResharingMessage>,
     pub(crate) ready: mpsc::Receiver<ReadyMessage>,
     pub(crate) msg_channel: MessageChannel,
-    pub(crate) rpc_channel: RpcChannel,
-    pub(crate) contract: ContractStateWatcher,
     pub(crate) config: watch::Receiver<Config>,
     pub(crate) mesh_state: watch::Receiver<MeshState>,
-    pub(crate) backlog: Backlog,
+}
+
+impl Drop for MpcSignProtocol {
+    fn drop(&mut self) {
+        self.sign_task.abort();
+    }
 }
 
 /// Interface required by the [`MpcSignProtocol`] to participate in the

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -231,8 +231,8 @@ enum SignPhase {
 
 impl SignPhase {
     async fn advance(
-        self,
-        ctx: &SignTask,
+        &mut self,
+        ctx: &mut SignTask,
         state: &mut SignState,
         task_rx: &mut mpsc::Receiver<SignTaskMessage>,
     ) -> SignPhase {
@@ -240,7 +240,7 @@ impl SignPhase {
             SignPhase::Organizing(phase) => phase.advance(ctx, state).await,
             SignPhase::Posit(phase) => phase.advance(ctx, state, task_rx).await,
             SignPhase::Generating(phase) => phase.advance(ctx, state).await,
-            SignPhase::Complete(result) => SignPhase::Complete(result),
+            SignPhase::Complete(result) => SignPhase::Complete(*result),
         }
     }
 }
@@ -260,7 +260,7 @@ impl SignOrganizer {
     /// Waits for threshold active participants to be present.
     async fn wait_active(
         &self,
-        ctx: &SignTask,
+        ctx: &mut SignTask,
         state: &mut SignState,
         threshold: usize,
     ) -> Option<BTreeSet<Participant>> {
@@ -293,7 +293,7 @@ impl SignOrganizer {
         }
     }
 
-    async fn advance(self, ctx: &SignTask, state: &mut SignState) -> SignPhase {
+    async fn advance(&mut self, ctx: &mut SignTask, state: &mut SignState) -> SignPhase {
         let sign_id = ctx.sign_id;
         let threshold = ctx.governance.threshold;
         let me = ctx.governance.me;
@@ -312,7 +312,7 @@ impl SignOrganizer {
             let Some(active) = self.wait_active(ctx, state, threshold).await else {
                 tracing::warn!(?sign_id, round = ?state.round, "no active participants, reorganizing");
                 state.bump_round();
-                return SignPhase::Organizing(self);
+                return SignPhase::Organizing(SignOrganizer);
             };
 
             let max_rounds = state.round + ROUND_INTERVAL;
@@ -389,7 +389,7 @@ impl SignOrganizer {
                         "proposer timeout waiting for presignature, reorganizing"
                     );
                     state.bump_round();
-                    return SignPhase::Organizing(self);
+                    return SignPhase::Organizing(SignOrganizer);
                 }
             };
 
@@ -434,7 +434,7 @@ impl SignOrganizer {
 impl SignPositor {
     /// Deliberator waits for the proposer to send a Propose message with a presignature_id.
     async fn wait_propose(
-        ctx: &SignTask,
+        ctx: &mut SignTask,
         state: &mut SignState,
         task_rx: &mut mpsc::Receiver<SignTaskMessage>,
         proposer: Participant,
@@ -544,7 +544,7 @@ impl SignPositor {
                         continue;
                     }
 
-                    break *presignature_id;
+                    break Ok(*presignature_id);
                 } else {
                     tracing::warn!(
                         ?sign_id,
@@ -574,7 +574,8 @@ impl SignPositor {
         .await;
 
         let presignature_id = match outcome {
-            Ok(id) => id,
+            Ok(Ok(id)) => id,
+            Ok(Err(phase)) => return Err(phase),
             Err(_) => {
                 tracing::warn!(
                     ?sign_id,
@@ -605,17 +606,15 @@ impl SignPositor {
     }
 
     async fn advance(
-        self,
-        ctx: &SignTask,
+        &mut self,
+        ctx: &mut SignTask,
         state: &mut SignState,
         task_rx: &mut mpsc::Receiver<SignTaskMessage>,
     ) -> SignPhase {
-        let SignPositor {
-            proposer,
-            active,
-            mut presignature_id,
-            presignature,
-        } = self;
+        let proposer = self.proposer;
+        let active = self.active.clone();
+        let mut presignature_id = self.presignature_id;
+        let presignature = self.presignature.take();
 
         let sign_id = ctx.sign_id;
         let round = state.round;
@@ -812,7 +811,7 @@ impl SignPositor {
 }
 
 impl SignGenerating {
-    async fn advance(mut self, ctx: &SignTask, state: &mut SignState) -> SignPhase {
+    async fn advance(&mut self, ctx: &SignTask, state: &mut SignState) -> SignPhase {
         let sign_id = ctx.sign_id;
         let round = state.round;
 
@@ -1165,7 +1164,9 @@ struct SignTask {
 }
 
 impl SignTask {
-    fn refresh_from_contract(&mut self, contract_state: &crate::protocol::ProtocolState) -> bool {
+    /// Refresh the governance info from the contract state, returning whether we are
+    /// in a running state with valid governance info after the refresh.
+    fn refresh_governance(&mut self, contract_state: &crate::protocol::ProtocolState) -> bool {
         match contract_state {
             crate::protocol::ProtocolState::Running(running)
                 if running.epoch != self.governance.epoch =>
@@ -1187,22 +1188,23 @@ impl SignTask {
                 true
             }
             crate::protocol::ProtocolState::Resharing(state) => {
-                let me = if let Some(me) = state
-                    .new_participants
-                    .find_participant(&self.node_account_id)
-                {
-                    *me
-                } else {
-                    return false;
-                };
-                self.governance = GovernanceInfo {
-                    me,
-                    participants: state.new_participants.keys().copied().collect(),
-                    threshold: state.threshold,
-                    public_key: state.public_key.into(),
-                    epoch: state.old_epoch + 1,
-                };
-                true
+                false
+                // let me = if let Some(me) = state
+                //     .new_participants
+                //     .find_participant(&self.node_account_id)
+                // {
+                //     *me
+                // } else {
+                //     return false;
+                // };
+                // self.governance = GovernanceInfo {
+                //     me,
+                //     participants: state.new_participants.keys().copied().collect(),
+                //     threshold: state.threshold,
+                //     public_key: state.public_key.into(),
+                //     epoch: state.old_epoch + 1,
+                // };
+                // true
             }
             crate::protocol::ProtocolState::Running(_) => true,
             crate::protocol::ProtocolState::Initializing(_) => false,
@@ -1227,23 +1229,33 @@ impl SignTask {
 
         let mut state = SignState::new(indexed, mesh_state);
         let mut phase = SignPhase::Organizing(SignOrganizer);
+        let mut contract_watcher = self.contract.clone();
+        let mut is_running = true;
 
         loop {
-            if let Some(contract_state) = self.contract.state() {
-                if !self.refresh_from_contract(&contract_state) {
-                    tracing::info!(
-                        ?sign_id,
-                        epoch = self.governance.epoch,
-                        "signature task paused waiting for running governance"
-                    );
-                    self.governance = self.contract.clone().wait_governance().await;
+            let contract_fut = contract_watcher.next_state();
+            tokio::select! {
+                Some(contract_state) = contract_fut => {
+                    is_running = self.refresh_governance(&contract_state);
+                    if is_running {
+                        // we're back into running, reset to SignOrganizer
+                        phase = SignPhase::Organizing(SignOrganizer);
+                    } else {
+                        tracing::info!(
+                            ?sign_id,
+                            gov = ?self.governance,
+                            "signature task paused waiting for running governance"
+                        );
+                    }
                 }
-            }
-
-            phase = match phase.advance(&self, &mut state, &mut task_rx).await {
-                SignPhase::Complete(result) => return result,
-                other => other,
-            }
+                // This branch in tokio::select will get cancelled since the future for next contract
+                // state is reached first. This effectively pauses this branch from executing and
+                // further advancing the signature organization/positing/generation flow.
+                new_phase = phase.advance(&mut self, &mut state, &mut task_rx), if is_running => match new_phase {
+                    SignPhase::Complete(result) => return result,
+                    new_phase => phase = new_phase,
+                }
+            };
         }
     }
 }
@@ -1669,7 +1681,7 @@ mod tests {
             leave_votes: Default::default(),
             threshold: 1,
         };
-        assert!(sign_task.refresh_from_contract(&crate::protocol::ProtocolState::Running(initial)));
+        assert!(sign_task.refresh_governance(&crate::protocol::ProtocolState::Running(initial)));
         assert_eq!(sign_task.governance.epoch, 0);
         assert_eq!(sign_task.governance.threshold, 1);
         assert_eq!(sign_task.governance.me, Participant::from(0));
@@ -1683,9 +1695,7 @@ mod tests {
             finished_votes: Default::default(),
             cancel_votes: Default::default(),
         };
-        assert!(
-            sign_task.refresh_from_contract(&crate::protocol::ProtocolState::Resharing(resharing))
-        );
+        assert!(sign_task.refresh_governance(&crate::protocol::ProtocolState::Resharing(resharing)));
         assert_eq!(sign_task.governance.epoch, 1);
         assert_eq!(sign_task.governance.threshold, 1);
         assert_eq!(sign_task.governance.me, Participant::from(0));
@@ -1699,7 +1709,7 @@ mod tests {
             leave_votes: Default::default(),
             threshold: 1,
         };
-        assert!(sign_task.refresh_from_contract(&crate::protocol::ProtocolState::Running(running)));
+        assert!(sign_task.refresh_governance(&crate::protocol::ProtocolState::Running(running)));
         assert_eq!(sign_task.governance.epoch, 1);
         assert_eq!(sign_task.governance.threshold, 1);
         assert_eq!(sign_task.governance.me, Participant::from(0));

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -9,7 +9,7 @@ use crate::protocol::message::{
 };
 use crate::protocol::posit::{PositAction, SinglePositCounter};
 use crate::protocol::presignature::PresignatureId;
-use crate::protocol::Chain;
+use crate::protocol::{Chain, ProtocolState};
 use crate::rpc::{ContractStateWatcher, GovernanceInfo, RpcChannel};
 use crate::storage::presignature_storage::{PresignatureTaken, PresignatureTakenDropper};
 use crate::storage::protocol_storage::ProtocolArtifact;
@@ -1166,11 +1166,10 @@ struct SignTask {
 impl SignTask {
     /// Refresh the governance info from the contract state, returning whether we are
     /// in a running state with valid governance info after the refresh.
-    fn refresh_governance(&mut self, contract_state: &crate::protocol::ProtocolState) -> bool {
+    fn refresh_governance(&mut self, contract_state: &ProtocolState) -> bool {
         match contract_state {
-            crate::protocol::ProtocolState::Running(running)
-                if running.epoch != self.governance.epoch =>
-            {
+            ProtocolState::Initializing(_) | ProtocolState::Resharing(_) => false,
+            ProtocolState::Running(running) if running.epoch != self.governance.epoch => {
                 let me = if let Some(me) =
                     running.participants.find_participant(&self.node_account_id)
                 {
@@ -1182,32 +1181,12 @@ impl SignTask {
                     me,
                     participants: running.participants.keys().copied().collect(),
                     threshold: running.threshold,
-                    public_key: running.public_key.into(),
+                    public_key: running.public_key,
                     epoch: running.epoch,
                 };
                 true
             }
-            crate::protocol::ProtocolState::Resharing(state) => {
-                false
-                // let me = if let Some(me) = state
-                //     .new_participants
-                //     .find_participant(&self.node_account_id)
-                // {
-                //     *me
-                // } else {
-                //     return false;
-                // };
-                // self.governance = GovernanceInfo {
-                //     me,
-                //     participants: state.new_participants.keys().copied().collect(),
-                //     threshold: state.threshold,
-                //     public_key: state.public_key.into(),
-                //     epoch: state.old_epoch + 1,
-                // };
-                // true
-            }
-            crate::protocol::ProtocolState::Running(_) => true,
-            crate::protocol::ProtocolState::Initializing(_) => false,
+            ProtocolState::Running(_) => true,
         }
     }
 }
@@ -1233,9 +1212,8 @@ impl SignTask {
         let mut is_running = true;
 
         loop {
-            let contract_fut = contract_watcher.next_state();
             tokio::select! {
-                Some(contract_state) = contract_fut => {
+                Some(contract_state) = contract_watcher.next_state() => {
                     is_running = self.refresh_governance(&contract_state);
                     if is_running {
                         // we're back into running, reset to SignOrganizer
@@ -1468,7 +1446,6 @@ impl SignatureSpawner {
         mut cfg: watch::Receiver<Config>,
     ) {
         let mut posits = self.msg.subscribe_signature_posit().await;
-
         let mut protocol = cfg.borrow().protocol.clone();
 
         loop {
@@ -1489,13 +1466,9 @@ impl SignatureSpawner {
                 Ok(()) = cfg.changed() => {
                     protocol = cfg.borrow().protocol.clone();
                 }
-                _ = contract.next_state() => {
-                    if let Some(state) = contract.state() {
-                        if let Some(governance) = contract.governance() {
-                            self.governance = governance;
-                        } else if matches!(state, crate::protocol::ProtocolState::Resharing(_)) {
-                            tracing::info!("signature spawner paused during resharing");
-                        }
+                Some(state) = contract.next_state() => {
+                    if let Some(governance) = state.governance(&self.node_account_id) {
+                        self.governance = governance;
                     }
                 }
             }
@@ -1515,6 +1488,7 @@ pub struct SignatureSpawnerTask {
 }
 
 impl SignatureSpawnerTask {
+    #[allow(clippy::too_many_arguments)]
     pub fn run(
         my_account_id: near_account_id::AccountId,
         sign_rx: mpsc::Receiver<Sign>,
@@ -1610,39 +1584,30 @@ impl PendingPresignature {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol::contract::primitives::{ParticipantInfo, Participants};
     use crate::protocol::contract::{ResharingContractState, RunningContractState};
     use crate::protocol::presignature::Presignature;
+    use crate::protocol::ProtocolState;
+
     use cait_sith::protocol::Participant;
     use deadpool_redis::Runtime;
 
     #[test]
     fn sign_task_refreshes_and_pauses_on_resharing() {
         let account_id: near_account_id::AccountId = "p-0".parse().unwrap();
-        let mut participants = crate::protocol::contract::primitives::Participants::default();
-        participants.insert(
-            &Participant::from(0),
-            crate::protocol::contract::primitives::ParticipantInfo::new(0),
-        );
-        participants.insert(
-            &Participant::from(1),
-            crate::protocol::contract::primitives::ParticipantInfo::new(1),
-        );
-        participants.insert(
-            &Participant::from(2),
-            crate::protocol::contract::primitives::ParticipantInfo::new(2),
-        );
+        let mut participants = Participants::default();
+        participants.insert(&Participant::from(0), ParticipantInfo::new(0));
+        participants.insert(&Participant::from(1), ParticipantInfo::new(1));
+        participants.insert(&Participant::from(2), ParticipantInfo::new(2));
 
-        let mut participants = crate::protocol::contract::primitives::Participants::default();
-        participants.insert(
-            &Participant::from(0),
-            crate::protocol::contract::primitives::ParticipantInfo::new(0),
-        );
+        let mut participants = Participants::default();
+        participants.insert(&Participant::from(0), ParticipantInfo::new(0));
 
         let governance = GovernanceInfo {
             me: Participant::from(0),
             threshold: 1,
             epoch: 0,
-            public_key: k256::AffinePoint::default().into(),
+            public_key: k256::AffinePoint::default(),
             participants: [Participant::from(0)].into_iter().collect(),
         };
 
@@ -1681,7 +1646,7 @@ mod tests {
             leave_votes: Default::default(),
             threshold: 1,
         };
-        assert!(sign_task.refresh_governance(&crate::protocol::ProtocolState::Running(initial)));
+        assert!(sign_task.refresh_governance(&ProtocolState::Running(initial)));
         assert_eq!(sign_task.governance.epoch, 0);
         assert_eq!(sign_task.governance.threshold, 1);
         assert_eq!(sign_task.governance.me, Participant::from(0));
@@ -1695,10 +1660,9 @@ mod tests {
             finished_votes: Default::default(),
             cancel_votes: Default::default(),
         };
-        assert!(sign_task.refresh_governance(&crate::protocol::ProtocolState::Resharing(resharing)));
-        assert_eq!(sign_task.governance.epoch, 1);
-        assert_eq!(sign_task.governance.threshold, 1);
-        assert_eq!(sign_task.governance.me, Participant::from(0));
+
+        // refreshing here should yield false where we are no longer in running.
+        assert!(!sign_task.refresh_governance(&ProtocolState::Resharing(resharing)));
 
         let running = RunningContractState {
             epoch: 1,
@@ -1709,7 +1673,8 @@ mod tests {
             leave_votes: Default::default(),
             threshold: 1,
         };
-        assert!(sign_task.refresh_governance(&crate::protocol::ProtocolState::Running(running)));
+
+        assert!(sign_task.refresh_governance(&ProtocolState::Running(running)));
         assert_eq!(sign_task.governance.epoch, 1);
         assert_eq!(sign_task.governance.threshold, 1);
         assert_eq!(sign_task.governance.me, Participant::from(0));

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -1,4 +1,3 @@
-use super::MpcSignProtocol;
 use crate::backlog::Backlog;
 use crate::config::Config;
 use crate::kdf::derive_delta;
@@ -895,7 +894,7 @@ impl SignGenerator {
         indexed: IndexedSignRequest,
         presignature: PendingPresignature,
         participants: Vec<Participant>,
-        _node_account_id: &str,
+        _node_account_id: &near_account_id::AccountId,
     ) -> Result<Self, InitializationError> {
         #[cfg(feature = "debug-page")]
         let node_account_id = _node_account_id;
@@ -1161,22 +1160,49 @@ struct SignTask {
     cfg: ProtocolConfig,
     contract: ContractStateWatcher,
     is_proposer: Arc<AtomicBool>,
-    node_account_id: String,
+    node_account_id: near_account_id::AccountId,
+}
+
+impl SignTask {
+    fn refresh_from_contract(&mut self, contract_state: &crate::protocol::ProtocolState) -> bool {
+        match contract_state {
+            crate::protocol::ProtocolState::Running(running) => {
+                if running.epoch == self.epoch {
+                    return true;
+                }
+                if let Some(me) = running.participants.find_participant(&self.node_account_id) {
+                    self.me = *me;
+                    self.participants = running.participants.keys().copied().collect();
+                    self.threshold = running.threshold;
+                    self.public_key = running.public_key;
+                    self.epoch = running.epoch;
+                    return true;
+                }
+                false
+            }
+            crate::protocol::ProtocolState::Resharing(state) => {
+                self.participants = state.new_participants.keys().copied().collect();
+                self.threshold = state.threshold;
+                self.public_key = state.public_key;
+                false
+            }
+            crate::protocol::ProtocolState::Initializing(_) => false,
+        }
+    }
 }
 
 impl SignTask {
     async fn run(
-        self,
+        mut self,
         indexed: IndexedSignRequest,
         mesh_state: watch::Receiver<MeshState>,
         mut task_rx: mpsc::Receiver<SignTaskMessage>,
     ) -> Result<(), SignError> {
         let sign_id = self.sign_id;
-        let task_epoch = self.epoch;
         tracing::info!(
             ?sign_id,
             me = ?self.me,
-            epoch = task_epoch,
+            epoch = self.epoch,
             "signature task starting with organizing loop"
         );
 
@@ -1184,29 +1210,20 @@ impl SignTask {
         let mut phase = SignPhase::Organizing(SignOrganizer);
 
         loop {
-            // Check if we should abort due to resharing or epoch change
             if let Some(contract_state) = self.contract.state() {
-                match contract_state {
-                    crate::protocol::ProtocolState::Resharing(_) => {
-                        tracing::info!(
-                            ?sign_id,
-                            epoch = task_epoch,
-                            "signature task interrupted: contract is resharing"
-                        );
-                        return Err(SignError::Aborted);
-                    }
-                    crate::protocol::ProtocolState::Running(running)
-                        if running.epoch != task_epoch =>
-                    {
-                        tracing::info!(
-                            ?sign_id,
-                            old_epoch = task_epoch,
-                            new_epoch = running.epoch,
-                            "signature task interrupted: epoch changed"
-                        );
-                        return Err(SignError::Aborted);
-                    }
-                    _ => {}
+                if !self.refresh_from_contract(&contract_state) {
+                    tracing::info!(
+                        ?sign_id,
+                        epoch = self.epoch,
+                        "signature task paused waiting for running governance"
+                    );
+                    let mut contract = self.contract.clone();
+                    let governance = contract.wait_governance().await;
+                    self.me = governance.me;
+                    self.participants = governance.participants.into_iter().collect();
+                    self.threshold = governance.threshold;
+                    self.public_key = governance.public_key;
+                    self.epoch = governance.epoch;
                 }
             }
 
@@ -1246,7 +1263,7 @@ pub struct SignatureSpawner {
     msg: MessageChannel,
     rpc: RpcChannel,
     backlog: Backlog,
-    node_account_id: String,
+    node_account_id: near_account_id::AccountId,
 }
 
 impl SignatureSpawner {
@@ -1395,7 +1412,6 @@ impl SignatureSpawner {
         &mut self,
         sign: Sign,
         cfg: &ProtocolConfig,
-        participants: &BTreeSet<Participant>,
         contract: &ContractStateWatcher,
     ) {
         match sign {
@@ -1421,7 +1437,11 @@ impl SignatureSpawner {
                     request.unix_timestamp_indexed,
                 );
 
-                self.spawn_task(request, participants.clone(), contract.clone(), cfg.clone());
+                let participants = contract
+                    .participants()
+                    .map(|participants| participants.keys().copied().collect())
+                    .unwrap_or_default();
+                self.spawn_task(request, participants, contract.clone(), cfg.clone());
             }
         }
 
@@ -1436,8 +1456,6 @@ impl SignatureSpawner {
     ) {
         let mut posits = self.msg.subscribe_signature_posit().await;
 
-        let running = contract.wait_running().await;
-        let all_participants = running.participants.keys().copied().collect();
         let mut protocol = cfg.borrow().protocol.clone();
 
         // we acquire the lock but since this is a tokio lock, aborting the task while holding
@@ -1451,7 +1469,7 @@ impl SignatureSpawner {
                         tracing::warn!("signature spawner sign_rx closed, terminating");
                         break;
                     };
-                    self.handle_request(sign, &protocol, &all_participants, &contract);
+                    self.handle_request(sign, &protocol, &contract);
                 }
                 Some((sign_id, presignature_id, round, from, action)) = posits.recv() => {
                     self.handle_posit(sign_id, presignature_id, round, from, action).await;
@@ -1461,6 +1479,18 @@ impl SignatureSpawner {
                 }
                 Ok(()) = cfg.changed() => {
                     protocol = cfg.borrow().protocol.clone();
+                }
+                _ = contract.next_state() => {
+                    if let Some(state) = contract.state() {
+                        if let Some(governance) = contract.governance() {
+                            self.me = governance.me;
+                            self.threshold = governance.threshold;
+                            self.public_key = governance.public_key;
+                            self.epoch = governance.epoch;
+                        } else if matches!(state, crate::protocol::ProtocolState::Resharing(_)) {
+                            tracing::info!("signature spawner paused during resharing");
+                        }
+                    }
                 }
             }
         }
@@ -1480,34 +1510,37 @@ pub struct SignatureSpawnerTask {
 
 impl SignatureSpawnerTask {
     pub fn run(
-        me: Participant,
-        threshold: usize,
-        epoch: u64,
-        ctx: &MpcSignProtocol,
-        public_key: PublicKey,
+        my_account_id: near_account_id::AccountId,
+        sign_rx: Arc<RwLock<mpsc::Receiver<Sign>>>,
+        contract: ContractStateWatcher,
+        config: watch::Receiver<Config>,
+        presignature_storage: PresignatureStorage,
+        mesh_state: watch::Receiver<MeshState>,
+        msg_channel: MessageChannel,
+        rpc_channel: RpcChannel,
+        backlog: Backlog,
     ) -> Self {
+        let governance = contract
+            .governance()
+            .unwrap_or_else(|| panic!("signature spawner requires running governance at startup"));
         let spawner = SignatureSpawner {
-            me,
+            me: governance.me,
             tasks: JoinMap::new(),
             inboxes: HashMap::new(),
             delayed_watchers: HashMap::new(),
-            threshold,
-            public_key,
-            epoch,
-            presignatures: ctx.presignature_storage.clone(),
-            mesh_state: ctx.mesh_state.clone(),
-            msg: ctx.msg_channel.clone(),
-            rpc: ctx.rpc_channel.clone(),
-            backlog: ctx.backlog.clone(),
-            node_account_id: ctx.my_account_id.to_string(),
+            threshold: governance.threshold,
+            public_key: governance.public_key,
+            epoch: governance.epoch,
+            presignatures: presignature_storage,
+            mesh_state,
+            msg: msg_channel,
+            rpc: rpc_channel,
+            backlog,
+            node_account_id: my_account_id,
         };
 
         Self {
-            handle: tokio::spawn(spawner.run(
-                ctx.sign_rx.clone(),
-                ctx.contract.clone(),
-                ctx.config.clone(),
-            )),
+            handle: tokio::spawn(spawner.run(sign_rx, contract, config)),
         }
     }
 

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -1164,34 +1164,6 @@ struct SignTask {
 }
 
 impl SignTask {
-    /// Refresh the governance info from the contract state, returning whether we are
-    /// in a running state with valid governance info after the refresh.
-    fn refresh_governance(&mut self, contract_state: &ProtocolState) -> bool {
-        match contract_state {
-            ProtocolState::Initializing(_) | ProtocolState::Resharing(_) => false,
-            ProtocolState::Running(running) if running.epoch != self.governance.epoch => {
-                let me = if let Some(me) =
-                    running.participants.find_participant(&self.node_account_id)
-                {
-                    *me
-                } else {
-                    return false;
-                };
-                self.governance = GovernanceInfo {
-                    me,
-                    participants: running.participants.keys().copied().collect(),
-                    threshold: running.threshold,
-                    public_key: running.public_key,
-                    epoch: running.epoch,
-                };
-                true
-            }
-            ProtocolState::Running(_) => true,
-        }
-    }
-}
-
-impl SignTask {
     async fn run(
         mut self,
         indexed: IndexedSignRequest,
@@ -1199,17 +1171,15 @@ impl SignTask {
         mut task_rx: mpsc::Receiver<SignTaskMessage>,
     ) -> Result<(), SignError> {
         let sign_id = self.sign_id;
-        tracing::info!(
-            ?sign_id,
-            me = ?self.governance.me,
-            epoch = self.governance.epoch,
-            "signature task starting with organizing loop"
-        );
+        tracing::info!(?sign_id, governance = ?self.governance, "signature task starting...");
 
         let mut state = SignState::new(indexed, mesh_state);
         let mut phase = SignPhase::Organizing(SignOrganizer);
         let mut contract_watcher = self.contract.clone();
-        let mut is_running = true;
+
+        // NOTE: even if we start the SignTask while in resharing, we will not advance
+        // since we won't in the running state
+        let mut is_running = self.governance.is_running;
 
         loop {
             tokio::select! {
@@ -1236,6 +1206,17 @@ impl SignTask {
             };
         }
     }
+
+    /// Refresh the governance info from the contract state, returning whether we are
+    /// in a running state with valid governance info after the refresh.
+    fn refresh_governance(&mut self, contract_state: &ProtocolState) -> bool {
+        if let Some(governance) = contract_state.governance(&self.node_account_id) {
+            self.governance = governance;
+        } else {
+            self.governance.is_running = false;
+        }
+        self.governance.is_running
+    }
 }
 
 /// Message types that can be sent to a running signature task
@@ -1249,6 +1230,7 @@ enum SignTaskMessage {
 }
 
 pub struct SignatureSpawner {
+    contract: ContractStateWatcher,
     /// Presignature storage that maintains all presignatures.
     presignatures: PresignatureStorage,
     /// Consolidated signature tasks - one per sign_id, each task is an async task handling complete lifecycle
@@ -1259,7 +1241,6 @@ pub struct SignatureSpawner {
     delayed_watchers: HashMap<SignId, JoinHandle<()>>,
     mesh_state: watch::Receiver<MeshState>,
 
-    governance: GovernanceInfo,
     msg: MessageChannel,
     rpc: RpcChannel,
     backlog: Backlog,
@@ -1275,8 +1256,8 @@ impl SignatureSpawner {
     /// The task will handle organizing, posit, and generation internally
     fn spawn_task(
         &mut self,
+        governance: &GovernanceInfo,
         indexed: IndexedSignRequest,
-        contract: ContractStateWatcher,
         cfg: ProtocolConfig,
     ) {
         let sign_id = indexed.id;
@@ -1317,14 +1298,14 @@ impl SignatureSpawner {
         // Subscribe to (or create) the posit inbox for this sign request
         let rx = self.inboxes.entry(sign_id).or_default().subscribe();
         let task = SignTask {
-            governance: self.governance.clone(),
+            governance: governance.clone(),
             sign_id,
             presignatures: self.presignatures.clone(),
             msg: self.msg.clone(),
             rpc: self.rpc.clone(),
             backlog: self.backlog.clone(),
             cfg,
-            contract,
+            contract: self.contract.clone(),
             is_proposer,
             node_account_id: self.node_account_id.clone(),
         };
@@ -1337,6 +1318,7 @@ impl SignatureSpawner {
     /// Handle a posit message - routes to existing task or buffers if task not yet created
     async fn handle_posit(
         &mut self,
+        me: Participant,
         sign_id: SignId,
         presignature_id: PresignatureId,
         round: usize,
@@ -1344,7 +1326,7 @@ impl SignatureSpawner {
         action: PositAction,
     ) {
         // Ignore messages from ourselves
-        if from == self.governance.me {
+        if from == me {
             return;
         }
         let _ = self
@@ -1403,12 +1385,7 @@ impl SignatureSpawner {
         }
     }
 
-    fn handle_request(
-        &mut self,
-        sign: Sign,
-        cfg: &ProtocolConfig,
-        contract: &ContractStateWatcher,
-    ) {
+    fn handle_request(&mut self, governance: &GovernanceInfo, sign: Sign, cfg: &ProtocolConfig) {
         match sign {
             Sign::Completion(sign_id) => {
                 self.handle_completion(sign_id);
@@ -1432,21 +1409,22 @@ impl SignatureSpawner {
                     request.unix_timestamp_indexed,
                 );
 
-                self.spawn_task(request, contract.clone(), cfg.clone());
+                self.spawn_task(governance, request, cfg.clone());
             }
         }
 
         self.observe_queue_size();
     }
 
-    async fn run(
-        mut self,
-        mut sign_rx: mpsc::Receiver<Sign>,
-        mut contract: ContractStateWatcher,
-        mut cfg: watch::Receiver<Config>,
-    ) {
+    async fn run(mut self, mut sign_rx: mpsc::Receiver<Sign>, mut cfg: watch::Receiver<Config>) {
         let mut posits = self.msg.subscribe_signature_posit().await;
         let mut protocol = cfg.borrow().protocol.clone();
+
+        let mut contract_watcher = self.contract.clone();
+
+        // GUARANTEE: contract is in a running state with valid governance info
+        // before we start processing any messages
+        let mut governance = contract_watcher.wait_governance().await;
 
         loop {
             tokio::select! {
@@ -1455,10 +1433,10 @@ impl SignatureSpawner {
                         tracing::warn!("signature spawner sign_rx closed, terminating");
                         break;
                     };
-                    self.handle_request(sign, &protocol, &contract);
+                    self.handle_request(&governance, sign, &protocol);
                 }
                 Some((sign_id, presignature_id, round, from, action)) = posits.recv() => {
-                    self.handle_posit(sign_id, presignature_id, round, from, action).await;
+                    self.handle_posit(governance.me, sign_id, presignature_id, round, from, action).await;
                 }
                 Some(result) = self.tasks.join_next(), if !self.tasks.is_empty() => {
                     self.handle_task_exit(result);
@@ -1466,9 +1444,9 @@ impl SignatureSpawner {
                 Ok(()) = cfg.changed() => {
                     protocol = cfg.borrow().protocol.clone();
                 }
-                Some(state) = contract.next_state() => {
-                    if let Some(governance) = state.governance(&self.node_account_id) {
-                        self.governance = governance;
+                Some(state) = contract_watcher.next_state() => {
+                    if let Some(new_governance) = state.governance(&self.node_account_id) {
+                        governance = new_governance;
                     }
                 }
             }
@@ -1500,11 +1478,8 @@ impl SignatureSpawnerTask {
         rpc_channel: RpcChannel,
         backlog: Backlog,
     ) -> Self {
-        let governance = contract
-            .governance()
-            .unwrap_or_else(|| panic!("signature spawner requires running governance at startup"));
         let spawner = SignatureSpawner {
-            governance,
+            contract,
             tasks: JoinMap::new(),
             inboxes: HashMap::new(),
             delayed_watchers: HashMap::new(),
@@ -1517,7 +1492,7 @@ impl SignatureSpawnerTask {
         };
 
         Self {
-            handle: tokio::spawn(spawner.run(sign_rx, contract, config)),
+            handle: tokio::spawn(spawner.run(sign_rx, config)),
         }
     }
 
@@ -1597,11 +1572,6 @@ mod tests {
         let account_id: near_account_id::AccountId = "p-0".parse().unwrap();
         let mut participants = Participants::default();
         participants.insert(&Participant::from(0), ParticipantInfo::new(0));
-        participants.insert(&Participant::from(1), ParticipantInfo::new(1));
-        participants.insert(&Participant::from(2), ParticipantInfo::new(2));
-
-        let mut participants = Participants::default();
-        participants.insert(&Participant::from(0), ParticipantInfo::new(0));
 
         let governance = GovernanceInfo {
             me: Participant::from(0),
@@ -1609,6 +1579,7 @@ mod tests {
             epoch: 0,
             public_key: k256::AffinePoint::default(),
             participants: [Participant::from(0)].into_iter().collect(),
+            is_running: true,
         };
 
         let redis_cfg = deadpool_redis::Config::from_url("redis://127.0.0.1/");

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -1163,30 +1163,77 @@ struct SignTask {
     node_account_id: near_account_id::AccountId,
 }
 
+#[derive(Debug, Clone)]
+struct SignTaskGovernance {
+    me: Participant,
+    participants: BTreeSet<Participant>,
+    threshold: usize,
+    public_key: PublicKey,
+    epoch: u64,
+}
+
+impl SignTaskGovernance {
+    fn from_running(
+        running: &crate::protocol::contract::RunningContractState,
+        node_account_id: &near_account_id::AccountId,
+    ) -> Option<Self> {
+        let me = *running.participants.find_participant(node_account_id)?;
+        Some(Self {
+            me,
+            participants: running.participants.keys().copied().collect(),
+            threshold: running.threshold,
+            public_key: running.public_key,
+            epoch: running.epoch,
+        })
+    }
+
+    fn from_resharing(
+        resharing: &crate::protocol::contract::ResharingContractState,
+        node_account_id: &near_account_id::AccountId,
+    ) -> Option<Self> {
+        let me = *resharing.new_participants.find_participant(node_account_id)?;
+        Some(Self {
+            me,
+            participants: resharing.new_participants.keys().copied().collect(),
+            threshold: resharing.threshold,
+            public_key: resharing.public_key,
+            epoch: resharing.old_epoch + 1,
+        })
+    }
+}
+
 impl SignTask {
     fn refresh_from_contract(&mut self, contract_state: &crate::protocol::ProtocolState) -> bool {
+        let Some(governance) = self.refresh_governance(contract_state) else {
+            return false;
+        };
+        self.me = governance.me;
+        self.participants = governance.participants;
+        self.threshold = governance.threshold;
+        self.public_key = governance.public_key;
+        self.epoch = governance.epoch;
+        true
+    }
+
+    fn refresh_governance(
+        &self,
+        contract_state: &crate::protocol::ProtocolState,
+    ) -> Option<SignTaskGovernance> {
         match contract_state {
-            crate::protocol::ProtocolState::Running(running) => {
-                if running.epoch == self.epoch {
-                    return true;
-                }
-                if let Some(me) = running.participants.find_participant(&self.node_account_id) {
-                    self.me = *me;
-                    self.participants = running.participants.keys().copied().collect();
-                    self.threshold = running.threshold;
-                    self.public_key = running.public_key;
-                    self.epoch = running.epoch;
-                    return true;
-                }
-                false
+            crate::protocol::ProtocolState::Running(running) if running.epoch != self.epoch => {
+                SignTaskGovernance::from_running(running, &self.node_account_id)
             }
             crate::protocol::ProtocolState::Resharing(state) => {
-                self.participants = state.new_participants.keys().copied().collect();
-                self.threshold = state.threshold;
-                self.public_key = state.public_key;
-                false
+                SignTaskGovernance::from_resharing(state, &self.node_account_id)
             }
-            crate::protocol::ProtocolState::Initializing(_) => false,
+            crate::protocol::ProtocolState::Running(_) => Some(SignTaskGovernance {
+                me: self.me,
+                participants: self.participants.clone(),
+                threshold: self.threshold,
+                public_key: self.public_key,
+                epoch: self.epoch,
+            }),
+            crate::protocol::ProtocolState::Initializing(_) => None,
         }
     }
 }
@@ -1601,5 +1648,72 @@ impl PendingPresignature {
                 None
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::contract::{ResharingContractState, RunningContractState};
+    use cait_sith::protocol::Participant;
+
+    #[test]
+    fn sign_task_refreshes_and_pauses_on_resharing() {
+        let account_id: near_account_id::AccountId = "p-0".parse().unwrap();
+        let mut participants = crate::protocol::contract::primitives::Participants::default();
+        participants.insert(
+            &Participant::from(0),
+            crate::protocol::contract::primitives::ParticipantInfo::new(0),
+        );
+        participants.insert(
+            &Participant::from(1),
+            crate::protocol::contract::primitives::ParticipantInfo::new(1),
+        );
+        participants.insert(
+            &Participant::from(2),
+            crate::protocol::contract::primitives::ParticipantInfo::new(2),
+        );
+
+        let initial = RunningContractState {
+            epoch: 0,
+            public_key: k256::AffinePoint::default(),
+            participants: participants.clone(),
+            candidates: Default::default(),
+            join_votes: Default::default(),
+            leave_votes: Default::default(),
+            threshold: 2,
+        };
+        let running_governance = SignTaskGovernance::from_running(&initial, &account_id).unwrap();
+        assert_eq!(running_governance.epoch, 0);
+        assert_eq!(running_governance.threshold, 2);
+        assert_eq!(running_governance.me, Participant::from(0));
+
+        let resharing = ResharingContractState {
+            old_epoch: 0,
+            old_participants: participants.clone(),
+            new_participants: participants.clone(),
+            threshold: 2,
+            public_key: k256::AffinePoint::default(),
+            finished_votes: Default::default(),
+            cancel_votes: Default::default(),
+        };
+        let paused_governance = SignTaskGovernance::from_resharing(&resharing, &account_id).unwrap();
+        assert_eq!(paused_governance.epoch, 1);
+        assert_eq!(paused_governance.threshold, 2);
+        assert_eq!(paused_governance.me, Participant::from(0));
+
+        let running = RunningContractState {
+            epoch: 1,
+            public_key: k256::AffinePoint::default(),
+            participants,
+            candidates: Default::default(),
+            join_votes: Default::default(),
+            leave_votes: Default::default(),
+            threshold: 2,
+        };
+        let resumed_governance = SignTaskGovernance::from_running(&running, &account_id).unwrap();
+        assert_eq!(resumed_governance.epoch, 1);
+        assert_eq!(resumed_governance.threshold, 2);
+        assert_eq!(resumed_governance.me, Participant::from(0));
     }
 }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -10,7 +10,7 @@ use crate::protocol::message::{
 use crate::protocol::posit::{PositAction, SinglePositCounter};
 use crate::protocol::presignature::PresignatureId;
 use crate::protocol::Chain;
-use crate::rpc::{ContractStateWatcher, RpcChannel};
+use crate::rpc::{ContractStateWatcher, GovernanceInfo, RpcChannel};
 use crate::storage::presignature_storage::{PresignatureTaken, PresignatureTakenDropper};
 use crate::storage::protocol_storage::ProtocolArtifact;
 use crate::storage::PresignatureStorage;
@@ -24,7 +24,7 @@ use cait_sith::PresignOutput;
 use chrono::Utc;
 use k256::Secp256k1;
 use mpc_contract::config::ProtocolConfig;
-use mpc_crypto::{derive_key, PublicKey};
+use mpc_crypto::derive_key;
 use mpc_primitives::{SignArgs, SignId};
 use rand::rngs::StdRng;
 use rand::seq::IteratorRandom;
@@ -33,7 +33,7 @@ use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::{mpsc, watch, RwLock};
+use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 
 /// The round interval to search for a proposer in the organizing phase.
@@ -295,10 +295,15 @@ impl SignOrganizer {
 
     async fn advance(self, ctx: &SignTask, state: &mut SignState) -> SignPhase {
         let sign_id = ctx.sign_id;
-        let threshold = ctx.threshold;
-        let me = ctx.me;
+        let threshold = ctx.governance.threshold;
+        let me = ctx.governance.me;
         let entropy = state.indexed.args.entropy;
-        let participants = ctx.participants.iter().copied().collect::<Vec<_>>();
+        let participants = ctx
+            .governance
+            .participants
+            .iter()
+            .copied()
+            .collect::<Vec<_>>();
 
         ctx.is_proposer.store(false, Ordering::Relaxed);
 
@@ -357,7 +362,7 @@ impl SignOrganizer {
                             continue;
                         };
                         let participants = intersect_vec(&[holders, &active]);
-                        if participants.len() < ctx.threshold {
+                        if participants.len() < ctx.governance.threshold {
                             tracing::warn!(
                                 ?sign_id,
                                 id = taken.artifact.id,
@@ -394,16 +399,16 @@ impl SignOrganizer {
 
             // broadcast to participants and let them reject if they don't have the presignature.
             for &p in &participants {
-                if p == ctx.me {
+                if p == ctx.governance.me {
                     continue;
                 }
                 ctx.msg
                     .send(
-                        ctx.me,
+                        ctx.governance.me,
                         p,
                         PositMessage {
                             id: PositProtocolId::Signature(sign_id, presignature_id, state.round),
-                            from: ctx.me,
+                            from: ctx.governance.me,
                             action: PositAction::Propose,
                         },
                     )
@@ -467,7 +472,7 @@ impl SignPositor {
                 if state.round > *peer_round {
                     ctx.msg
                         .send(
-                            ctx.me,
+                            ctx.governance.me,
                             *from,
                             PositMessage {
                                 id: PositProtocolId::Signature(
@@ -475,7 +480,7 @@ impl SignPositor {
                                     *presignature_id,
                                     *peer_round,
                                 ),
-                                from: ctx.me,
+                                from: ctx.governance.me,
                                 action: PositAction::Reject,
                             },
                         )
@@ -523,7 +528,7 @@ impl SignPositor {
                         );
                         ctx.msg
                             .send(
-                                ctx.me,
+                                ctx.governance.me,
                                 proposer,
                                 PositMessage {
                                     id: PositProtocolId::Signature(
@@ -531,7 +536,7 @@ impl SignPositor {
                                         *presignature_id,
                                         state.round,
                                     ),
-                                    from: ctx.me,
+                                    from: ctx.governance.me,
                                     action: PositAction::Reject,
                                 },
                             )
@@ -550,7 +555,7 @@ impl SignPositor {
 
                     ctx.msg
                         .send(
-                            ctx.me,
+                            ctx.governance.me,
                             *from,
                             PositMessage {
                                 id: PositProtocolId::Signature(
@@ -558,7 +563,7 @@ impl SignPositor {
                                     *presignature_id,
                                     state.round,
                                 ),
-                                from: ctx.me,
+                                from: ctx.governance.me,
                                 action: PositAction::Reject,
                             },
                         )
@@ -575,7 +580,7 @@ impl SignPositor {
                     ?sign_id,
                     ?round,
                     ?proposer,
-                    me=?ctx.me,
+                    me=?ctx.governance.me,
                     "deliberator timeout waiting for Propose, reorganizing"
                 );
                 state.bump_round();
@@ -586,11 +591,11 @@ impl SignPositor {
         // received propose, send Accept
         ctx.msg
             .send(
-                ctx.me,
+                ctx.governance.me,
                 proposer,
                 PositMessage {
                     id: PositProtocolId::Signature(sign_id, presignature_id, state.round),
-                    from: ctx.me,
+                    from: ctx.governance.me,
                     action: PositAction::Accept,
                 },
             )
@@ -614,7 +619,7 @@ impl SignPositor {
 
         let sign_id = ctx.sign_id;
         let round = state.round;
-        let is_proposer = proposer == ctx.me;
+        let is_proposer = proposer == ctx.governance.me;
         let is_deliberator = !is_proposer;
 
         tracing::info!(
@@ -641,7 +646,7 @@ impl SignPositor {
 
         // GUARANTEE: at least threshold participants from organizing phase.
         let posit_participants = active.iter().copied().collect::<Vec<_>>();
-        let mut counter = SinglePositCounter::new(ctx.me, &posit_participants);
+        let mut counter = SinglePositCounter::new(ctx.governance.me, &posit_participants);
 
         let remaining = state.budget.remaining();
         let posit_deadline = tokio::time::sleep(remaining);
@@ -683,7 +688,7 @@ impl SignPositor {
                                 continue;
                             }
 
-                            if participants.len() < ctx.threshold {
+                            if participants.len() < ctx.governance.threshold {
                                 tracing::warn!(
                                     ?sign_id,
                                     ?round,
@@ -693,7 +698,7 @@ impl SignPositor {
                                 return SignPhase::Organizing(SignOrganizer);
                             }
 
-                            tracing::info!(?sign_id, participant = ?ctx.me, ?participants, "deliberator received Start");
+                            tracing::info!(?sign_id, participant = ?ctx.governance.me, ?participants, "deliberator received Start");
                             break participants;
                         }
                     } else {
@@ -701,7 +706,7 @@ impl SignPositor {
                             continue;
                         }
 
-                        if counter.enough_rejects(ctx.threshold) {
+                        if counter.enough_rejects(ctx.governance.threshold) {
                             tracing::warn!(?sign_id, ?round, ?from, "received enough REJECTs, reorganizing");
                             if let Some(_taken) = presignature {
                                 tracing::warn!(?sign_id, "discarding presignature due to REJECTs");
@@ -720,7 +725,7 @@ impl SignPositor {
                         // perfect but much better than always forcing nodes
                         // into the bad state.
                         let ready_to_go = counter.meets_totality() ||  accept_deadline_reached;
-                        if ready_to_go && counter.enough_accepts(ctx.threshold) {
+                        if ready_to_go && counter.enough_accepts(ctx.governance.threshold) {
                             let participants = Self::start_with_current_accepts(
                                 ctx,
                                 state,
@@ -737,7 +742,7 @@ impl SignPositor {
                         tracing::warn!(
                             ?sign_id,
                             accepts = counter.accepts.len(),
-                            threshold = ctx.threshold,
+                            threshold = ctx.governance.threshold,
                             ?round,
                             "proposer posit deadline reached, expiring round"
                         );
@@ -745,7 +750,7 @@ impl SignPositor {
                             tracing::warn!(?sign_id, "discarding presignature due to proposer timeout");
                         }
                     } else {
-                        tracing::warn!(?sign_id, me=?ctx.me, ?proposer, "deliberator posit timeout waiting for Start, reorganizing");
+                        tracing::warn!(?sign_id, me=?ctx.governance.me, ?proposer, "deliberator posit timeout waiting for Start, reorganizing");
                     }
 
                     state.bump_round();
@@ -753,7 +758,7 @@ impl SignPositor {
                 }
                 _ = &mut accept_deadline, if is_proposer && !accept_deadline_reached => {
                     accept_deadline_reached = true;
-                    if counter.enough_accepts(ctx.threshold) {
+                    if counter.enough_accepts(ctx.governance.threshold) {
                         let participants = Self::start_with_current_accepts(
                             ctx,
                             state,
@@ -784,19 +789,19 @@ impl SignPositor {
         presignature_id: PresignatureId,
     ) -> Vec<Participant> {
         let participants = counter.accepts.into_iter().collect::<Vec<_>>();
-        tracing::info!(?sign_id, round=?state.round, me = ?ctx.me, ?participants, "proposer broadcasting Start");
+        tracing::info!(?sign_id, round=?state.round, me = ?ctx.governance.me, ?participants, "proposer broadcasting Start");
 
         for &p in &participants {
-            if p == ctx.me {
+            if p == ctx.governance.me {
                 continue;
             }
             ctx.msg
                 .send(
-                    ctx.me,
+                    ctx.governance.me,
                     p,
                     PositMessage {
                         id: PositProtocolId::Signature(sign_id, presignature_id, state.round),
-                        from: ctx.me,
+                        from: ctx.governance.me,
                         action: PositAction::Start(participants.clone()),
                     },
                 )
@@ -861,7 +866,7 @@ impl SignGenerating {
                     ?sign_id,
                     ?round,
                     ?err,
-                    me=?ctx.me,
+                    me=?ctx.governance.me,
                     "signature generation failed, reorganizing"
                 );
                 state.bump_round();
@@ -913,7 +918,7 @@ impl SignGenerator {
 
         let sign_id = indexed.id;
         tracing::info!(
-            me = ?ctx.me,
+            me = ?ctx.governance.me,
             ?sign_id,
             ?presignature_id,
             "starting protocol to generate a new signature",
@@ -930,8 +935,8 @@ impl SignGenerator {
         };
         let protocol = Box::new(cait_sith::sign(
             &participants,
-            ctx.me,
-            derive_key(ctx.public_key, indexed.args.epsilon),
+            ctx.governance.me,
+            derive_key(ctx.governance.public_key, indexed.args.epsilon),
             output,
             indexed.args.payload,
         )?);
@@ -977,8 +982,8 @@ impl SignGenerator {
     }
 
     async fn run(mut self, ctx: &SignTask) -> Result<(), SignError> {
-        let me = ctx.me;
-        let epoch = ctx.epoch;
+        let me = ctx.governance.me;
+        let epoch = ctx.governance.epoch;
 
         let sign_id = self.indexed.id;
         let presignature_id = self.dropper.id;
@@ -1095,7 +1100,7 @@ impl SignGenerator {
                     if self.proposer == me {
                         crate::metrics::protocols::SIGNATURE_GENERATOR_MINE_SUCCESS.inc();
                         ctx.rpc.publish(
-                            ctx.public_key,
+                            ctx.governance.public_key,
                             self.indexed.clone(),
                             output,
                             self.participants.clone(),
@@ -1142,12 +1147,8 @@ impl Drop for SignGenerator {
 }
 
 struct SignTask {
-    me: Participant,
-    participants: BTreeSet<Participant>,
+    governance: GovernanceInfo,
     sign_id: SignId,
-    threshold: usize,
-    public_key: PublicKey,
-    epoch: u64,
     presignatures: PresignatureStorage,
     msg: MessageChannel,
     rpc: RpcChannel,
@@ -1163,77 +1164,48 @@ struct SignTask {
     node_account_id: near_account_id::AccountId,
 }
 
-#[derive(Debug, Clone)]
-struct SignTaskGovernance {
-    me: Participant,
-    participants: BTreeSet<Participant>,
-    threshold: usize,
-    public_key: PublicKey,
-    epoch: u64,
-}
-
-impl SignTaskGovernance {
-    fn from_running(
-        running: &crate::protocol::contract::RunningContractState,
-        node_account_id: &near_account_id::AccountId,
-    ) -> Option<Self> {
-        let me = *running.participants.find_participant(node_account_id)?;
-        Some(Self {
-            me,
-            participants: running.participants.keys().copied().collect(),
-            threshold: running.threshold,
-            public_key: running.public_key,
-            epoch: running.epoch,
-        })
-    }
-
-    fn from_resharing(
-        resharing: &crate::protocol::contract::ResharingContractState,
-        node_account_id: &near_account_id::AccountId,
-    ) -> Option<Self> {
-        let me = *resharing.new_participants.find_participant(node_account_id)?;
-        Some(Self {
-            me,
-            participants: resharing.new_participants.keys().copied().collect(),
-            threshold: resharing.threshold,
-            public_key: resharing.public_key,
-            epoch: resharing.old_epoch + 1,
-        })
-    }
-}
-
 impl SignTask {
     fn refresh_from_contract(&mut self, contract_state: &crate::protocol::ProtocolState) -> bool {
-        let Some(governance) = self.refresh_governance(contract_state) else {
-            return false;
-        };
-        self.me = governance.me;
-        self.participants = governance.participants;
-        self.threshold = governance.threshold;
-        self.public_key = governance.public_key;
-        self.epoch = governance.epoch;
-        true
-    }
-
-    fn refresh_governance(
-        &self,
-        contract_state: &crate::protocol::ProtocolState,
-    ) -> Option<SignTaskGovernance> {
         match contract_state {
-            crate::protocol::ProtocolState::Running(running) if running.epoch != self.epoch => {
-                SignTaskGovernance::from_running(running, &self.node_account_id)
+            crate::protocol::ProtocolState::Running(running)
+                if running.epoch != self.governance.epoch =>
+            {
+                let me = if let Some(me) =
+                    running.participants.find_participant(&self.node_account_id)
+                {
+                    *me
+                } else {
+                    return false;
+                };
+                self.governance = GovernanceInfo {
+                    me,
+                    participants: running.participants.keys().copied().collect(),
+                    threshold: running.threshold,
+                    public_key: running.public_key.into(),
+                    epoch: running.epoch,
+                };
+                true
             }
             crate::protocol::ProtocolState::Resharing(state) => {
-                SignTaskGovernance::from_resharing(state, &self.node_account_id)
+                let me = if let Some(me) = state
+                    .new_participants
+                    .find_participant(&self.node_account_id)
+                {
+                    *me
+                } else {
+                    return false;
+                };
+                self.governance = GovernanceInfo {
+                    me,
+                    participants: state.new_participants.keys().copied().collect(),
+                    threshold: state.threshold,
+                    public_key: state.public_key.into(),
+                    epoch: state.old_epoch + 1,
+                };
+                true
             }
-            crate::protocol::ProtocolState::Running(_) => Some(SignTaskGovernance {
-                me: self.me,
-                participants: self.participants.clone(),
-                threshold: self.threshold,
-                public_key: self.public_key,
-                epoch: self.epoch,
-            }),
-            crate::protocol::ProtocolState::Initializing(_) => None,
+            crate::protocol::ProtocolState::Running(_) => true,
+            crate::protocol::ProtocolState::Initializing(_) => false,
         }
     }
 }
@@ -1248,8 +1220,8 @@ impl SignTask {
         let sign_id = self.sign_id;
         tracing::info!(
             ?sign_id,
-            me = ?self.me,
-            epoch = self.epoch,
+            me = ?self.governance.me,
+            epoch = self.governance.epoch,
             "signature task starting with organizing loop"
         );
 
@@ -1261,16 +1233,10 @@ impl SignTask {
                 if !self.refresh_from_contract(&contract_state) {
                     tracing::info!(
                         ?sign_id,
-                        epoch = self.epoch,
+                        epoch = self.governance.epoch,
                         "signature task paused waiting for running governance"
                     );
-                    let mut contract = self.contract.clone();
-                    let governance = contract.wait_governance().await;
-                    self.me = governance.me;
-                    self.participants = governance.participants.into_iter().collect();
-                    self.threshold = governance.threshold;
-                    self.public_key = governance.public_key;
-                    self.epoch = governance.epoch;
+                    self.governance = self.contract.clone().wait_governance().await;
                 }
             }
 
@@ -1303,10 +1269,7 @@ pub struct SignatureSpawner {
     delayed_watchers: HashMap<SignId, JoinHandle<()>>,
     mesh_state: watch::Receiver<MeshState>,
 
-    me: Participant,
-    threshold: usize,
-    public_key: PublicKey,
-    epoch: u64,
+    governance: GovernanceInfo,
     msg: MessageChannel,
     rpc: RpcChannel,
     backlog: Backlog,
@@ -1323,7 +1286,6 @@ impl SignatureSpawner {
     fn spawn_task(
         &mut self,
         indexed: IndexedSignRequest,
-        participants: BTreeSet<Participant>,
         contract: ContractStateWatcher,
         cfg: ProtocolConfig,
     ) {
@@ -1365,12 +1327,8 @@ impl SignatureSpawner {
         // Subscribe to (or create) the posit inbox for this sign request
         let rx = self.inboxes.entry(sign_id).or_default().subscribe();
         let task = SignTask {
-            me: self.me,
-            participants,
+            governance: self.governance.clone(),
             sign_id,
-            threshold: self.threshold,
-            public_key: self.public_key,
-            epoch: self.epoch,
             presignatures: self.presignatures.clone(),
             msg: self.msg.clone(),
             rpc: self.rpc.clone(),
@@ -1396,7 +1354,7 @@ impl SignatureSpawner {
         action: PositAction,
     ) {
         // Ignore messages from ourselves
-        if from == self.me {
+        if from == self.governance.me {
             return;
         }
         let _ = self
@@ -1484,11 +1442,7 @@ impl SignatureSpawner {
                     request.unix_timestamp_indexed,
                 );
 
-                let participants = contract
-                    .participants()
-                    .map(|participants| participants.keys().copied().collect())
-                    .unwrap_or_default();
-                self.spawn_task(request, participants, contract.clone(), cfg.clone());
+                self.spawn_task(request, contract.clone(), cfg.clone());
             }
         }
 
@@ -1497,17 +1451,13 @@ impl SignatureSpawner {
 
     async fn run(
         mut self,
-        sign_rx: Arc<RwLock<mpsc::Receiver<Sign>>>,
+        mut sign_rx: mpsc::Receiver<Sign>,
         mut contract: ContractStateWatcher,
         mut cfg: watch::Receiver<Config>,
     ) {
         let mut posits = self.msg.subscribe_signature_posit().await;
 
         let mut protocol = cfg.borrow().protocol.clone();
-
-        // we acquire the lock but since this is a tokio lock, aborting the task while holding
-        // the lock is safe and will not deadlock other tasks trying to acquire the lock
-        let mut sign_rx = sign_rx.write().await;
 
         loop {
             tokio::select! {
@@ -1530,10 +1480,7 @@ impl SignatureSpawner {
                 _ = contract.next_state() => {
                     if let Some(state) = contract.state() {
                         if let Some(governance) = contract.governance() {
-                            self.me = governance.me;
-                            self.threshold = governance.threshold;
-                            self.public_key = governance.public_key;
-                            self.epoch = governance.epoch;
+                            self.governance = governance;
                         } else if matches!(state, crate::protocol::ProtocolState::Resharing(_)) {
                             tracing::info!("signature spawner paused during resharing");
                         }
@@ -1558,7 +1505,7 @@ pub struct SignatureSpawnerTask {
 impl SignatureSpawnerTask {
     pub fn run(
         my_account_id: near_account_id::AccountId,
-        sign_rx: Arc<RwLock<mpsc::Receiver<Sign>>>,
+        sign_rx: mpsc::Receiver<Sign>,
         contract: ContractStateWatcher,
         config: watch::Receiver<Config>,
         presignature_storage: PresignatureStorage,
@@ -1571,13 +1518,10 @@ impl SignatureSpawnerTask {
             .governance()
             .unwrap_or_else(|| panic!("signature spawner requires running governance at startup"));
         let spawner = SignatureSpawner {
-            me: governance.me,
+            governance,
             tasks: JoinMap::new(),
             inboxes: HashMap::new(),
             delayed_watchers: HashMap::new(),
-            threshold: governance.threshold,
-            public_key: governance.public_key,
-            epoch: governance.epoch,
             presignatures: presignature_storage,
             mesh_state,
             msg: msg_channel,
@@ -1655,7 +1599,9 @@ impl PendingPresignature {
 mod tests {
     use super::*;
     use crate::protocol::contract::{ResharingContractState, RunningContractState};
+    use crate::protocol::presignature::Presignature;
     use cait_sith::protocol::Participant;
+    use deadpool_redis::Runtime;
 
     #[test]
     fn sign_task_refreshes_and_pauses_on_resharing() {
@@ -1674,6 +1620,46 @@ mod tests {
             crate::protocol::contract::primitives::ParticipantInfo::new(2),
         );
 
+        let mut participants = crate::protocol::contract::primitives::Participants::default();
+        participants.insert(
+            &Participant::from(0),
+            crate::protocol::contract::primitives::ParticipantInfo::new(0),
+        );
+
+        let governance = GovernanceInfo {
+            me: Participant::from(0),
+            threshold: 1,
+            epoch: 0,
+            public_key: k256::AffinePoint::default().into(),
+            participants: [Participant::from(0)].into_iter().collect(),
+        };
+
+        let redis_cfg = deadpool_redis::Config::from_url("redis://127.0.0.1/");
+        let pool = redis_cfg.create_pool(Some(Runtime::Tokio1)).unwrap();
+        let presignatures = Presignature::storage(&pool, &account_id);
+        let (_inbox, _outbox, msg_channel) = MessageChannel::new();
+        let (rpc_tx, _rpc_rx) = mpsc::channel(1);
+        let rpc_channel = RpcChannel { tx: rpc_tx };
+        let (contract, _tx) = ContractStateWatcher::with_running(
+            &account_id,
+            k256::AffinePoint::default(),
+            1,
+            participants.clone(),
+        );
+
+        let mut sign_task = SignTask {
+            governance: governance.clone(),
+            sign_id: SignId::new([0u8; 32]),
+            presignatures,
+            msg: msg_channel,
+            rpc: rpc_channel,
+            backlog: Backlog::new(),
+            cfg: ProtocolConfig::default(),
+            contract,
+            is_proposer: Arc::new(AtomicBool::new(false)),
+            node_account_id: account_id.clone(),
+        };
+
         let initial = RunningContractState {
             epoch: 0,
             public_key: k256::AffinePoint::default(),
@@ -1681,26 +1667,28 @@ mod tests {
             candidates: Default::default(),
             join_votes: Default::default(),
             leave_votes: Default::default(),
-            threshold: 2,
+            threshold: 1,
         };
-        let running_governance = SignTaskGovernance::from_running(&initial, &account_id).unwrap();
-        assert_eq!(running_governance.epoch, 0);
-        assert_eq!(running_governance.threshold, 2);
-        assert_eq!(running_governance.me, Participant::from(0));
+        assert!(sign_task.refresh_from_contract(&crate::protocol::ProtocolState::Running(initial)));
+        assert_eq!(sign_task.governance.epoch, 0);
+        assert_eq!(sign_task.governance.threshold, 1);
+        assert_eq!(sign_task.governance.me, Participant::from(0));
 
         let resharing = ResharingContractState {
             old_epoch: 0,
             old_participants: participants.clone(),
             new_participants: participants.clone(),
-            threshold: 2,
+            threshold: 1,
             public_key: k256::AffinePoint::default(),
             finished_votes: Default::default(),
             cancel_votes: Default::default(),
         };
-        let paused_governance = SignTaskGovernance::from_resharing(&resharing, &account_id).unwrap();
-        assert_eq!(paused_governance.epoch, 1);
-        assert_eq!(paused_governance.threshold, 2);
-        assert_eq!(paused_governance.me, Participant::from(0));
+        assert!(
+            sign_task.refresh_from_contract(&crate::protocol::ProtocolState::Resharing(resharing))
+        );
+        assert_eq!(sign_task.governance.epoch, 1);
+        assert_eq!(sign_task.governance.threshold, 1);
+        assert_eq!(sign_task.governance.me, Participant::from(0));
 
         let running = RunningContractState {
             epoch: 1,
@@ -1709,11 +1697,11 @@ mod tests {
             candidates: Default::default(),
             join_votes: Default::default(),
             leave_votes: Default::default(),
-            threshold: 2,
+            threshold: 1,
         };
-        let resumed_governance = SignTaskGovernance::from_running(&running, &account_id).unwrap();
-        assert_eq!(resumed_governance.epoch, 1);
-        assert_eq!(resumed_governance.threshold, 2);
-        assert_eq!(resumed_governance.me, Participant::from(0));
+        assert!(sign_task.refresh_from_contract(&crate::protocol::ProtocolState::Running(running)));
+        assert_eq!(sign_task.governance.epoch, 1);
+        assert_eq!(sign_task.governance.threshold, 1);
+        assert_eq!(sign_task.governance.me, Participant::from(0));
     }
 }

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -1,7 +1,6 @@
 use super::contract::{primitives::Participants, ResharingContractState};
 use super::triple::TripleSpawnerTask;
 use crate::protocol::presignature::PresignatureSpawnerTask;
-use crate::protocol::signature::SignatureSpawnerTask;
 use crate::types::{KeygenProtocol, ReshareProtocol, SecretKeyShare};
 
 use cait_sith::protocol::Participant;
@@ -77,7 +76,6 @@ pub struct RunningState {
     pub public_key: PublicKey,
     pub triple_task: TripleSpawnerTask,
     pub presign_task: PresignatureSpawnerTask,
-    pub sign_task: SignatureSpawnerTask,
 }
 
 pub struct ResharingState {

--- a/chain-signatures/node/src/protocol/test_setup.rs
+++ b/chain-signatures/node/src/protocol/test_setup.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 use crate::backlog::Backlog;
 use crate::config::Config;
 use crate::mesh::MeshState;
-use crate::protocol::{MessageChannel, MpcSignProtocol, Sign};
 use crate::protocol::signature::SignatureSpawnerTask;
+use crate::protocol::{MessageChannel, MpcSignProtocol, Sign};
 use crate::rpc::{ContractStateWatcher, RpcChannel};
 use crate::storage::secret_storage::SecretNodeStorageBox;
 use crate::storage::{PresignatureStorage, TripleStorage};
 use near_sdk::AccountId;
-use tokio::sync::{mpsc, watch, RwLock};
+use tokio::sync::{mpsc, watch};
 
 pub struct TestProtocolStorage {
     pub secret_storage: SecretNodeStorageBox,
@@ -18,7 +18,7 @@ pub struct TestProtocolStorage {
 }
 
 pub struct TestProtocolChannels {
-    pub sign_rx: Arc<RwLock<mpsc::Receiver<Sign>>>,
+    pub sign_rx: mpsc::Receiver<Sign>,
     pub msg_channel: MessageChannel,
     pub rpc_channel: RpcChannel,
     pub config: watch::Receiver<Config>,

--- a/chain-signatures/node/src/protocol/test_setup.rs
+++ b/chain-signatures/node/src/protocol/test_setup.rs
@@ -4,6 +4,7 @@ use crate::backlog::Backlog;
 use crate::config::Config;
 use crate::mesh::MeshState;
 use crate::protocol::{MessageChannel, MpcSignProtocol, Sign};
+use crate::protocol::signature::SignatureSpawnerTask;
 use crate::rpc::{ContractStateWatcher, RpcChannel};
 use crate::storage::secret_storage::SecretNodeStorageBox;
 use crate::storage::{PresignatureStorage, TripleStorage};
@@ -34,21 +35,29 @@ impl MpcSignProtocol {
         let generating = channels.msg_channel.subscribe_generation().await;
         let resharing = channels.msg_channel.subscribe_resharing().await;
         let ready = channels.msg_channel.subscribe_ready().await;
+        let sign_task = SignatureSpawnerTask::run(
+            my_account_id.clone(),
+            channels.sign_rx,
+            contract.clone(),
+            channels.config.clone(),
+            storage.presignature_storage.clone(),
+            channels.mesh_state.clone(),
+            channels.msg_channel.clone(),
+            channels.rpc_channel.clone(),
+            Backlog::new(),
+        );
         Self {
             my_account_id,
             secret_storage: storage.secret_storage,
             triple_storage: storage.triple_storage,
             presignature_storage: storage.presignature_storage,
-            sign_rx: channels.sign_rx,
+            sign_task,
             msg_channel: channels.msg_channel,
             generating,
             resharing,
             ready,
-            rpc_channel: channels.rpc_channel,
-            contract,
             config: channels.config,
             mesh_state: channels.mesh_state,
-            backlog: Backlog::new(),
         }
     }
 }

--- a/chain-signatures/node/src/protocol/test_setup.rs
+++ b/chain-signatures/node/src/protocol/test_setup.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::backlog::Backlog;
 use crate::config::Config;
 use crate::mesh::MeshState;

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -1805,9 +1805,13 @@ async fn try_publish_hydration(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol::contract::primitives::{ParticipantInfo, Participants};
+    use crate::protocol::contract::{ResharingContractState, RunningContractState};
+    use crate::protocol::ProtocolState;
     use k256::elliptic_curve::ops::Reduce;
     use k256::elliptic_curve::point::DecompressPoint;
     use mpc_crypto::kdf::derive_secret_key;
+    use cait_sith::protocol::Participant;
 
     fn scalar(bytes: &[u8; 32]) -> k256::Scalar {
         <k256::Scalar as Reduce<<Secp256k1 as k256::elliptic_curve::Curve>::Uint>>::reduce_bytes(
@@ -1851,6 +1855,69 @@ mod tests {
             unix_timestamp_indexed: 0,
             kind: SignKind::Sign,
         }
+    }
+
+    fn test_participants() -> Participants {
+        let mut participants = Participants::default();
+        participants.insert(&Participant::from(0), ParticipantInfo::new(0));
+        participants.insert(&Participant::from(1), ParticipantInfo::new(1));
+        participants.insert(&Participant::from(2), ParticipantInfo::new(2));
+        participants
+    }
+
+    #[tokio::test]
+    async fn wait_governance_tracks_resharing_state() {
+        let account_id: AccountId = "p-0".parse().unwrap();
+        let participants = test_participants();
+        let (mut watcher, tx) = ContractStateWatcher::new(&account_id);
+
+        let initial = RunningContractState {
+            epoch: 0,
+            public_key: AffinePoint::default(),
+            participants: participants.clone(),
+            candidates: Default::default(),
+            join_votes: Default::default(),
+            leave_votes: Default::default(),
+            threshold: 2,
+        };
+        tx.send(Some(ProtocolState::Running(initial))).unwrap();
+
+        let governance = watcher.governance().expect("running governance");
+        assert_eq!(governance.epoch, 0);
+        assert_eq!(governance.threshold, 2);
+        assert_eq!(governance.me, Participant::from(0));
+
+        let resharing = ResharingContractState {
+            old_epoch: 0,
+            old_participants: participants.clone(),
+            new_participants: participants.clone(),
+            threshold: 2,
+            public_key: AffinePoint::default(),
+            finished_votes: Default::default(),
+            cancel_votes: Default::default(),
+        };
+        tx.send(Some(ProtocolState::Resharing(resharing))).unwrap();
+
+        let paused = watcher.governance().expect("resharing governance");
+        assert_eq!(paused.epoch, 1);
+        assert_eq!(paused.threshold, 2);
+        assert_eq!(paused.me, Participant::from(0));
+
+        let running = RunningContractState {
+            epoch: 1,
+            public_key: AffinePoint::default(),
+            participants,
+            candidates: Default::default(),
+            join_votes: Default::default(),
+            leave_votes: Default::default(),
+            threshold: 2,
+        };
+        tx.send(Some(ProtocolState::Running(running))).unwrap();
+
+        let resumed = watcher.wait_governance().await;
+        assert_eq!(resumed.epoch, 1);
+        assert_eq!(resumed.threshold, 2);
+        assert_eq!(resumed.me, Participant::from(0));
     }
 
     #[test]

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -134,6 +134,7 @@ pub struct GovernanceInfo {
     pub epoch: u64,
     pub public_key: mpc_crypto::PublicKey,
     pub participants: BTreeSet<Participant>,
+    pub is_running: bool,
 }
 
 #[derive(Clone)]

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -126,6 +126,15 @@ pub enum RpcAction {
     Publish(PublishAction),
 }
 
+#[derive(Debug, Clone)]
+pub struct GovernanceInfo {
+    pub me: Participant,
+    pub threshold: usize,
+    pub epoch: u64,
+    pub public_key: mpc_crypto::PublicKey,
+    pub participants: Vec<Participant>,
+}
+
 #[derive(Clone)]
 pub struct RpcChannel {
     pub tx: mpsc::Sender<RpcAction>,
@@ -220,6 +229,35 @@ impl ContractStateWatcher {
 
     pub fn state(&self) -> Option<ProtocolState> {
         self.borrow_state().clone()
+    }
+
+    pub fn governance(&self) -> Option<GovernanceInfo> {
+        match self.state()? {
+            ProtocolState::Running(state) => Some(GovernanceInfo {
+                me: *state.participants.find_participant(&self.account_id)?,
+                threshold: state.threshold,
+                epoch: state.epoch,
+                public_key: state.public_key.into(),
+                participants: state.participants.keys().copied().collect(),
+            }),
+            ProtocolState::Resharing(state) => Some(GovernanceInfo {
+                me: *state.new_participants.find_participant(&self.account_id)?,
+                threshold: state.threshold,
+                epoch: state.old_epoch + 1,
+                public_key: state.public_key.into(),
+                participants: state.new_participants.keys().copied().collect(),
+            }),
+            ProtocolState::Initializing(_) => None,
+        }
+    }
+
+    pub async fn wait_governance(&mut self) -> GovernanceInfo {
+        loop {
+            if let Some(governance) = self.governance() {
+                return governance;
+            }
+            let _ = self.contract_state.changed().await;
+        }
     }
 
     pub async fn next_state(&mut self) -> Option<ProtocolState> {

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -233,23 +233,7 @@ impl ContractStateWatcher {
     }
 
     pub fn governance(&self) -> Option<GovernanceInfo> {
-        match self.state()? {
-            ProtocolState::Running(state) => Some(GovernanceInfo {
-                me: *state.participants.find_participant(&self.account_id)?,
-                threshold: state.threshold,
-                epoch: state.epoch,
-                public_key: state.public_key.into(),
-                participants: state.participants.keys().copied().collect(),
-            }),
-            ProtocolState::Resharing(state) => Some(GovernanceInfo {
-                me: *state.new_participants.find_participant(&self.account_id)?,
-                threshold: state.threshold,
-                epoch: state.old_epoch + 1,
-                public_key: state.public_key.into(),
-                participants: state.new_participants.keys().copied().collect(),
-            }),
-            ProtocolState::Initializing(_) => None,
-        }
+        self.state()?.governance(&self.account_id)
     }
 
     pub async fn wait_governance(&mut self) -> GovernanceInfo {

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -7,6 +7,7 @@ use crate::protocol::contract::primitives::{ParticipantMap, Participants};
 use crate::protocol::contract::RunningContractState;
 use crate::protocol::{Chain, Governance, IndexedSignRequest, ProtocolState, SignKind};
 use crate::util::AffinePointExt as _;
+use std::collections::BTreeSet;
 
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::pubkey::Pubkey;
@@ -132,7 +133,7 @@ pub struct GovernanceInfo {
     pub threshold: usize,
     pub epoch: u64,
     pub public_key: mpc_crypto::PublicKey,
-    pub participants: Vec<Participant>,
+    pub participants: BTreeSet<Participant>,
 }
 
 #[derive(Clone)]
@@ -1808,10 +1809,10 @@ mod tests {
     use crate::protocol::contract::primitives::{ParticipantInfo, Participants};
     use crate::protocol::contract::{ResharingContractState, RunningContractState};
     use crate::protocol::ProtocolState;
+    use cait_sith::protocol::Participant;
     use k256::elliptic_curve::ops::Reduce;
     use k256::elliptic_curve::point::DecompressPoint;
     use mpc_crypto::kdf::derive_secret_key;
-    use cait_sith::protocol::Participant;
 
     fn scalar(bytes: &[u8; 32]) -> k256::Scalar {
         <k256::Scalar as Reduce<<Secp256k1 as k256::elliptic_curve::Curve>::Uint>>::reduce_bytes(

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -8,6 +8,7 @@ use crate::mpc_fixture::input::FixtureInput;
 use crate::mpc_fixture::message_collector::CollectMessages;
 use crate::mpc_fixture::mock_governance::MockGovernance;
 use crate::mpc_fixture::{fixture_tasks, MpcFixture, MpcFixtureNode};
+
 use cait_sith::protocol::Participant;
 use mpc_contract::config::{
     min_to_ms, PresignatureConfig, ProtocolConfig, SignatureConfig, TripleConfig,
@@ -35,7 +36,7 @@ use near_sdk::AccountId;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc::{self, Sender};
-use tokio::sync::{watch, Mutex, RwLock};
+use tokio::sync::{watch, Mutex};
 
 pub struct MpcFixtureBuilder {
     prepared_nodes: Vec<MpcFixtureNodeBuilder>,
@@ -494,7 +495,7 @@ impl MpcFixtureNodeBuilder {
         let (config_tx, config_rx) = watch::channel(self.config);
 
         let channels = protocol::test_setup::TestProtocolChannels {
-            sign_rx: Arc::new(RwLock::new(sign_rx)),
+            sign_rx,
             msg_channel: self.messaging.channel.clone(),
             rpc_channel,
             config: config_rx.clone(),

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -57,7 +57,8 @@ impl MpcFixture {
     }
 
     pub fn trigger_resharing(&self) {
-        let Some(ProtocolState::Running(running)) = self.shared_contract_state.borrow().clone() else {
+        let Some(ProtocolState::Running(running)) = self.shared_contract_state.borrow().clone()
+        else {
             return;
         };
 

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -8,6 +8,7 @@ use mpc_node::backlog::Backlog;
 use mpc_node::config::Config;
 use mpc_node::mesh::MeshState;
 use mpc_node::protocol::state::NodeStateWatcher;
+use mpc_node::protocol::state::NodeStatus;
 use mpc_node::protocol::sync::{SyncChannel, SyncUpdate};
 use mpc_node::protocol::{MessageChannel, ProtocolState, Sign};
 use mpc_node::storage::{PresignatureStorage, TripleStorage};
@@ -49,6 +50,51 @@ pub struct SharedOutput {
 }
 
 impl MpcFixture {
+    pub async fn wait_for_running(&self) {
+        for node in &self.nodes {
+            node.wait_for_running().await;
+        }
+    }
+
+    pub fn trigger_resharing(&self) {
+        let Some(ProtocolState::Running(running)) = self.shared_contract_state.borrow().clone() else {
+            return;
+        };
+
+        let resharing = mpc_node::protocol::contract::ResharingContractState {
+            old_epoch: running.epoch,
+            old_participants: running.participants.clone(),
+            new_participants: running.participants.clone(),
+            threshold: running.threshold,
+            public_key: running.public_key,
+            finished_votes: Default::default(),
+            cancel_votes: Default::default(),
+        };
+        let _ = self
+            .shared_contract_state
+            .send(Some(ProtocolState::Resharing(resharing)));
+    }
+
+    pub fn complete_resharing(&self) {
+        let Some(ProtocolState::Resharing(resharing)) = self.shared_contract_state.borrow().clone()
+        else {
+            return;
+        };
+
+        let running = mpc_node::protocol::contract::RunningContractState {
+            epoch: resharing.old_epoch + 1,
+            participants: resharing.new_participants.clone(),
+            threshold: resharing.threshold,
+            public_key: resharing.public_key,
+            candidates: Default::default(),
+            join_votes: Default::default(),
+            leave_votes: Default::default(),
+        };
+        let _ = self
+            .shared_contract_state
+            .send(Some(ProtocolState::Running(running)));
+    }
+
     pub fn sorted_participants(&self) -> Vec<Participant> {
         let mut p: Vec<_> = self.nodes.iter().map(|n| n.me).collect();
         p.sort();
@@ -139,6 +185,15 @@ impl MpcFixture {
 }
 
 impl MpcFixtureNode {
+    pub async fn wait_for_running(&self) {
+        loop {
+            if matches!(self.state.status(), NodeStatus::Running { .. }) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
     pub async fn wait_for_triples(&self, threshold_per_node: usize) {
         loop {
             let count = self.triple_storage.len_by_owner(self.me).await;

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -214,6 +214,62 @@ async fn test_basic_sign() {
     );
 }
 
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_sign_task_survives_resharing() {
+    let network = MpcFixtureBuilder::default()
+        .only_generate_signatures()
+        .build()
+        .await;
+
+    tokio::time::timeout(Duration::from_secs(5), network.wait_for_running())
+        .await
+        .expect("nodes should reach running state");
+
+    network
+        .assert_presignatures(1, Duration::from_secs(5))
+        .await;
+
+    let request = sign_request(7);
+    for node in &network.nodes {
+        node.sign_tx.send(request.clone()).await.unwrap();
+    }
+
+    network.trigger_resharing();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    network.complete_resharing();
+
+    let actions = network.assert_actions(1, Duration::from_secs(15)).await;
+    let action_str = actions.iter().next().unwrap();
+    assert!(action_str.contains("RpcAction::Publish"), "unexpected rpc action {action_str}");
+}
+
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_sign_request_during_resharing() {
+    let network = MpcFixtureBuilder::default()
+        .only_generate_signatures()
+        .build()
+        .await;
+
+    tokio::time::timeout(Duration::from_secs(5), network.wait_for_running())
+        .await
+        .expect("nodes should reach running state");
+
+    network.trigger_resharing();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let request = sign_request(8);
+    for node in &network.nodes {
+        node.sign_tx.send(request.clone()).await.unwrap();
+    }
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    network.complete_resharing();
+
+    let actions = network.assert_actions(1, Duration::from_secs(15)).await;
+    let action_str = actions.iter().next().unwrap();
+    assert!(action_str.contains("RpcAction::Publish"), "unexpected rpc action {action_str}");
+}
+
 fn sign_request(seed: u8) -> Sign {
     Sign::Request(IndexedSignRequest::sign(
         SignId::new([seed; 32]),

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -240,7 +240,10 @@ async fn test_sign_task_survives_resharing() {
 
     let actions = network.assert_actions(1, Duration::from_secs(15)).await;
     let action_str = actions.iter().next().unwrap();
-    assert!(action_str.contains("RpcAction::Publish"), "unexpected rpc action {action_str}");
+    assert!(
+        action_str.contains("RpcAction::Publish"),
+        "unexpected rpc action {action_str}"
+    );
 }
 
 #[test(tokio::test(flavor = "multi_thread"))]
@@ -267,7 +270,10 @@ async fn test_sign_request_during_resharing() {
 
     let actions = network.assert_actions(1, Duration::from_secs(15)).await;
     let action_str = actions.iter().next().unwrap();
-    assert!(action_str.contains("RpcAction::Publish"), "unexpected rpc action {action_str}");
+    assert!(
+        action_str.contains("RpcAction::Publish"),
+        "unexpected rpc action {action_str}"
+    );
 }
 
 fn sign_request(seed: u8) -> Sign {


### PR DESCRIPTION
This makes signature be handle on the cases of resharing. Before, we would just terminate the sign tasks on reaching resharing, which is not ideal when we want to guarantee 100% signatures.

So with this PR, there are a couple changes to specifically handle resharing cases when doing signature requests:
- we will now have the `SignatureSpawner` never be aborted since it will always be receiving sign requests and self update it's own relevant information.
- `SignTask` will check if we're in resharing, reset itself to organization and then pause if so. It will then update with new governance info when resharing completes and go back into running.
- component tests can now trigger a psuedo resharing like state to test this case specifically.

NOTE: The only time where we can throw away sign requests should be on key refreshing (changing out the whole master key) or when we no longer support a specific key version. These cases still need to be handled eventually.

I built this on top of the fix for sign requests on devnet, so https://github.com/sig-net/mpc/pull/607 needs to go in first