### PR TITLE
fix: Sign::Completion not triggering task abort

### DIFF
--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -27,7 +27,7 @@ use mpc_primitives::{SignArgs, SignId};
 use rand::rngs::StdRng;
 use rand::seq::IteratorRandom;
 use rand::SeedableRng;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, watch, RwLock};
@@ -1051,6 +1051,9 @@ pub struct SignatureSpawner {
     tasks: JoinMap<SignId, Result<(), SignError>>,
     /// Buffered inboxes for posit messages, allowing us to queue before tasks spawn
     inboxes: HashMap<SignId, Subscriber<SignTaskMessage>>,
+    /// Tracks sign_ids for which we've received completion events before the request.
+    /// This prevents spawning tasks for requests that are already completed.
+    completed: HashSet<SignId>,
     mesh_state: watch::Receiver<MeshState>,
 
     me: Participant,
@@ -1123,15 +1126,6 @@ impl SignatureSpawner {
             .await;
     }
 
-    fn handle_completion(&mut self, sign_id: SignId) {
-        self.inboxes.remove(&sign_id);
-        if self.tasks.abort(sign_id) {
-            tracing::info!(?sign_id, "aborting signature task due to completion event");
-        } else {
-            tracing::info!(?sign_id, "task already completed or unable to be aborted");
-        }
-    }
-
     fn handle_request(
         &mut self,
         sign: Sign,
@@ -1141,10 +1135,27 @@ impl SignatureSpawner {
     ) {
         match sign {
             Sign::Completion(sign_id) => {
-                self.handle_completion(sign_id);
+                self.inboxes.remove(&sign_id);
+                self.completed.insert(sign_id);
+                if self.tasks.abort(sign_id) {
+                    tracing::info!(?sign_id, "aborting signature task due to completion event");
+                } else {
+                    tracing::info!(
+                        ?sign_id,
+                        "completion received before task spawn, tracking for later"
+                    );
+                }
             }
             Sign::Request(indexed) => {
                 let sign_id = indexed.id;
+
+                // Skip if we already received a completion event for this request.
+                // This can happen when the completion arrives before the request due to
+                // finalization delays (e.g., Ethereum waiting for block finalization).
+                if self.completed.remove(&sign_id) {
+                    tracing::info!(?sign_id, "skipping sign request - already completed");
+                    return;
+                }
 
                 // Skip if we already have a task handling this request.
                 // Use tasks instead of inbox map since it may already contain buffered messages
@@ -1248,6 +1259,7 @@ impl SignatureSpawnerTask {
             me,
             tasks: JoinMap::new(),
             inboxes: HashMap::new(),
+            completed: HashSet::new(),
             my_account_id: ctx.my_account_id.clone(),
             threshold,
             public_key,

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -43,7 +43,9 @@ const ORGANIZE_POSIT_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// The TTL is determined by the maximum expected time for the longest finalization
 /// time of whatever chains are being supported, plus some buffer.
-const COMPLETION_TTL: Duration = Duration::from_secs(1200);
+/// One of our longest finalizing chain is Ethereum with 32 slots ≈ 6.4 minutes.
+/// Bitcoin has a practical finalization time of around 1 hour (6 blocks).
+const COMPLETION_TTL: Duration = Duration::from_secs(3600);
 
 /// All relevant info pertaining to an Indexed sign request from an indexer.
 #[derive(Debug, Clone, PartialEq)]
@@ -1144,10 +1146,7 @@ impl SignatureSpawner {
                 if self.tasks.abort(sign_id) {
                     tracing::info!(?sign_id, "aborting signature task due to completion event");
                 } else {
-                    tracing::info!(
-                        ?sign_id,
-                        "completion received before task spawn, tracking for later"
-                    );
+                    tracing::info!(?sign_id, "task already completed or unable to be aborted");
                 }
             }
             Sign::Request(indexed) => {

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -14,7 +14,7 @@ use crate::rpc::{ContractStateWatcher, RpcChannel};
 use crate::storage::presignature_storage::{PresignatureTaken, PresignatureTakenDropper};
 use crate::storage::PresignatureStorage;
 use crate::types::SignatureProtocol;
-use crate::util::{AffinePointExt, JoinMap, TimeoutBudget};
+use crate::util::{AffinePointExt, ExpirationSet, JoinMap, TimeoutBudget};
 
 use crate::protocol::SignRequestType;
 use cait_sith::protocol::{Action, InitializationError, Participant};
@@ -27,7 +27,7 @@ use mpc_primitives::{SignArgs, SignId};
 use rand::rngs::StdRng;
 use rand::seq::IteratorRandom;
 use rand::SeedableRng;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, watch, RwLock};
@@ -40,6 +40,10 @@ const ROUND_INTERVAL: usize = 512;
 
 /// The default timeout budget for organizing and posit phases.
 const ORGANIZE_POSIT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// The TTL is determined by the maximum expected time for the longest finalization
+/// time of whatever chains are being supported, plus some buffer.
+const COMPLETION_TTL: Duration = Duration::from_secs(1200);
 
 /// All relevant info pertaining to an Indexed sign request from an indexer.
 #[derive(Debug, Clone, PartialEq)]
@@ -1053,7 +1057,7 @@ pub struct SignatureSpawner {
     inboxes: HashMap<SignId, Subscriber<SignTaskMessage>>,
     /// Tracks sign_ids for which we've received completion events before the request.
     /// This prevents spawning tasks for requests that are already completed.
-    completed: HashSet<SignId>,
+    completed: ExpirationSet<SignId>,
     mesh_state: watch::Receiver<MeshState>,
 
     me: Participant,
@@ -1152,7 +1156,7 @@ impl SignatureSpawner {
                 // Skip if we already received a completion event for this request.
                 // This can happen when the completion arrives before the request due to
                 // finalization delays (e.g., Ethereum waiting for block finalization).
-                if self.completed.remove(&sign_id) {
+                if self.completed.contains(&sign_id) {
                     tracing::info!(?sign_id, "skipping sign request - already completed");
                     return;
                 }
@@ -1259,7 +1263,7 @@ impl SignatureSpawnerTask {
             me,
             tasks: JoinMap::new(),
             inboxes: HashMap::new(),
-            completed: HashSet::new(),
+            completed: ExpirationSet::new(COMPLETION_TTL),
             my_account_id: ctx.my_account_id.clone(),
             threshold,
             public_key,

--- a/chain-signatures/node/src/util.rs
+++ b/chain-signatures/node/src/util.rs
@@ -253,10 +253,11 @@ impl<K: Eq + Hash + Clone, V> ExpirationMap<K, V> {
         }
     }
 
-    pub fn insert(&mut self, key: K, value: V) {
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         self.evict_expired();
-        self.map.insert(key.clone(), value);
+        let old = self.map.insert(key.clone(), value);
         self.order.push_back((key, Instant::now()));
+        old
     }
 
     pub fn get(&mut self, key: &K) -> Option<&V> {
@@ -275,5 +276,29 @@ impl<K: Eq + Hash + Clone, V> ExpirationMap<K, V> {
 
     pub fn is_empty(&mut self) -> bool {
         self.len() == 0
+    }
+}
+
+pub struct ExpirationSet<K> {
+    inner: ExpirationMap<K, ()>,
+}
+
+impl<K: Eq + Hash + Clone> ExpirationSet<K> {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            inner: ExpirationMap::new(ttl),
+        }
+    }
+
+    pub fn insert(&mut self, key: K) -> bool {
+        self.inner.insert(key, ()).is_none()
+    }
+
+    pub fn remove(&mut self, key: &K) -> bool {
+        self.inner.remove(key).is_some()
+    }
+
+    pub fn contains(&mut self, key: &K) -> bool {
+        self.inner.get(key).is_some()
     }
 }

--- a/chain-signatures/node/src/util.rs
+++ b/chain-signatures/node/src/util.rs
@@ -5,7 +5,7 @@ use k256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use k256::{AffinePoint, EncodedPoint};
 use tokio::task::{AbortHandle, JoinSet};
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::hash::Hash;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -221,5 +221,59 @@ impl TimeoutBudget {
     pub fn reset(&mut self, timeout: Duration) {
         self.started = Instant::now();
         self.timeout = timeout;
+    }
+}
+
+pub struct ExpirationMap<K, V> {
+    ttl: Duration,
+    map: HashMap<K, V>,
+    order: VecDeque<(K, Instant)>,
+}
+
+impl<K, V> ExpirationMap<K, V> {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            ttl,
+            map: HashMap::new(),
+            order: VecDeque::new(),
+        }
+    }
+}
+
+impl<K: Eq + Hash + Clone, V> ExpirationMap<K, V> {
+    fn evict_expired(&mut self) {
+        let now = Instant::now();
+        while let Some((_, inserted_at)) = self.order.front() {
+            if now.duration_since(*inserted_at) < self.ttl {
+                break;
+            }
+
+            let (key, _) = self.order.pop_front().unwrap();
+            self.map.remove(&key);
+        }
+    }
+
+    pub fn insert(&mut self, key: K, value: V) {
+        self.evict_expired();
+        self.map.insert(key.clone(), value);
+        self.order.push_back((key, Instant::now()));
+    }
+
+    pub fn get(&mut self, key: &K) -> Option<&V> {
+        self.evict_expired();
+        self.map.get(key)
+    }
+
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        self.map.remove(key)
+    }
+
+    pub fn len(&mut self) -> usize {
+        self.evict_expired();
+        self.map.len()
+    }
+
+    pub fn is_empty(&mut self) -> bool {
+        self.len() == 0
     }
 }


### PR DESCRIPTION
This fixes a case where ethereum will observe the respond event before sending off the actual sign request to be processed by the SignatureSpawner due to waiting for finality for the request to be sent, meanwhile other nodes already had sent their request and thus completing the request faster than us seeing the finalized request.

A `completed: ExpirationSet` is used to keep track of sign requests that we've already received `Sign::Completion`s for from the indexer. This keeps the COMPLETION_TTL which is highest value for a finalized block for a chain we support. Currently default to 1 hour for future bitcoin integrations which has a practical finality of 1 hour.