### PR TITLE
test: signing with missing presignatures

### DIFF
--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -74,6 +74,14 @@ impl MpcFixture {
             tokio::time::sleep(interval).await;
         }
     }
+
+    /// Print all messages to debug.
+    pub async fn print_msg_log(&self) {
+        let guard = self.output.msg_log.lock().await;
+        for msg in guard.iter() {
+            tracing::debug!("{msg}");
+        }
+    }
 }
 
 impl MpcFixtureNode {

--- a/integration-tests/src/mpc_fixture/fixture_tasks.rs
+++ b/integration-tests/src/mpc_fixture/fixture_tasks.rs
@@ -91,7 +91,7 @@ pub(super) fn test_mock_network(
                             )
                         },
                     };
-                    tracing::error!(target: "mock_network", ?action_str, "Received RPC action");
+                    tracing::info!(target: "mock_network", ?action_str, "Received RPC action");
                     let mut actions_log = rpc_actions.lock().await;
                     actions_log.insert(action_str);
                 }

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -660,3 +660,57 @@ async fn test_sign_contention_5_nodes() {
         presignatures_consumed
     );
 }
+
+/// Test that a node losing their presignatures locally doesn't prevent
+/// signatures from going through.
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_sign_missing_presignature() {
+    // 3 nodes, threshold 2, should be possible to generate a signature with one
+    // node missing their presignatures
+    let network = MpcFixtureBuilder::new(3, 2)
+        .only_generate_signatures()
+        .build()
+        .await;
+
+    tokio::time::timeout(
+        Duration::from_millis(300),
+        network.wait_for_presignatures(2),
+    )
+    .await
+    .expect("should start with enough presignatures");
+
+    // Now delete presignatures of one node
+    let bad_node = 0;
+    let success = network.nodes[bad_node].presignature_storage.clear().await;
+    assert!(success, "failed to clear presignature storage");
+    // give some time for redis to fully delete state
+    // (the test is flaky without this delay)
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Now we submit the request
+    tracing::info!("sending requests now");
+    let request = sign_request(0);
+    for node in &network.nodes {
+        node.sign_tx
+            .send(Sign::Request(request.clone()))
+            .await
+            .unwrap();
+    }
+
+    // give 2 minutes to resolve the problem
+    // expectation: the node without the presignature will reject a posit, or if
+    // they are deliberator, a timeout will let the next deliberator take over
+    let timeout = Duration::from_secs(120);
+    let actions = tokio::time::timeout(timeout, network.wait_for_actions(1))
+        .await
+        .expect("should publish RPC action eventually");
+
+    network.print_msg_log().await;
+
+    assert_eq!(actions.len(), 1);
+    let action_str = actions.iter().next().unwrap();
+    assert!(
+        action_str.contains("RpcAction::Publish"),
+        "unexpected rpc action {action_str}"
+    );
+}


### PR DESCRIPTION
Add a component test where a node has all their presignatures removed.

The node itself detects that it does not have the required input for a signature, so they will reject the posits. The other nodes will succeed signing without the node that lacks presignatures.