### PR TITLE
Update LT strategies

### DIFF
--- a/.github/workflows/k6-ci-loadtest.yml
+++ b/.github/workflows/k6-ci-loadtest.yml
@@ -17,13 +17,19 @@ on:
       lt_strategy:
         type: choice
         options:
-          - constant_low_rate_1h
-          - constant_medium_rate_1h
-          - constant_high_rate_1h
-          - ramping_low_rate_1h
-          - ramping_medium_rate_1h
-          - ramping_high_rate_1h
-        default: ramping_high_rate_1h
+          - rps_0_1
+          - rps_1
+          - rps_5
+          - rps_10
+        default: rps_5
+        required: true
+      lt_duration:
+        type: choice
+        options:
+          - 5m
+          - 20m
+          - 1h
+        default: 20m
         required: true
       environment:
         type: choice
@@ -38,7 +44,6 @@ on:
         options:
           - Solana
           - Ethereum
-          - NEAR
         default: Solana
         required: true
       check_signature:
@@ -51,9 +56,9 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     runs-on: ${{ github.event_name == 'schedule' && 'arc-runners-arc-runner-set' || 'ubuntu-latest' }}
     steps:
-      - name: Wait for 5 minutes due to new version deployment
+      - name: Wait for 1 hour due to new version deployment
         if: ${{ github.event.pull_request.merged == true }}
-        run: sleep 300
+        run: sleep 3600
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -61,22 +66,32 @@ jobs:
       - name: Normalize inputs
         id: normalized
         run: |
-          # Set defaults based on event type
+          # Set defaults based on event type (schedule, pull_request, else)
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             echo "lt_chain=${CHAIN:-Solana}" >> "$GITHUB_OUTPUT"
             echo "lt_env=${ENV:-dev}" >> "$GITHUB_OUTPUT"
-            echo "lt_strategy=${STRATEGY:-constant_medium_rate_1h}" >> "$GITHUB_OUTPUT"
+            echo "lt_strategy=${STRATEGY:-rps_0_1}" >> "$GITHUB_OUTPUT"
+            echo "lt_duration=${DURATION:-1h}" >> "$GITHUB_OUTPUT"
+            echo "lt_check_signature=${CHECK_SIGNATURE:-true}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # Short PR-friendly defaults
+            echo "lt_chain=${CHAIN:-Solana}" >> "$GITHUB_OUTPUT"
+            echo "lt_env=${ENV:-dev}" >> "$GITHUB_OUTPUT"
+            echo "lt_strategy=${STRATEGY:-rps_5}" >> "$GITHUB_OUTPUT"
+            echo "lt_duration=${DURATION:-5m}" >> "$GITHUB_OUTPUT"
             echo "lt_check_signature=${CHECK_SIGNATURE:-true}" >> "$GITHUB_OUTPUT"
           else
             echo "lt_chain=${CHAIN:-Solana}" >> "$GITHUB_OUTPUT"
             echo "lt_env=${ENV:-dev}" >> "$GITHUB_OUTPUT"
-            echo "lt_strategy=${STRATEGY:-ramping_high_rate_1h}" >> "$GITHUB_OUTPUT"
+            echo "lt_strategy=${STRATEGY:-rps_0_1}" >> "$GITHUB_OUTPUT"
+            echo "lt_duration=${DURATION:-20m}" >> "$GITHUB_OUTPUT"
             echo "lt_check_signature=${CHECK_SIGNATURE:-true}" >> "$GITHUB_OUTPUT"
           fi
         env:
           CHAIN: ${{ github.event.inputs.chain }}
           ENV: ${{ github.event.inputs.environment }}
           STRATEGY: ${{ github.event.inputs.lt_strategy }}
+          DURATION: ${{ github.event.inputs.lt_duration }}
           CHECK_SIGNATURE: ${{ github.event.inputs.check_signature }}
 
       - name: Setup K6
@@ -90,8 +105,9 @@ jobs:
           LT_PINGER_API_KEY: ${{ secrets.LT_PINGER_API_KEY }}
           LT_CHAIN: ${{ steps.normalized.outputs.lt_chain }}
           LT_CHAIN_ENV: ${{ steps.normalized.outputs.lt_env }}
-          LT_CHECK_SIGNATURE: ${{ steps.normalized.outputs.lt_check_signature == 'true' }}
+          LT_CHECK_SIGNATURE: ${{ steps.normalized.outputs.lt_check_signature }}
           LT_STRATEGY: ${{ steps.normalized.outputs.lt_strategy }}
+          LT_DURATION: ${{ steps.normalized.outputs.lt_duration }}
         with:
           path: ./infra/loadtests/k6-load-test.js
           cloud-run-locally: ${{ github.event_name == 'schedule' && 'true' || 'false' }}

--- a/infra/loadtests/k6-load-test.js
+++ b/infra/loadtests/k6-load-test.js
@@ -1,154 +1,102 @@
 import http from 'k6/http';
-import { group } from 'k6';
+import { check, fail } from 'k6';
 
 const PINGER_URL = "https://contract-ping.sig.network/ping";
 
 const strategies = {
-  constant_low_rate_1h: {
+  "rps_0_1": {
     scenarios: {
-      ramping_smoke: {
-        executor: 'ramping-arrival-rate',
-        startRate: 1,
-        timeUnit: '5m',
-        preAllocatedVUs: 1,
-        maxVUs: 10,
-        stages: [
-          { duration: '1m', target: 1 },
-          { duration: '58m', target: 1 },
-          { duration: '1m', target: 0 },
-        ],
-      },
-    },
-    thresholds: {
-      http_req_failed: ['rate<0.03'],
-      http_req_duration: ['p(95)<1500'],
-    },
-  },
-  constant_medium_rate_1h: {
-    scenarios: {
-      ramping_smoke: {
-        executor: 'ramping-arrival-rate',
-        startRate: 1,
-        timeUnit: '10s',
-        preAllocatedVUs: 2,
-        maxVUs: 10,
-        stages: [
-          { duration: '1m', target: 1 },
-          { duration: '58m', target: 1 },
-          { duration: '1m', target: 0 },
-        ],
-      },
-    },
-    thresholds: {
-      http_req_failed: ['rate<0.03'],
-      http_req_duration: ['p(95)<1500'],
-    },
-  },
-  constant_high_rate_1h: {
-    scenarios: {
-      ramping_smoke: {
-        executor: 'ramping-arrival-rate',
-        startRate: 1,
-        timeUnit: '1s',
-        preAllocatedVUs: 5,
-        maxVUs: 20,
-        stages: [
-          { duration: '1m', target: 1 },
-          { duration: '58m', target: 1 },
-          { duration: '1m', target: 0 },
-        ],
-      },
-    },
-    thresholds: {
-      http_req_failed: ['rate<0.03'],
-      http_req_duration: ['p(95)<1500'],
-    },
-  },
-  ramping_low_rate_1h: {
-    scenarios: {
-      ramping_smoke: {
-        executor: 'ramping-arrival-rate',
-        startRate: 0,
+      smoke: {
+        executor: 'constant-arrival-rate',
+        rate: 6,
         timeUnit: '1m',
         preAllocatedVUs: 1,
         maxVUs: 10,
-        stages: [
-          { duration: '10m', target: 1 },
-          { duration: '10m', target: 3 },
-          { duration: '10m', target: 1 },
-          { duration: '10m', target: 3 },
-          { duration: '10m', target: 1 },
-          { duration: '10m', target: 0 },
-        ],
       },
     },
     thresholds: {
       http_req_failed: ['rate<0.03'],
-      http_req_duration: ['p(95)<1500'],
+      http_req_duration: ['p(95)<10000'],
     },
   },
-  ramping_medium_rate_1h: {
+  "rps_1": {
     scenarios: {
-      ramping_smoke: {
-        executor: 'ramping-arrival-rate',
-        startRate: 1,
-        timeUnit: '1s',
-        preAllocatedVUs: 5,
+      smoke: {
+        executor: 'constant-arrival-rate',
+        rate: 60,
+        timeUnit: '1m',
+        preAllocatedVUs: 2,
+        maxVUs: 20,
+      },
+    },
+    thresholds: {
+      http_req_failed: ['rate<0.03'],
+      http_req_duration: ['p(95)<10000'],
+    },
+  },
+  "rps_5": {
+    scenarios: {
+      smoke: {
+        executor: 'constant-arrival-rate',
+        rate: 300,
+        timeUnit: '1m',
+        preAllocatedVUs: 10,
         maxVUs: 50,
-        stages: [
-          { duration: '10m', target: 1 },
-          { duration: '10m', target: 3 },
-          { duration: '10m', target: 1 },
-          { duration: '10m', target: 3 },
-          { duration: '10m', target: 1 },
-          { duration: '10m', target: 0 },
-        ],
       },
     },
     thresholds: {
       http_req_failed: ['rate<0.03'],
-      http_req_duration: ['p(95)<1500'],
+      http_req_duration: ['p(95)<10000'],
     },
   },
-  ramping_high_rate_1h: {
+  "rps_10": {
     scenarios: {
-      ramping_smoke: {
-        executor: 'ramping-arrival-rate',
-        startRate: 1,
-        timeUnit: '1s',
+      smoke: {
+        executor: 'constant-arrival-rate',
+        rate: 600,
+        timeUnit: '1m',
         preAllocatedVUs: 20,
         maxVUs: 100,
-        stages: [
-          { duration: '10m', target: 1 },
-          { duration: '10m', target: 2 },
-          { duration: '10m', target: 3 },
-          { duration: '10m', target: 4 },
-          { duration: '10m', target: 5 },
-          { duration: '10m', target: 0 },
-        ],
       },
     },
     thresholds: {
       http_req_failed: ['rate<0.03'],
-      http_req_duration: ['p(95)<1500'],
+      http_req_duration: ['p(95)<10000'],
     },
   },
+
 };
 
-export const options = strategies[__ENV.LT_STRATEGY] || (() => {
-  throw new Error(`Invalid or missing LT_STRATEGY environment variable: ${__ENV.LT_STRATEGY}`);
+export const options = (() => {
+  const key = __ENV.LT_STRATEGY;
+  if (!key) {
+    throw new Error(`Invalid or missing LT_STRATEGY environment variable: ${__ENV.LT_STRATEGY}`);
+  }
+  const base = strategies[key];
+  if (!base) {
+    throw new Error(`Unknown LT_STRATEGY: ${key}`);
+  }
+  const duration = __ENV.LT_DURATION || '1h';
+  // Deep clone to avoid mutating the shared `strategies` object
+  const opts = JSON.parse(JSON.stringify(base));
+  for (const scen of Object.keys(opts.scenarios || {})) {
+    opts.scenarios[scen].duration = duration;
+  }
+  return opts;
 })();
 
 
 export default function () {
   let chain = __ENV.LT_CHAIN;
   let env = __ENV.LT_CHAIN_ENV;
-  let check = __ENV.LT_CHECK_SIGNATURE === 'true'; // Convert string to boolean
-
-  if (!chain || !env || !check) {
-    console.error(`One or more required environment variables are not set: chain ${chain}, env ${env}, check ${check}`);
+  // LT_CHECK_SIGNATURE should be provided as the literal string 'true' or 'false'.
+  // Validate presence separately from its boolean value so that a deliberate 'false' is accepted.
+  let checkRaw = __ENV.LT_CHECK_SIGNATURE;
+  if (chain == null || env == null || checkRaw == null) {
+    console.error(`One or more required environment variables are not set: chain ${chain}, env ${env}, check ${checkRaw}`);
     throw new Error("Missing required environment variables. Exiting script.");
   }
+  let check = checkRaw === 'true';
 
   let params = JSON.stringify({
     chain: chain,
@@ -165,9 +113,17 @@ export default function () {
     },
   });
 
-  if (response.status >= 200 && response.status < 300) {
-    console.log(`Status ${response.status}, Body: ${response.body}`);
-  } else {
-    console.error(`Request failed with status ${response.status}, Body: ${response.body}`);
+  // Validate response content and status. Mark run as failed on critical validation failure.
+  const ok = check(response, {
+    'status is 2xx': (r) => r.status >= 200 && r.status < 300,
+    'body not empty': (r) => !!(r.body && r.body.length > 0),
+  });
+
+  if (!ok) {
+    console.error(`Validation failed for response. status=${response.status}, body=${response.body}`);
+    fail(`Critical validation failed for k6 run (status ${response.status})`);
   }
+
+  // Minimal success logging to avoid noisy CI logs for long runs
+  console.log(`Status ${response.status}`);
 }


### PR DESCRIPTION
- Move away from ramping strategies, they do not make much sense now
- Specify RPS in names for clarity
- Allow to choose RPC and DURATION separately
- Remove NEAR option
- Update load values and CI defaults
- Change PR run to: 5 RPS for 5M after 1 Hour delay (for deployment)
- Better error handling