### PR TITLE
Request latancies

### DIFF
--- a/chain-signatures/node/src/indexer.rs
+++ b/chain-signatures/node/src/indexer.rs
@@ -199,10 +199,6 @@ async fn poll_pending_requests(ctx: &mut Context) -> anyhow::Result<()> {
         );
         if let Err(err) = ctx.sign_tx.send(Sign::Request(request)).await {
             tracing::error!(?err, "failed to send the sign request into sign queue");
-        } else {
-            crate::metrics::requests::NUM_SIGN_REQUESTS
-                .with_label_values(&[Chain::NEAR.as_str()])
-                .inc();
         }
     }
 

--- a/chain-signatures/node/src/indexer.rs
+++ b/chain-signatures/node/src/indexer.rs
@@ -122,7 +122,7 @@ impl NearIndexer {
             },
             chain: Chain::NEAR,
             unix_timestamp_indexed: crate::util::current_unix_timestamp(),
-            timestamp_indexed: Instant::now(),
+            timestamp_created: Instant::now(),
             total_timeout: Duration::from_secs(200),
             sign_request_type: crate::protocol::SignRequestType::Sign,
         }

--- a/chain-signatures/node/src/indexer.rs
+++ b/chain-signatures/node/src/indexer.rs
@@ -122,7 +122,7 @@ impl NearIndexer {
             },
             chain: Chain::NEAR,
             unix_timestamp_indexed: crate::util::current_unix_timestamp(),
-            timestamp_sign_queue: Instant::now(),
+            timestamp_indexed: Instant::now(),
             total_timeout: Duration::from_secs(200),
             sign_request_type: crate::protocol::SignRequestType::Sign,
         }

--- a/chain-signatures/node/src/indexer_common.rs
+++ b/chain-signatures/node/src/indexer_common.rs
@@ -273,10 +273,6 @@ pub(crate) async fn process_sign_event(
         // TODO: handle error to ensure 100% success rate
         let chain = sign_event.source_chain();
         tracing::error!(?err, chain = %chain, "Failed to send {} sign request into queue", chain.as_str());
-    } else {
-        crate::metrics::requests::NUM_SIGN_REQUESTS
-            .with_label_values(&[sign_event.source_chain().as_str()])
-            .inc();
     }
 
     Ok(())

--- a/chain-signatures/node/src/indexer_common.rs
+++ b/chain-signatures/node/src/indexer_common.rs
@@ -7,6 +7,7 @@ use crate::indexer_hydration::{
 };
 use crate::mesh::wait_threshold_active;
 use crate::mesh::MeshState;
+use crate::metrics::requests::{record_request_latency, SignRequestStep};
 
 use crate::node_client::NodeClient;
 use crate::protocol::Chain;
@@ -22,6 +23,7 @@ use k256::Scalar;
 use mpc_primitives::SignId;
 use mpc_primitives::Signature;
 use std::str::FromStr;
+use std::time::SystemTime;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tokio::sync::watch;
@@ -232,6 +234,15 @@ pub(crate) async fn process_sign_event(
     backlog: Backlog,
 ) -> anyhow::Result<()> {
     let sign_request = sign_event.generate_sign_request(entropy, total_timeout)?;
+
+    record_request_latency(
+        sign_event.source_chain(),
+        SignRequestStep::Indexing,
+        "ok",
+        // Note: we need to pass actual indexing time here,
+        // may not be supported for all chains
+        SystemTime::now(),
+    );
 
     // Insert the transaction into the backlog when we first see the sign request
     let sign_id = sign_request.id;

--- a/chain-signatures/node/src/indexer_common.rs
+++ b/chain-signatures/node/src/indexer_common.rs
@@ -7,7 +7,7 @@ use crate::indexer_hydration::{
 };
 use crate::mesh::wait_threshold_active;
 use crate::mesh::MeshState;
-use crate::metrics::requests::{record_request_latency, SignRequestStep};
+use crate::metrics::requests::record_indexing_step_reached;
 
 use crate::node_client::NodeClient;
 use crate::protocol::Chain;
@@ -23,7 +23,6 @@ use k256::Scalar;
 use mpc_primitives::SignId;
 use mpc_primitives::Signature;
 use std::str::FromStr;
-use std::time::SystemTime;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tokio::sync::watch;
@@ -235,14 +234,7 @@ pub(crate) async fn process_sign_event(
 ) -> anyhow::Result<()> {
     let sign_request = sign_event.generate_sign_request(entropy, total_timeout)?;
 
-    record_request_latency(
-        sign_event.source_chain(),
-        SignRequestStep::Indexing,
-        "ok",
-        // Note: we need to pass actual indexing time here,
-        // may not be supported for all chains
-        SystemTime::now(),
-    );
+    record_indexing_step_reached(sign_event.source_chain());
 
     // Insert the transaction into the backlog when we first see the sign request
     let sign_id = sign_request.id;
@@ -336,7 +328,7 @@ pub(crate) async fn recover_backlog(
             args: sign_tx_entry.args.clone(),
             chain: sign_tx_entry.source_chain,
             unix_timestamp_indexed: sign_tx_entry.unix_timestamp_indexed,
-            timestamp_indexed: Instant::now(),
+            timestamp_created: Instant::now(),
             total_timeout,
             sign_request_type: sign_type,
         };

--- a/chain-signatures/node/src/indexer_common.rs
+++ b/chain-signatures/node/src/indexer_common.rs
@@ -325,7 +325,7 @@ pub(crate) async fn recover_backlog(
             args: sign_tx_entry.args.clone(),
             chain: sign_tx_entry.source_chain,
             unix_timestamp_indexed: sign_tx_entry.unix_timestamp_indexed,
-            timestamp_sign_queue: Instant::now(),
+            timestamp_indexed: Instant::now(),
             total_timeout,
             sign_request_type: sign_type,
         };

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -394,7 +394,7 @@ fn sign_request_from_filtered_log(log: Log, total_timeout: Duration) -> Option<I
         },
         chain: Chain::Ethereum,
         unix_timestamp_indexed: crate::util::current_unix_timestamp(),
-        timestamp_indexed: Instant::now(),
+        timestamp_created: Instant::now(),
         total_timeout,
         sign_request_type: SignRequestType::Sign,
     })

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -394,7 +394,7 @@ fn sign_request_from_filtered_log(log: Log, total_timeout: Duration) -> Option<I
         },
         chain: Chain::Ethereum,
         unix_timestamp_indexed: crate::util::current_unix_timestamp(),
-        timestamp_sign_queue: Instant::now(),
+        timestamp_indexed: Instant::now(),
         total_timeout,
         sign_request_type: SignRequestType::Sign,
     })

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -4,6 +4,7 @@ pub mod indexer_eth_helios;
 use crate::backlog::Backlog;
 use crate::mesh::MeshState;
 
+use crate::metrics::requests::{record_request_latency, SignRequestStep};
 use crate::node_client::NodeClient;
 use crate::protocol::{Chain, IndexedSignRequest, Sign, SignRequestType};
 use crate::respond_bidirectional::CompletedTx;
@@ -542,15 +543,8 @@ fn send_indexed_requests_to_sign_queue(
     for request in requests {
         let sign_tx = sign_tx.clone();
         tokio::spawn(async move {
-            match sign_tx.send(Sign::Request(request)).await {
-                Ok(_) => {
-                    crate::metrics::requests::NUM_SIGN_REQUESTS
-                        .with_label_values(&[Chain::Ethereum.as_str()])
-                        .inc();
-                }
-                Err(err) => {
-                    tracing::error!(?err, "Failed to send ETH sign request into queue");
-                }
+            if let Err(err) = sign_tx.send(Sign::Request(request)).await {
+                tracing::error!(?err, "Failed to send ETH sign request into queue");
             }
         });
     }
@@ -929,17 +923,17 @@ impl EthereumIndexer {
             block_number,
             block_hash
         );
-        let start = Instant::now();
-        let block_receipts_result = client.get_block_receipts(block_number.into()).await;
-        crate::metrics::indexers::ETH_BLOCK_RECEIPT_LATENCY
-            .observe(start.elapsed().as_millis() as f64);
-        let Some(block_receipts) = block_receipts_result.map_err(|err| {
-            anyhow::anyhow!(
-                "Failed to get block receipts for block number {block_number}: {:?}",
-                err
-            )
-        })?
-        else {
+        let block_receipts = client
+            .get_block_receipts(block_number.into())
+            .await
+            .map_err(|err| {
+                anyhow::anyhow!(
+                    "Failed to get block receipts for block number {block_number}: {:?}",
+                    err
+                )
+            })?;
+
+        let Some(block_receipts) = block_receipts else {
             tracing::info!("no receipts for block number {block_number}");
             return Ok(());
         };
@@ -987,11 +981,14 @@ impl EthereumIndexer {
         sign_requests.extend(respond_requests);
 
         if !sign_requests.is_empty() || !respond_logs.is_empty() {
-            let timestamps = sign_requests
-                .iter()
-                .map(|r| r.unix_timestamp_indexed)
-                .collect::<Vec<_>>();
-
+            for _request in &sign_requests {
+                record_request_latency(
+                    Chain::Ethereum,
+                    SignRequestStep::Indexing,
+                    "ok",
+                    block_timestamp,
+                );
+            }
             requests_indexed
                 .send(BlockAndRequests::new(
                     block_number,
@@ -1001,15 +998,6 @@ impl EthereumIndexer {
                 ))
                 .await
                 .map_err(|err| anyhow::anyhow!("Failed to send indexed requests: {:?}", err))?;
-
-            for request_timestamp in timestamps {
-                crate::metrics::indexers::INDEXER_DELAY
-                    .with_label_values(&[Chain::Ethereum.as_str()])
-                    .observe(
-                        crate::util::duration_between_unix(block_timestamp, request_timestamp)
-                            .as_secs() as f64,
-                    );
-            }
         }
 
         Ok(())

--- a/chain-signatures/node/src/indexer_hydration.rs
+++ b/chain-signatures/node/src/indexer_hydration.rs
@@ -192,7 +192,7 @@ impl SignatureEvent for HydrationSignatureRequestedEvent {
                 key_version: self.key_version,
             },
             chain: Chain::Hydration,
-            timestamp_indexed: Instant::now(),
+            timestamp_created: Instant::now(),
             unix_timestamp_indexed: crate::util::current_unix_timestamp(),
             total_timeout,
             sign_request_type: SignRequestType::Sign,
@@ -290,7 +290,7 @@ impl SignatureEvent for HydrationSignBidirectionalRequestedEvent {
                 key_version: self.key_version,
             },
             chain: Chain::Hydration,
-            timestamp_indexed: Instant::now(),
+            timestamp_created: Instant::now(),
             unix_timestamp_indexed: crate::util::current_unix_timestamp(),
             total_timeout,
             sign_request_type: SignRequestType::SignBidirectional(

--- a/chain-signatures/node/src/indexer_hydration.rs
+++ b/chain-signatures/node/src/indexer_hydration.rs
@@ -192,7 +192,7 @@ impl SignatureEvent for HydrationSignatureRequestedEvent {
                 key_version: self.key_version,
             },
             chain: Chain::Hydration,
-            timestamp_sign_queue: Instant::now(),
+            timestamp_indexed: Instant::now(),
             unix_timestamp_indexed: crate::util::current_unix_timestamp(),
             total_timeout,
             sign_request_type: SignRequestType::Sign,
@@ -290,7 +290,7 @@ impl SignatureEvent for HydrationSignBidirectionalRequestedEvent {
                 key_version: self.key_version,
             },
             chain: Chain::Hydration,
-            timestamp_sign_queue: Instant::now(),
+            timestamp_indexed: Instant::now(),
             unix_timestamp_indexed: crate::util::current_unix_timestamp(),
             total_timeout,
             sign_request_type: SignRequestType::SignBidirectional(

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -228,7 +228,7 @@ impl SignatureEvent for SignatureRequestedEvent {
                 key_version: self.key_version,
             },
             chain: Chain::Solana,
-            timestamp_sign_queue: Instant::now(),
+            timestamp_indexed: Instant::now(),
             unix_timestamp_indexed: crate::util::current_unix_timestamp(),
             total_timeout,
             sign_request_type: SignRequestType::Sign,
@@ -307,7 +307,7 @@ impl SignatureEvent for SignBidirectionalEvent {
                 key_version: self.key_version,
             },
             chain: Chain::Solana,
-            timestamp_sign_queue: Instant::now(),
+            timestamp_indexed: Instant::now(),
             unix_timestamp_indexed: crate::util::current_unix_timestamp(),
             total_timeout,
             sign_request_type: SignRequestType::SignBidirectional(

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -228,7 +228,7 @@ impl SignatureEvent for SignatureRequestedEvent {
                 key_version: self.key_version,
             },
             chain: Chain::Solana,
-            timestamp_indexed: Instant::now(),
+            timestamp_created: Instant::now(),
             unix_timestamp_indexed: crate::util::current_unix_timestamp(),
             total_timeout,
             sign_request_type: SignRequestType::Sign,
@@ -307,7 +307,7 @@ impl SignatureEvent for SignBidirectionalEvent {
                 key_version: self.key_version,
             },
             chain: Chain::Solana,
-            timestamp_indexed: Instant::now(),
+            timestamp_created: Instant::now(),
             unix_timestamp_indexed: crate::util::current_unix_timestamp(),
             total_timeout,
             sign_request_type: SignRequestType::SignBidirectional(

--- a/chain-signatures/node/src/metrics/indexers.rs
+++ b/chain-signatures/node/src/metrics/indexers.rs
@@ -1,10 +1,8 @@
 use std::sync::LazyLock;
 
-use prometheus::{exponential_buckets, Histogram, HistogramVec, IntGaugeVec};
+use prometheus::IntGaugeVec;
 
-use super::{
-    try_create_histogram_vec_with_node_account_id, try_create_int_gauge_vec_with_node_account_id,
-};
+use super::try_create_int_gauge_vec_with_node_account_id;
 
 pub(crate) static LATEST_BLOCK_NUMBER: LazyLock<IntGaugeVec> = LazyLock::new(|| {
     try_create_int_gauge_vec_with_node_account_id(
@@ -13,25 +11,4 @@ pub(crate) static LATEST_BLOCK_NUMBER: LazyLock<IntGaugeVec> = LazyLock::new(|| 
         &["chain"],
     )
     .unwrap()
-});
-
-pub(crate) static INDEXER_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    try_create_histogram_vec_with_node_account_id(
-        "multichain_indexer_delay_secs",
-        "Delay between block time of the request and the time a request gets indexed",
-        &["chain"],
-        Some(exponential_buckets(0.01, 1.5, 30).unwrap()),
-    )
-    .unwrap()
-});
-
-pub(crate) static ETH_BLOCK_RECEIPT_LATENCY: LazyLock<Histogram> = LazyLock::new(|| {
-    try_create_histogram_vec_with_node_account_id(
-        "multichain_eth_block_receipt_latency_ms",
-        "Latency of eth indexer getting block recepipts",
-        &[],
-        Some(exponential_buckets(5.0, 1.5, 20).unwrap()),
-    )
-    .unwrap()
-    .with_label_values(&[] as &[&str])
 });

--- a/chain-signatures/node/src/metrics/mod.rs
+++ b/chain-signatures/node/src/metrics/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     sync::{Mutex, OnceLock},
-    time::{Instant, SystemTime, UNIX_EPOCH},
+    time::{Instant, SystemTime},
 };
 
 use near_account_id::AccountId;

--- a/chain-signatures/node/src/metrics/mod.rs
+++ b/chain-signatures/node/src/metrics/mod.rs
@@ -1,4 +1,7 @@
-use std::sync::{Mutex, OnceLock};
+use std::{
+    sync::{Mutex, OnceLock},
+    time::{Instant, SystemTime, UNIX_EPOCH},
+};
 
 use near_account_id::AccountId;
 use prometheus::{HistogramOpts, HistogramVec, Opts, Result};
@@ -100,6 +103,25 @@ pub fn try_create_histogram_vec_with_node_account_id(
     Ok(histogram)
 }
 
+pub fn try_create_histogram_vec_with_node_and_version(
+    name: &str,
+    help: &str,
+    labels: &[&str],
+    buckets: Option<Vec<f64>>,
+) -> Result<HistogramVec> {
+    check_metric_multichain_prefix(name)?;
+    let mut opts = HistogramOpts::new(name, help);
+    if let Some(buckets) = buckets {
+        opts = opts.buckets(buckets);
+    }
+    opts = opts
+        .const_label("node_account_id".to_string(), node_account_id().to_string())
+        .const_label("version".to_string(), version().to_string());
+    let histogram = HistogramVec::new(opts, labels)?;
+    prometheus::register(Box::new(histogram.clone()))?;
+    Ok(histogram)
+}
+
 fn check_metric_multichain_prefix(name: &str) -> Result<()> {
     if name.starts_with("multichain_") {
         Ok(())
@@ -152,5 +174,27 @@ impl Histogram {
 
     pub fn exact(&self) -> Vec<f64> {
         self.exact.lock().unwrap().clone()
+    }
+}
+
+pub trait LatencyStart {
+    fn elapsed_seconds(&self) -> f64;
+}
+
+impl LatencyStart for Instant {
+    fn elapsed_seconds(&self) -> f64 {
+        self.elapsed().as_secs_f64()
+    }
+}
+
+impl LatencyStart for u64 {
+    fn elapsed_seconds(&self) -> f64 {
+        crate::util::unix_elapsed(*self).as_secs_f64()
+    }
+}
+
+impl LatencyStart for SystemTime {
+    fn elapsed_seconds(&self) -> f64 {
+        self.elapsed().unwrap_or_default().as_secs_f64()
     }
 }

--- a/chain-signatures/node/src/metrics/requests.rs
+++ b/chain-signatures/node/src/metrics/requests.rs
@@ -8,23 +8,25 @@ use crate::protocol::Chain;
 /// Steps and statuses of the sign request
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SignRequestStep {
-    /// Time from block timestamp to first seen by indexer (status: ok)
+    /// Time from block timestamp to first seen by indexer (Status: ok)
     /// Measures: network propagation delay + indexer polling latency
     Indexing,
-    /// Time from indexed in our system to sent to sign queue (status: ok)
+    /// Time from indexed in our system to sent to sign queue (Status: ok)
     /// Measures: finality wait time if applicable
     Finalizing,
-    /// Time from queue entry to signature generation start (status: ok)
+    /// Time from queue entry to signature generation start (Status: ok)
     Queuing,
-    /// Time to generate the signature (status: ok, error)
+    /// Time to generate the signature (Status: ok, error)
     Generating,
-    /// Time to respond to the sign request (status: ok, error)
+    /// Time to respond to the sign request (Status: ok)
     Responding,
     /// Total time from indexing to responding
+    /// Status:
     ///     - in_time: request was delivered in time (expected finality delay + margin)
     ///     - expired: request was delivered after expiration (expected finality delay + margin)
     Total,
     /// Can be used to track latency for failures, e.g., time to error out
+    /// Status:
     ///     - delayed: request was delayed, no response yet
     Other,
 }

--- a/chain-signatures/node/src/metrics/requests.rs
+++ b/chain-signatures/node/src/metrics/requests.rs
@@ -71,7 +71,6 @@ pub fn record_indexing_step_reached(chain: Chain) {
         .observe(0.0);
 }
 
-// histogram with node_account_id and version
 pub(crate) static SIGN_REQUEST_DELAYED: LazyLock<CounterVec> = LazyLock::new(|| {
     try_create_counter_vec_with_node_and_version(
         "multichain_sign_request_delayed",

--- a/chain-signatures/node/src/metrics/requests.rs
+++ b/chain-signatures/node/src/metrics/requests.rs
@@ -1,76 +1,72 @@
 use std::sync::LazyLock;
 
-use prometheus::{exponential_buckets, Counter, CounterVec, HistogramVec, IntGauge};
+use prometheus::{exponential_buckets, HistogramVec, IntGauge};
 
-use super::{
-    try_create_counter_vec_with_node_account_id, try_create_counter_vec_with_node_and_version,
-    try_create_histogram_vec_with_node_account_id, Histogram,
-};
+use crate::metrics::{try_create_histogram_vec_with_node_and_version, LatencyStart};
+use crate::protocol::Chain;
 
-pub(crate) static NUM_SIGN_REQUESTS: LazyLock<CounterVec> = LazyLock::new(|| {
-    try_create_counter_vec_with_node_account_id(
-        "multichain_sign_requests_count",
-        "number of multichain sign requests, marked by sign requests indexed",
-        &["chain"],
+/// Steps and statuses of the sign request
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignRequestStep {
+    /// Time from block timestamp to first seen by indexer (status: ok)
+    /// Measures: network propagation delay + indexer polling latency
+    Indexing,
+    /// Time from indexed in our system to sent to sign queue (status: ok)
+    /// Measures: finality wait time if applicable
+    Finalizing,
+    /// Time from queue entry to signature generation start (status: ok)
+    Queuing,
+    /// Time to generate the signature (status: ok, error)
+    Generating,
+    /// Time to respond to the sign request (status: ok, error)
+    Responding,
+    /// Total time from indexing to responding
+    ///     - in_time: request was delivered in time (expected finality delay + margin)
+    ///     - expired: request was delivered after expiration (expected finality delay + margin)
+    Total,
+    /// Can be used to track latency for failures, e.g., time to error out
+    ///     - delayed: request was delayed, no response yet
+    Other,
+}
+
+impl SignRequestStep {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Indexing => "indexing",
+            Self::Finalizing => "finalizing",
+            Self::Queuing => "queuing",
+            Self::Generating => "generating",
+            Self::Responding => "responding",
+            Self::Total => "total",
+            Self::Other => "other",
+        }
+    }
+}
+
+static SIGN_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
+    try_create_histogram_vec_with_node_and_version(
+        "multichain_sign_request_latency_sec",
+        "Latency of multichain sign request processing with step and status specification.",
+        &["chain", "step", "status"],
+        // Start: 30ms, Factor: 1.4, Count: 42
+        // Range: 0.03s -> ~29,300s (8.1 hours)
+        Some(exponential_buckets(0.03, 1.4, 42).unwrap()),
     )
     .unwrap()
 });
 
-pub(crate) static NUM_SIGN_REQUESTS_MINE: LazyLock<Counter> = LazyLock::new(|| {
-    try_create_counter_vec_with_node_account_id(
-        "multichain_sign_requests_count_mine",
-        "number of multichain sign requests, marked by sign requests indexed",
-        &[],
-    )
-    .unwrap()
-    .with_label_values(&[] as &[&str])
-});
+pub fn record_request_latency(
+    chain: Chain,
+    step: SignRequestStep,
+    status: &str,
+    start: impl LatencyStart,
+) {
+    let duration = start.elapsed_seconds();
 
-pub(crate) static NUM_UNIQUE_SIGN_REQUESTS: LazyLock<CounterVec> = LazyLock::new(|| {
-    try_create_counter_vec_with_node_account_id(
-        "multichain_sign_requests_count_unique",
-        "number of multichain sign requests, marked by sign requests indexed and deduped",
-        &["chain"],
-    )
-    .unwrap()
-});
-
-pub(crate) static NUM_SIGN_REQUESTS_MINE_IN_TIME: LazyLock<CounterVec> = LazyLock::new(|| {
-    try_create_counter_vec_with_node_and_version(
-        "multichain_sign_requests_success",
-        "number of mine sign requests with in time response",
-        &["chain"],
-    )
-    .unwrap()
-});
-
-pub(crate) static NUM_SIGN_REQUESTS_MINE_DELAYED: LazyLock<CounterVec> = LazyLock::new(|| {
-    try_create_counter_vec_with_node_and_version(
-        "multichain_sign_requests_delayed",
-        "number of mine sign requests that are delayed",
-        &["chain"],
-    )
-    .unwrap()
-});
-
-pub(crate) static SIGN_TOTAL_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-    try_create_histogram_vec_with_node_account_id(
-        "multichain_sign_latency_sec",
-        "Latency of multichain signing, start from indexing sign request, end when publish() called.",
-        &["chain"],
-        Some(exponential_buckets(0.001, 2.0, 20).unwrap()),
-    )
-    .unwrap()
-});
-
-pub(crate) static SIGN_RESPOND_LATENCY: LazyLock<Histogram> = LazyLock::new(|| {
-    Histogram::new(
-        "multichain_sign_respond_latency_sec",
-        "Latency of multichain signing, from received publish request to publish complete.",
-        &["chain"],
-        Some(exponential_buckets(0.001, 2.0, 20).unwrap()),
-    )
-});
+    SIGN_REQUEST_LATENCY
+        .with_label_values(&[chain.as_str(), step.as_str(), status])
+        .observe(duration);
+}
 
 pub(crate) static SIGN_QUEUE_SIZE: LazyLock<IntGauge> = LazyLock::new(|| {
     super::try_create_int_gauge_vec_with_node_account_id(

--- a/chain-signatures/node/src/metrics/requests.rs
+++ b/chain-signatures/node/src/metrics/requests.rs
@@ -11,11 +11,8 @@ pub enum SignRequestStep {
     /// Time from block timestamp to first seen by indexer (Status: ok)
     /// Measures: network propagation delay + indexer polling latency
     Indexing,
-    /// Time from indexed in our system to sent to sign queue (Status: ok)
-    /// Measures: finality wait time if applicable
-    Finalizing,
-    /// Time from queue entry to signature generation start (Status: ok)
-    Queuing,
+    /// Time from indexing to signature generation start (Status: ok)
+    AwaitingGeneration,
     /// Time to generate the signature (Status: ok, error)
     Generating,
     /// Time to respond to the sign request (Status: ok)
@@ -35,8 +32,7 @@ impl SignRequestStep {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Indexing => "indexing",
-            Self::Finalizing => "finalizing",
-            Self::Queuing => "queuing",
+            Self::AwaitingGeneration => "awaiting_generation",
             Self::Generating => "generating",
             Self::Responding => "responding",
             Self::Total => "total",

--- a/chain-signatures/node/src/metrics/requests.rs
+++ b/chain-signatures/node/src/metrics/requests.rs
@@ -1,6 +1,6 @@
 use std::sync::LazyLock;
 
-use prometheus::{CounterVec, HistogramVec, IntGauge, exponential_buckets};
+use prometheus::{exponential_buckets, CounterVec, HistogramVec, IntGauge};
 
 use crate::metrics::{
     try_create_counter_vec_with_node_and_version, try_create_histogram_vec_with_node_and_version,

--- a/chain-signatures/node/src/metrics/requests.rs
+++ b/chain-signatures/node/src/metrics/requests.rs
@@ -1,8 +1,11 @@
 use std::sync::LazyLock;
 
-use prometheus::{exponential_buckets, HistogramVec, IntGauge};
+use prometheus::{CounterVec, HistogramVec, IntGauge, exponential_buckets};
 
-use crate::metrics::{try_create_histogram_vec_with_node_and_version, LatencyStart};
+use crate::metrics::{
+    try_create_counter_vec_with_node_and_version, try_create_histogram_vec_with_node_and_version,
+    LatencyStart,
+};
 use crate::protocol::Chain;
 
 /// Steps and statuses of the sign request
@@ -22,10 +25,6 @@ pub enum SignRequestStep {
     ///     - in_time: request was delivered in time (expected finality delay + margin)
     ///     - expired: request was delivered after expiration (expected finality delay + margin)
     Total,
-    /// Can be used to track latency for failures, e.g., time to error out
-    /// Status:
-    ///     - delayed: request was delayed, no response yet
-    Other,
 }
 
 impl SignRequestStep {
@@ -36,7 +35,6 @@ impl SignRequestStep {
             Self::Generating => "generating",
             Self::Responding => "responding",
             Self::Total => "total",
-            Self::Other => "other",
         }
     }
 }
@@ -72,6 +70,16 @@ pub fn record_indexing_step_reached(chain: Chain) {
         .with_label_values(&[chain.as_str(), SignRequestStep::Indexing.as_str(), "ok"])
         .observe(0.0);
 }
+
+// histogram with node_account_id and version
+pub(crate) static SIGN_REQUEST_DELAYED: LazyLock<CounterVec> = LazyLock::new(|| {
+    try_create_counter_vec_with_node_and_version(
+        "multichain_sign_request_delayed",
+        "Number of delayed requests by chain",
+        &["chain"],
+    )
+    .unwrap()
+});
 
 pub(crate) static SIGN_QUEUE_SIZE: LazyLock<IntGauge> = LazyLock::new(|| {
     super::try_create_int_gauge_vec_with_node_account_id(

--- a/chain-signatures/node/src/metrics/requests.rs
+++ b/chain-signatures/node/src/metrics/requests.rs
@@ -65,6 +65,13 @@ pub fn record_request_latency(
         .with_label_values(&[chain.as_str(), step.as_str(), status])
         .observe(duration);
 }
+/// Some chains do not provide information about the block time.
+/// For that reason we record indexing step reached with 0.0 latency.
+pub fn record_indexing_step_reached(chain: Chain) {
+    SIGN_REQUEST_LATENCY
+        .with_label_values(&[chain.as_str(), SignRequestStep::Indexing.as_str(), "ok"])
+        .observe(0.0);
+}
 
 pub(crate) static SIGN_QUEUE_SIZE: LazyLock<IntGauge> = LazyLock::new(|| {
     super::try_create_int_gauge_vec_with_node_account_id(

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -49,10 +49,9 @@ pub struct IndexedSignRequest {
     /// Unix timestamp when the request was indexed by MPC node.
     /// Preserved across recoveries to maintain original request creation time.
     pub unix_timestamp_indexed: u64,
-    /// Monotonic system time when the request entered the signing queue.
-    /// Used for internal timeout enforcement and latency tracking.
-    /// Updated on recovery/requeue to current system time.
-    pub timestamp_sign_queue: Instant,
+    /// Monotonic system time when the request entered the system for processing.
+    /// Set during initial indexing or updated on recovery/requeue to current system time.
+    pub timestamp_indexed: Instant,
     pub total_timeout: Duration,
     pub sign_request_type: SignRequestType,
 }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -1248,12 +1248,11 @@ impl SignatureSpawner {
                     return;
                 }
 
-                let queuing_start = Instant::now(); // TODO: measure queuing time
                 record_request_latency(
                     request.chain,
-                    SignRequestStep::Queuing,
+                    SignRequestStep::AwaitingGeneration,
                     "ok",
-                    queuing_start,
+                    request.unix_timestamp_indexed,
                 );
 
                 self.spawn_task(request, participants.clone(), contract.clone(), cfg.clone());

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -3,6 +3,7 @@ use crate::backlog::Backlog;
 use crate::config::Config;
 use crate::kdf::derive_delta;
 use crate::mesh::MeshState;
+use crate::metrics::requests::{record_request_latency, SignRequestStep};
 use crate::protocol::contract::primitives::intersect_vec;
 use crate::protocol::message::{
     MessageChannel, PositMessage, PositProtocolId, SignatureMessage, Subscriber,
@@ -264,10 +265,6 @@ impl SignOrganizer {
                 stable_count = stable.len(),
                 "organized: selected proposer"
             );
-
-            if is_mine && state.round == 0 {
-                crate::metrics::requests::NUM_SIGN_REQUESTS_MINE.inc();
-            }
 
             (stable, proposer)
         };
@@ -1129,19 +1126,14 @@ impl SignatureSpawner {
         let chain = indexed.chain;
         let unix_timestamp_indexed = indexed.unix_timestamp_indexed;
         let expected_response_time_secs = chain.expected_response_time_secs();
-        let current_timestamp = crate::util::current_unix_timestamp();
-        let already_elapsed =
-            crate::util::duration_between_unix(unix_timestamp_indexed, current_timestamp);
+        let already_elapsed = crate::util::unix_elapsed(unix_timestamp_indexed);
         let remaining_time =
             Duration::from_secs(expected_response_time_secs).saturating_sub(already_elapsed);
         // prevent incrementing delayed metric for already delayed requests
         if remaining_time > Duration::from_secs(0) {
             let watcher = tokio::spawn(async move {
                 tokio::time::sleep(remaining_time).await;
-                let elapsed = crate::util::duration_between_unix(
-                    unix_timestamp_indexed,
-                    crate::util::current_unix_timestamp(),
-                );
+                let elapsed = crate::util::unix_elapsed(unix_timestamp_indexed);
                 tracing::warn!(
                     ?sign_id,
                     ?chain,
@@ -1149,9 +1141,12 @@ impl SignatureSpawner {
                     expected_secs = expected_response_time_secs,
                     "signature request delayed beyond expected response time"
                 );
-                crate::metrics::requests::NUM_SIGN_REQUESTS_MINE_DELAYED
-                    .with_label_values(&[chain.as_str()])
-                    .inc();
+                record_request_latency(
+                    chain,
+                    crate::metrics::requests::SignRequestStep::Other,
+                    "delayed",
+                    unix_timestamp_indexed,
+                );
             });
             self.delayed_watchers.insert(sign_id, watcher);
         }
@@ -1235,8 +1230,8 @@ impl SignatureSpawner {
             Sign::Completion(sign_id) => {
                 self.handle_completion(sign_id);
             }
-            Sign::Request(indexed) => {
-                let sign_id = indexed.id;
+            Sign::Request(request) => {
+                let sign_id = request.id;
 
                 // Skip if we already have a task handling this request.
                 // Use tasks instead of inbox map since it may already contain buffered messages
@@ -1247,11 +1242,15 @@ impl SignatureSpawner {
                     return;
                 }
 
-                crate::metrics::requests::NUM_UNIQUE_SIGN_REQUESTS
-                    .with_label_values(&[indexed.chain.as_str()])
-                    .inc();
+                let queuing_start = Instant::now(); // TODO: measure queuing time
+                record_request_latency(
+                    request.chain,
+                    SignRequestStep::Queuing,
+                    "ok",
+                    queuing_start,
+                );
 
-                self.spawn_task(indexed, participants.clone(), contract.clone(), cfg.clone());
+                self.spawn_task(request, participants.clone(), contract.clone(), cfg.clone());
             }
         }
 

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -944,6 +944,13 @@ impl SignGenerator {
                         "completed signature generation"
                     );
 
+                    record_request_latency(
+                        self.indexed.chain,
+                        SignRequestStep::Generating,
+                        "ok",
+                        self.created,
+                    );
+
                     crate::metrics::protocols::SIGNATURE_ACCRUED_WAIT_DELAY
                         .observe(total_wait.as_millis() as f64);
                     crate::metrics::protocols::SIGNATURE_POKES_CNT.observe(total_pokes as f64);

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -1147,12 +1147,9 @@ impl SignatureSpawner {
                     expected_secs = expected_response_time_secs,
                     "signature request delayed beyond expected response time"
                 );
-                record_request_latency(
-                    chain,
-                    crate::metrics::requests::SignRequestStep::Other,
-                    "delayed",
-                    unix_timestamp_indexed,
-                );
+                crate::metrics::requests::SIGN_REQUEST_DELAYED
+                    .with_label_values(&[chain.as_str()])
+                    .inc();
             });
             self.delayed_watchers.insert(sign_id, watcher);
         }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -51,7 +51,7 @@ pub struct IndexedSignRequest {
     pub unix_timestamp_indexed: u64,
     /// Monotonic system time when the request entered the system for processing.
     /// Set during initial indexing or updated on recovery/requeue to current system time.
-    pub timestamp_indexed: Instant,
+    pub timestamp_created: Instant,
     pub total_timeout: Duration,
     pub sign_request_type: SignRequestType,
 }

--- a/chain-signatures/node/src/respond_bidirectional.rs
+++ b/chain-signatures/node/src/respond_bidirectional.rs
@@ -136,7 +136,7 @@ impl CompletedTx {
                 key_version: self.tx.key_version,
             },
             unix_timestamp_indexed: crate::util::current_unix_timestamp(),
-            timestamp_sign_queue: std::time::Instant::now(),
+            timestamp_indexed: std::time::Instant::now(),
             total_timeout: signature_generation_total_timeout,
             sign_request_type: crate::protocol::SignRequestType::RespondBidirectional(
                 RespondBidirectionalTx {

--- a/chain-signatures/node/src/respond_bidirectional.rs
+++ b/chain-signatures/node/src/respond_bidirectional.rs
@@ -136,7 +136,7 @@ impl CompletedTx {
                 key_version: self.tx.key_version,
             },
             unix_timestamp_indexed: crate::util::current_unix_timestamp(),
-            timestamp_indexed: std::time::Instant::now(),
+            timestamp_created: std::time::Instant::now(),
             total_timeout: signature_generation_total_timeout,
             sign_request_type: crate::protocol::SignRequestType::RespondBidirectional(
                 RespondBidirectionalTx {

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -1459,12 +1459,7 @@ async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAc
                         action.indexed.unix_timestamp_indexed,
                     );
                 }
-                record_request_latency(
-                    chain,
-                    SignRequestStep::Responding,
-                    "ok",
-                    action.indexed.unix_timestamp_indexed,
-                );
+                record_request_latency(chain, SignRequestStep::Responding, "ok", action.timestamp);
             }
             actions.clear();
             break;

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -2,6 +2,7 @@ use crate::backlog::Backlog;
 use crate::config::{Config, ContractConfig, NetworkConfig};
 use crate::indexer_eth::EthConfig;
 use crate::indexer_sol::SolConfig;
+use crate::metrics::requests::{record_request_latency, SignRequestStep};
 use crate::protocol::contract::primitives::{ParticipantMap, Participants};
 use crate::protocol::contract::RunningContractState;
 use crate::protocol::{Chain, Governance, IndexedSignRequest, ProtocolState, SignRequestType};
@@ -976,23 +977,25 @@ async fn execute_publish(client: ChainClient, mut action: PublishAction, backlog
         }
     };
 
-    let chain_str = chain.as_str();
     if publish_result.is_ok() {
-        let elapsed = crate::util::duration_between_unix(
-            action.indexed.unix_timestamp_indexed,
-            crate::util::current_unix_timestamp(),
-        );
-        if elapsed.as_secs() <= chain.expected_response_time_secs() {
-            crate::metrics::requests::NUM_SIGN_REQUESTS_MINE_IN_TIME
-                .with_label_values(&[chain_str])
-                .inc();
+        let elapsed_secs =
+            crate::util::unix_elapsed(action.indexed.unix_timestamp_indexed).as_secs();
+        if elapsed_secs <= chain.expected_response_time_secs() {
+            record_request_latency(
+                chain,
+                SignRequestStep::Total,
+                "in_time",
+                action.indexed.unix_timestamp_indexed,
+            );
+        } else {
+            record_request_latency(
+                chain,
+                SignRequestStep::Total,
+                "expired",
+                action.indexed.unix_timestamp_indexed,
+            );
         }
-        crate::metrics::requests::SIGN_TOTAL_LATENCY
-            .with_label_values(&[chain_str])
-            .observe(elapsed.as_secs_f64());
-        crate::metrics::requests::SIGN_RESPOND_LATENCY
-            .with_label_values(&[chain_str])
-            .observe(action.timestamp.elapsed().as_secs_f64());
+        record_request_latency(chain, SignRequestStep::Responding, "ok", action.timestamp);
     }
 
     // Mark completion in Backlog for SignBidirectional requests
@@ -1025,7 +1028,7 @@ async fn run_batch_respond(
                 num_requests = actions_batch.len(),
                 "publishing batch of signatures",
             );
-            execute_batch_publish(&client, &mut actions_batch, Instant::now()).await;
+            execute_batch_publish(&client, &mut actions_batch).await;
             start = Instant::now();
         }
         if let Ok(action) = actions_rx.try_recv() {
@@ -1392,11 +1395,7 @@ async fn try_batch_publish_eth(
     Ok(())
 }
 
-async fn execute_batch_publish(
-    client: &ChainClient,
-    actions: &mut Vec<PublishAction>,
-    start: Instant,
-) {
+async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAction>) {
     let mut signatures: HashMap<SignId, Signature> = HashMap::new();
 
     for action in actions.iter() {
@@ -1442,25 +1441,31 @@ async fn execute_batch_publish(
         };
         if publish.is_ok() {
             // Record metrics for successful batch publish
-            let current_timestamp = crate::util::current_unix_timestamp();
             for action in actions.iter() {
                 let chain = action.indexed.chain;
-                let elapsed = crate::util::duration_between_unix(
-                    action.indexed.unix_timestamp_indexed,
-                    current_timestamp,
-                );
+                let elapsed = crate::util::unix_elapsed(action.indexed.unix_timestamp_indexed);
                 if elapsed.as_secs() <= chain.expected_response_time_secs() {
-                    crate::metrics::requests::NUM_SIGN_REQUESTS_MINE_IN_TIME
-                        .with_label_values(&[chain.as_str()])
-                        .inc();
+                    record_request_latency(
+                        chain,
+                        SignRequestStep::Total,
+                        "in_time",
+                        action.indexed.unix_timestamp_indexed,
+                    );
+                } else {
+                    record_request_latency(
+                        chain,
+                        SignRequestStep::Total,
+                        "expired",
+                        action.indexed.unix_timestamp_indexed,
+                    );
                 }
-                crate::metrics::requests::SIGN_TOTAL_LATENCY
-                    .with_label_values(&[chain.as_str()])
-                    .observe(elapsed.as_secs_f64());
+                record_request_latency(
+                    chain,
+                    SignRequestStep::Responding,
+                    "ok",
+                    action.indexed.unix_timestamp_indexed,
+                );
             }
-            crate::metrics::requests::SIGN_RESPOND_LATENCY
-                .with_label_values(&[Chain::Ethereum.as_str()])
-                .observe(start.elapsed().as_secs_f64());
             actions.clear();
             break;
         }

--- a/chain-signatures/node/src/util.rs
+++ b/chain-signatures/node/src/util.rs
@@ -83,15 +83,20 @@ pub fn is_elapsed_longer_than_timeout(timestamp_sec: u64, timeout: u64) -> bool 
     }
 }
 
-pub fn duration_between_unix(from_timestamp: u64, to_timestamp: u64) -> Duration {
-    Duration::from_secs(to_timestamp - from_timestamp)
-}
-
 pub fn current_unix_timestamp() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("Time went backwards")
         .as_secs()
+}
+
+/// Calculate elapsed time from a unix timestamp to now
+pub fn unix_elapsed(unix_timestamp: u64) -> Duration {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    Duration::from_secs(now.saturating_sub(unix_timestamp))
 }
 
 pub const fn first_8_bytes(input: [u8; 32]) -> [u8; 8] {

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -254,7 +254,6 @@ async fn metrics() -> (StatusCode, String) {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BenchMetrics {
     pub sig_gen: Vec<f64>,
-    pub sig_respond: Vec<f64>,
     pub presig_gen: Vec<f64>,
 }
 
@@ -262,7 +261,6 @@ pub struct BenchMetrics {
 async fn bench_metrics() -> Json<BenchMetrics> {
     Json(BenchMetrics {
         sig_gen: crate::metrics::protocols::SIGN_GENERATION_LATENCY.exact(),
-        sig_respond: crate::metrics::requests::SIGN_RESPOND_LATENCY.exact(),
         presig_gen: crate::metrics::protocols::PRESIGNATURE_LATENCY.exact(),
     })
 }

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -196,7 +196,7 @@ fn sign_request(seed: u8) -> Sign {
         args: sign_arg(seed),
         chain: Chain::NEAR,
         unix_timestamp_indexed: 0,
-        timestamp_indexed: std::time::Instant::now(),
+        timestamp_created: std::time::Instant::now(),
         total_timeout: Duration::from_secs(45),
         sign_request_type: SignRequestType::Sign,
     })

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -196,7 +196,7 @@ fn sign_request(seed: u8) -> Sign {
         args: sign_arg(seed),
         chain: Chain::NEAR,
         unix_timestamp_indexed: 0,
-        timestamp_sign_queue: std::time::Instant::now(),
+        timestamp_indexed: std::time::Instant::now(),
         total_timeout: Duration::from_secs(45),
         sign_request_type: SignRequestType::Sign,
     })


### PR DESCRIPTION
The goal of this PR is to unify, simplify, and extend the measurement of the request latencies. I've added a single metric (`multichain_sign_request_latency_sec`) with a `step` label for that purpose. Since Histogram creates `_count` metric automatically, I've removed many counters, as well as other histogram metrics that were measuring specific steps in request processing.

I recommend starting the review from the `SignRequestStep` struct. This PR does not implement measuring all the steps of the request processing. Current status is:
- Indexing: Only Ethereum has access to the block time, atm. Other chains record zeros. cc @ppca
- AwaitingGeneration: Done, but more of a placeholder. We can divide this step into Finalizing, Queueing, etc. Up for a discussion. cc @ChaoticTempest 
- Generating: Done
- Responding: Done
- Total: Done
- Other (delayed): Done