### PR TITLE
fix: send tx on backlog recover

### DIFF
--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -655,7 +655,6 @@ pub enum BacklogError {
 pub struct SignTx {
     pub request_id: [u8; 32],
     pub source_chain: Chain,
-    pub key_version: u32,
     pub status: PendingRequestStatus,
     pub args: SignArgs,
 }

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -7,7 +7,7 @@ use crate::protocol::{Chain, SignRequestType};
 use crate::sign_bidirectional::{BidirectionalTx, BidirectionalTxId, PendingRequestStatus};
 use crate::storage::checkpoint_storage::CheckpointStorage;
 use anyhow::Context;
-use mpc_primitives::{PendingTx, SignId};
+use mpc_primitives::{PendingTx, SignArgs, SignId};
 use std::collections::{hash_map, HashMap};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -570,7 +570,7 @@ impl Backlog {
         node_client: &NodeClient,
         threshold: usize,
         chains: &[Chain],
-    ) {
+    ) -> HashMap<Chain, HashMap<SignId, BacklogTransaction>> {
         tracing::info!("attempting to recover from latest checkpoints via node selection");
 
         // Load local checkpoints first
@@ -606,7 +606,7 @@ impl Backlog {
 
         if checkpoints.is_empty() {
             tracing::info!("no selected checkpoints found, starting with empty state");
-            return;
+            return HashMap::new();
         }
 
         for (chain, checkpoint) in checkpoints {
@@ -623,6 +623,17 @@ impl Backlog {
                 );
             }
         }
+
+        // Snapshot pending requests for the requested chains
+        let requests = self.requests.read().await;
+        let mut recovered = HashMap::new();
+        for &chain in chains {
+            if let Some(pending) = requests.get(&chain) {
+                recovered.insert(chain, pending.requests.clone());
+            }
+        }
+
+        recovered
     }
 }
 
@@ -640,16 +651,17 @@ pub enum BacklogError {
 }
 
 /// Sign request transaction metadata (non-bidirectional).
-#[derive(Debug, Clone, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SignTx {
     pub request_id: [u8; 32],
     pub source_chain: Chain,
     pub key_version: u32,
     pub status: PendingRequestStatus,
+    pub args: SignArgs,
 }
 
 /// Pending transaction in the backlog - can be either a sign-only or bidirectional.
-#[derive(Debug, Clone, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum BacklogTransaction {
     Sign(SignTx),

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -657,6 +657,7 @@ pub struct SignTx {
     pub source_chain: Chain,
     pub status: PendingRequestStatus,
     pub args: SignArgs,
+    pub unix_timestamp_indexed: u64,
 }
 
 /// Pending transaction in the backlog - can be either a sign-only or bidirectional.

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -209,7 +209,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 .with_label_values(&[account_id.as_str()])
                 .set(digest);
 
-            let (sign_tx, sign_rx) = mpsc::channel(1024);
+            let (sign_tx, sign_rx) = mpsc::channel(16384);
 
             let gcp_service = GcpService::init(&account_id, &storage_options).await?;
 

--- a/chain-signatures/node/src/indexer_common.rs
+++ b/chain-signatures/node/src/indexer_common.rs
@@ -16,7 +16,6 @@ use crate::rpc::ContractStateWatcher;
 use crate::sign_bidirectional::BidirectionalTx;
 use crate::sign_bidirectional::BidirectionalTxId;
 use crate::sign_bidirectional::PendingRequestStatus;
-use crate::util::current_unix_timestamp;
 use anchor_lang::prelude::Pubkey;
 use k256::Scalar;
 use mpc_primitives::SignId;
@@ -246,6 +245,7 @@ pub(crate) async fn process_sign_event(
             source_chain: sign_event.source_chain(),
             status: PendingRequestStatus::AwaitingResponse,
             args: sign_request.args.clone(),
+            unix_timestamp_indexed: sign_request.unix_timestamp_indexed,
         }),
         SignRequestType::SignBidirectional(_event) => {
             // For bidirectional requests, start with a Sign transaction
@@ -255,6 +255,7 @@ pub(crate) async fn process_sign_event(
                 source_chain: sign_event.source_chain(),
                 status: PendingRequestStatus::AwaitingResponse,
                 args: sign_request.args.clone(),
+                unix_timestamp_indexed: sign_request.unix_timestamp_indexed,
             })
         }
         _ => anyhow::bail!("Unexpected sign request type"),
@@ -285,7 +286,6 @@ pub(crate) async fn process_sign_event(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn recover_backlog(
     backlog: &Backlog,
     contract_watcher: &mut ContractStateWatcher,
@@ -293,62 +293,58 @@ pub(crate) async fn recover_backlog(
     node_client: &NodeClient,
     source_chain: Chain,
     sign_tx: mpsc::Sender<Sign>,
-    node_near_account_id: AccountId,
     total_timeout: Duration,
 ) {
     // Recover backlog before doing anything.
     // Wait for threshold to be available
     let threshold = contract_watcher.wait_threshold().await;
-    if threshold > 0 {
-        wait_threshold_active(mesh_state, threshold).await;
+    if threshold == 0 {
+        return;
+    }
+    wait_threshold_active(mesh_state, threshold).await;
 
-        let mesh_state = mesh_state.borrow().clone();
-        let mut pending = backlog
-            .recover(&mesh_state, node_client, threshold, &[source_chain])
-            .await;
+    let mesh_state = mesh_state.borrow().clone();
+    let mut pending = backlog
+        .recover(&mesh_state, node_client, threshold, &[source_chain])
+        .await;
 
-        // Re-enqueue any pending sign requests so the node processes them after recovery
-        let pending = pending.remove(&source_chain).unwrap_or_default();
+    // Re-enqueue any pending sign requests so the node processes them after recovery
+    let pending = pending.remove(&source_chain).unwrap_or_default();
 
-        for (sign_id, tx) in pending
-            .into_iter()
-            .filter(|(_, tx)| matches!(tx.status(), PendingRequestStatus::AwaitingResponse))
-        {
-            let BacklogTransaction::Sign(sign_tx_entry) = tx else {
-                continue;
-            };
+    for (sign_id, tx) in pending
+        .into_iter()
+        .filter(|(_, tx)| matches!(tx.status(), PendingRequestStatus::AwaitingResponse))
+    {
+        let BacklogTransaction::Sign(sign_tx_entry) = tx else {
+            continue;
+        };
 
-            let Some(sign_type) = backlog.sign_type(source_chain, &sign_id).await else {
-                tracing::warn!(
-                    ?sign_id,
-                    ?source_chain,
-                    "sign type missing during backlog recovery"
-                );
-                continue;
-            };
+        let Some(sign_type) = backlog.sign_type(source_chain, &sign_id).await else {
+            tracing::warn!(
+                ?sign_id,
+                ?source_chain,
+                "sign type missing during backlog recovery"
+            );
+            continue;
+        };
 
-            let sign_request = IndexedSignRequest {
-                id: sign_id,
-                args: sign_tx_entry.args.clone(),
-                chain: sign_tx_entry.source_chain,
-                unix_timestamp_indexed: current_unix_timestamp(),
-                timestamp_sign_queue: Instant::now(),
-                total_timeout,
-                sign_request_type: sign_type,
-            };
+        let sign_request = IndexedSignRequest {
+            id: sign_id,
+            args: sign_tx_entry.args.clone(),
+            chain: sign_tx_entry.source_chain,
+            unix_timestamp_indexed: sign_tx_entry.unix_timestamp_indexed,
+            timestamp_sign_queue: Instant::now(),
+            total_timeout,
+            sign_request_type: sign_type,
+        };
 
-            if let Err(err) = sign_tx.send(Sign::Request(sign_request)).await {
-                tracing::error!(
-                    ?err,
-                    ?sign_id,
-                    ?source_chain,
-                    "failed to requeue sign request after recovery"
-                );
-            } else {
-                crate::metrics::requests::NUM_SIGN_REQUESTS
-                    .with_label_values(&[source_chain.as_str(), node_near_account_id.as_str()])
-                    .inc();
-            }
+        if let Err(err) = sign_tx.send(Sign::Request(sign_request)).await {
+            tracing::error!(
+                ?err,
+                ?sign_id,
+                ?source_chain,
+                "failed to requeue sign request after recovery"
+            );
         }
     }
 }
@@ -530,6 +526,7 @@ mod tests {
         };
 
         // Add a request and persist a checkpoint so recover() can load it
+        let unix_timestamp_indexed = current_unix_timestamp();
         backlog
             .insert(
                 Chain::Ethereum,
@@ -539,6 +536,7 @@ mod tests {
                     source_chain: Chain::Ethereum,
                     status: PendingRequestStatus::AwaitingResponse,
                     args: args.clone(),
+                    unix_timestamp_indexed,
                 }),
                 SignRequestType::Sign,
             )
@@ -571,7 +569,6 @@ mod tests {
             &node_client,
             Chain::Ethereum,
             sign_tx,
-            account_id,
             Duration::from_secs(5),
         )
         .await;
@@ -587,6 +584,8 @@ mod tests {
                 assert_eq!(req.args, args);
                 assert_eq!(req.chain, Chain::Ethereum);
                 assert_eq!(req.sign_request_type, SignRequestType::Sign);
+                // Verify that the unix_timestamp_indexed is preserved from the original entry
+                assert_eq!(req.unix_timestamp_indexed, unix_timestamp_indexed);
                 assert!(req.unix_timestamp_indexed <= current_unix_timestamp());
             }
             other => panic!("unexpected message: {:?}", other),

--- a/chain-signatures/node/src/indexer_common.rs
+++ b/chain-signatures/node/src/indexer_common.rs
@@ -502,3 +502,97 @@ pub(crate) fn sender_string(sender: [u8; 32], source_chain: Chain) -> anyhow::Re
         _ => anyhow::bail!("Unsupported chain: {source_chain}"),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backlog::Backlog;
+    use crate::mesh::wait_threshold_active;
+    use crate::node_client::NodeClient;
+    use crate::protocol::contract::primitives::{ParticipantInfo, Participants};
+    use crate::util::current_unix_timestamp;
+    use cait_sith::protocol::Participant;
+    use k256::ProjectivePoint;
+    use mpc_primitives::SignArgs;
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+    use tokio::time::timeout;
+
+    #[tokio::test]
+    async fn recover_backlog_requeues_pending_signs() {
+        // Prepare backlog with a single pending sign request
+        let backlog = Backlog::new();
+        let sign_id = SignId::new([9u8; 32]);
+        let args = SignArgs {
+            entropy: [1u8; 32],
+            epsilon: Scalar::from(1u64),
+            payload: Scalar::from(2u64),
+            path: "test".to_string(),
+            key_version: 1,
+        };
+
+        // Add a request and persist a checkpoint so recover() can load it
+        backlog
+            .insert(
+                Chain::Ethereum,
+                sign_id,
+                BacklogTransaction::Sign(SignTx {
+                    request_id: sign_id.request_id,
+                    source_chain: Chain::Ethereum,
+                    key_version: args.key_version,
+                    status: PendingRequestStatus::AwaitingResponse,
+                    args: args.clone(),
+                }),
+                SignRequestType::Sign,
+            )
+            .await;
+        backlog.checkpoint(Chain::Ethereum).await;
+
+        let threshold = 1;
+        let mut mesh_state = MeshState::default();
+        let participant = Participant::from(0u32);
+        mesh_state
+            .active
+            .insert(&participant, ParticipantInfo::new(0));
+        mesh_state.stable.insert(participant);
+        let (_mesh_tx, mut mesh_rx) = watch::channel(mesh_state);
+        wait_threshold_active(&mut mesh_rx, threshold).await;
+
+        let account_id: AccountId = "test.near".parse().unwrap();
+        let public_key = ProjectivePoint::GENERATOR.to_affine();
+        let participants = Participants::default();
+        let (mut contract_watcher, _tx) =
+            ContractStateWatcher::with_running(&account_id, public_key, threshold, participants);
+
+        let (sign_tx, mut sign_rx) = mpsc::channel(4);
+        let node_client = NodeClient::new(&Default::default());
+
+        recover_backlog(
+            &backlog,
+            &mut contract_watcher,
+            &mut mesh_rx,
+            &node_client,
+            Chain::Ethereum,
+            sign_tx,
+            account_id,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        // We should receive the recovered sign request
+        let msg = timeout(Duration::from_secs(1), sign_rx.recv())
+            .await
+            .expect("recv should not timeout");
+
+        match msg.expect("sign_rx should contain a message") {
+            Sign::Request(req) => {
+                assert_eq!(req.id, sign_id);
+                assert_eq!(req.args, args);
+                assert_eq!(req.chain, Chain::Ethereum);
+                assert_eq!(req.sign_request_type, SignRequestType::Sign);
+                assert!(req.unix_timestamp_indexed <= current_unix_timestamp());
+            }
+            other => panic!("unexpected message: {:?}", other),
+        }
+    }
+}

--- a/chain-signatures/node/src/indexer_common.rs
+++ b/chain-signatures/node/src/indexer_common.rs
@@ -16,13 +16,14 @@ use crate::rpc::ContractStateWatcher;
 use crate::sign_bidirectional::BidirectionalTx;
 use crate::sign_bidirectional::BidirectionalTxId;
 use crate::sign_bidirectional::PendingRequestStatus;
+use crate::util::current_unix_timestamp;
 use anchor_lang::prelude::Pubkey;
 use k256::Scalar;
 use mpc_primitives::SignId;
 use mpc_primitives::Signature;
 use near_account_id::AccountId;
 use std::str::FromStr;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tokio::sync::watch;
 
@@ -245,6 +246,7 @@ pub(crate) async fn process_sign_event(
             source_chain: sign_event.source_chain(),
             key_version: sign_request.args.key_version,
             status: PendingRequestStatus::AwaitingResponse,
+            args: sign_request.args.clone(),
         }),
         SignRequestType::SignBidirectional(_event) => {
             // For bidirectional requests, start with a Sign transaction
@@ -254,6 +256,7 @@ pub(crate) async fn process_sign_event(
                 source_chain: sign_event.source_chain(),
                 key_version: sign_request.args.key_version,
                 status: PendingRequestStatus::AwaitingResponse,
+                args: sign_request.args.clone(),
             })
         }
         _ => anyhow::bail!("Unexpected sign request type"),
@@ -284,12 +287,16 @@ pub(crate) async fn process_sign_event(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn recover_backlog(
     backlog: &Backlog,
     contract_watcher: &mut ContractStateWatcher,
     mesh_state: &mut watch::Receiver<MeshState>,
     node_client: &NodeClient,
     source_chain: Chain,
+    sign_tx: mpsc::Sender<Sign>,
+    node_near_account_id: AccountId,
+    total_timeout: Duration,
 ) {
     // Recover backlog before doing anything.
     // Wait for threshold to be available
@@ -298,9 +305,53 @@ pub(crate) async fn recover_backlog(
         wait_threshold_active(mesh_state, threshold).await;
 
         let mesh_state = mesh_state.borrow().clone();
-        backlog
+        let mut pending = backlog
             .recover(&mesh_state, node_client, threshold, &[source_chain])
             .await;
+
+        // Re-enqueue any pending sign requests so the node processes them after recovery
+        let pending = pending.remove(&source_chain).unwrap_or_default();
+
+        for (sign_id, tx) in pending
+            .into_iter()
+            .filter(|(_, tx)| matches!(tx.status(), PendingRequestStatus::AwaitingResponse))
+        {
+            let BacklogTransaction::Sign(sign_tx_entry) = tx else {
+                continue;
+            };
+
+            let Some(sign_type) = backlog.sign_type(source_chain, &sign_id).await else {
+                tracing::warn!(
+                    ?sign_id,
+                    ?source_chain,
+                    "sign type missing during backlog recovery"
+                );
+                continue;
+            };
+
+            let sign_request = IndexedSignRequest {
+                id: sign_id,
+                args: sign_tx_entry.args.clone(),
+                chain: sign_tx_entry.source_chain,
+                unix_timestamp_indexed: current_unix_timestamp(),
+                timestamp_sign_queue: Instant::now(),
+                total_timeout,
+                sign_request_type: sign_type,
+            };
+
+            if let Err(err) = sign_tx.send(Sign::Request(sign_request)).await {
+                tracing::error!(
+                    ?err,
+                    ?sign_id,
+                    ?source_chain,
+                    "failed to requeue sign request after recovery"
+                );
+            } else {
+                crate::metrics::requests::NUM_SIGN_REQUESTS
+                    .with_label_values(&[source_chain.as_str(), node_near_account_id.as_str()])
+                    .inc();
+            }
+        }
     }
 }
 

--- a/chain-signatures/node/src/indexer_common.rs
+++ b/chain-signatures/node/src/indexer_common.rs
@@ -244,7 +244,6 @@ pub(crate) async fn process_sign_event(
         SignRequestType::Sign => BacklogTransaction::Sign(SignTx {
             request_id: sign_id.request_id,
             source_chain: sign_event.source_chain(),
-            key_version: sign_request.args.key_version,
             status: PendingRequestStatus::AwaitingResponse,
             args: sign_request.args.clone(),
         }),
@@ -254,7 +253,6 @@ pub(crate) async fn process_sign_event(
             BacklogTransaction::Sign(SignTx {
                 request_id: sign_id.request_id,
                 source_chain: sign_event.source_chain(),
-                key_version: sign_request.args.key_version,
                 status: PendingRequestStatus::AwaitingResponse,
                 args: sign_request.args.clone(),
             })
@@ -539,7 +537,6 @@ mod tests {
                 BacklogTransaction::Sign(SignTx {
                     request_id: sign_id.request_id,
                     source_chain: Chain::Ethereum,
-                    key_version: args.key_version,
                     status: PendingRequestStatus::AwaitingResponse,
                     args: args.clone(),
                 }),

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -732,12 +732,17 @@ impl EthereumIndexer {
         let sign_tx = self.sign_tx;
         let node_near_account_id = self.node_near_account_id;
 
+        let total_timeout = Duration::from_secs(eth.total_timeout);
+
         crate::indexer_common::recover_backlog(
             &backlog,
             &mut contract_watcher,
             &mut mesh_state,
             &node_client,
             Chain::Ethereum,
+            sign_tx.clone(),
+            node_near_account_id.clone(),
+            total_timeout,
         )
         .await;
 
@@ -758,8 +763,6 @@ impl EthereumIndexer {
             );
             return;
         };
-        let total_timeout = Duration::from_secs(eth.total_timeout);
-
         let (blocks_failed_send, blocks_failed_recv) = failed_blocks_channel();
 
         let (requests_indexed_send, requests_indexed_recv) = indexed_channel();

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -741,7 +741,6 @@ impl EthereumIndexer {
             &node_client,
             Chain::Ethereum,
             sign_tx.clone(),
-            node_near_account_id.clone(),
             total_timeout,
         )
         .await;

--- a/chain-signatures/node/src/indexer_hydration.rs
+++ b/chain-signatures/node/src/indexer_hydration.rs
@@ -420,6 +420,9 @@ pub async fn run(
         &mut mesh_state,
         &node_client,
         Chain::Hydration,
+        sign_tx.clone(),
+        node_near_account_id.clone(),
+        total_timeout,
     )
     .await;
 

--- a/chain-signatures/node/src/indexer_hydration.rs
+++ b/chain-signatures/node/src/indexer_hydration.rs
@@ -421,7 +421,6 @@ pub async fn run(
         &node_client,
         Chain::Hydration,
         sign_tx.clone(),
-        node_near_account_id.clone(),
         total_timeout,
     )
     .await;

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -347,6 +347,8 @@ pub async fn run(
         return;
     };
 
+    let total_timeout = Duration::from_secs(sol.total_timeout);
+
     // Wait for threshold to be available
     crate::indexer_common::recover_backlog(
         &backlog,
@@ -354,6 +356,9 @@ pub async fn run(
         &mut mesh_state,
         &node_client,
         Chain::Solana,
+        sign_tx.clone(),
+        node_near_account_id.clone(),
+        total_timeout,
     )
     .await;
 
@@ -368,8 +373,6 @@ pub async fn run(
         sol.rpc_ws_url,
         program_id
     );
-
-    let total_timeout = Duration::from_secs(sol.total_timeout);
 
     // Clone sol for respond events subscription
     let sol_for_respond = sol.clone();

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -357,7 +357,6 @@ pub async fn run(
         &node_client,
         Chain::Solana,
         sign_tx.clone(),
-        node_near_account_id.clone(),
         total_timeout,
     )
     .await;

--- a/chain-signatures/node/src/storage/checkpoint_storage.rs
+++ b/chain-signatures/node/src/storage/checkpoint_storage.rs
@@ -10,6 +10,8 @@ use tokio::sync::RwLock;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+const CHECKPOINT_VERSION: &str = "v0";
+
 #[derive(Clone, Debug)]
 pub enum CheckpointStorage {
     Redis(Pool, AccountId),
@@ -30,7 +32,7 @@ impl CheckpointStorage {
     fn checkpoint_key(&self, chain: Chain) -> String {
         match self {
             CheckpointStorage::Redis(_, account_id) => {
-                format!("{account_id}:checkpoint:latest:{chain}")
+                format!("{account_id}:checkpoint:latest:{CHECKPOINT_VERSION}:{chain}")
             }
             CheckpointStorage::InMemory(_) => format!("checkpoint:latest:{chain}"),
         }


### PR DESCRIPTION
We weren't sending the recovered sign request back into the sign queue when we restart the node, so this will do that. Also added a unit test to make sure that we are indeed recovering.

Note, this is a breaking change on the checkpoint serialization/persistence since `SignArgs` was added so we could recover it into a `IndexedSignRequest`. Also bumped the sign channel to ~16000 so we don't drop anything beyond ~1000. Will probably make it unbounded in another PR so we can always have guaranteed signature delivery

Also looks like `total_timeout` seems to still be in the indexers so will remove that in a different PR.