### PR TITLE
feat: persist latest checkpoint for each chain

### DIFF
--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -5,6 +5,7 @@ use crate::mesh::MeshState;
 use crate::node_client::NodeClient;
 use crate::protocol::{Chain, SignRequestType};
 use crate::sign_bidirectional::{BidirectionalTx, BidirectionalTxId, PendingRequestStatus};
+use crate::storage::checkpoint_storage::CheckpointStorage;
 use anyhow::Context;
 use mpc_primitives::{PendingTx, SignId};
 use std::collections::{hash_map, HashMap};
@@ -185,6 +186,7 @@ struct HistoricalCheckpoint {
 /// publish queues.
 #[derive(Debug, Clone)]
 pub struct Backlog {
+    storage: CheckpointStorage,
     requests: Arc<RwLock<HashMap<Chain, PendingRequests>>>,
     execution_watchers: Arc<RwLock<HashMap<Chain, ExecutionWatchers>>>,
     sign_request_types: Arc<RwLock<HashMap<(Chain, SignId), SignRequestType>>>,
@@ -200,7 +202,12 @@ impl Default for Backlog {
 
 impl Backlog {
     pub fn new() -> Self {
+        Self::persisted(CheckpointStorage::in_memory())
+    }
+
+    pub fn persisted(storage: CheckpointStorage) -> Self {
         Self {
+            storage,
             requests: Arc::new(RwLock::new(HashMap::new())),
             execution_watchers: Arc::new(RwLock::new(HashMap::new())),
             sign_request_types: Arc::new(RwLock::new(HashMap::new())),
@@ -463,6 +470,10 @@ impl Backlog {
         });
         historical.retain(|hcp| hcp.created_at.elapsed() < RETENTION_DURATION);
 
+        if let Err(err) = self.storage.persist(&checkpoint).await {
+            tracing::warn!(?chain, %err, "failed to persist checkpoint");
+        }
+
         checkpoint
     }
 
@@ -562,11 +573,38 @@ impl Backlog {
     ) {
         tracing::info!("attempting to recover from latest checkpoints via node selection");
 
+        // Load local checkpoints first
+        let mut local_checkpoints = HashMap::new();
+        for &chain in chains {
+            match self.storage.load_latest(chain).await {
+                Ok(Some(checkpoint)) => {
+                    tracing::info!(
+                        ?chain,
+                        block_height = checkpoint.block_height,
+                        "loaded local checkpoint"
+                    );
+                    local_checkpoints.insert(chain, checkpoint);
+                }
+                Ok(None) => {
+                    tracing::info!(?chain, "no local checkpoint found");
+                }
+                Err(err) => {
+                    tracing::warn!(?chain, %err, "failed to load local checkpoint");
+                }
+            }
+        }
+
         // p2p node selection to find checkpoints.
         // Fetches all checkpoints from active participants and creates a selected checkpoint:
         // - sorts all checkpoints by block height
         // - selects threshold lowest block height checkpoint
-        let checkpoints = select_checkpoints(mesh_state, node_client, threshold, chains).await;
+        let remote_checkpoints =
+            select_checkpoints(mesh_state, node_client, threshold, chains).await;
+
+        // Merge local and remote checkpoints, preferring the one with higher block height
+
+        let checkpoints = merge_checkpoints(local_checkpoints, remote_checkpoints);
+
         if checkpoints.is_empty() {
             tracing::info!("no selected checkpoints found, starting with empty state");
             return;
@@ -1139,4 +1177,82 @@ mod tests {
         assert_eq!(checkpoint.block_height, interval);
         assert_eq!(checkpoint.chain, Chain::Solana);
     }
+    #[test]
+    fn test_merge_checkpoints() {
+        let mut local = HashMap::new();
+        let mut remote = HashMap::new();
+
+        // Case 1: Only local
+        local.insert(
+            Chain::Ethereum,
+            Checkpoint {
+                chain: Chain::Ethereum,
+                block_height: 100,
+                pending_requests: vec![],
+            },
+        );
+        let merged = merge_checkpoints(local.clone(), remote.clone());
+        assert_eq!(merged.get(&Chain::Ethereum).unwrap().block_height, 100);
+
+        // Case 2: Only remote
+        local.clear();
+        remote.insert(
+            Chain::Ethereum,
+            Checkpoint {
+                chain: Chain::Ethereum,
+                block_height: 200,
+                pending_requests: vec![],
+            },
+        );
+        let merged = merge_checkpoints(local.clone(), remote.clone());
+        assert_eq!(merged.get(&Chain::Ethereum).unwrap().block_height, 200);
+
+        // Case 3: Local higher
+        local.insert(
+            Chain::Ethereum,
+            Checkpoint {
+                chain: Chain::Ethereum,
+                block_height: 300,
+                pending_requests: vec![],
+            },
+        );
+        let merged = merge_checkpoints(local.clone(), remote.clone());
+        assert_eq!(merged.get(&Chain::Ethereum).unwrap().block_height, 300);
+
+        // Case 4: Remote higher
+        remote.insert(
+            Chain::Ethereum,
+            Checkpoint {
+                chain: Chain::Ethereum,
+                block_height: 400,
+                pending_requests: vec![],
+            },
+        );
+        let merged = merge_checkpoints(local.clone(), remote.clone());
+        assert_eq!(merged.get(&Chain::Ethereum).unwrap().block_height, 400);
+    }
+}
+
+fn merge_checkpoints(
+    local: HashMap<Chain, Checkpoint>,
+    remote: HashMap<Chain, Checkpoint>,
+) -> HashMap<Chain, Checkpoint> {
+    let mut checkpoints = remote;
+    for (chain, local_cp) in local {
+        checkpoints
+            .entry(chain)
+            .and_modify(|remote_cp| {
+                if local_cp.block_height > remote_cp.block_height {
+                    tracing::info!(
+                        ?chain,
+                        local_height = local_cp.block_height,
+                        remote_height = remote_cp.block_height,
+                        "local checkpoint is newer than remote selection"
+                    );
+                    *remote_cp = local_cp.clone();
+                }
+            })
+            .or_insert(local_cp);
+    }
+    checkpoints
 }

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -602,7 +602,6 @@ impl Backlog {
             select_checkpoints(mesh_state, node_client, threshold, chains).await;
 
         // Merge local and remote checkpoints, preferring the one with higher block height
-
         let checkpoints = merge_checkpoints(local_checkpoints, remote_checkpoints);
 
         if checkpoints.is_empty() {
@@ -702,6 +701,29 @@ impl BacklogTransaction {
     pub fn is_bidirectional(&self) -> bool {
         matches!(self, Self::Bidirectional(_))
     }
+}
+
+fn merge_checkpoints(
+    local: HashMap<Chain, Checkpoint>,
+    mut remote: HashMap<Chain, Checkpoint>,
+) -> HashMap<Chain, Checkpoint> {
+    for (chain, local_cp) in local {
+        remote
+            .entry(chain)
+            .and_modify(|remote_cp| {
+                if local_cp.block_height > remote_cp.block_height {
+                    tracing::info!(
+                        ?chain,
+                        local_height = local_cp.block_height,
+                        remote_height = remote_cp.block_height,
+                        "local checkpoint is newer than remote selection"
+                    );
+                    *remote_cp = local_cp.clone();
+                }
+            })
+            .or_insert(local_cp);
+    }
+    remote
 }
 
 #[cfg(test)]
@@ -1231,28 +1253,4 @@ mod tests {
         let merged = merge_checkpoints(local.clone(), remote.clone());
         assert_eq!(merged.get(&Chain::Ethereum).unwrap().block_height, 400);
     }
-}
-
-fn merge_checkpoints(
-    local: HashMap<Chain, Checkpoint>,
-    remote: HashMap<Chain, Checkpoint>,
-) -> HashMap<Chain, Checkpoint> {
-    let mut checkpoints = remote;
-    for (chain, local_cp) in local {
-        checkpoints
-            .entry(chain)
-            .and_modify(|remote_cp| {
-                if local_cp.block_height > remote_cp.block_height {
-                    tracing::info!(
-                        ?chain,
-                        local_height = local_cp.block_height,
-                        remote_height = remote_cp.block_height,
-                        "local checkpoint is newer than remote selection"
-                    );
-                    *remote_cp = local_cp.clone();
-                }
-            })
-            .or_insert(local_cp);
-    }
-    checkpoints
 }

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -10,6 +10,7 @@ use crate::protocol::sync::SyncTask;
 use crate::protocol::{spawn_system_metrics, MpcSignProtocol};
 use crate::rpc::{ContractStateWatcher, NearClient, RpcExecutor};
 use crate::storage::app_data_storage;
+use crate::storage::checkpoint_storage::CheckpointStorage;
 use crate::storage::triple_storage::TriplePair;
 use crate::{indexer, indexer_eth, indexer_sol, logs, mesh, storage, web};
 
@@ -224,7 +225,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             }
             tracing::info!(rpc_addr = rpc_client.rpc_addr(), "rpc client initialized");
 
-            let backlog = Backlog::new();
+            let backlog = Backlog::persisted(CheckpointStorage::Redis(redis_pool.clone()));
 
             // NEAR Indexer is only used for integration tests
             // TODO: Remove this once we have integration tests built on other chains

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -225,7 +225,10 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             }
             tracing::info!(rpc_addr = rpc_client.rpc_addr(), "rpc client initialized");
 
-            let backlog = Backlog::persisted(CheckpointStorage::Redis(redis_pool.clone()));
+            let backlog = Backlog::persisted(CheckpointStorage::Redis(
+                redis_pool.clone(),
+                account_id.clone(),
+            ));
 
             // NEAR Indexer is only used for integration tests
             // TODO: Remove this once we have integration tests built on other chains

--- a/chain-signatures/node/src/storage/checkpoint_storage.rs
+++ b/chain-signatures/node/src/storage/checkpoint_storage.rs
@@ -1,0 +1,71 @@
+use crate::protocol::Chain;
+
+use anyhow::Context;
+use deadpool_redis::Pool;
+use mpc_primitives::Checkpoint;
+use redis::AsyncCommands;
+use tokio::sync::RwLock;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub enum CheckpointStorage {
+    Redis(Pool),
+    InMemory(Arc<RwLock<HashMap<Chain, Checkpoint>>>),
+}
+
+impl Default for CheckpointStorage {
+    fn default() -> Self {
+        Self::in_memory()
+    }
+}
+
+impl CheckpointStorage {
+    pub fn in_memory() -> Self {
+        Self::InMemory(Arc::new(RwLock::new(HashMap::new())))
+    }
+
+    pub async fn persist(&self, checkpoint: &Checkpoint) -> anyhow::Result<()> {
+        match self {
+            CheckpointStorage::Redis(pool) => {
+                let mut conn = pool.get().await.context("failed to get redis connection")?;
+                let key = format!("checkpoint:{}", checkpoint.chain);
+                let value =
+                    serde_json::to_string(checkpoint).context("failed to serialize checkpoint")?;
+                conn.set::<_, _, ()>(key, value)
+                    .await
+                    .context("failed to set checkpoint in redis")?;
+            }
+            CheckpointStorage::InMemory(storage) => {
+                storage
+                    .write()
+                    .await
+                    .insert(checkpoint.chain, checkpoint.clone());
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn load_latest(&self, chain: Chain) -> anyhow::Result<Option<Checkpoint>> {
+        match self {
+            CheckpointStorage::Redis(pool) => {
+                let mut conn = pool.get().await.context("failed to get redis connection")?;
+                let key = format!("checkpoint:{}", chain);
+                let value: Option<String> = conn
+                    .get(key)
+                    .await
+                    .context("failed to get checkpoint from redis")?;
+                match value {
+                    Some(v) => {
+                        let checkpoint: Checkpoint =
+                            serde_json::from_str(&v).context("failed to deserialize checkpoint")?;
+                        Ok(Some(checkpoint))
+                    }
+                    None => Ok(None),
+                }
+            }
+            CheckpointStorage::InMemory(storage) => Ok(storage.read().await.get(&chain).cloned()),
+        }
+    }
+}

--- a/chain-signatures/node/src/storage/checkpoint_storage.rs
+++ b/chain-signatures/node/src/storage/checkpoint_storage.rs
@@ -3,6 +3,7 @@ use crate::protocol::Chain;
 use anyhow::Context;
 use deadpool_redis::Pool;
 use mpc_primitives::Checkpoint;
+use near_account_id::AccountId;
 use redis::AsyncCommands;
 use tokio::sync::RwLock;
 
@@ -11,7 +12,7 @@ use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub enum CheckpointStorage {
-    Redis(Pool),
+    Redis(Pool, AccountId),
     InMemory(Arc<RwLock<HashMap<Chain, Checkpoint>>>),
 }
 
@@ -26,14 +27,22 @@ impl CheckpointStorage {
         Self::InMemory(Arc::new(RwLock::new(HashMap::new())))
     }
 
+    fn checkpoint_key(&self, chain: Chain) -> String {
+        match self {
+            CheckpointStorage::Redis(_, account_id) => {
+                format!("{account_id}:checkpoint:latest:{chain}")
+            }
+            CheckpointStorage::InMemory(_) => format!("checkpoint:latest:{chain}"),
+        }
+    }
+
     pub async fn persist(&self, checkpoint: &Checkpoint) -> anyhow::Result<()> {
         match self {
-            CheckpointStorage::Redis(pool) => {
+            CheckpointStorage::Redis(pool, _) => {
                 let mut conn = pool.get().await.context("failed to get redis connection")?;
-                let key = format!("checkpoint:{}", checkpoint.chain);
-                let value =
-                    serde_json::to_string(checkpoint).context("failed to serialize checkpoint")?;
-                conn.set::<_, _, ()>(key, value)
+                let value = serde_json::to_string(checkpoint)
+                    .context("failed to serialize checkpoint persistence")?;
+                conn.set::<_, _, ()>(self.checkpoint_key(checkpoint.chain), value)
                     .await
                     .context("failed to set checkpoint in redis")?;
             }
@@ -49,11 +58,10 @@ impl CheckpointStorage {
 
     pub async fn load_latest(&self, chain: Chain) -> anyhow::Result<Option<Checkpoint>> {
         match self {
-            CheckpointStorage::Redis(pool) => {
+            CheckpointStorage::Redis(pool, _) => {
                 let mut conn = pool.get().await.context("failed to get redis connection")?;
-                let key = format!("checkpoint:{}", chain);
                 let value: Option<String> = conn
-                    .get(key)
+                    .get(self.checkpoint_key(chain))
                     .await
                     .context("failed to get checkpoint from redis")?;
                 match value {

--- a/chain-signatures/node/src/storage/mod.rs
+++ b/chain-signatures/node/src/storage/mod.rs
@@ -1,4 +1,5 @@
 pub mod app_data_storage;
+pub mod checkpoint_storage;
 pub mod presignature_storage;
 pub mod protocol_storage;
 pub mod secret_storage;


### PR DESCRIPTION
This PR adds persistence of the latest checkpoint for each chain to redis.

How this works with checkpoing bootstrap selection is query all nodes for their checkpoints, compare each chains checkpoint to our local chain checkpoint and take the one with the higher block height (or more recent one).