### PR TITLE
fix: deterministic proposer election via scoring

### DIFF
--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -36,13 +36,9 @@ use tokio::task::JoinHandle;
 
 use near_account_id::AccountId;
 
-/// The round interval to search for a proposer in the organizing phase.
-const ROUND_INTERVAL: usize = 512;
-
-// If the message comes from someone who isn't the expected proposer,
-// don't immediately reject. Accept proposers who would be selected
-// for any round within +/- ACCEPT_ROUND_RANGE of our current round.
-const ACCEPT_ROUND_RANGE: usize = 3;
+/// No multi-round proposer selection anymore.
+/// We select a deterministic leader per-request using a hash-score
+/// computed from the request id and participant id.
 
 /// Timeout durations for the posit phase. Propose is should be faster than deliberator
 /// for the purpose of starting sooner if we have enough participants.
@@ -76,7 +72,7 @@ enum SignError {
 }
 
 struct SignState {
-    round: usize,
+    attempt: usize,
     indexed: IndexedSignRequest,
     mesh_state: watch::Receiver<MeshState>,
 }
@@ -84,7 +80,7 @@ struct SignState {
 impl SignState {
     fn new(indexed: IndexedSignRequest, mesh_state: watch::Receiver<MeshState>) -> Self {
         Self {
-            round: 0,
+            attempt: 0,
             indexed,
             mesh_state,
         }
@@ -94,8 +90,8 @@ impl SignState {
         &self.indexed
     }
 
-    fn bump_round(&mut self) {
-        self.round += 1;
+    fn bump_attempt(&mut self) {
+        self.attempt += 1;
     }
 }
 
@@ -139,18 +135,29 @@ impl SignPhase {
 struct SignOrganizer;
 
 impl SignOrganizer {
-    fn proposer_per_round(
-        round: usize,
-        participants: &[Participant],
-        entropy: &[u8; 32],
-    ) -> Participant {
-        let mut hasher = sha3::Sha3_256::new();
-        hasher.update(entropy);
-        hasher.update(&(round as u64).to_le_bytes());
-        let hash = hasher.finalize();
+    /// Deterministically score participants for a sign request and return a ranking.
+    /// Uses the SignId.request_id as the per-request seed so every participant
+    /// can independently compute the same ordering.
+    fn proposer_ordering(sign_id: &SignId, participants: &[Participant]) -> Vec<Participant> {
+        // Build a vector of (score, participant)
+        let mut scored: Vec<(u64, Participant)> = participants
+            .iter()
+            .copied()
+            .map(|p| {
+                let mut hasher = sha3::Sha3_256::new();
+                // request id gives uniqueness per-request
+                hasher.update(&sign_id.request_id);
+                // participant id deterministic bytes
+                hasher.update(&Into::<u32>::into(p).to_le_bytes());
+                let hash = hasher.finalize();
+                let score = u64::from_le_bytes(hash[0..8].try_into().unwrap());
+                (score, p)
+            })
+            .collect();
 
-        let index = u64::from_le_bytes(hash[0..8].try_into().unwrap()) as usize;
-        participants[index % participants.len()]
+        // sort by score ascending (lower scores have priority)
+        scored.sort_by_key(|(score, _)| *score);
+        scored.into_iter().map(|(_, p)| p).collect()
     }
 
     /// Waits for threshold stable participants to be present.
@@ -193,36 +200,33 @@ impl SignOrganizer {
         let threshold = ctx.threshold;
         let me = ctx.me;
         let entropy = state.indexed.args.entropy;
+        let attempt = state.attempt;
         let participants = ctx.participants.iter().copied().collect::<Vec<_>>();
 
-        tracing::info!(?sign_id, round = ?state.round, "entering organizing phase");
+        tracing::info!(?sign_id, attempt, "entering organizing phase");
         let (stable, proposer) = {
             let Some(stable) = self.wait_stable(ctx, state, threshold).await else {
-                tracing::warn!(?sign_id, round = ?state.round, "no stable participants, reorganizing");
-                state.bump_round();
+                tracing::warn!(?sign_id, attempt, "no stable participants, reorganizing");
+                state.bump_attempt();
                 return SignPhase::Organizing(self);
             };
 
-            let max_rounds = state.round + ROUND_INTERVAL;
-            let (selected_round, proposer) = (state.round..max_rounds)
-                .map(|r| (r, Self::proposer_per_round(r, &participants, &entropy)))
-                .find(|(_, potential_proposer)| stable.contains(potential_proposer))
+            // Select proposer based on deterministic proposer ordering based on the first that is stable.
+            let proposer = Self::proposer_ordering(&ctx.sign_id, &participants)
+                .into_iter()
+                .find(|p| stable.contains(p))
                 .unwrap_or_else(|| {
-                    (
-                        max_rounds,
-                        *stable
-                            .iter()
-                            .choose(&mut StdRng::from_seed(entropy))
-                            .unwrap(),
-                    )
+                    *stable
+                        .iter()
+                        .choose(&mut StdRng::from_seed(entropy))
+                        .unwrap()
                 });
 
             let is_mine = proposer == me;
-            state.round = selected_round;
 
             tracing::info!(
                 ?sign_id,
-                round = selected_round,
+                attempt,
                 ?proposer,
                 ?me,
                 is_mine,
@@ -230,7 +234,7 @@ impl SignOrganizer {
                 "organized: selected proposer"
             );
 
-            if is_mine && state.round == 0 {
+            if is_mine && state.attempt == 0 {
                 crate::metrics::NUM_SIGN_REQUESTS_MINE
                     .with_label_values(&[ctx.my_account_id.as_str()])
                     .inc();
@@ -241,7 +245,7 @@ impl SignOrganizer {
 
         let is_proposer = proposer == ctx.me;
         let (presignature_id, presignature, stable) = if is_proposer {
-            tracing::info!(?sign_id, round = ?state.round, "proposer waiting for presignature");
+            tracing::info!(?sign_id, attempt, "proposer waiting for presignature");
             let stable = stable.iter().copied().collect::<Vec<_>>();
             let mut recycle = Vec::new();
             let fetch = tokio::time::timeout(PROPOSER_TIMEOUT, async {
@@ -272,10 +276,10 @@ impl SignOrganizer {
                 Err(_) => {
                     tracing::warn!(
                         ?sign_id,
-                        round = ?state.round,
+                        attempt,
                         "proposer timeout waiting for presignature, reorganizing"
                     );
-                    state.bump_round();
+                    state.bump_attempt();
                     return SignPhase::Organizing(self);
                 }
             };
@@ -327,7 +331,7 @@ impl SignPositor {
         proposer: Participant,
     ) -> Result<PresignatureId, SignPhase> {
         let sign_id = ctx.sign_id;
-        let round = state.round;
+        let attempt = state.attempt;
         let outcome = tokio::time::timeout(DELIBERATOR_TIMEOUT, async {
             loop {
                 let Some(task_msg) = task_rx.recv().await else {
@@ -343,88 +347,50 @@ impl SignPositor {
                     continue;
                 }
 
-                if from == &proposer {
-                    tracing::info!(
+                if from != &proposer {
+                    ctx.msg
+                        .send(
+                            ctx.me,
+                            *from,
+                            PositMessage {
+                                id: PositProtocolId::Signature(sign_id, *presignature_id),
+                                from: ctx.me,
+                                action: PositAction::Reject,
+                            },
+                        )
+                        .await;
+                    continue;
+                }
+
+                tracing::info!(
+                    ?sign_id,
+                    presignature_id,
+                    ?from,
+                    "deliberator received Propose"
+                );
+
+                // Check if we have access to this presignature (in storage or generating)
+                if !ctx.presignatures.contains(*presignature_id).await {
+                    tracing::warn!(
                         ?sign_id,
                         presignature_id,
-                        ?from,
-                        "deliberator received Propose"
+                        "deliberator does not have access to proposed presignature, rejecting"
                     );
-
-                    // Check if we have access to this presignature (in storage or generating)
-                    if !ctx.presignatures.contains(*presignature_id).await {
-                        tracing::warn!(
-                            ?sign_id,
-                            presignature_id,
-                            "deliberator does not have access to proposed presignature, rejecting"
-                        );
-                        ctx.msg
-                            .send(
-                                ctx.me,
-                                proposer,
-                                PositMessage {
-                                    id: PositProtocolId::Signature(sign_id, *presignature_id),
-                                    from: ctx.me,
-                                    action: PositAction::Reject,
-                                },
-                            )
-                            .await;
-                        continue;
-                    }
-
-                    break *presignature_id;
-                } else {
-
-                    // Build participants vector (same ordering used elsewhere)
-                    let participants = ctx.participants.iter().copied().collect::<Vec<_>>();
-
-                    // Check if `from` would be proposer for any round in the neighborhood
-                    let mut is_nearby_proposer = false;
-                    let start = round.saturating_sub(ACCEPT_ROUND_RANGE);
-                    let end = round + ACCEPT_ROUND_RANGE;
-                    for r in start..=end {
-                        let candidate = SignOrganizer::proposer_per_round(r, &participants, &state.indexed.args.entropy);
-                        if candidate == *from {
-                            tracing::info!(?sign_id, round = r, ?from, "received Propose from proposer valid for nearby round, accepting");
-                            is_nearby_proposer = true;
-                            break;
-                        }
-                    }
-
-                    if !is_nearby_proposer {
-                        tracing::warn!(?sign_id, ?from, ?proposer, "received Propose from non-proposer and not in nearby rounds, ignoring");
-                        // We intentionally *do not* send an explicit Reject here — the sender
-                        // might simply be a proposer for a different view and rejecting is noisy.
-                        continue;
-                    }
-
-                    // If the sender is a nearby proposer, check that we have access to the presignature.
-                    if !ctx.presignatures.contains(*presignature_id).await {
-                        tracing::warn!(
-                            ?sign_id,
-                            presignature_id,
-                            "deliberator does not have access to proposed presignature, rejecting"
-                        );
-                        // Inform the (nearby) proposer we cannot accept this proposal because
-                        // we do not have the presignature required to participate.
-                        ctx.msg
-                            .send(
-                                ctx.me,
-                                *from,
-                                PositMessage {
-                                    id: PositProtocolId::Signature(sign_id, *presignature_id),
-                                    from: ctx.me,
-                                    action: PositAction::Reject,
-                                },
-                            )
-                            .await;
-                        continue;
-                    }
-
-                    // Otherwise accept this proposal.
-                    tracing::info!(?sign_id, ?from, ?proposer, "accepting propose from nearby proposer");
-                    break *presignature_id;
+                    ctx.msg
+                        .send(
+                            ctx.me,
+                            proposer,
+                            PositMessage {
+                                id: PositProtocolId::Signature(sign_id, *presignature_id),
+                                from: ctx.me,
+                                action: PositAction::Reject,
+                            },
+                        )
+                        .await;
+                    continue;
                 }
+
+                break *presignature_id;
             }
         })
         .await;
@@ -434,11 +400,11 @@ impl SignPositor {
             Err(_) => {
                 tracing::warn!(
                     ?sign_id,
-                    ?round,
+                    attempt,
                     ?proposer,
                     "deliberator timeout waiting for Propose, reorganizing"
                 );
-                state.bump_round();
+                state.bump_attempt();
                 return Err(SignPhase::Organizing(SignOrganizer));
             }
         };
@@ -473,7 +439,7 @@ impl SignPositor {
         } = self;
 
         let sign_id = ctx.sign_id;
-        let round = state.round;
+        let attempt = state.attempt;
         let is_proposer = proposer == ctx.me;
         let is_deliberator = !is_proposer;
 
@@ -488,7 +454,7 @@ impl SignPositor {
         tracing::info!(
             ?sign_id,
             ?presignature_id,
-            ?round,
+            attempt,
             is_proposer,
             "entering posit phase"
         );
@@ -496,7 +462,7 @@ impl SignPositor {
         if is_deliberator {
             tracing::info!(
                 ?sign_id,
-                ?round,
+                attempt,
                 ?proposer,
                 "deliberator waiting for Propose"
             );
@@ -511,7 +477,11 @@ impl SignPositor {
         let posit_participants = stable.iter().copied().collect::<Vec<_>>();
         let mut counter = SinglePositCounter::new(ctx.me, &posit_participants);
 
-        let posit_timeout = if is_proposer { PROPOSER_TIMEOUT } else { DELIBERATOR_TIMEOUT };
+        let posit_timeout = if is_proposer {
+            PROPOSER_TIMEOUT
+        } else {
+            DELIBERATOR_TIMEOUT
+        };
         let posit_deadline = tokio::time::sleep(posit_timeout);
         tokio::pin!(posit_deadline);
 
@@ -529,10 +499,10 @@ impl SignPositor {
                             if participants.len() < ctx.threshold {
                                 tracing::warn!(
                                     ?sign_id,
-                                    ?round,
+                                    attempt,
                                     "not enough start participants"
                                 );
-                                state.bump_round();
+                                state.bump_attempt();
                                 return SignPhase::Organizing(SignOrganizer);
                             }
 
@@ -550,7 +520,7 @@ impl SignPositor {
                                 tracing::warn!(?sign_id, "recycling presignature due to REJECTs");
                                 ctx.presignatures.recycle_mine(ctx.me, taken).await;
                             }
-                            state.bump_round();
+                            state.bump_attempt();
                             return SignPhase::Organizing(SignOrganizer);
                         }
 
@@ -574,7 +544,7 @@ impl SignPositor {
                                     tracing::warn!(?sign_id, "recycling presignature due to insufficient participants");
                                     ctx.presignatures.recycle_mine(ctx.me, taken).await;
                                 }
-                                state.bump_round();
+                                state.bump_attempt();
                                 return SignPhase::Organizing(SignOrganizer);
                             }
 
@@ -621,7 +591,7 @@ impl SignPositor {
                                     tracing::warn!(?sign_id, "recycling presignature due to posit timeout");
                                     ctx.presignatures.recycle_mine(ctx.me, taken).await;
                                 }
-                                state.bump_round();
+                                state.bump_attempt();
                                 return SignPhase::Organizing(SignOrganizer);
                             }
 
@@ -649,12 +619,12 @@ impl SignPositor {
                                 tracing::warn!(?sign_id, "recycling presignature due to posit timeout (no accepts)");
                                 ctx.presignatures.recycle_mine(ctx.me, taken).await;
                             }
-                            state.bump_round();
+                            state.bump_attempt();
                             return SignPhase::Organizing(SignOrganizer);
                         }
                     } else {
                         tracing::warn!(?sign_id, "deliberator posit timeout waiting for Start, reorganizing");
-                        state.bump_round();
+                        state.bump_attempt();
                         return SignPhase::Organizing(SignOrganizer);
                     }
                 }
@@ -673,10 +643,11 @@ impl SignPositor {
 impl SignGenerating {
     async fn advance(mut self, ctx: &SignTask, state: &mut SignState) -> SignPhase {
         let sign_id = ctx.sign_id;
-        let round = state.round;
+        let attempt = state.attempt;
 
         tracing::info!(
             ?sign_id,
+            attempt,
             presignature_id = ?self.presignature_id,
             participants = ?self.accepted_participants,
             "posit complete, starting generation"
@@ -705,11 +676,11 @@ impl SignGenerating {
             Err(err) => {
                 tracing::warn!(
                     ?sign_id,
-                    ?round,
+                    attempt,
                     ?err,
                     "failed to create generator, reorganizing"
                 );
-                state.bump_round();
+                state.bump_attempt();
                 return SignPhase::Organizing(SignOrganizer);
             }
         };
@@ -724,11 +695,11 @@ impl SignGenerating {
             Err(err) => {
                 tracing::warn!(
                     ?sign_id,
-                    ?round,
+                    attempt,
                     ?err,
                     "signature generation failed, reorganizing"
                 );
-                state.bump_round();
+                state.bump_attempt();
                 SignPhase::Organizing(SignOrganizer)
             }
         }
@@ -1031,6 +1002,7 @@ impl SignTask {
             ?sign_id,
             me = ?self.me,
             epoch = task_epoch,
+            attempt = 0,
             "signature task starting with organizing loop"
         );
 
@@ -1365,50 +1337,53 @@ impl PendingPresignature {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn make_entropy(seed: u8) -> [u8; 32] {
-        let mut e = [0u8; 32];
-        e[0] = seed;
-        e
+    #[test]
+    fn proposer_order_varies_with_request_id() {
+        let participants = vec![
+            Participant::from(0),
+            Participant::from(1),
+            Participant::from(2),
+            Participant::from(3),
+        ];
+
+        let mut id0 = [0u8; 32];
+        id0[0] = 1;
+        let sign0 = SignId::new(id0);
+
+        let mut id1 = [0u8; 32];
+        id1[0] = 2;
+        let sign1 = SignId::new(id1);
+
+        let o0 = SignOrganizer::proposer_ordering(&sign0, &participants);
+        let o1 = SignOrganizer::proposer_ordering(&sign1, &participants);
+
+        // It's extremely unlikely the ordering is identical for two different request ids
+        assert_ne!(o0, o1);
     }
 
     #[test]
-    fn proposer_per_round_varies_with_round_and_entropy() {
-        let participants = vec![Participant::from(0), Participant::from(1), Participant::from(2), Participant::from(3)];
-        let entropy = make_entropy(1);
+    fn proposer_selection_determinism() {
+        let participants = vec![
+            Participant::from(0),
+            Participant::from(1),
+            Participant::from(2),
+            Participant::from(3),
+        ];
 
-        let p0 = SignOrganizer::proposer_per_round(0, &participants, &entropy);
-        let p1 = SignOrganizer::proposer_per_round(1, &participants, &entropy);
-        let p2 = SignOrganizer::proposer_per_round(2, &participants, &entropy);
+        let mut id0 = [0u8; 32];
+        id0[0] = 17;
+        let sign0 = SignId::new(id0);
 
-        // For a non-trivial hash it's extremely unlikely all three are equal
-        assert!(!(p0 == p1 && p1 == p2));
-    }
+        let order = SignOrganizer::proposer_ordering(&sign0, &participants);
+        // first leader must be one of participants
+        assert!(participants.contains(&order[0]));
 
-    #[test]
-    fn nearby_proposer_detection_within_3_rounds() {
-        let participants = vec![Participant::from(0), Participant::from(1), Participant::from(2), Participant::from(3)];
-        let entropy = make_entropy(2);
-
-        let round = 10usize;
-        // pick a 'from' that is the proposer for round + 2
-        let from = SignOrganizer::proposer_per_round(round + 2, &participants, &entropy);
-
-        // verify the algorithm would accept it when checking +/-3 rounds around `round`
-        let mut found = false;
-        for r in round.saturating_sub(3)..=round + 3 {
-            if SignOrganizer::proposer_per_round(r, &participants, &entropy) == from {
-                found = true;
-                break;
-            }
-        }
-        assert!(found, "expected proposer from nearby round to be detected");
-
-        // We only assert the nearby detection here; far-away rounds could collide due to
-        // hash periodicity in small test setups and are not reliable to assert against.
+        // calling again with same id gives same ordering
+        let order2 = SignOrganizer::proposer_ordering(&sign0, &participants);
+        assert_eq!(order, order2);
     }
 }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -27,6 +27,7 @@ use mpc_primitives::{SignArgs, SignId};
 use rand::rngs::StdRng;
 use rand::seq::IteratorRandom;
 use rand::SeedableRng;
+use sha3::Digest;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -37,6 +38,11 @@ use near_account_id::AccountId;
 
 /// The round interval to search for a proposer in the organizing phase.
 const ROUND_INTERVAL: usize = 512;
+
+// If the message comes from someone who isn't the expected proposer,
+// don't immediately reject. Accept proposers who would be selected
+// for any round within +/- ACCEPT_ROUND_RANGE of our current round.
+const ACCEPT_ROUND_RANGE: usize = 3;
 
 /// All relevant info pertaining to an Indexed sign request from an indexer.
 #[derive(Debug, Clone, PartialEq)]
@@ -131,7 +137,12 @@ impl SignOrganizer {
         participants: &[Participant],
         entropy: &[u8; 32],
     ) -> Participant {
-        let index = entropy[0] as usize + round;
+        let mut hasher = sha3::Sha3_256::new();
+        hasher.update(entropy);
+        hasher.update(&(round as u64).to_le_bytes());
+        let hash = hasher.finalize();
+
+        let index = u64::from_le_bytes(hash[0..8].try_into().unwrap()) as usize;
         participants[index % participants.len()]
     }
 
@@ -356,24 +367,56 @@ impl SignPositor {
 
                     break *presignature_id;
                 } else {
-                    tracing::warn!(
-                        ?sign_id,
-                        ?from,
-                        ?proposer,
-                        "received Propose from non-proposer, rejecting"
-                    );
 
-                    ctx.msg
-                        .send(
-                            ctx.me,
-                            *from,
-                            PositMessage {
-                                id: PositProtocolId::Signature(sign_id, *presignature_id),
-                                from: ctx.me,
-                                action: PositAction::Reject,
-                            },
-                        )
-                        .await;
+                    // Build participants vector (same ordering used elsewhere)
+                    let participants = ctx.participants.iter().copied().collect::<Vec<_>>();
+
+                    // Check if `from` would be proposer for any round in the neighborhood
+                    let mut is_nearby_proposer = false;
+                    let start = round.saturating_sub(ACCEPT_ROUND_RANGE);
+                    let end = round + ACCEPT_ROUND_RANGE;
+                    for r in start..=end {
+                        let candidate = SignOrganizer::proposer_per_round(r, &participants, &state.indexed.args.entropy);
+                        if candidate == *from {
+                            tracing::info!(?sign_id, round = r, ?from, "received Propose from proposer valid for nearby round, accepting");
+                            is_nearby_proposer = true;
+                            break;
+                        }
+                    }
+
+                    if !is_nearby_proposer {
+                        tracing::warn!(?sign_id, ?from, ?proposer, "received Propose from non-proposer and not in nearby rounds, ignoring");
+                        // We intentionally *do not* send an explicit Reject here — the sender
+                        // might simply be a proposer for a different view and rejecting is noisy.
+                        continue;
+                    }
+
+                    // If the sender is a nearby proposer, check that we have access to the presignature.
+                    if !ctx.presignatures.contains(*presignature_id).await {
+                        tracing::warn!(
+                            ?sign_id,
+                            presignature_id,
+                            "deliberator does not have access to proposed presignature, rejecting"
+                        );
+                        // Inform the (nearby) proposer we cannot accept this proposal because
+                        // we do not have the presignature required to participate.
+                        ctx.msg
+                            .send(
+                                ctx.me,
+                                *from,
+                                PositMessage {
+                                    id: PositProtocolId::Signature(sign_id, *presignature_id),
+                                    from: ctx.me,
+                                    action: PositAction::Reject,
+                                },
+                            )
+                            .await;
+                        continue;
+                    }
+
+                    // Otherwise accept this proposal.
+                    tracing::info!(?sign_id, ?from, ?proposer, "accepting propose from nearby proposer");
+                    break *presignature_id;
                 }
             }
         })
@@ -1312,5 +1355,53 @@ impl PendingPresignature {
                 None
             }
         }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_entropy(seed: u8) -> [u8; 32] {
+        let mut e = [0u8; 32];
+        e[0] = seed;
+        e
+    }
+
+    #[test]
+    fn proposer_per_round_varies_with_round_and_entropy() {
+        let participants = vec![Participant::from(0), Participant::from(1), Participant::from(2), Participant::from(3)];
+        let entropy = make_entropy(1);
+
+        let p0 = SignOrganizer::proposer_per_round(0, &participants, &entropy);
+        let p1 = SignOrganizer::proposer_per_round(1, &participants, &entropy);
+        let p2 = SignOrganizer::proposer_per_round(2, &participants, &entropy);
+
+        // For a non-trivial hash it's extremely unlikely all three are equal
+        assert!(!(p0 == p1 && p1 == p2));
+    }
+
+    #[test]
+    fn nearby_proposer_detection_within_3_rounds() {
+        let participants = vec![Participant::from(0), Participant::from(1), Participant::from(2), Participant::from(3)];
+        let entropy = make_entropy(2);
+
+        let round = 10usize;
+        // pick a 'from' that is the proposer for round + 2
+        let from = SignOrganizer::proposer_per_round(round + 2, &participants, &entropy);
+
+        // verify the algorithm would accept it when checking +/-3 rounds around `round`
+        let mut found = false;
+        for r in round.saturating_sub(3)..=round + 3 {
+            if SignOrganizer::proposer_per_round(r, &participants, &entropy) == from {
+                found = true;
+                break;
+            }
+        }
+        assert!(found, "expected proposer from nearby round to be detected");
+
+        // We only assert the nearby detection here; far-away rounds could collide due to
+        // hash periodicity in small test setups and are not reliable to assert against.
     }
 }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -36,10 +36,6 @@ use tokio::task::JoinHandle;
 
 use near_account_id::AccountId;
 
-/// No multi-round proposer selection anymore.
-/// We select a deterministic leader per-request using a hash-score
-/// computed from the request id and participant id.
-
 /// Timeout durations for the posit phase. Propose is should be faster than deliberator
 /// for the purpose of starting sooner if we have enough participants.
 const PROPOSER_TIMEOUT: Duration = Duration::from_secs(5);
@@ -146,9 +142,9 @@ impl SignOrganizer {
             .map(|p| {
                 let mut hasher = sha3::Sha3_256::new();
                 // request id gives uniqueness per-request
-                hasher.update(&sign_id.request_id);
+                hasher.update(sign_id.request_id);
                 // participant id deterministic bytes
-                hasher.update(&Into::<u32>::into(p).to_le_bytes());
+                hasher.update(Into::<u32>::into(p).to_le_bytes());
                 let hash = hasher.finalize();
                 let score = u64::from_le_bytes(hash[0..8].try_into().unwrap());
                 (score, p)

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -36,7 +36,7 @@ use tokio::task::JoinHandle;
 
 use near_account_id::AccountId;
 
-/// Timeout durations for the posit phase. Propose is should be faster than deliberator
+/// Timeout durations for the posit phase. Proposer should be faster than deliberator
 /// for the purpose of starting sooner if we have enough participants.
 const PROPOSER_TIMEOUT: Duration = Duration::from_secs(5);
 /// Deliberator timeout should be slightly longer to account for proposer expiring their

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -44,6 +44,13 @@ const ROUND_INTERVAL: usize = 512;
 // for any round within +/- ACCEPT_ROUND_RANGE of our current round.
 const ACCEPT_ROUND_RANGE: usize = 3;
 
+/// Timeout durations for the posit phase. Propose is should be faster than deliberator
+/// for the purpose of starting sooner if we have enough participants.
+const PROPOSER_TIMEOUT: Duration = Duration::from_secs(5);
+/// Deliberator timeout should be slightly longer to account for proposer expiring their
+/// posit and then issuing a start message.
+const DELIBERATOR_TIMEOUT: Duration = Duration::from_secs(7);
+
 /// All relevant info pertaining to an Indexed sign request from an indexer.
 #[derive(Debug, Clone, PartialEq)]
 pub struct IndexedSignRequest {
@@ -237,7 +244,7 @@ impl SignOrganizer {
             tracing::info!(?sign_id, round = ?state.round, "proposer waiting for presignature");
             let stable = stable.iter().copied().collect::<Vec<_>>();
             let mut recycle = Vec::new();
-            let fetch = tokio::time::timeout(Duration::from_secs(30), async {
+            let fetch = tokio::time::timeout(PROPOSER_TIMEOUT, async {
                 loop {
                     if let Some(taken) = ctx.presignatures.take_mine(ctx.me).await {
                         let participants = intersect_vec(&[&taken.artifact.participants, &stable]);
@@ -248,7 +255,7 @@ impl SignOrganizer {
 
                         break (taken, participants);
                     }
-                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    tokio::time::sleep(Duration::from_millis(250)).await;
                 }
             })
             .await;
@@ -321,7 +328,7 @@ impl SignPositor {
     ) -> Result<PresignatureId, SignPhase> {
         let sign_id = ctx.sign_id;
         let round = state.round;
-        let outcome = tokio::time::timeout(Duration::from_secs(30), async {
+        let outcome = tokio::time::timeout(DELIBERATOR_TIMEOUT, async {
             loop {
                 let Some(task_msg) = task_rx.recv().await else {
                     continue;
@@ -504,7 +511,7 @@ impl SignPositor {
         let posit_participants = stable.iter().copied().collect::<Vec<_>>();
         let mut counter = SinglePositCounter::new(ctx.me, &posit_participants);
 
-        let posit_timeout = Duration::from_secs(60);
+        let posit_timeout = if is_proposer { PROPOSER_TIMEOUT } else { DELIBERATOR_TIMEOUT };
         let posit_deadline = tokio::time::sleep(posit_timeout);
         tokio::pin!(posit_deadline);
 

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -2,7 +2,7 @@
 //! it before it starts running.
 
 use crate::containers::Redis;
-use crate::mpc_fixture::fixture_interface::SharedOutput;
+use crate::mpc_fixture::fixture_interface::{CompletionBroadcast, SharedOutput};
 use crate::mpc_fixture::fixture_tasks::MessageFilter;
 use crate::mpc_fixture::input::FixtureInput;
 use crate::mpc_fixture::mock_governance::MockGovernance;
@@ -159,6 +159,7 @@ impl MpcFixtureBuilder {
         let initial_mesh_state = self.build_mesh_state();
 
         let output = SharedOutput::default();
+        let completion_broadcast = CompletionBroadcast::new();
         let mut nodes = vec![];
 
         let account_ids: Vec<_> = self
@@ -185,6 +186,7 @@ impl MpcFixtureBuilder {
                     shared_contract_state_tx.clone(),
                     &mut self.fixture_config,
                     &output,
+                    &completion_broadcast,
                 )
                 .await;
 
@@ -405,6 +407,7 @@ impl MpcFixtureNodeBuilder {
         protocol_state_tx: watch::Sender<Option<ProtocolState>>,
         fixture_config: &mut FixtureConfig,
         shared_output: &SharedOutput,
+        completion_broadcast: &CompletionBroadcast,
     ) -> MpcFixtureNode {
         // overwrite the default protocol config with the built config
         self.config.protocol = context.protocol_config.clone();
@@ -471,6 +474,9 @@ impl MpcFixtureNodeBuilder {
             mesh_tx.clone(),
             config_tx.clone(),
             self.messaging.filter,
+            sign_tx.clone(),
+            completion_broadcast.tx.clone(),
+            completion_broadcast.subscribe(),
         );
 
         let mut node = MpcFixtureNode {

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -60,10 +60,6 @@ struct FixtureConfig {
 
     use_preshared_triples: bool,
     presignature_stockpile: bool,
-    /// If set, only load this many presignatures initially (total, across owners) for
-    /// each participant. The rest are stored for later addition via
-    /// `MpcFixture::add_presignatures()`.
-    initial_presignature_count: Option<usize>,
 
     min_triples: u32,
     max_triples: u32,
@@ -109,7 +105,6 @@ impl FixtureConfig {
             input: FixtureInput::load(num_nodes),
             use_preshared_triples: false,
             presignature_stockpile: false,
-            initial_presignature_count: None,
             min_triples: 10,
             max_triples: 30,
             min_presignatures: 10,
@@ -303,14 +298,6 @@ impl MpcFixtureBuilder {
     /// Set protocol config
     pub fn with_max_presignatures_stockpile(mut self, value: u32) -> Self {
         self.fixture_config.max_presignatures = value;
-        self
-    }
-
-    /// Only load this many presignatures initially (total, across owners) per participant.
-    /// The remaining presignatures can be added later via `MpcFixture::add_presignatures()`.
-    /// This is useful for testing scenarios where presignatures run out and more need to be added.
-    pub fn with_initial_presignature_count(mut self, count: usize) -> Self {
-        self.fixture_config.initial_presignature_count = Some(count);
         self
     }
 

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -26,7 +26,7 @@ use mpc_node::rpc::ContractStateWatcher;
 use mpc_node::rpc::RpcChannel;
 use mpc_node::storage::{secret_storage, triple_storage::TriplePair, Options};
 use near_sdk::AccountId;
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc::{self, Sender};
 use tokio::sync::watch;
@@ -167,14 +167,8 @@ impl MpcFixtureBuilder {
         let completion_broadcast = CompletionBroadcast::new();
         let mut nodes = vec![];
 
-        let remaining_presignatures = if self.fixture_config.initial_presignature_count.is_some() {
-            // Build a fresh copy of the fixture presignatures which will be owned by the
-            // running `MpcFixture` and later consumed by `add_presignatures()`.
-            let num_nodes = self.prepared_nodes.len() as u32;
-            FixtureInput::load(num_nodes).presignatures
-        } else {
-            BTreeMap::new()
-        };
+        let num_nodes = self.prepared_nodes.len() as u32;
+        let pregenerated_presignatures = FixtureInput::load(num_nodes).presignatures;
 
         let account_ids: Vec<_> = self
             .prepared_nodes
@@ -212,7 +206,7 @@ impl MpcFixtureBuilder {
             nodes,
             output,
             shared_contract_state: shared_contract_state_tx,
-            remaining_presignatures: tokio::sync::Mutex::new(remaining_presignatures),
+            pregenerated_presignatures,
         }
     }
 
@@ -561,86 +555,26 @@ impl MpcFixtureNodeBuilder {
             Presignature::storage(&context.redis_pool, &self.participant_info.account_id);
 
         if fixture_config.presignature_stockpile {
-            // If an initial_presignature_count is configured, we intentionally keep
-            // all fixture presignatures in the builder's `remaining_presignatures` and
-            // only load *that many* shares into the node right now. To keep things
-            // simple and allow duplication when the initial count exceeds the
-            // available items in the fixture file, we repeatedly reload the static
-            // fixture (via FixtureInput::load) and consume entries until we've
-            // inserted the requested `initial_presignature_count` shares.
-            if let Some(initial_count) = fixture_config.initial_presignature_count {
-                tracing::info!(me = ?self.me, initial_count, "loading limited set of presignatures for test (may duplicate)");
-
-                // Number of nodes in fixtures (3 or 5 currently)
-                let num_nodes = fixture_config.input.presignatures.len() as u32;
-                let mut inserted = 0usize;
-
-                // Keep loading the fixture until we've inserted `initial_count` shares.
-                while inserted < initial_count {
-                    let fresh = FixtureInput::load(num_nodes);
-
-                    if let Some((_participant, owner_map)) =
-                        fresh.presignatures.into_iter().find(|(p, _)| *p == self.me)
-                    {
-                        // Build owner -> VecDeque so we can select presignatures in a
-                        // round-robin fashion across owners for this participant. This
-                        // helps make initial selection balanced and increases the
-                        // likelihood that proposers will find usable presignatures.
-                        let mut owner_deques: Vec<(Participant, VecDeque<Presignature>)> =
-                            owner_map
-                                .into_iter()
-                                .map(|(owner, v)| (owner, VecDeque::from(v)))
-                                .collect();
-
-                        let mut made_progress = true;
-                        while inserted < initial_count && made_progress {
-                            made_progress = false;
-                            for (owner, dq) in owner_deques.iter_mut() {
-                                if inserted >= initial_count {
-                                    break;
-                                }
-                                if let Some(presignature_share) = dq.pop_front() {
-                                    let mut slot = presignature_storage
-                                        .reserve(presignature_share.id)
-                                        .await
-                                        .unwrap();
-                                    slot.insert(presignature_share, *owner).await;
-                                    inserted += 1;
-                                    made_progress = true;
-                                }
-                            }
-                        }
-                    } else {
-                        // Fixture didn't contain any entries for this participant — nothing to do
-                        break;
-                    }
-                }
-
-                tracing::info!(me = ?self.me, inserted, "loaded initial presignatures for node");
-            } else {
-                // Original behaviour: move all presignatures for this node into storage
-                // (no remaining split logic here).
-                let my_shares = fixture_config.input.presignatures.remove(&self.me).unwrap();
+            let my_shares = fixture_config.input.presignatures.remove(&self.me).unwrap();
+            tracing::info!(
+                me = ?self.me,
+                owners = my_shares.len(),
+                total_presigs = my_shares.values().map(|v| v.len()).sum::<usize>(),
+                "loading presignatures from fixture"
+            );
+            for (owner, presignature_shares) in my_shares {
                 tracing::info!(
                     me = ?self.me,
-                    owners = my_shares.len(),
-                    total_presigs = my_shares.values().map(|v| v.len()).sum::<usize>(),
-                    "loading presignatures from fixture"
+                    ?owner,
+                    count = presignature_shares.len(),
+                    "loading presignatures for owner"
                 );
-                for (owner, presignature_shares) in my_shares {
-                    tracing::info!(
-                        me = ?self.me,
-                        ?owner,
-                        count = presignature_shares.len(),
-                        "loading presignatures for owner"
-                    );
-                    for presignature_share in presignature_shares {
-                        let mut slot = presignature_storage
-                            .reserve(presignature_share.id)
-                            .await
-                            .unwrap();
-                        slot.insert(presignature_share, owner).await;
-                    }
+                for presignature_share in presignature_shares {
+                    let mut slot = presignature_storage
+                        .reserve(presignature_share.id)
+                        .await
+                        .unwrap();
+                    slot.insert(presignature_share, owner).await;
                 }
             }
         }

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -26,7 +26,7 @@ use mpc_node::rpc::ContractStateWatcher;
 use mpc_node::rpc::RpcChannel;
 use mpc_node::storage::{secret_storage, triple_storage::TriplePair, Options};
 use near_sdk::AccountId;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::Arc;
 use tokio::sync::mpsc::{self, Sender};
 use tokio::sync::watch;
@@ -60,6 +60,10 @@ struct FixtureConfig {
 
     use_preshared_triples: bool,
     presignature_stockpile: bool,
+    /// If set, only load this many presignatures initially (total, across owners) for
+    /// each participant. The rest are stored for later addition via
+    /// `MpcFixture::add_presignatures()`.
+    initial_presignature_count: Option<usize>,
 
     min_triples: u32,
     max_triples: u32,
@@ -105,6 +109,7 @@ impl FixtureConfig {
             input: FixtureInput::load(num_nodes),
             use_preshared_triples: false,
             presignature_stockpile: false,
+            initial_presignature_count: None,
             min_triples: 10,
             max_triples: 30,
             min_presignatures: 10,
@@ -162,6 +167,15 @@ impl MpcFixtureBuilder {
         let completion_broadcast = CompletionBroadcast::new();
         let mut nodes = vec![];
 
+        let remaining_presignatures = if self.fixture_config.initial_presignature_count.is_some() {
+            // Build a fresh copy of the fixture presignatures which will be owned by the
+            // running `MpcFixture` and later consumed by `add_presignatures()`.
+            let num_nodes = self.prepared_nodes.len() as u32;
+            FixtureInput::load(num_nodes).presignatures
+        } else {
+            BTreeMap::new()
+        };
+
         let account_ids: Vec<_> = self
             .prepared_nodes
             .iter()
@@ -198,6 +212,7 @@ impl MpcFixtureBuilder {
             nodes,
             output,
             shared_contract_state: shared_contract_state_tx,
+            remaining_presignatures: tokio::sync::Mutex::new(remaining_presignatures),
         }
     }
 
@@ -294,6 +309,14 @@ impl MpcFixtureBuilder {
     /// Set protocol config
     pub fn with_max_presignatures_stockpile(mut self, value: u32) -> Self {
         self.fixture_config.max_presignatures = value;
+        self
+    }
+
+    /// Only load this many presignatures initially (total, across owners) per participant.
+    /// The remaining presignatures can be added later via `MpcFixture::add_presignatures()`.
+    /// This is useful for testing scenarios where presignatures run out and more need to be added.
+    pub fn with_initial_presignature_count(mut self, count: usize) -> Self {
+        self.fixture_config.initial_presignature_count = Some(count);
         self
     }
 
@@ -538,15 +561,86 @@ impl MpcFixtureNodeBuilder {
             Presignature::storage(&context.redis_pool, &self.participant_info.account_id);
 
         if fixture_config.presignature_stockpile {
-            // removing here because we can't clone a presignature
-            let my_shares = fixture_config.input.presignatures.remove(&self.me).unwrap();
-            for (owner, presignature_shares) in my_shares {
-                for presignature_share in presignature_shares {
-                    let mut slot = presignature_storage
-                        .reserve(presignature_share.id)
-                        .await
-                        .unwrap();
-                    slot.insert(presignature_share, owner).await;
+            // If an initial_presignature_count is configured, we intentionally keep
+            // all fixture presignatures in the builder's `remaining_presignatures` and
+            // only load *that many* shares into the node right now. To keep things
+            // simple and allow duplication when the initial count exceeds the
+            // available items in the fixture file, we repeatedly reload the static
+            // fixture (via FixtureInput::load) and consume entries until we've
+            // inserted the requested `initial_presignature_count` shares.
+            if let Some(initial_count) = fixture_config.initial_presignature_count {
+                tracing::info!(me = ?self.me, initial_count, "loading limited set of presignatures for test (may duplicate)");
+
+                // Number of nodes in fixtures (3 or 5 currently)
+                let num_nodes = fixture_config.input.presignatures.len() as u32;
+                let mut inserted = 0usize;
+
+                // Keep loading the fixture until we've inserted `initial_count` shares.
+                while inserted < initial_count {
+                    let fresh = FixtureInput::load(num_nodes);
+
+                    if let Some((_participant, owner_map)) =
+                        fresh.presignatures.into_iter().find(|(p, _)| *p == self.me)
+                    {
+                        // Build owner -> VecDeque so we can select presignatures in a
+                        // round-robin fashion across owners for this participant. This
+                        // helps make initial selection balanced and increases the
+                        // likelihood that proposers will find usable presignatures.
+                        let mut owner_deques: Vec<(Participant, VecDeque<Presignature>)> =
+                            owner_map
+                                .into_iter()
+                                .map(|(owner, v)| (owner, VecDeque::from(v)))
+                                .collect();
+
+                        let mut made_progress = true;
+                        while inserted < initial_count && made_progress {
+                            made_progress = false;
+                            for (owner, dq) in owner_deques.iter_mut() {
+                                if inserted >= initial_count {
+                                    break;
+                                }
+                                if let Some(presignature_share) = dq.pop_front() {
+                                    let mut slot = presignature_storage
+                                        .reserve(presignature_share.id)
+                                        .await
+                                        .unwrap();
+                                    slot.insert(presignature_share, *owner).await;
+                                    inserted += 1;
+                                    made_progress = true;
+                                }
+                            }
+                        }
+                    } else {
+                        // Fixture didn't contain any entries for this participant — nothing to do
+                        break;
+                    }
+                }
+
+                tracing::info!(me = ?self.me, inserted, "loaded initial presignatures for node");
+            } else {
+                // Original behaviour: move all presignatures for this node into storage
+                // (no remaining split logic here).
+                let my_shares = fixture_config.input.presignatures.remove(&self.me).unwrap();
+                tracing::info!(
+                    me = ?self.me,
+                    owners = my_shares.len(),
+                    total_presigs = my_shares.values().map(|v| v.len()).sum::<usize>(),
+                    "loading presignatures from fixture"
+                );
+                for (owner, presignature_shares) in my_shares {
+                    tracing::info!(
+                        me = ?self.me,
+                        ?owner,
+                        count = presignature_shares.len(),
+                        "loading presignatures for owner"
+                    );
+                    for presignature_share in presignature_shares {
+                        let mut slot = presignature_storage
+                            .reserve(presignature_share.id)
+                            .await
+                            .unwrap();
+                        slot.insert(presignature_share, owner).await;
+                    }
                 }
             }
         }

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -2,7 +2,7 @@
 //! it before it starts running.
 
 use crate::containers::Redis;
-use crate::mpc_fixture::fixture_interface::{CompletionBroadcast, SharedOutput};
+use crate::mpc_fixture::fixture_interface::{CompletionBroadcaster, SharedOutput};
 use crate::mpc_fixture::fixture_tasks::MessageFilter;
 use crate::mpc_fixture::input::FixtureInput;
 use crate::mpc_fixture::mock_governance::MockGovernance;
@@ -164,7 +164,7 @@ impl MpcFixtureBuilder {
         let initial_mesh_state = self.build_mesh_state();
 
         let output = SharedOutput::default();
-        let completion_broadcast = CompletionBroadcast::new();
+        let completion = CompletionBroadcaster::new();
         let mut nodes = vec![];
 
         let num_nodes = self.prepared_nodes.len() as u32;
@@ -194,7 +194,7 @@ impl MpcFixtureBuilder {
                     shared_contract_state_tx.clone(),
                     &mut self.fixture_config,
                     &output,
-                    &completion_broadcast,
+                    &completion,
                 )
                 .await;
 
@@ -424,7 +424,7 @@ impl MpcFixtureNodeBuilder {
         protocol_state_tx: watch::Sender<Option<ProtocolState>>,
         fixture_config: &mut FixtureConfig,
         shared_output: &SharedOutput,
-        completion_broadcast: &CompletionBroadcast,
+        completion: &CompletionBroadcaster,
     ) -> MpcFixtureNode {
         // overwrite the default protocol config with the built config
         self.config.protocol = context.protocol_config.clone();
@@ -492,8 +492,8 @@ impl MpcFixtureNodeBuilder {
             config_tx.clone(),
             self.messaging.filter,
             sign_tx.clone(),
-            completion_broadcast.tx.clone(),
-            completion_broadcast.subscribe(),
+            completion.tx.clone(),
+            completion.subscribe(),
         );
 
         let mut node = MpcFixtureNode {

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -92,15 +92,10 @@ impl MpcFixture {
 
     pub async fn add_presignatures(&mut self) -> usize {
         let mut total_added = 0;
-
         let mut id_mapping = HashMap::new();
-        // let mut shares = HashMap::new();
-
         for node in &self.nodes {
             if let Some(my_shares) = self.pregenerated_presignatures.get(&node.me) {
                 for (owner, presignature_shares) in my_shares {
-                    // let id: PresignatureId = random();
-
                     for presignature_share in presignature_shares {
                         let id = id_mapping
                             .entry(presignature_share.id)

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -13,7 +13,8 @@ use mpc_node::protocol::{MessageChannel, ProtocolState, Sign};
 use mpc_node::storage::{PresignatureStorage, TripleStorage};
 use mpc_primitives::SignId;
 use near_sdk::AccountId;
-use std::collections::{BTreeMap, HashSet};
+use rand::random;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{broadcast, mpsc};
@@ -26,8 +27,7 @@ pub struct MpcFixture {
     pub output: SharedOutput,
     /// Presignatures that were held back during fixture creation.
     /// Can be added later via `add_presignatures()`.
-    pub remaining_presignatures:
-        Mutex<BTreeMap<Participant, BTreeMap<Participant, Vec<Presignature>>>>,
+    pub pregenerated_presignatures: BTreeMap<Participant, BTreeMap<Participant, Vec<Presignature>>>,
 }
 
 pub struct MpcFixtureNode {
@@ -84,20 +84,35 @@ impl MpcFixture {
         }
     }
 
-    pub async fn add_presignatures(&self) -> usize {
-        let mut remaining = self.remaining_presignatures.lock().await;
+    pub async fn add_presignatures(&mut self) -> usize {
         let mut total_added = 0;
 
+        let mut id_mapping = HashMap::new();
+        // let mut shares = HashMap::new();
+
         for node in &self.nodes {
-            if let Some(my_shares) = remaining.remove(&node.me) {
+            if let Some(my_shares) = self.pregenerated_presignatures.get(&node.me) {
                 for (owner, presignature_shares) in my_shares {
+                    // let id: PresignatureId = random();
+
                     for presignature_share in presignature_shares {
-                        if let Some(mut slot) = node
-                            .presignature_storage
-                            .reserve(presignature_share.id)
-                            .await
-                        {
-                            slot.insert(presignature_share, owner).await;
+                        let id = id_mapping
+                            .entry(presignature_share.id)
+                            .or_insert_with(random);
+
+                        let share = Presignature {
+                            id: *id,
+                            output: presignature_share.output.clone(),
+                            participants: presignature_share.participants.clone(),
+                        };
+
+                        // shares
+                        //     .entry(*id)
+                        //     .or_insert_with(Vec::new)
+                        //     .push((node.me, *owner, share));
+
+                        if let Some(mut slot) = node.presignature_storage.reserve(share.id).await {
+                            slot.insert(share, *owner).await;
                             total_added += 1;
                         }
                     }

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -56,11 +56,11 @@ pub struct SharedOutput {
 /// Broadcast channel for sign completions across all nodes.
 /// When any node publishes a signature, this channel is used to notify
 /// all other nodes so they can abort their tasks for the same SignId.
-pub struct CompletionBroadcast {
+pub struct CompletionBroadcaster {
     pub tx: broadcast::Sender<SignId>,
 }
 
-impl CompletionBroadcast {
+impl CompletionBroadcaster {
     pub fn new() -> Self {
         let (tx, _) = broadcast::channel(1024);
         Self { tx }
@@ -68,6 +68,12 @@ impl CompletionBroadcast {
 
     pub fn subscribe(&self) -> broadcast::Receiver<SignId> {
         self.tx.subscribe()
+    }
+}
+
+impl Default for CompletionBroadcaster {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -105,11 +111,6 @@ impl MpcFixture {
                             output: presignature_share.output.clone(),
                             participants: presignature_share.participants.clone(),
                         };
-
-                        // shares
-                        //     .entry(*id)
-                        //     .or_insert_with(Vec::new)
-                        //     .push((node.me, *owner, share));
 
                         if let Some(mut slot) = node.presignature_storage.reserve(share.id).await {
                             slot.insert(share, *owner).await;

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -10,11 +10,12 @@ use mpc_node::protocol::state::NodeStateWatcher;
 use mpc_node::protocol::sync::SyncChannel;
 use mpc_node::protocol::{MessageChannel, ProtocolState, Sign};
 use mpc_node::storage::{PresignatureStorage, TripleStorage};
+use mpc_primitives::SignId;
 use near_sdk::AccountId;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::mpsc;
+use tokio::sync::{broadcast, mpsc};
 use tokio::sync::{watch, Mutex};
 
 pub struct MpcFixture {
@@ -45,6 +46,24 @@ pub struct MpcFixtureNode {
 pub struct SharedOutput {
     pub msg_log: Arc<Mutex<Vec<String>>>,
     pub rpc_actions: Arc<Mutex<HashSet<String>>>,
+}
+
+/// Broadcast channel for sign completions across all nodes.
+/// When any node publishes a signature, this channel is used to notify
+/// all other nodes so they can abort their tasks for the same SignId.
+pub struct CompletionBroadcast {
+    pub tx: broadcast::Sender<SignId>,
+}
+
+impl CompletionBroadcast {
+    pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(1024);
+        Self { tx }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<SignId> {
+        self.tx.subscribe()
+    }
 }
 
 impl MpcFixture {

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -6,13 +6,14 @@ use cait_sith::protocol::Participant;
 use mpc_node::backlog::Backlog;
 use mpc_node::config::Config;
 use mpc_node::mesh::MeshState;
+use mpc_node::protocol::presignature::Presignature;
 use mpc_node::protocol::state::NodeStateWatcher;
 use mpc_node::protocol::sync::SyncChannel;
 use mpc_node::protocol::{MessageChannel, ProtocolState, Sign};
 use mpc_node::storage::{PresignatureStorage, TripleStorage};
 use mpc_primitives::SignId;
 use near_sdk::AccountId;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{broadcast, mpsc};
@@ -23,6 +24,10 @@ pub struct MpcFixture {
     pub redis_container: Redis,
     pub shared_contract_state: watch::Sender<Option<ProtocolState>>,
     pub output: SharedOutput,
+    /// Presignatures that were held back during fixture creation.
+    /// Can be added later via `add_presignatures()`.
+    pub remaining_presignatures:
+        Mutex<BTreeMap<Participant, BTreeMap<Participant, Vec<Presignature>>>>,
 }
 
 pub struct MpcFixtureNode {
@@ -77,6 +82,31 @@ impl MpcFixture {
         for node in &self.nodes {
             node.wait_for_presignatures(threshold_per_node).await;
         }
+    }
+
+    pub async fn add_presignatures(&self) -> usize {
+        let mut remaining = self.remaining_presignatures.lock().await;
+        let mut total_added = 0;
+
+        for node in &self.nodes {
+            if let Some(my_shares) = remaining.remove(&node.me) {
+                for (owner, presignature_shares) in my_shares {
+                    for presignature_share in presignature_shares {
+                        if let Some(mut slot) = node
+                            .presignature_storage
+                            .reserve(presignature_share.id)
+                            .await
+                        {
+                            slot.insert(presignature_share, owner).await;
+                            total_added += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        tracing::info!(total_added, "added more presignatures");
+        total_added
     }
 
     pub async fn wait_for_actions(&self, threshold: usize) -> HashSet<String> {

--- a/integration-tests/src/mpc_fixture/fixture_tasks.rs
+++ b/integration-tests/src/mpc_fixture/fixture_tasks.rs
@@ -20,6 +20,7 @@ use tokio::task::JoinHandle;
 
 pub type MessageFilter = Box<dyn FnMut(&SendMessage) -> bool + Send>;
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn test_mock_network(
     routing_table: HashMap<Participant, Sender<Ciphered>>,
     shared_output: &SharedOutput,
@@ -94,7 +95,7 @@ pub(super) fn test_mock_network(
                             (format!(
                                 "RpcAction::Publish({:?})",
                                 publish_action.indexed,
-                            ), publish_action.indexed.id.clone())
+                            ), publish_action.indexed.id)
                         },
                     };
                     tracing::info!(target: "mock_network", ?action_str, "Received RPC action, broadcasting completion");

--- a/integration-tests/src/mpc_fixture/fixture_tasks.rs
+++ b/integration-tests/src/mpc_fixture/fixture_tasks.rs
@@ -8,9 +8,12 @@ use mpc_node::config::Config;
 use mpc_node::mesh::MeshState;
 use mpc_node::protocol;
 use mpc_node::protocol::message::{MessageOutbox, SendMessage, SignedMessage};
+use mpc_node::protocol::Sign;
 use mpc_node::rpc::RpcAction;
+use mpc_primitives::SignId;
 use std::collections::HashMap;
 use std::sync::Arc;
+use tokio::sync::broadcast;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -25,6 +28,9 @@ pub(super) fn test_mock_network(
     mesh: watch::Sender<MeshState>,
     config: watch::Sender<Config>,
     mut filter: MessageFilter,
+    sign_tx: Sender<Sign>,
+    completion_tx: broadcast::Sender<SignId>,
+    mut completion_rx: broadcast::Receiver<SignId>,
 ) -> JoinHandle<()> {
     let msg_log = Arc::clone(&shared_output.msg_log);
     let rpc_actions = Arc::clone(&shared_output.rpc_actions);
@@ -83,17 +89,30 @@ pub(super) fn test_mock_network(
                 }
 
                 Some(rpc) = rpc_rx.recv() => {
-                    let action_str = match rpc {
-                        RpcAction::Publish(publish_action) => {
-                            format!(
+                    let (action_str, sign_id) = match rpc {
+                        RpcAction::Publish(ref publish_action) => {
+                            (format!(
                                 "RpcAction::Publish({:?})",
                                 publish_action.indexed,
-                            )
+                            ), publish_action.indexed.id.clone())
                         },
                     };
-                    tracing::error!(target: "mock_network", ?action_str, "Received RPC action");
+                    tracing::info!(target: "mock_network", ?action_str, "Received RPC action, broadcasting completion");
                     let mut actions_log = rpc_actions.lock().await;
                     actions_log.insert(action_str);
+
+                    // Broadcast completion to all nodes
+                    if let Err(e) = completion_tx.send(sign_id) {
+                        tracing::warn!(target: "mock_network", ?e, "Failed to broadcast completion");
+                    }
+                }
+
+                Ok(sign_id) = completion_rx.recv() => {
+                    // Received a completion from another node, forward to our sign_tx
+                    tracing::info!(target: "mock_network", ?sign_id, "Received completion broadcast, forwarding to sign channel");
+                    if let Err(e) = sign_tx.send(Sign::Completion(sign_id)).await {
+                        tracing::warn!(target: "mock_network", ?e, "Failed to send completion to sign channel");
+                    }
                 }
 
                 else => {

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -440,7 +440,7 @@ async fn test_sign_limited_stockpile_contention() {
 /// 3. No presignature burning during the waiting period
 #[test(tokio::test(flavor = "multi_thread"))]
 async fn test_sign_requests_wait_for_presignatures() {
-    // We'll send 10 sign requests but start with only 5 presignatures.
+    // We'll send 20 sign requests but start with only 15 presignatures.
     // The first batch should complete, then we add more presignatures to
     // complete the remaining requests.
     const TOTAL_SIGN_REQUESTS: u8 = 20;
@@ -470,7 +470,7 @@ async fn test_sign_requests_wait_for_presignatures() {
     );
     assert_eq!(
         initial_presignatures, INITIAL_STOCKPILE,
-        "should start with at least 1 presignature"
+        "should start with exactly {INITIAL_STOCKPILE} presignatures"
     );
 
     // Send ALL sign requests at once - more than we have presignatures for
@@ -510,16 +510,22 @@ async fn test_sign_requests_wait_for_presignatures() {
     let current_actions = network.output.rpc_actions.lock().await.len();
     tracing::info!(current_actions, "actions before adding more presignatures");
 
-    let final_actions = tokio::time::timeout(
+    let initial_actions = tokio::time::timeout(
         Duration::from_secs(10),
         network.wait_for_actions(INITIAL_STOCKPILE),
     )
     .await
     .expect("initial stockpile signatures should complete");
     tracing::info!(
-        ?final_actions,
+        ?initial_actions,
         "finished waiting for initial stockpile signatures"
     );
+    for action_str in &initial_actions {
+        assert!(
+            action_str.contains("RpcAction::Publish"),
+            "unexpected rpc action {action_str}"
+        );
+    }
 
     // Now add the remaining presignatures
     tracing::info!("adding more presignatures");

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -513,28 +513,46 @@ async fn test_sign_requests_wait_for_presignatures() {
         "presignatures after first batch"
     );
 
-    // Now wait for more presignatures to be generated
-    // The remaining sign requests should be waiting
-    tracing::info!("waiting for presignature generation to catch up");
-    tokio::time::timeout(
-        Duration::from_secs(120),
-        network.wait_for_presignatures(3), // wait for at least 3 owned presignatures per node
-    )
-    .await
-    .expect("should generate more presignatures");
-
-    let after_generation = network[0].presignature_storage.len_generated().await;
-    tracing::info!(after_generation, "presignatures after generation");
-
-    // Now wait for remaining signatures to complete
-    tracing::info!("waiting for remaining signatures");
-    let final_timeout = Duration::from_secs(60);
-    let final_actions = tokio::time::timeout(
-        final_timeout,
+    // Try to get all signatures quickly first (fast path)
+    // With improvements to proposer election, signatures can complete very quickly
+    tracing::info!("attempting fast path - waiting briefly for all signatures");
+    let fast_result = tokio::time::timeout(
+        Duration::from_secs(5),
         network.wait_for_actions(TOTAL_SIGN_REQUESTS as usize),
     )
-    .await
-    .expect("all signatures should complete after presignature generation");
+    .await;
+
+    let final_actions = match fast_result {
+        Ok(actions) => {
+            tracing::info!("fast path succeeded - all signatures completed quickly!");
+            actions
+        }
+        Err(_) => {
+            // Fast path timed out - need to wait for more presignatures
+            let current_actions = network.output.rpc_actions.lock().await.len();
+            tracing::info!(current_actions, "fast path timed out, waiting for presignatures");
+
+            tokio::time::timeout(
+                Duration::from_secs(120),
+                network.wait_for_presignatures(3), // wait for at least 3 owned presignatures per node
+            )
+            .await
+            .expect("should generate more presignatures");
+
+            let after_generation = network[0].presignature_storage.len_generated().await;
+            tracing::info!(after_generation, "presignatures after generation");
+
+            // Now wait for remaining signatures to complete
+            tracing::info!("waiting for remaining signatures");
+            let final_timeout = Duration::from_secs(60);
+            tokio::time::timeout(
+                final_timeout,
+                network.wait_for_actions(TOTAL_SIGN_REQUESTS as usize),
+            )
+            .await
+            .expect("all signatures should complete after presignature generation")
+        }
+    };
 
     tracing::info!(
         total_signatures = final_actions.len(),

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -440,40 +440,38 @@ async fn test_sign_limited_stockpile_contention() {
 /// 3. No presignature burning during the waiting period
 #[test(tokio::test(flavor = "multi_thread"))]
 async fn test_sign_requests_wait_for_presignatures() {
-    // We'll send 20 sign requests but start with only enough presignatures for ~10.
-    // The first batch should complete, then we generate more presignatures to
+    // We'll send 10 sign requests but start with only 5 presignatures.
+    // The first batch should complete, then we add more presignatures to
     // complete the remaining requests.
-    const TOTAL_SIGN_REQUESTS: u8 = 20;
-    const FIRST_BATCH_SIZE: usize = 10;
+    // Note: The fixture has ~15 presignatures total per participant.
+    const TOTAL_SIGN_REQUESTS: u8 = 10;
+    const INITIAL_PRESIGNATURES: usize = 5;
 
-    // Use a network that can generate presignatures (has preshared triples)
-    // but starts with the stockpiled presignatures from fixture
+    // Use a network with preshared presignatures, but only load some initially
+    // Disable presignature generation so we control exactly when more are available
     let network = MpcFixtureBuilder::default()
         .with_preshared_key()
         .with_preshared_triples()
         .with_presignature_stockpile()
-        // Disable triple generation since we're using preshared triples
+        .with_initial_presignature_count(INITIAL_PRESIGNATURES)
+        // Disable triple and presignature generation
         .with_min_triples_stockpile(0)
         .with_max_triples_stockpile(0)
-        // Enable presignature generation for second batch
-        .with_min_presignatures_stockpile(5)
-        .with_max_presignatures_stockpile(20)
+        .with_min_presignatures_stockpile(0)
+        .with_max_presignatures_stockpile(0)
         .build()
         .await;
 
-    // Wait for initial presignatures to be loaded
-    tokio::time::timeout(
-        Duration::from_millis(500),
-        network.wait_for_presignatures(1),
-    )
-    .await
-    .expect("should start with presignatures");
-
+    // Wait for initial presignatures to be loaded (checking total, not by owner)
     let initial_presignatures = network[0].presignature_storage.len_generated().await;
     tracing::info!(
         initial_presignatures,
         total_requests = TOTAL_SIGN_REQUESTS,
         "starting presignature wait test"
+    );
+    assert!(
+        initial_presignatures >= 1,
+        "should start with at least 1 presignature"
     );
 
     // Send ALL sign requests at once - more than we have presignatures for
@@ -488,13 +486,13 @@ async fn test_sign_requests_wait_for_presignatures() {
         }
     }
 
-    // First batch: wait for as many signatures as we initially have presignatures
-    let first_batch_expected = initial_presignatures.min(FIRST_BATCH_SIZE);
+    // First batch: wait for signatures to complete using available presignatures
+    // We expect roughly INITIAL_PRESIGNATURES to complete (some variance due to ownership)
+    let first_batch_expected = INITIAL_PRESIGNATURES.min(15); // at most what we started with
     tracing::info!(first_batch_expected, "waiting for first batch");
 
-    let first_batch_timeout = Duration::from_secs(30);
     let first_actions = tokio::time::timeout(
-        first_batch_timeout,
+        Duration::from_secs(30),
         network.wait_for_actions(first_batch_expected),
     )
     .await
@@ -505,7 +503,7 @@ async fn test_sign_requests_wait_for_presignatures() {
         "first batch completed"
     );
 
-    // Check presignatures after first batch
+    // Check presignatures after first batch - should be depleted
     let after_first_batch = network[0].presignature_storage.len_generated().await;
     tracing::info!(
         after_first_batch,
@@ -513,46 +511,24 @@ async fn test_sign_requests_wait_for_presignatures() {
         "presignatures after first batch"
     );
 
-    // Try to get all signatures quickly first (fast path)
-    // With improvements to proposer election, signatures can complete very quickly
-    tracing::info!("attempting fast path - waiting briefly for all signatures");
-    let fast_result = tokio::time::timeout(
-        Duration::from_secs(5),
+    // Verify we haven't completed all requests yet (some should be waiting)
+    let current_actions = network.output.rpc_actions.lock().await.len();
+    tracing::info!(current_actions, "actions before adding more presignatures");
+
+    // Now add the remaining presignatures
+    tracing::info!("adding remaining presignatures");
+    let added = network.add_presignatures().await;
+    tracing::info!(added, "presignatures added");
+
+    // Wait for remaining signatures to complete
+    tracing::info!("waiting for remaining signatures");
+    let final_timeout = Duration::from_secs(30);
+    let final_actions = tokio::time::timeout(
+        final_timeout,
         network.wait_for_actions(TOTAL_SIGN_REQUESTS as usize),
     )
-    .await;
-
-    let final_actions = match fast_result {
-        Ok(actions) => {
-            tracing::info!("fast path succeeded - all signatures completed quickly!");
-            actions
-        }
-        Err(_) => {
-            // Fast path timed out - need to wait for more presignatures
-            let current_actions = network.output.rpc_actions.lock().await.len();
-            tracing::info!(current_actions, "fast path timed out, waiting for presignatures");
-
-            tokio::time::timeout(
-                Duration::from_secs(120),
-                network.wait_for_presignatures(3), // wait for at least 3 owned presignatures per node
-            )
-            .await
-            .expect("should generate more presignatures");
-
-            let after_generation = network[0].presignature_storage.len_generated().await;
-            tracing::info!(after_generation, "presignatures after generation");
-
-            // Now wait for remaining signatures to complete
-            tracing::info!("waiting for remaining signatures");
-            let final_timeout = Duration::from_secs(60);
-            tokio::time::timeout(
-                final_timeout,
-                network.wait_for_actions(TOTAL_SIGN_REQUESTS as usize),
-            )
-            .await
-            .expect("all signatures should complete after presignature generation")
-        }
-    };
+    .await
+    .expect("all signatures should complete after adding presignatures");
 
     tracing::info!(
         total_signatures = final_actions.len(),

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -443,17 +443,16 @@ async fn test_sign_requests_wait_for_presignatures() {
     // We'll send 10 sign requests but start with only 5 presignatures.
     // The first batch should complete, then we add more presignatures to
     // complete the remaining requests.
-    // Note: The fixture has ~15 presignatures total per participant.
-    const TOTAL_SIGN_REQUESTS: u8 = 10;
-    const INITIAL_PRESIGNATURES: usize = 5;
+    const TOTAL_SIGN_REQUESTS: u8 = 20;
+    // Note: The fixture has 15 presignatures in the node setup.
+    const INITIAL_STOCKPILE: usize = 15;
 
     // Use a network with preshared presignatures, but only load some initially
     // Disable presignature generation so we control exactly when more are available
-    let network = MpcFixtureBuilder::default()
+    let mut network = MpcFixtureBuilder::default()
         .with_preshared_key()
         .with_preshared_triples()
         .with_presignature_stockpile()
-        .with_initial_presignature_count(INITIAL_PRESIGNATURES)
         // Disable triple and presignature generation
         .with_min_triples_stockpile(0)
         .with_max_triples_stockpile(0)
@@ -469,8 +468,8 @@ async fn test_sign_requests_wait_for_presignatures() {
         total_requests = TOTAL_SIGN_REQUESTS,
         "starting presignature wait test"
     );
-    assert!(
-        initial_presignatures >= 1,
+    assert_eq!(
+        initial_presignatures, INITIAL_STOCKPILE,
         "should start with at least 1 presignature"
     );
 
@@ -486,14 +485,10 @@ async fn test_sign_requests_wait_for_presignatures() {
         }
     }
 
-    // First batch: wait for signatures to complete using available presignatures
-    // We expect roughly INITIAL_PRESIGNATURES to complete (some variance due to ownership)
-    let first_batch_expected = INITIAL_PRESIGNATURES.min(15); // at most what we started with
-    tracing::info!(first_batch_expected, "waiting for first batch");
-
+    tracing::info!("waiting for first batch of sign requests to complete");
     let first_actions = tokio::time::timeout(
         Duration::from_secs(30),
-        network.wait_for_actions(first_batch_expected),
+        network.wait_for_actions(INITIAL_STOCKPILE),
     )
     .await
     .expect("first batch should complete with available presignatures");
@@ -515,8 +510,19 @@ async fn test_sign_requests_wait_for_presignatures() {
     let current_actions = network.output.rpc_actions.lock().await.len();
     tracing::info!(current_actions, "actions before adding more presignatures");
 
+    let final_actions = tokio::time::timeout(
+        Duration::from_secs(10),
+        network.wait_for_actions(INITIAL_STOCKPILE),
+    )
+    .await
+    .expect("initial stockpile signatures should complete");
+    tracing::info!(
+        ?final_actions,
+        "finished waiting for initial stockpile signatures"
+    );
+
     // Now add the remaining presignatures
-    tracing::info!("adding remaining presignatures");
+    tracing::info!("adding more presignatures");
     let added = network.add_presignatures().await;
     tracing::info!(added, "presignatures added");
 


### PR DESCRIPTION
The sign task issues we're seeing right now on devnet is due to how each sign task could not agree on the correct proposer due to different rounds not being aligned.

So this gets rid of the notion of rounds and instead uses a scoring on each participant `hash(sign_id + participant_id)`, where we then sort all participants in increasing order. We take the first online/stable from this list as our proposer. This is pretty deterministic but comes with the caveat of electing the same leader over and over again if the sign request fails. The only time this should happen is either from timeout where some nodes are not responding which should be pretty rare.

- component tests now have the ability to send sign competions.
- redesigned the depleted stockpile test to first start with how many presignatures we have in the pregenerated file, and then add more not from generation but from us loading in the same set of presignatures (this is fine for testing purposes since we can just set different presignature ids for them)
- adjusted the proposer and deliberator timeouts for the posit phase to be much shorter now. Note that proposer timeout is shorter than deliberator since if we expire on a proposer to issue a START, then the deliberator might end up expiring at the same time and not be able to start. These timeouts aren't ideal either but I will address this in a future PR to make this more robust by not expiring and rather just start on enough accepts.