### PR TITLE
fix/feat: time drift for determining rounds in sign task

### DIFF
--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -342,6 +342,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 web_port,
                 msg_channel,
                 node_watcher,
+                contract_watcher.clone(),
                 triple_storage,
                 presignature_storage,
                 sync_channel,

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -260,7 +260,8 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let (synced_peer_tx, synced_peer_rx) = SyncTask::synced_nodes_channel();
             let mesh = Mesh::new(&client, mesh_options, &account_id, synced_peer_rx);
             let mesh_state = mesh.watch();
-            let (contract_watcher, contract_state_tx) = ContractStateWatcher::new(&account_id);
+            let (contract_watcher, contract_state_tx, timestamp_tx) =
+                ContractStateWatcher::new(&account_id);
 
             let eth = eth.into_config();
             let sol = sol.into_config();
@@ -326,7 +327,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
 
             tracing::info!("protocol initialized");
             tokio::spawn(sync.run());
-            tokio::spawn(rpc.run(contract_state_tx, config_tx.clone()));
+            tokio::spawn(rpc.run(contract_state_tx, timestamp_tx, config_tx.clone()));
 
             tokio::spawn(mesh.run(contract_watcher.clone()));
             let system_handle = spawn_system_metrics(account_id.as_str()).await;

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -37,7 +37,7 @@ pub enum NodeStatus {
     /// The mirrored synchronization, with IDs owned by node B, should also
     /// happen. But this is irrelevant for what node A does. Hence, only node B
     /// tracks it.
-    Syncing,
+    Syncing(DateTime<Utc>),
     /// The node responds but is in an inactive NodeState, hence it is not ready
     /// for participating in any MPC protocols, yet.
     Inactive,
@@ -141,7 +141,7 @@ impl NodeConnection {
                         | OtherNodeStatus::Started
                         | OtherNodeStatus::WaitingForConsensus { .. } => NodeStatus::Inactive,
                     };
-                    if matches!(old_status, NodeStatus::Inactive | NodeStatus::Offline | NodeStatus::Syncing)
+                    if matches!(old_status, NodeStatus::Inactive | NodeStatus::Offline | NodeStatus::Syncing(_))
                         && matches!(new_status, NodeStatus::Active(_)) {
                         // Sync when we want to enter an active state
                         //
@@ -149,7 +149,7 @@ impl NodeConnection {
                         // use the connected node in protocols we initiate,
                         // we need to ensure the peer has the up-to-date
                         // data about out owned IDs.
-                        new_status = NodeStatus::Syncing;
+                        new_status = NodeStatus::Syncing(resp.time);
                     }
                     if old_status != new_status {
                         tracing::info!(?node, ?old_status, ?new_status, "updated with new status");
@@ -312,8 +312,8 @@ impl Pool {
         if let Some(conn) = self.connections.get(&participant) {
             tracing::info!(?participant, "reporting node synced");
             conn.status_tx.send_if_modified(|(status, _)| {
-                if *status == NodeStatus::Syncing {
-                    *status = NodeStatus::Active(Utc::now());
+                if let NodeStatus::Syncing(time) = *status {
+                    *status = NodeStatus::Active(time);
                     true
                 } else {
                     false

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -61,8 +61,7 @@ impl NodeConnection {
         info: &ParticipantInfo,
         ping_interval: Duration,
     ) -> Self {
-        let (status_tx, status_rx) =
-            watch::channel((NodeStatus::Offline, info.clone()));
+        let (status_tx, status_rx) = watch::channel((NodeStatus::Offline, info.clone()));
         let (info_tx, info_rx) = watch::channel(info.clone());
         let task = tokio::spawn(Self::run(
             client.clone(),
@@ -341,10 +340,7 @@ pub struct ConnectionWatcher {
     // not just the latest entry with watcher channel.
     conn_update: broadcast::Receiver<ConnectionUpdate>,
     /// Set of active connections that we are watching.
-    watchers: StreamMap<
-        Participant,
-        WatchStream<(NodeStatus, ParticipantInfo)>,
-    >,
+    watchers: StreamMap<Participant, WatchStream<(NodeStatus, ParticipantInfo)>>,
 }
 
 impl ConnectionWatcher {
@@ -355,13 +351,7 @@ impl ConnectionWatcher {
         }
     }
 
-    pub async fn next(
-        &mut self,
-    ) -> (
-        Participant,
-        NodeStatus,
-        ParticipantInfo,
-    ) {
+    pub async fn next(&mut self) -> (Participant, NodeStatus, ParticipantInfo) {
         loop {
             tokio::select! {
                 // Update our watchers if the connections changed.

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use cait_sith::protocol::Participant;
+use chrono::{DateTime, Utc};
 use near_account_id::AccountId;
 use tokio::sync::{broadcast, watch};
 use tokio::task::JoinHandle;
@@ -18,7 +19,7 @@ use crate::protocol::{ParticipantInfo, ProtocolState};
 pub enum NodeStatus {
     /// The connected node responds and is actively participating in the MPC
     /// network.
-    Active,
+    Active(DateTime<Utc>),
     /// State sync is running for node in this state.
     ///
     /// State sync needs to run once for every connection when a node starts.
@@ -60,7 +61,8 @@ impl NodeConnection {
         info: &ParticipantInfo,
         ping_interval: Duration,
     ) -> Self {
-        let (status_tx, status_rx) = watch::channel((NodeStatus::Offline, info.clone()));
+        let (status_tx, status_rx) =
+            watch::channel((NodeStatus::Offline, info.clone()));
         let (info_tx, info_rx) = watch::channel(info.clone());
         let task = tokio::spawn(Self::run(
             client.clone(),
@@ -132,7 +134,7 @@ impl NodeConnection {
 
                     let old_status = status_tx.borrow().0;
                     let mut new_status = match resp.status {
-                        OtherNodeStatus::Running { .. } => NodeStatus::Active,
+                        OtherNodeStatus::Running { .. } => NodeStatus::Active(resp.time),
                         OtherNodeStatus::Resharing { .. }
                         | OtherNodeStatus::Generating { .. }
                         | OtherNodeStatus::Joining { .. }
@@ -141,7 +143,7 @@ impl NodeConnection {
                         | OtherNodeStatus::WaitingForConsensus { .. } => NodeStatus::Inactive,
                     };
                     if matches!(old_status, NodeStatus::Inactive | NodeStatus::Offline | NodeStatus::Syncing)
-                        && new_status == NodeStatus::Active {
+                        && matches!(new_status, NodeStatus::Active(_)) {
                         // Sync when we want to enter an active state
                         //
                         // The peer is running. But before we can reliably
@@ -312,7 +314,7 @@ impl Pool {
             tracing::info!(?participant, "reporting node synced");
             conn.status_tx.send_if_modified(|(status, _)| {
                 if *status == NodeStatus::Syncing {
-                    *status = NodeStatus::Active;
+                    *status = NodeStatus::Active(Utc::now());
                     true
                 } else {
                     false
@@ -339,7 +341,10 @@ pub struct ConnectionWatcher {
     // not just the latest entry with watcher channel.
     conn_update: broadcast::Receiver<ConnectionUpdate>,
     /// Set of active connections that we are watching.
-    watchers: StreamMap<Participant, WatchStream<(NodeStatus, ParticipantInfo)>>,
+    watchers: StreamMap<
+        Participant,
+        WatchStream<(NodeStatus, ParticipantInfo)>,
+    >,
 }
 
 impl ConnectionWatcher {
@@ -350,7 +355,13 @@ impl ConnectionWatcher {
         }
     }
 
-    pub async fn next(&mut self) -> (Participant, NodeStatus, ParticipantInfo) {
+    pub async fn next(
+        &mut self,
+    ) -> (
+        Participant,
+        NodeStatus,
+        ParticipantInfo,
+    ) {
         loop {
             tokio::select! {
                 // Update our watchers if the connections changed.

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use crate::mesh::connection::NodeStatus;
 use crate::node_client::NodeClient;
 use crate::protocol::contract::primitives::Participants;
+use crate::protocol::signature::DRIFT_INTERVAL;
 use crate::protocol::ParticipantInfo;
 use crate::protocol::ProtocolState;
 use crate::rpc::ContractStateWatcher;
@@ -31,9 +32,6 @@ impl Options {
         ]
     }
 }
-
-/// The +/- drift range in milliseconds.
-pub const DRIFT_INTERVAL: i64 = 3000;
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct MeshState {
@@ -67,7 +65,7 @@ impl MeshState {
 
                 // Check drift is within the expected DRIFT_INTERVAL range.
                 let drift = (time - Utc::now()).num_milliseconds().abs();
-                if drift <= DRIFT_INTERVAL {
+                if drift <= DRIFT_INTERVAL as i64 {
                     changed |= self.stable.insert(participant);
                 } else {
                     changed |= self.stable.remove(&participant);

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -73,7 +73,7 @@ impl MeshState {
                     changed |= self.stable.remove(&participant);
                 }
             }
-            NodeStatus::Syncing => {
+            NodeStatus::Syncing(_) => {
                 changed = if let Some(old) = self.need_sync.insert(&participant, info.clone()) {
                     old != info
                 } else {
@@ -240,6 +240,7 @@ mod tests {
                 if p == participant {
                     match (&status, &expected) {
                         (NodeStatus::Active(_), NodeStatus::Active(_)) => return,
+                        (NodeStatus::Syncing(_), NodeStatus::Syncing(_)) => return,
                         (s1, s2) if s1 == s2 => return,
                         _ => {}
                     }
@@ -267,7 +268,7 @@ mod tests {
             match tokio::time::timeout(Duration::from_millis(100), watcher.next()).await {
                 Ok((participant, status, _info)) => {
                     tracing::info!(?participant, ?status, "got connection update for syncing");
-                    if matches!(status, NodeStatus::Syncing) {
+                    if matches!(status, NodeStatus::Syncing(_)) {
                         syncing.insert(participant);
                     }
                 }
@@ -500,7 +501,7 @@ mod tests {
 
         let remote_id = servers[1].id();
 
-        expect_status(&mut watcher, remote_id, NodeStatus::Syncing).await;
+        expect_status(&mut watcher, remote_id, NodeStatus::Syncing(Utc::now())).await;
         pool.report_node_synced(remote_id).await;
         expect_status(&mut watcher, remote_id, NodeStatus::Active(Utc::now())).await;
 
@@ -508,7 +509,7 @@ mod tests {
         expect_status(&mut watcher, remote_id, NodeStatus::Offline).await;
 
         servers[1].make_online().await;
-        expect_status(&mut watcher, remote_id, NodeStatus::Syncing).await;
+        expect_status(&mut watcher, remote_id, NodeStatus::Syncing(Utc::now())).await;
         pool.report_node_synced(remote_id).await;
         expect_status(&mut watcher, remote_id, NodeStatus::Active(Utc::now())).await;
 

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 use std::time::Duration;
 
 use crate::mesh::connection::NodeStatus;
@@ -55,29 +55,38 @@ impl MeshState {
         status: NodeStatus,
         info: ParticipantInfo,
     ) -> bool {
+        let mut changed = false;
         match status {
             NodeStatus::Active(time) => {
-                self.active.insert(&participant, info);
-                self.need_sync.remove(&participant);
+                changed = if let Some(old) = self.active.insert(&participant, info.clone()) {
+                    old != info
+                } else {
+                    true
+                };
+                changed |= self.need_sync.remove(&participant).is_some();
 
                 // Check drift is within the expected DRIFT_INTERVAL range.
                 let drift = (time - Utc::now()).num_milliseconds().abs();
                 if drift <= DRIFT_INTERVAL {
-                    self.stable.insert(participant);
+                    changed |= self.stable.insert(participant);
                 } else {
-                    self.stable.remove(&participant);
+                    changed |= self.stable.remove(&participant);
                 }
             }
             NodeStatus::Syncing => {
-                self.need_sync.insert(&participant, info);
+                changed = if let Some(old) = self.need_sync.insert(&participant, info.clone()) {
+                    old != info
+                } else {
+                    true
+                };
             }
             NodeStatus::Inactive | NodeStatus::Offline => {
-                self.active.remove(&participant);
-                self.need_sync.remove(&participant);
-                self.stable.remove(&participant);
+                changed |= self.active.remove(&participant).is_some();
+                changed |= self.need_sync.remove(&participant).is_some();
+                changed |= self.stable.remove(&participant);
             }
         }
-        true
+        changed
     }
 }
 
@@ -124,9 +133,7 @@ impl Mesh {
             loop {
                 let (p, status, info) = conn_update.next().await;
                 tracing::info!(?p, ?status, "mesh connection status changed");
-                state_tx.send_modify(|state| {
-                    state.update(p, status, info);
-                });
+                state_tx.send_if_modified(|state| state.update(p, status, info));
             }
         });
 
@@ -145,15 +152,17 @@ impl Mesh {
                             ProtocolState::Running(_) => NodeStatus::Active(Utc::now()),
                         };
                         self.connections.connect(contract).await;
-                        self.state_tx.send_modify(|state| {
+                        self.state_tx.send_if_modified(|state| {
+                            let mut changed = false;
                             // if the previous me is different from the current me, remove the
                             // previous me from the MeshState.
                             if let Some(previous_me) = previous_me.filter(|old| *old != participant) {
-                                state.active.remove(&previous_me);
-                                state.need_sync.remove(&previous_me);
-                                state.stable.remove(&previous_me);
+                                changed |= state.active.remove(&previous_me).is_some();
+                                changed |= state.need_sync.remove(&previous_me).is_some();
+                                changed |= state.stable.remove(&previous_me);
                             }
-                            state.update(participant, new_status, info);
+                            changed |= state.update(participant, new_status, info);
+                            changed
                         });
                     } else {
                         tracing::warn!(?previous_me, ?contract, "we are no longer part of the MPC network");

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -309,7 +309,7 @@ mod tests {
         let node_id = servers[0].account_id().clone();
         let expected_participants = participants.clone();
 
-        let (contract_watcher, _contract_tx) = ContractStateWatcher::with_running(
+        let (contract_watcher, _contract_tx, _timestamp_tx) = ContractStateWatcher::with_running(
             &node_id,
             root_sk.public_key().into_affine_point(),
             2,
@@ -396,7 +396,7 @@ mod tests {
         let mut servers = MockServers::run(num_nodes).await;
         let node_id = servers[0].account_id().clone();
 
-        let (contract_watcher, contract_tx) = ContractStateWatcher::with_running(
+        let (contract_watcher, contract_tx, _timestamp_tx) = ContractStateWatcher::with_running(
             &node_id,
             root_sk.public_key().into_affine_point(),
             2,

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::time::Duration;
 
 use crate::mesh::connection::NodeStatus;
@@ -8,6 +8,7 @@ use crate::protocol::ParticipantInfo;
 use crate::protocol::ProtocolState;
 use crate::rpc::ContractStateWatcher;
 use cait_sith::protocol::Participant;
+use chrono::Utc;
 use near_account_id::AccountId;
 use tokio::sync::{mpsc, watch};
 
@@ -31,6 +32,9 @@ impl Options {
     }
 }
 
+/// The +/- drift range in milliseconds.
+pub const DRIFT_INTERVAL: i64 = 3000;
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct MeshState {
     /// Participants that are active in the network; as in they respond when pinged.
@@ -45,12 +49,24 @@ pub struct MeshState {
 }
 
 impl MeshState {
-    pub fn update(&mut self, participant: Participant, status: NodeStatus, info: ParticipantInfo) {
+    pub fn update(
+        &mut self,
+        participant: Participant,
+        status: NodeStatus,
+        info: ParticipantInfo,
+    ) -> bool {
         match status {
-            NodeStatus::Active => {
+            NodeStatus::Active(time) => {
                 self.active.insert(&participant, info);
                 self.need_sync.remove(&participant);
-                self.stable.insert(participant);
+
+                // Check drift is within the expected DRIFT_INTERVAL range.
+                let drift = (time - Utc::now()).num_milliseconds().abs();
+                if drift <= DRIFT_INTERVAL {
+                    self.stable.insert(participant);
+                } else {
+                    self.stable.remove(&participant);
+                }
             }
             NodeStatus::Syncing => {
                 self.need_sync.insert(&participant, info);
@@ -61,6 +77,7 @@ impl MeshState {
                 self.stable.remove(&participant);
             }
         }
+        true
     }
 }
 
@@ -125,7 +142,7 @@ impl Mesh {
                     if let Some((participant, info)) = my_info {
                         let new_status = match &contract {
                             ProtocolState::Initializing(_) | ProtocolState::Resharing(_) => NodeStatus::Inactive,
-                            ProtocolState::Running(_) => NodeStatus::Active,
+                            ProtocolState::Running(_) => NodeStatus::Active(Utc::now()),
                         };
                         self.connections.connect(contract).await;
                         self.state_tx.send_modify(|state| {
@@ -211,8 +228,12 @@ mod tests {
             if let Ok((p, status, _info)) =
                 tokio::time::timeout(Duration::from_millis(500), watcher.next()).await
             {
-                if p == participant && status == expected {
-                    return;
+                if p == participant {
+                    match (&status, &expected) {
+                        (NodeStatus::Active(_), NodeStatus::Active(_)) => return,
+                        (s1, s2) if s1 == s2 => return,
+                        _ => {}
+                    }
                 }
             }
         }
@@ -256,7 +277,7 @@ mod tests {
             match tokio::time::timeout(Duration::from_millis(100), watcher.next()).await {
                 Ok((participant, status, _info)) => {
                     tracing::info!(?participant, ?status, "got connection update for active");
-                    if matches!(status, NodeStatus::Active) {
+                    if matches!(status, NodeStatus::Active(_)) {
                         syncing.insert(participant);
                     }
                 }
@@ -472,7 +493,7 @@ mod tests {
 
         expect_status(&mut watcher, remote_id, NodeStatus::Syncing).await;
         pool.report_node_synced(remote_id).await;
-        expect_status(&mut watcher, remote_id, NodeStatus::Active).await;
+        expect_status(&mut watcher, remote_id, NodeStatus::Active(Utc::now())).await;
 
         servers[1].set_protocol_version(None).await;
         expect_status(&mut watcher, remote_id, NodeStatus::Offline).await;
@@ -480,7 +501,7 @@ mod tests {
         servers[1].make_online().await;
         expect_status(&mut watcher, remote_id, NodeStatus::Syncing).await;
         pool.report_node_synced(remote_id).await;
-        expect_status(&mut watcher, remote_id, NodeStatus::Active).await;
+        expect_status(&mut watcher, remote_id, NodeStatus::Active(Utc::now())).await;
 
         servers[1].set_protocol_version(Some(0)).await;
         expect_status(&mut watcher, remote_id, NodeStatus::Offline).await;

--- a/chain-signatures/node/src/protocol/contract/primitives.rs
+++ b/chain-signatures/node/src/protocol/contract/primitives.rs
@@ -115,8 +115,8 @@ impl Participants {
         self.participants.is_empty()
     }
 
-    pub fn insert(&mut self, id: &Participant, info: ParticipantInfo) {
-        self.participants.insert(*id, info);
+    pub fn insert(&mut self, id: &Participant, info: ParticipantInfo) -> Option<ParticipantInfo> {
+        self.participants.insert(*id, info)
     }
 
     pub fn remove(&mut self, id: &Participant) -> Option<ParticipantInfo> {

--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -1340,7 +1340,7 @@ mod tests {
                 cipher_sk,
             },
         });
-        let (contract_watcher, _contract_tx) = ContractStateWatcher::with_running(
+        let (contract_watcher, _contract_tx, _timestamp_tx) = ContractStateWatcher::with_running(
             &node_id,
             root_sk.public_key().into_affine_point(),
             2,

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -37,7 +37,8 @@ use near_account_id::AccountId;
 
 /// The round interval to search for a proposer in the organizing phase.
 const ROUND_INTERVAL: usize = 512;
-const DRIFT_INTERVAL: u64 = 35000;
+/// The +/- range of time drift to account for in milliseconds.
+pub const DRIFT_INTERVAL: u64 = 21000;
 
 /// All relevant info pertaining to an Indexed sign request from an indexer.
 #[derive(Debug, Clone, PartialEq)]
@@ -178,7 +179,7 @@ impl SignOrganizer {
             tracing::warn!("no timestamp available from contract, falling back to local time");
             Utc::now().timestamp_millis() as u64
         });
-        let round = ((now + DRIFT_INTERVAL) / (4 * DRIFT_INTERVAL)) as usize;
+        let round = ((now + DRIFT_INTERVAL) / (3 * DRIFT_INTERVAL)) as usize;
         state.round = round;
 
         tracing::info!(?sign_id, round, "entering organizing phase");

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -37,6 +37,7 @@ use near_account_id::AccountId;
 
 /// The round interval to search for a proposer in the organizing phase.
 const ROUND_INTERVAL: usize = 512;
+const DRIFT_INTERVAL: u64 = 3000;
 
 /// All relevant info pertaining to an Indexed sign request from an indexer.
 #[derive(Debug, Clone, PartialEq)]
@@ -177,34 +178,33 @@ impl SignOrganizer {
         let entropy = state.indexed.args.entropy;
         let participants = ctx.participants.iter().copied().collect::<Vec<_>>();
 
+        // Deterministic round based on time
+        let now = Utc::now().timestamp_millis() as u64;
+        let drift_interval = DRIFT_INTERVAL as u64;
+        state.round = ((now + drift_interval) / (4 * drift_interval)) as usize;
+
         tracing::info!(?sign_id, round = ?state.round, "entering organizing phase");
         let (stable, proposer) = {
             let Some(stable) = self.wait_stable(ctx, state, threshold).await else {
                 tracing::warn!(?sign_id, round = ?state.round, "no stable participants, reorganizing");
-                state.bump_round();
                 return SignPhase::Organizing(self);
             };
 
-            let max_rounds = state.round + ROUND_INTERVAL;
-            let (selected_round, proposer) = (state.round..max_rounds)
-                .map(|r| (r, Self::proposer_per_round(r, &participants, &entropy)))
-                .find(|(_, potential_proposer)| stable.contains(potential_proposer))
+            let proposer = (state.round..state.round + ROUND_INTERVAL)
+                .map(|r| Self::proposer_per_round(r, &participants, &entropy))
+                .find(|potential_proposer| stable.contains(potential_proposer))
                 .unwrap_or_else(|| {
-                    (
-                        max_rounds,
-                        *stable
-                            .iter()
-                            .choose(&mut StdRng::from_seed(entropy))
-                            .unwrap(),
-                    )
+                    *stable
+                        .iter()
+                        .choose(&mut StdRng::from_seed(entropy))
+                        .unwrap()
                 });
 
             let is_mine = proposer == me;
-            state.round = selected_round;
 
             tracing::info!(
                 ?sign_id,
-                round = selected_round,
+                round = state.round,
                 ?proposer,
                 ?me,
                 is_mine,

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -81,10 +81,6 @@ impl SignState {
     fn indexed(&self) -> &IndexedSignRequest {
         &self.indexed
     }
-
-    fn bump_round(&mut self) {
-        self.round += 1;
-    }
 }
 
 struct SignPositor {
@@ -178,22 +174,21 @@ impl SignOrganizer {
         let entropy = state.indexed.args.entropy;
         let participants = ctx.participants.iter().copied().collect::<Vec<_>>();
 
-        // Deterministic round based on time
         let now = ctx.contract.timestamp().unwrap_or_else(|| {
             tracing::warn!("no timestamp available from contract, falling back to local time");
             Utc::now().timestamp_millis() as u64
         });
-        let drift_interval = DRIFT_INTERVAL as u64;
-        state.round = ((now + drift_interval) / (4 * drift_interval)) as usize;
+        let round = ((now + DRIFT_INTERVAL) / (4 * DRIFT_INTERVAL)) as usize;
+        state.round = round;
 
-        tracing::info!(?sign_id, round = ?state.round, "entering organizing phase");
+        tracing::info!(?sign_id, round, "entering organizing phase");
         let (stable, proposer) = {
             let Some(stable) = self.wait_stable(ctx, state, threshold).await else {
-                tracing::warn!(?sign_id, round = ?state.round, "no stable participants, reorganizing");
+                tracing::warn!(?sign_id, round, "no stable participants, reorganizing");
                 return SignPhase::Organizing(self);
             };
 
-            let proposer = (state.round..state.round + ROUND_INTERVAL)
+            let proposer = (round..round + ROUND_INTERVAL)
                 .map(|r| Self::proposer_per_round(r, &participants, &entropy))
                 .find(|potential_proposer| stable.contains(potential_proposer))
                 .unwrap_or_else(|| {
@@ -207,7 +202,7 @@ impl SignOrganizer {
 
             tracing::info!(
                 ?sign_id,
-                round = state.round,
+                round,
                 ?proposer,
                 ?me,
                 is_mine,
@@ -215,7 +210,7 @@ impl SignOrganizer {
                 "organized: selected proposer"
             );
 
-            if is_mine && state.round == 0 {
+            if is_mine && round == 0 {
                 crate::metrics::NUM_SIGN_REQUESTS_MINE
                     .with_label_values(&[ctx.my_account_id.as_str()])
                     .inc();
@@ -226,7 +221,7 @@ impl SignOrganizer {
 
         let is_proposer = proposer == ctx.me;
         let (presignature_id, presignature, stable) = if is_proposer {
-            tracing::info!(?sign_id, round = ?state.round, "proposer waiting for presignature");
+            tracing::info!(?sign_id, round, "proposer waiting for presignature");
             let stable = stable.iter().copied().collect::<Vec<_>>();
             let mut recycle = Vec::new();
             let fetch = tokio::time::timeout(Duration::from_secs(30), async {
@@ -257,16 +252,14 @@ impl SignOrganizer {
                 Err(_) => {
                     tracing::warn!(
                         ?sign_id,
-                        round = ?state.round,
+                        round,
                         "proposer timeout waiting for presignature, reorganizing"
                     );
-                    state.bump_round();
                     return SignPhase::Organizing(self);
                 }
             };
 
             let presignature_id = taken.artifact.id;
-
             tracing::info!(?sign_id, presignature_id, "proposer got presignature");
 
             // broadcast to participants and let them reject if they don't have the presignature.
@@ -391,7 +384,6 @@ impl SignPositor {
                     ?proposer,
                     "deliberator timeout waiting for Propose, reorganizing"
                 );
-                state.bump_round();
                 return Err(SignPhase::Organizing(SignOrganizer));
             }
         };
@@ -485,7 +477,6 @@ impl SignPositor {
                                     ?round,
                                     "not enough start participants"
                                 );
-                                state.bump_round();
                                 return SignPhase::Organizing(SignOrganizer);
                             }
 
@@ -503,7 +494,6 @@ impl SignPositor {
                                 tracing::warn!(?sign_id, "recycling presignature due to REJECTs");
                                 ctx.presignatures.recycle_mine(ctx.me, taken).await;
                             }
-                            state.bump_round();
                             return SignPhase::Organizing(SignOrganizer);
                         }
 
@@ -527,7 +517,6 @@ impl SignPositor {
                                     tracing::warn!(?sign_id, "recycling presignature due to insufficient participants");
                                     ctx.presignatures.recycle_mine(ctx.me, taken).await;
                                 }
-                                state.bump_round();
                                 return SignPhase::Organizing(SignOrganizer);
                             }
 
@@ -574,7 +563,6 @@ impl SignPositor {
                                     tracing::warn!(?sign_id, "recycling presignature due to posit timeout");
                                     ctx.presignatures.recycle_mine(ctx.me, taken).await;
                                 }
-                                state.bump_round();
                                 return SignPhase::Organizing(SignOrganizer);
                             }
 
@@ -602,12 +590,10 @@ impl SignPositor {
                                 tracing::warn!(?sign_id, "recycling presignature due to posit timeout (no accepts)");
                                 ctx.presignatures.recycle_mine(ctx.me, taken).await;
                             }
-                            state.bump_round();
                             return SignPhase::Organizing(SignOrganizer);
                         }
                     } else {
                         tracing::warn!(?sign_id, "deliberator posit timeout waiting for Start, reorganizing");
-                        state.bump_round();
                         return SignPhase::Organizing(SignOrganizer);
                     }
                 }
@@ -662,7 +648,6 @@ impl SignGenerating {
                     ?err,
                     "failed to create generator, reorganizing"
                 );
-                state.bump_round();
                 return SignPhase::Organizing(SignOrganizer);
             }
         };
@@ -681,7 +666,6 @@ impl SignGenerating {
                     ?err,
                     "signature generation failed, reorganizing"
                 );
-                state.bump_round();
                 SignPhase::Organizing(SignOrganizer)
             }
         }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -38,7 +38,7 @@ use near_account_id::AccountId;
 /// The round interval to search for a proposer in the organizing phase.
 const ROUND_INTERVAL: usize = 512;
 /// The +/- range of time drift to account for in milliseconds.
-pub const DRIFT_INTERVAL: u64 = 21000;
+pub const DRIFT_INTERVAL: u64 = 20000;
 
 /// All relevant info pertaining to an Indexed sign request from an indexer.
 #[derive(Debug, Clone, PartialEq)]
@@ -175,10 +175,10 @@ impl SignOrganizer {
         let entropy = state.indexed.args.entropy;
         let participants = ctx.participants.iter().copied().collect::<Vec<_>>();
 
-        let now = ctx.contract.timestamp().unwrap_or_else(|| {
-            tracing::warn!("no timestamp available from contract, falling back to local time");
-            Utc::now().timestamp_millis() as u64
-        });
+        let Some(now) = ctx.contract.timestamp() else {
+            tracing::error!(?sign_id, "unexpected missing timestamp for round calc");
+            return SignPhase::Organizing(self);
+        };
         let round = ((now + DRIFT_INTERVAL) / (3 * DRIFT_INTERVAL)) as usize;
         state.round = round;
 

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -37,7 +37,7 @@ use near_account_id::AccountId;
 
 /// The round interval to search for a proposer in the organizing phase.
 const ROUND_INTERVAL: usize = 512;
-const DRIFT_INTERVAL: u64 = 3000;
+const DRIFT_INTERVAL: u64 = 35000;
 
 /// All relevant info pertaining to an Indexed sign request from an indexer.
 #[derive(Debug, Clone, PartialEq)]
@@ -179,7 +179,10 @@ impl SignOrganizer {
         let participants = ctx.participants.iter().copied().collect::<Vec<_>>();
 
         // Deterministic round based on time
-        let now = Utc::now().timestamp_millis() as u64;
+        let now = ctx.contract.timestamp().unwrap_or_else(|| {
+            tracing::warn!("no timestamp available from contract, falling back to local time");
+            Utc::now().timestamp_millis() as u64
+        });
         let drift_interval = DRIFT_INTERVAL as u64;
         state.round = ((now + drift_interval) / (4 * drift_interval)) as usize;
 

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -127,33 +127,50 @@ impl RpcChannel {
 pub struct ContractStateWatcher {
     account_id: AccountId,
     contract_state: watch::Receiver<Option<ProtocolState>>,
+    timestamp: watch::Receiver<Option<u64>>,
 }
 
 impl ContractStateWatcher {
-    pub fn new(id: &AccountId) -> (Self, watch::Sender<Option<ProtocolState>>) {
+    pub fn new(
+        id: &AccountId,
+    ) -> (
+        Self,
+        watch::Sender<Option<ProtocolState>>,
+        watch::Sender<Option<u64>>,
+    ) {
         let (tx, rx) = watch::channel(None);
+        let (time_tx, time_rx) = watch::channel(None);
         (
             Self {
                 account_id: id.clone(),
                 contract_state: rx,
+                timestamp: time_rx,
             },
             tx,
+            time_tx,
         )
     }
 
     pub fn with(
         id: &AccountId,
         state: ProtocolState,
-    ) -> (Self, watch::Sender<Option<ProtocolState>>) {
+    ) -> (
+        Self,
+        watch::Sender<Option<ProtocolState>>,
+        watch::Sender<Option<u64>>,
+    ) {
         // Set the initial state to be None so that `changed()` will pick up the first state change.
         let (tx, rx) = watch::channel(None);
         let _ = tx.send(Some(state));
+        let (time_tx, time_rx) = watch::channel(None);
         (
             Self {
                 account_id: id.clone(),
                 contract_state: rx,
+                timestamp: time_rx,
             },
             tx,
+            time_tx,
         )
     }
 
@@ -162,7 +179,11 @@ impl ContractStateWatcher {
         public_key: AffinePoint,
         threshold: usize,
         participants: Participants,
-    ) -> (Self, watch::Sender<Option<ProtocolState>>) {
+    ) -> (
+        Self,
+        watch::Sender<Option<ProtocolState>>,
+        watch::Sender<Option<u64>>,
+    ) {
         Self::with(
             node_id,
             ProtocolState::Running(RunningContractState {
@@ -192,6 +213,10 @@ impl ContractStateWatcher {
     pub async fn next_state(&mut self) -> Option<ProtocolState> {
         let _ = self.contract_state.changed().await;
         self.contract_state.borrow_and_update().clone()
+    }
+
+    pub fn timestamp(&self) -> Option<u64> {
+        *self.timestamp.borrow()
     }
 
     pub fn mark_changed(&mut self) {
@@ -299,19 +324,26 @@ impl ContractStateWatcher {
 
     /// Create a list of contract states that share a single channel but use different account ids.
     #[cfg(feature = "test-feature")]
+    #[cfg(feature = "test-feature")]
     pub fn test_batch(
         ids: &[AccountId],
         state: ProtocolState,
-    ) -> (Vec<Self>, watch::Sender<Option<ProtocolState>>) {
+    ) -> (
+        Vec<Self>,
+        watch::Sender<Option<ProtocolState>>,
+        watch::Sender<Option<u64>>,
+    ) {
         let (tx, rx) = watch::channel(Some(state));
+        let (time_tx, time_rx) = watch::channel(None);
         let selfs = ids
             .iter()
             .map(|id| Self {
                 account_id: id.clone(),
                 contract_state: rx.clone(),
+                timestamp: time_rx.clone(),
             })
             .collect();
-        (selfs, tx)
+        (selfs, tx, time_tx)
     }
 }
 
@@ -348,6 +380,7 @@ impl RpcExecutor {
     pub async fn run(
         mut self,
         contract: watch::Sender<Option<ProtocolState>>,
+        timestamp: watch::Sender<Option<u64>>,
         config: watch::Sender<Config>,
     ) {
         // spin up update task for updating contract state and config
@@ -356,7 +389,11 @@ impl RpcExecutor {
             let mut interval = tokio::time::interval(UPDATE_INTERVAL);
             loop {
                 interval.tick().await;
-                tokio::spawn(update_contract(near.clone(), contract.clone()));
+                tokio::spawn(update_contract(
+                    near.clone(),
+                    contract.clone(),
+                    timestamp.clone(),
+                ));
                 tokio::spawn(update_config(near.clone(), config.clone()));
             }
         });
@@ -473,7 +510,7 @@ impl NearClient {
         self.client.rpc_addr()
     }
 
-    pub async fn fetch_state(&self) -> anyhow::Result<ProtocolState> {
+    pub async fn fetch_state(&self) -> anyhow::Result<(ProtocolState, u64)> {
         let contract_state: mpc_contract::ProtocolContractState =
             self.client.view(&self.contract_id, "state").await?.json()?;
 
@@ -481,8 +518,11 @@ impl NearClient {
             anyhow::anyhow!("failed to parse protocol state, has it been initialized?")
         })?;
 
-        tracing::debug!(?protocol_state, "protocol state");
-        Ok(protocol_state)
+        let block = self.client.view_block().await?;
+        let timestamp = block.header.timestamp_nanosec / 1_000_000;
+
+        tracing::debug!(timestamp, ?protocol_state, "protocol state");
+        Ok((protocol_state, timestamp))
     }
 
     pub async fn fetch_config(&self) -> Option<ContractConfig> {
@@ -651,8 +691,12 @@ pub enum ChainClient {
     Solana(SolanaClient),
 }
 
-async fn update_contract(near: NearClient, contract: watch::Sender<Option<ProtocolState>>) {
-    let new_state = match near.fetch_state().await {
+async fn update_contract(
+    near: NearClient,
+    contract: watch::Sender<Option<ProtocolState>>,
+    timestamp: watch::Sender<Option<u64>>,
+) {
+    let (new_state, new_timestamp) = match near.fetch_state().await {
         Ok(state) => state,
         Err(error) => {
             tracing::error!(?error, "could not fetch contract state");
@@ -669,6 +713,8 @@ async fn update_contract(near: NearClient, contract: watch::Sender<Option<Protoc
         *old_state = Some(new_state);
         true
     });
+
+    let _ = timestamp.send(Some(new_timestamp));
 }
 
 async fn update_config(near: NearClient, config: watch::Sender<Config>) {

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -324,7 +324,6 @@ impl ContractStateWatcher {
 
     /// Create a list of contract states that share a single channel but use different account ids.
     #[cfg(feature = "test-feature")]
-    #[cfg(feature = "test-feature")]
     pub fn test_batch(
         ids: &[AccountId],
         state: ProtocolState,

--- a/chain-signatures/node/src/web/mock.rs
+++ b/chain-signatures/node/src/web/mock.rs
@@ -1,4 +1,5 @@
 use cait_sith::protocol::Participant;
+use chrono::Utc;
 use mockito::ServerGuard;
 use near_sdk::AccountId;
 
@@ -187,6 +188,7 @@ fn status_body(id: u32, version: Option<u64>) -> Vec<u8> {
         Some(protocol_version) => serde_json::to_vec(&StatusResponse {
             protocol_version,
             status: status.clone(),
+            time: Utc::now(),
         })
         .unwrap(),
         None => serde_json::to_vec(&status).unwrap(),

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -23,6 +23,7 @@ use axum::routing::{get, post};
 use axum::{Extension, Json, Router};
 use axum_extra::extract::WithRejection;
 use cait_sith::protocol::Participant;
+use chrono::{DateTime, Utc};
 use mpc_keys::hpke::Ciphered;
 use near_account_id::AccountId;
 use near_primitives::types::BlockHeight;
@@ -213,6 +214,7 @@ pub struct StatusResponse {
     pub status: NodeStatus,
     #[serde(default)]
     pub protocol_version: u64,
+    pub time: DateTime<Utc>,
 }
 
 #[tracing::instrument(level = "debug", skip_all)]
@@ -220,6 +222,7 @@ async fn status(Extension(web): Extension<Arc<AxumState>>) -> Json<StatusRespons
     Json(StatusResponse {
         status: web.node.status(),
         protocol_version: crate::PROTOCOL_VERSION,
+        time: Utc::now(),
     })
 }
 

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -12,6 +12,7 @@ use crate::metrics::WEB_ENDPOINT_LATENCY;
 use crate::protocol::state::{NodeStateWatcher, NodeStatus, ResharingStatus};
 use crate::protocol::sync::{SyncChannel, SyncUpdate};
 use crate::protocol::{Chain, MessageChannel};
+use crate::rpc::ContractStateWatcher;
 use crate::storage::{PresignatureStorage, TripleStorage};
 use crate::web::cbor::Cbor;
 use crate::web::error::Result;
@@ -35,6 +36,7 @@ use std::time::Instant;
 
 struct AxumState {
     node: NodeStateWatcher,
+    contract_state: ContractStateWatcher,
     triple_storage: TripleStorage,
     presignature_storage: PresignatureStorage,
     sync_channel: SyncChannel,
@@ -48,6 +50,7 @@ pub async fn run(
     port: u16,
     msg_channel: MessageChannel,
     node: NodeStateWatcher,
+    contract_state: ContractStateWatcher,
     triple_storage: TripleStorage,
     presignature_storage: PresignatureStorage,
     sync_channel: SyncChannel,
@@ -58,6 +61,7 @@ pub async fn run(
     let axum_state = AxumState {
         msg_channel,
         node,
+        contract_state,
         triple_storage,
         presignature_storage,
         sync_channel,
@@ -214,15 +218,21 @@ pub struct StatusResponse {
     pub status: NodeStatus,
     #[serde(default)]
     pub protocol_version: u64,
+    #[serde(default)]
     pub time: DateTime<Utc>,
 }
 
 #[tracing::instrument(level = "debug", skip_all)]
 async fn status(Extension(web): Extension<Arc<AxumState>>) -> Json<StatusResponse> {
+    let time = web
+        .contract_state
+        .timestamp()
+        .and_then(|ts| DateTime::from_timestamp_millis(ts as i64))
+        .unwrap_or_else(Utc::now);
     Json(StatusResponse {
         status: web.node.status(),
         protocol_version: crate::PROTOCOL_VERSION,
-        time: Utc::now(),
+        time,
     })
 }
 

--- a/integration-tests/benches/store.rs
+++ b/integration-tests/benches/store.rs
@@ -108,7 +108,7 @@ fn env() -> (Runtime, SyncEnv) {
 
         let sk = k256::SecretKey::random(&mut rand::thread_rng());
         let pk = sk.public_key();
-        let (contract_watcher, _contract_tx) = ContractStateWatcher::with(
+        let (contract_watcher, _contract_tx, _timestamp_tx) = ContractStateWatcher::with(
             &node_id,
             ProtocolState::Running(RunningContractState {
                 epoch: 0,

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -166,7 +166,7 @@ impl MpcFixtureBuilder {
             .iter()
             .map(|node| node.participant_info.account_id.clone())
             .collect();
-        let (contract_state_watchers, shared_contract_state_tx) =
+        let (contract_state_watchers, shared_contract_state_tx, _shared_timestamp_tx) =
             ContractStateWatcher::test_batch(&account_ids, self.protocol_state);
 
         // Start each node's tokio tasks

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -166,7 +166,7 @@ impl MpcFixtureBuilder {
             .iter()
             .map(|node| node.participant_info.account_id.clone())
             .collect();
-        let (contract_state_watchers, shared_contract_state_tx, _shared_timestamp_tx) =
+        let (contract_state_watchers, shared_contract_state_tx, _timestamp_tx) =
             ContractStateWatcher::test_batch(&account_ids, self.protocol_state);
 
         // Start each node's tokio tasks
@@ -451,6 +451,7 @@ impl MpcFixtureNodeBuilder {
         let account_id = protocol.my_account_id().clone();
         let node = protocol::Node::new();
         let node_state = node.watch();
+        let contract_state_for_fixture = context.contract_state.clone();
         let _protocol_handle = tokio::spawn(protocol.run(
             node,
             MockGovernance {
@@ -476,6 +477,7 @@ impl MpcFixtureNodeBuilder {
         let mut node = MpcFixtureNode {
             me: self.me,
             state: node_state,
+            contract_state: contract_state_for_fixture,
             mesh: mesh_tx,
             config: config_tx,
             sign_tx,

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -9,6 +9,7 @@ use mpc_node::mesh::MeshState;
 use mpc_node::protocol::state::NodeStateWatcher;
 use mpc_node::protocol::sync::SyncChannel;
 use mpc_node::protocol::{MessageChannel, ProtocolState, Sign};
+use mpc_node::rpc::ContractStateWatcher;
 use mpc_node::storage::{PresignatureStorage, TripleStorage};
 use near_sdk::AccountId;
 use std::collections::HashSet;
@@ -27,6 +28,7 @@ pub struct MpcFixture {
 pub struct MpcFixtureNode {
     pub me: Participant,
     pub state: NodeStateWatcher,
+    pub contract_state: ContractStateWatcher,
     pub mesh: watch::Sender<MeshState>,
     pub config: watch::Sender<Config>,
 
@@ -102,6 +104,7 @@ impl MpcFixtureNode {
             8200 + u32::from(self.me) as u16,
             self.msg_channel.clone(),
             self.state.clone(),
+            self.contract_state.clone(),
             self.triple_storage.clone(),
             self.presignature_storage.clone(),
             // unused but needed to call the web interface

--- a/integration-tests/tests/cases/sync.rs
+++ b/integration-tests/tests/cases/sync.rs
@@ -41,7 +41,7 @@ async fn test_state_sync_update() -> anyhow::Result<()> {
     let node0_triples = redis.triple_storage(&node0_account_id);
     let node0_presignatures = redis.presignature_storage(&node0_account_id);
 
-    let (contract_watcher, _contract_tx) = ContractStateWatcher::with(
+    let (contract_watcher, _contract_tx, _timestamp_tx) = ContractStateWatcher::with(
         &node0_account_id,
         ProtocolState::Running(RunningContractState {
             epoch: 0,


### PR DESCRIPTION
This utilizes governance time from near to create deterministic rounds used by our sign task. This is a more deterministic way to get a sense of where we are at in round without needing to synchronize with every other node per sign request.

This is done on /status where their latest governance time is set. So how it works is we set our peer to be in the stable set if and only if they are within +/- 20 seconds (the drift interval). We poll from the governance chain every 10s, so they can only be about 2 polls ahead or behind. It's 10s per poll because of rate limits and matches how many time we poll for contract.state.

This additionally gives us the property that we are only participating with nodes that are tracking the state of the governance chain within the drift interval.

The formula for calculating round is `round = floor((gov_time + drift) / (3 * drift))`.
- `gov_time + drift` just shifts our peers over to our round if they're just before the edge.
- `3 * drift` makes for about 60 second range (which is about the amount of time we timeout for our sign task). Caveat to this is  that might make it so we choose the same proposer for every x amount of attempts if our timeouts were to decrease.