### PR TITLE
Use unix_timestamp_indexed instead of timestamp_sign_queue for metrics

### DIFF
--- a/chain-signatures/node/src/indexer_common.rs
+++ b/chain-signatures/node/src/indexer_common.rs
@@ -504,6 +504,7 @@ mod tests {
     use cait_sith::protocol::Participant;
     use k256::ProjectivePoint;
     use mpc_primitives::SignArgs;
+    use near_primitives::types::AccountId;
     use std::time::Duration;
     use tokio::sync::mpsc;
     use tokio::time::timeout;

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -46,7 +46,12 @@ pub struct IndexedSignRequest {
     pub id: SignId,
     pub args: SignArgs,
     pub chain: Chain,
+    /// Unix timestamp when the request was indexed by MPC node.
+    /// Preserved across recoveries to maintain original request creation time.
     pub unix_timestamp_indexed: u64,
+    /// Monotonic system time when the request entered the signing queue.
+    /// Used for internal timeout enforcement and latency tracking.
+    /// Updated on recovery/requeue to current system time.
     pub timestamp_sign_queue: Instant,
     pub total_timeout: Duration,
     pub sign_request_type: SignRequestType,
@@ -1137,20 +1142,26 @@ impl SignatureSpawner {
         // Spawn a reactive watcher task that increments the delayed metric
         // if the signature is not completed within the expected response time
         let chain = indexed.chain;
-        let timestamp_sign_queue = indexed.timestamp_sign_queue;
-        let expected_response_time = Duration::from_secs(chain.expected_response_time_secs());
-        let already_elapsed = timestamp_sign_queue.elapsed();
-        let remaining_time = expected_response_time.saturating_sub(already_elapsed);
+        let unix_timestamp_indexed = indexed.unix_timestamp_indexed;
+        let expected_response_time_secs = chain.expected_response_time_secs();
+        let current_timestamp = crate::util::current_unix_timestamp();
+        let already_elapsed =
+            crate::util::duration_between_unix(unix_timestamp_indexed, current_timestamp);
+        let remaining_time =
+            Duration::from_secs(expected_response_time_secs as u64).saturating_sub(already_elapsed);
         // prevent incrementing delayed metric for already delayed requests
         if remaining_time > Duration::from_secs(0) {
             let watcher = tokio::spawn(async move {
                 tokio::time::sleep(remaining_time).await;
-                let elapsed = timestamp_sign_queue.elapsed();
+                let elapsed = crate::util::duration_between_unix(
+                    unix_timestamp_indexed,
+                    crate::util::current_unix_timestamp(),
+                );
                 tracing::warn!(
                     ?sign_id,
                     ?chain,
                     elapsed_secs = elapsed.as_secs(),
-                    expected_secs = expected_response_time.as_secs(),
+                    expected_secs = expected_response_time_secs,
                     "signature request delayed beyond expected response time"
                 );
                 crate::metrics::requests::NUM_SIGN_REQUESTS_MINE_DELAYED

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -1148,7 +1148,7 @@ impl SignatureSpawner {
         let already_elapsed =
             crate::util::duration_between_unix(unix_timestamp_indexed, current_timestamp);
         let remaining_time =
-            Duration::from_secs(expected_response_time_secs as u64).saturating_sub(already_elapsed);
+            Duration::from_secs(expected_response_time_secs).saturating_sub(already_elapsed);
         // prevent incrementing delayed metric for already delayed requests
         if remaining_time > Duration::from_secs(0) {
             let watcher = tokio::spawn(async move {

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -979,7 +979,10 @@ async fn execute_publish(client: ChainClient, mut action: PublishAction, backlog
 
     let chain_str = chain.as_str();
     if publish_result.is_ok() {
-        let elapsed = action.indexed.timestamp_sign_queue.elapsed();
+        let elapsed = crate::util::duration_between_unix(
+            action.indexed.unix_timestamp_indexed,
+            crate::util::current_unix_timestamp(),
+        );
         if elapsed.as_secs() <= chain.expected_response_time_secs() {
             crate::metrics::requests::NUM_SIGN_REQUESTS_MINE_IN_TIME
                 .with_label_values(&[chain_str, node_account_id()])
@@ -1440,9 +1443,13 @@ async fn execute_batch_publish(
         };
         if publish.is_ok() {
             // Record metrics for successful batch publish
+            let current_timestamp = crate::util::current_unix_timestamp();
             for action in actions.iter() {
                 let chain = action.indexed.chain;
-                let elapsed = action.indexed.timestamp_sign_queue.elapsed();
+                let elapsed = crate::util::duration_between_unix(
+                    action.indexed.unix_timestamp_indexed,
+                    current_timestamp,
+                );
                 if elapsed.as_secs() <= chain.expected_response_time_secs() {
                     crate::metrics::requests::NUM_SIGN_REQUESTS_MINE_IN_TIME
                         .with_label_values(&[chain.as_str(), node_account_id()])


### PR DESCRIPTION
`timestamp_sign_queue` is reiintialized in request recovery, what we need is a real delay that is experienced by the user
The downside is that we are loosing the precision (1s now)