### PR TITLE
fix: solana indexer hang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,9 +2576,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -3516,7 +3516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.101",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/chain-signatures/node/src/indexer_eth/indexer_eth_direct_rpc.rs
+++ b/chain-signatures/node/src/indexer_eth/indexer_eth_direct_rpc.rs
@@ -26,8 +26,8 @@ impl RpcEthereumClient {
     pub async fn get_block(
         &self,
         block_id: alloy::rpc::types::BlockId,
-    ) -> Option<alloy::rpc::types::Block> {
-        self.block(block_id).await.unwrap_or(None)
+    ) -> anyhow::Result<Option<alloy::rpc::types::Block>> {
+        self.block(block_id).await
     }
 
     pub async fn get_block_receipts(
@@ -60,10 +60,6 @@ impl RpcEthereumClient {
         tx_hash: alloy::primitives::B256,
     ) -> anyhow::Result<Option<alloy::rpc::types::Transaction>> {
         self.transaction_by_hash(tx_hash).await
-    }
-
-    pub async fn get_latest_block_number(&self) -> anyhow::Result<u64> {
-        self.block_number().await
     }
 
     pub async fn call(
@@ -116,11 +112,6 @@ impl RpcEthereumClient {
             .cloned()
             .unwrap_or(serde_json::Value::Null);
         Ok(serde_json::from_value(result)?)
-    }
-
-    async fn block_number(&self) -> anyhow::Result<u64> {
-        let hex: String = self.rpc_call("eth_blockNumber", Vec::new()).await?;
-        hex_to_u64(&hex)
     }
 
     async fn block(

--- a/chain-signatures/node/src/indexer_eth/indexer_eth_helios.rs
+++ b/chain-signatures/node/src/indexer_eth/indexer_eth_helios.rs
@@ -7,28 +7,23 @@ use helios::ethereum::{config::networks::Network, EthereumClient, EthereumClient
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
-use tokio::time::Duration;
 
 #[derive(Clone)]
 pub struct HeliosEthereumClient {
     client: Arc<EthereumClient>,
-    max_retries: u8,
-    base_delay: Duration,
 }
 
 impl HeliosEthereumClient {
-    fn new(client: EthereumClient, max_retries: u8, base_delay: Duration) -> Self {
+    fn new(client: EthereumClient) -> Self {
         Self {
             client: Arc::new(client),
-            max_retries,
-            base_delay,
         }
     }
 
     pub async fn get_block(
         &self,
         block_id: alloy::rpc::types::BlockId,
-    ) -> Option<alloy::rpc::types::Block> {
+    ) -> anyhow::Result<Option<alloy::rpc::types::Block>> {
         self.fetch_block(block_id).await
     }
 
@@ -103,43 +98,14 @@ impl HeliosEthereumClient {
             .map_err(|err| anyhow::anyhow!("Failed to call: {err:?}"))
     }
 
-    pub async fn get_latest_block_number(&self) -> anyhow::Result<u64> {
-        let Some(block) = self
-            .fetch_block(BlockId::Number(BlockNumberOrTag::Latest))
-            .await
-        else {
-            return Err(anyhow::anyhow!("Latest block not found"));
-        };
-        Ok(block.header.number)
-    }
-
     // retry getting block from helios with exponential backoff
-    async fn fetch_block(&self, block_id: BlockId) -> Option<alloy::rpc::types::Block> {
-        let mut retries = 0;
-        loop {
-            match self.client.get_block(block_id, false).await {
-                Ok(Some(block)) => return Some(block),
-                Ok(None) => {
-                    tracing::warn!("Block {block_id} not found from Helios client");
-                    return None;
-                }
-                Err(e) => {
-                    if retries < self.max_retries {
-                        retries += 1;
-                        let delay = self.base_delay * 2u32.pow((retries - 1) as u32);
-                        tracing::warn!(
-                        "Failed to fetch block number {block_id} from Helios client: {e:?}, retrying"
-                    );
-                        tokio::time::sleep(delay).await;
-                        continue;
-                    }
-                    tracing::warn!(
-                    "Failed to fetch block number {block_id} from Helios client: {e:?}, exceeded maximum retry"
-                );
-                    return None;
-                }
-            }
-        }
+    async fn fetch_block(
+        &self,
+        block_id: BlockId,
+    ) -> anyhow::Result<Option<alloy::rpc::types::Block>> {
+        self.client.get_block(block_id, false).await.map_err(|err| {
+            anyhow::anyhow!("Failed to fetch block for block id {block_id:?}: {:?}", err)
+        })
     }
 }
 
@@ -163,9 +129,5 @@ pub async fn build_client(eth: EthConfig) -> anyhow::Result<HeliosEthereumClient
         .await
         .map_err(|err| anyhow::anyhow!("Failed to wait for synced: {err:?}"))?;
 
-    Ok(HeliosEthereumClient::new(
-        client,
-        6,
-        Duration::from_millis(200),
-    ))
+    Ok(HeliosEthereumClient::new(client))
 }

--- a/chain-signatures/node/src/indexer_eth/indexer_eth_helios.rs
+++ b/chain-signatures/node/src/indexer_eth/indexer_eth_helios.rs
@@ -98,7 +98,6 @@ impl HeliosEthereumClient {
             .map_err(|err| anyhow::anyhow!("Failed to call: {err:?}"))
     }
 
-    // retry getting block from helios with exponential backoff
     async fn fetch_block(
         &self,
         block_id: BlockId,

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -616,8 +616,7 @@ impl EthereumClient {
     ) -> Option<alloy::rpc::types::Block> {
         // Configure retry behaviour and delegate to shared retry_async helper.
         let retry_config = crate::util::retry::RetryConfig::default();
-        // the retry helper expects the operation closure to accept one argument (attempt/index)
-        let op = |_attempt: usize| async {
+        let get_block_op = |_attempt: usize| async {
             match self {
                 EthereumClient::Helios(client) => client.get_block(block_id).await,
                 EthereumClient::DirectRpc(client) => client.get_block(block_id).await,
@@ -626,7 +625,7 @@ impl EthereumClient {
 
         let res = crate::util::retry::retry_async(
             retry_config,
-            op,
+            get_block_op,
             |_attempt, _reason| true,
             |attempt, reason, sleep_duration| match reason {
                 crate::util::retry::RetryReason::Error(e) => {

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -11,6 +11,7 @@ use crate::respond_bidirectional::CompletedTx;
 use crate::rpc::ContractStateWatcher;
 use crate::sign_bidirectional::PendingRequestStatus;
 use crate::storage::app_data_storage::AppDataStorage;
+use alloy::eips::BlockId;
 use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::hex::{self, ToHexExt};
 use alloy::primitives::{Address, Bytes, U256};
@@ -603,13 +604,74 @@ impl EthereumClient {
         }
     }
 
+    fn client_name(&self) -> &str {
+        match self {
+            EthereumClient::Helios(_) => "Helios",
+            EthereumClient::DirectRpc(_) => "DirectRpc",
+        }
+    }
+
     async fn get_block(
         &self,
         block_id: alloy::rpc::types::BlockId,
     ) -> Option<alloy::rpc::types::Block> {
-        match self {
-            EthereumClient::Helios(client) => client.get_block(block_id).await,
-            EthereumClient::DirectRpc(client) => client.get_block(block_id).await,
+        // Configure retry behaviour and delegate to shared retry_async helper.
+        let retry_config = crate::util::retry::RetryConfig::default();
+        // the retry helper expects the operation closure to accept one argument (attempt/index)
+        let op = |_attempt: usize| async {
+            match self {
+                EthereumClient::Helios(client) => client.get_block(block_id).await,
+                EthereumClient::DirectRpc(client) => client.get_block(block_id).await,
+            }
+        };
+
+        let res = crate::util::retry::retry_async(
+            retry_config,
+            op,
+            |_attempt, _reason| true,
+            |attempt, reason, sleep_duration| match reason {
+                crate::util::retry::RetryReason::Error(e) => {
+                    tracing::warn!(
+                        client = self.client_name(),
+                        "get_block failed (attempt {attempt}) for {block_id:?}: {e:#}; retrying in {sleep_duration:?}"
+                    );
+                }
+                crate::util::retry::RetryReason::Timeout(t) => {
+                    tracing::warn!(
+                        client = self.client_name(),
+                        "get_block timed out after {t:?} (attempt {attempt}) for {block_id:?}; retrying in {sleep_duration:?}"
+                    );
+                }
+            },
+        )
+        .await;
+
+        match res {
+            Ok(Some(block)) => Some(block),
+            Ok(None) => {
+                tracing::warn!(client = self.client_name(), "Block {block_id:?} not found");
+                None
+            }
+            Err(crate::util::retry::RetryError::Exhausted {
+                attempts,
+                last_error,
+            }) => {
+                tracing::warn!(
+                    client = self.client_name(),
+                    "get_block failed for {block_id:?}: {last_error:#}; exhausted after {attempts} attempts"
+                );
+                None
+            }
+            Err(crate::util::retry::RetryError::TimeoutExhausted {
+                attempts,
+                last_timeout,
+            }) => {
+                tracing::warn!(
+                    client = self.client_name(),
+                    "get_block timed out for {block_id:?} (last timeout {last_timeout:?}); exhausted after {attempts} attempts"
+                );
+                None
+            }
         }
     }
 
@@ -657,11 +719,10 @@ impl EthereumClient {
         }
     }
 
-    async fn get_latest_block_number(&self) -> anyhow::Result<u64> {
-        match self {
-            EthereumClient::Helios(client) => client.get_latest_block_number().await,
-            EthereumClient::DirectRpc(client) => client.get_latest_block_number().await,
-        }
+    async fn get_latest_block_number(&self) -> Option<u64> {
+        self.get_block(BlockId::Number(BlockNumberOrTag::Latest))
+            .await
+            .map(|block| block.header.number)
     }
 }
 
@@ -804,7 +865,7 @@ impl EthereumIndexer {
         let blocks_to_process_send_clone = blocks_to_process_send.clone();
         if let Some(last_processed_block) = last_processed_block {
             match Self::catchup_end_block_number(Arc::clone(&client)).await {
-                Ok(end_block_number) => {
+                Some(end_block_number) => {
                     Self::add_catchup_blocks_to_process(
                         blocks_to_process_send_clone,
                         last_processed_block,
@@ -812,8 +873,8 @@ impl EthereumIndexer {
                     )
                     .await
                 }
-                Err(err) => {
-                    tracing::error!("Failed to get catchup end block number: {err:?}");
+                None => {
+                    tracing::error!("Failed to get catchup end block number");
                 }
             }
         }
@@ -903,7 +964,7 @@ impl EthereumIndexer {
             current_block = block_number;
         }
     }
-    async fn catchup_end_block_number(client: Arc<EthereumClient>) -> anyhow::Result<BlockNumber> {
+    async fn catchup_end_block_number(client: Arc<EthereumClient>) -> Option<BlockNumber> {
         client.get_latest_block_number().await
     }
 

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -11,7 +11,6 @@ use crate::respond_bidirectional::CompletedTx;
 use crate::rpc::ContractStateWatcher;
 use crate::sign_bidirectional::PendingRequestStatus;
 use crate::storage::app_data_storage::AppDataStorage;
-use alloy::eips::BlockId;
 use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::hex::{self, ToHexExt};
 use alloy::primitives::{Address, Bytes, U256};
@@ -720,9 +719,11 @@ impl EthereumClient {
     }
 
     async fn get_latest_block_number(&self) -> Option<u64> {
-        self.get_block(BlockId::Number(BlockNumberOrTag::Latest))
-            .await
-            .map(|block| block.header.number)
+        self.get_block(alloy::rpc::types::BlockId::Number(
+            alloy::rpc::types::BlockNumberOrTag::Latest,
+        ))
+        .await
+        .map(|block| block.header.number)
     }
 }
 

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -7,6 +7,7 @@ use crate::protocol::{Chain, IndexedSignRequest, Sign, SignRequestType};
 use crate::rpc::ContractStateWatcher;
 use crate::sign_bidirectional::hash_rlp_data;
 
+use crate::util::retry::{retry_async, RetryConfig, RetryError, RetryReason};
 use alloy_sol_types::SolValue;
 use anchor_client::anchor_lang::AnchorDeserialize;
 use anchor_client::{Client, Cluster, Program};
@@ -19,7 +20,6 @@ use k256::{AffinePoint, Scalar};
 use mpc_crypto::kdf::derive_epsilon_sol;
 use mpc_crypto::ScalarExt as _;
 use mpc_primitives::{SignArgs, SignId, LATEST_MPC_KEY_VERSION};
-use rand::Rng;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 use signet_program::{
@@ -40,7 +40,6 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, watch};
-use tokio::time::timeout;
 
 pub(crate) static MAX_SECP256K1_SCALAR: LazyLock<Scalar> = LazyLock::new(|| {
     Scalar::from_bytes(
@@ -328,33 +327,6 @@ impl SignatureEvent for SignBidirectionalEvent {
 }
 
 type Result<T> = anyhow::Result<T>;
-
-/// Configuration knobs for timeout + retry.
-#[derive(Debug, Clone)]
-struct TxFetchRetryConfig {
-    /// Timeout per attempt.
-    per_attempt_timeout: Duration,
-    /// Max number of attempts (including the first).
-    max_attempts: usize,
-    /// Base backoff delay after first failure.
-    backoff_base: Duration,
-    /// Maximum backoff delay cap.
-    backoff_max: Duration,
-    /// Random jitter range added to backoff (0..=jitter_max_ms).
-    jitter_max_ms: u64,
-}
-
-impl Default for TxFetchRetryConfig {
-    fn default() -> Self {
-        Self {
-            per_attempt_timeout: Duration::from_secs(3),
-            max_attempts: 5,
-            backoff_base: Duration::from_millis(300),
-            backoff_max: Duration::from_secs(5),
-            jitter_max_ms: 250,
-        }
-    }
-}
 
 pub async fn run(
     sol: Option<SolConfig>,
@@ -703,7 +675,7 @@ where
                             continue;
                         }
 
-                        let tx = match get_tx_with_timeout_retry(&rpc_client, &signature, TxFetchRetryConfig::default()).await {
+                        let tx = match get_tx(&rpc_client, &signature, RetryConfig::default()).await {
                             Ok(tx) => tx,
                             Err(e) => {
                                 tracing::warn!("Failed to fetch transaction {}: {}", signature, e);
@@ -924,7 +896,7 @@ async fn subscribe_to_program_respond_events(
                             continue;
                         }
 
-                        let tx = match get_tx_with_timeout_retry(&rpc_client, &signature, TxFetchRetryConfig::default()).await {
+                        let tx = match get_tx(&rpc_client, &signature, RetryConfig::default()).await {
                             Ok(tx) => tx,
                             Err(e) => {
                                 tracing::warn!("Failed to fetch transaction {}: {}", signature, e);
@@ -1013,87 +985,64 @@ pub fn to_mpc_signature(
 
 /// Fetch transaction with timeout + retry.
 /// Returns the same type as `RpcClient::get_transaction_with_config`.
-async fn get_tx_with_timeout_retry(
+async fn get_tx(
     rpc_client: &RpcClient,
     signature: &Signature,
-    cfg: TxFetchRetryConfig,
+    retry_cfg: RetryConfig,
 ) -> anyhow::Result<solana_transaction_status::EncodedConfirmedTransactionWithStatusMeta> {
-    let mut last_err: Option<anyhow::Error> = None;
-    if cfg.max_attempts == 0 {
-        anyhow::bail!("max_attempts must be at least 1");
-    }
+    let max_attempts = retry_cfg.max_attempts;
 
-    for attempt in 1..=cfg.max_attempts {
-        let fut = rpc_client.get_transaction_with_config(
-            signature,
-            solana_client::rpc_config::RpcTransactionConfig {
-                encoding: Some(solana_transaction_status::UiTransactionEncoding::JsonParsed),
-                commitment: Some(CommitmentConfig::confirmed()),
-                max_supported_transaction_version: Some(0),
-            },
-        );
-        match timeout(cfg.per_attempt_timeout, fut).await {
-            Ok(Ok(tx)) => return Ok(tx),
-
-            Ok(Err(e)) => {
-                // On any RPC error, retry until max_attempts is reached.
-                let e_anyhow = anyhow::anyhow!(e).context(format!(
-                    "getTransaction failed (attempt {attempt}/{}) for {}",
-                    cfg.max_attempts, signature
-                ));
-
-                if attempt == cfg.max_attempts {
-                    return Err(e_anyhow);
-                }
-                last_err = Some(e_anyhow);
-            }
-
-            Err(_elapsed) => {
-                let e_anyhow = anyhow::anyhow!(
-                    "getTransaction timed out after {:?} (attempt {attempt}/{}) for {}",
-                    cfg.per_attempt_timeout,
-                    cfg.max_attempts,
+    let res = retry_async(
+        retry_cfg,
+        |attempt| async move {
+            rpc_client
+                .get_transaction_with_config(
+                    signature,
+                    solana_client::rpc_config::RpcTransactionConfig {
+                        encoding: Some(solana_transaction_status::UiTransactionEncoding::JsonParsed),
+                        commitment: Some(CommitmentConfig::confirmed()),
+                        max_supported_transaction_version: Some(0),
+                    },
+                )
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!(e).context(format!(
+                        "getTransaction failed (attempt {attempt}/{}) for {}",
+                        max_attempts, signature
+                    ))
+                })
+        },
+        |_attempt, _reason| true,
+        |attempt, reason, sleep| match reason {
+            RetryReason::Error(e) => {
+                tracing::warn!(
+                    "getTransaction failed (attempt {attempt}/{}) for {}: {e:#}; retrying in {sleep:?}",
+                    max_attempts,
                     signature
                 );
-
-                if attempt == cfg.max_attempts {
-                    return Err(e_anyhow);
-                }
-                last_err = Some(e_anyhow);
             }
-        }
+            RetryReason::Timeout(t) => {
+                tracing::warn!(
+                    "getTransaction timed out after {t:?} (attempt {attempt}/{}) for {}; retrying in {sleep:?}",
+                    max_attempts,
+                    signature
+                );
+            }
+        },
+    )
+    .await;
 
-        // Backoff before next attempt (exponential + jitter).
-        let backoff = compute_backoff_with_jitter(
-            cfg.backoff_base,
-            cfg.backoff_max,
-            attempt,
-            cfg.jitter_max_ms,
-        );
-        tokio::time::sleep(backoff).await;
+    match res {
+        Ok(tx) => Ok(tx),
+        Err(RetryError::Exhausted { last_error, .. }) => Err(last_error),
+        Err(RetryError::TimeoutExhausted {
+            attempts,
+            last_timeout,
+        }) => Err(anyhow::anyhow!(
+            "getTransaction timed out after {:?} (attempt {attempts}/{}) for {}",
+            last_timeout,
+            max_attempts,
+            signature
+        )),
     }
-
-    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("getTransaction failed without error details")))
-}
-
-/// Exponential backoff with jitter.
-///
-/// attempt: 1-based attempt count (1,2,3,...)
-fn compute_backoff_with_jitter(
-    base: Duration,
-    cap: Duration,
-    attempt: usize,
-    jitter_max_ms: u64,
-) -> Duration {
-    // Exponential: base * 2^(attempt-1)
-    let pow = (attempt.saturating_sub(1)).min(16) as u32;
-    let exp_ms = base.as_millis().saturating_mul(1u128 << pow);
-
-    let mut delay = Duration::from_millis(exp_ms.min(cap.as_millis()) as u64);
-
-    if jitter_max_ms > 0 {
-        let jitter = rand::thread_rng().gen_range(0..=jitter_max_ms);
-        delay += Duration::from_millis(jitter);
-    }
-    delay
 }

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -706,7 +706,7 @@ where
                         }
 
                         crate::metrics::indexers::LATEST_BLOCK_NUMBER
-                            .with_label_values(&[Chain::Solana.as_str()])
+                            .with_label_values(&[Chain::Solana.as_str(), "indexed"])
                             .set(response.context.slot as i64);
                     }
                     None => {

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -19,6 +19,7 @@ use k256::{AffinePoint, Scalar};
 use mpc_crypto::kdf::derive_epsilon_sol;
 use mpc_crypto::ScalarExt as _;
 use mpc_primitives::{SignArgs, SignId, LATEST_MPC_KEY_VERSION};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 use signet_program::{
@@ -39,6 +40,7 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, watch};
+use tokio::time::timeout;
 
 pub(crate) static MAX_SECP256K1_SCALAR: LazyLock<Scalar> = LazyLock::new(|| {
     Scalar::from_bytes(
@@ -327,6 +329,33 @@ impl SignatureEvent for SignBidirectionalEvent {
 
 type Result<T> = anyhow::Result<T>;
 
+/// Configuration knobs for timeout + retry.
+#[derive(Debug, Clone)]
+struct TxFetchRetryConfig {
+    /// Timeout per attempt.
+    per_attempt_timeout: Duration,
+    /// Max number of attempts (including the first).
+    max_attempts: usize,
+    /// Base backoff delay after first failure.
+    backoff_base: Duration,
+    /// Maximum backoff delay cap.
+    backoff_max: Duration,
+    /// Random jitter range added to backoff (0..=jitter_max_ms).
+    jitter_max_ms: u64,
+}
+
+impl Default for TxFetchRetryConfig {
+    fn default() -> Self {
+        Self {
+            per_attempt_timeout: Duration::from_secs(3),
+            max_attempts: 5,
+            backoff_base: Duration::from_millis(300),
+            backoff_max: Duration::from_secs(5),
+            jitter_max_ms: 250,
+        }
+    }
+}
+
 pub async fn run(
     sol: Option<SolConfig>,
     sign_tx: mpsc::Sender<Sign>,
@@ -529,23 +558,11 @@ async fn subscribe_and_process_sign_events(
     }
 }
 
-async fn parse_cpi_events(
-    rpc_client: &RpcClient,
-    signature: &Signature,
+fn parse_cpi_events(
+    tx: solana_transaction_status::EncodedConfirmedTransactionWithStatusMeta,
     target_program_id: &Pubkey,
 ) -> Result<Vec<SignatureEventBox>> {
     use solana_transaction_status::{UiInstruction, UiParsedInstruction};
-
-    let tx = rpc_client
-        .get_transaction_with_config(
-            signature,
-            solana_client::rpc_config::RpcTransactionConfig {
-                encoding: Some(solana_transaction_status::UiTransactionEncoding::JsonParsed),
-                commitment: Some(CommitmentConfig::confirmed()),
-                max_supported_transaction_version: Some(0),
-            },
-        )
-        .await?;
 
     let Some(meta) = tx.transaction.meta else {
         return Ok(Vec::new());
@@ -647,59 +664,97 @@ where
 
     let (mut stream, _unsubscriber) = pubsub_client.logs_subscribe(filter, config).await?;
 
+    // stall watchdog
+    let stall_timeout = Duration::from_secs(60);
+    let mut last_ws_msg = Instant::now();
+    let mut watchdog = tokio::time::interval(Duration::from_secs(5));
+
     // Simple TTL cache to avoid multiple getTransaction calls for the same signature
     let mut seen: HashMap<Signature, Instant> = HashMap::new();
     let ttl = Duration::from_secs(30);
 
     let target_program_str = program_id.to_string();
     let program_invoke_str = format!("Program {} invoke [", target_program_str);
-    while let Some(response) = stream.next().await {
-        if response.value.err.is_some() {
-            continue;
-        }
 
-        let logs = &response.value.logs;
-        if !looks_like_cpi_sign_event(logs) || !has_log_starts_with(logs, &program_invoke_str) {
-            continue;
-        }
+    loop {
+        cleanup_seen_cache(&mut seen, ttl);
+        tokio::select! {
+            // Receive WS logs
+            maybe = stream.next() => {
+                match maybe {
+                    Some(response) => {
+                        last_ws_msg = Instant::now();
 
-        let Ok(signature) = Signature::from_str(&response.value.signature) else {
-            tracing::warn!("Invalid signature format");
-            continue;
-        };
-        let now = Instant::now();
-        // Periodic cleanup of expired entries in the TTL cache
-        seen.retain(|_, &mut timestamp| now.duration_since(timestamp) < ttl);
-        if seen.contains_key(&signature) {
-            continue;
-        }
-        seen.insert(signature, now);
+                        if response.value.err.is_some() {
+                            continue;
+                        }
 
-        if let Ok(events) = parse_cpi_events(&rpc_client, &signature, &program_id).await {
-            for ev in events {
-                event_handler(ev, signature, response.context.slot);
+                        let logs = &response.value.logs;
+                        if !looks_like_cpi_sign_event(logs) || !has_log_starts_with(logs, &program_invoke_str) {
+                            continue;
+                        }
+
+                        let Ok(signature) = Signature::from_str(&response.value.signature) else {
+                            tracing::warn!("Invalid signature format");
+                            continue;
+                        };
+
+                        if seen.contains_key(&signature) {
+                            continue;
+                        }
+
+                        let tx = match get_tx_with_timeout_retry(&rpc_client, &signature, TxFetchRetryConfig::default()).await {
+                            Ok(tx) => tx,
+                            Err(e) => {
+                                tracing::warn!("Failed to fetch transaction {}: {}", signature, e);
+                                continue;
+                            }
+                        };
+
+                        let now = Instant::now();
+                        seen.insert(signature, now);
+
+                        match parse_cpi_events(tx, &program_id) {
+                            Ok(events) => {
+                                for ev in events {
+                                    event_handler(ev, signature, response.context.slot);
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!("Failed to parse cpi events for {}: {}", signature, e);
+                                continue;
+                            }
+                        }
+
+                        if let Some(checkpoint) = backlog
+                            .set_processed_block(Chain::Solana, response.context.slot)
+                            .await
+                        {
+                            tracing::info!(slot = response.context.slot, ?checkpoint, "created Solana checkpoint");
+                        }
+
+                        crate::metrics::indexers::LATEST_BLOCK_NUMBER
+                            .with_label_values(&[Chain::Solana.as_str()])
+                            .set(response.context.slot as i64);
+                    }
+                    None => {
+                        // stream ended => force reconnect
+                        anyhow::bail!("solana logs stream ended (None), reconnecting");
+                    }
+                }
+            }
+
+            // Watchdog tick
+            _ = watchdog.tick() => {
+                if last_ws_msg.elapsed() > stall_timeout {
+                    anyhow::bail!(
+                        "solana logs subscription stalled: no ws message for {:?}",
+                        stall_timeout
+                    );
+                }
             }
         }
-
-        // Create checkpoint if one was created at this slot
-        if let Some(checkpoint) = backlog
-            .set_processed_block(Chain::Solana, response.context.slot)
-            .await
-        {
-            tracing::info!(
-                slot = response.context.slot,
-                ?checkpoint,
-                "created Solana checkpoint"
-            );
-        }
-
-        // Update block height metric
-        crate::metrics::indexers::LATEST_BLOCK_NUMBER
-            .with_label_values(&[Chain::Solana.as_str()])
-            .set(response.context.slot as i64);
     }
-
-    Ok(())
 }
 
 fn looks_like_cpi_sign_event(logs: &[String]) -> bool {
@@ -711,23 +766,11 @@ fn has_log_starts_with(logs: &[String], start_with: &str) -> bool {
     logs.iter().any(|l| l.starts_with(start_with))
 }
 
-async fn parse_cpi_respond_events(
-    rpc_client: &RpcClient,
-    signature: &Signature,
+fn parse_cpi_respond_events(
+    tx: solana_transaction_status::EncodedConfirmedTransactionWithStatusMeta,
     target_program_id: &Pubkey,
 ) -> Result<(Vec<RespondBidirectionalEvent>, Vec<SignatureRespondedEvent>)> {
     use solana_transaction_status::{UiInstruction, UiParsedInstruction};
-
-    let tx = rpc_client
-        .get_transaction_with_config(
-            signature,
-            solana_client::rpc_config::RpcTransactionConfig {
-                encoding: Some(solana_transaction_status::UiTransactionEncoding::JsonParsed),
-                commitment: Some(CommitmentConfig::confirmed()),
-                max_supported_transaction_version: Some(0),
-            },
-        )
-        .await?;
 
     let Some(meta) = tx.transaction.meta else {
         return Ok((Vec::new(), Vec::new()));
@@ -843,65 +886,103 @@ async fn subscribe_to_program_respond_events(
 
     let (mut stream, _unsubscriber) = pubsub_client.logs_subscribe(filter, config).await?;
 
-    // Simple TTL cache to avoid multiple getTransaction calls for the same signature
+    // TTL cache: avoid repeated getTransaction on same sig
     let mut seen: HashMap<Signature, Instant> = HashMap::new();
     let ttl = Duration::from_secs(30);
 
+    // Watchdog: force reconnect if WS goes silent
+    let stall_timeout = Duration::from_secs(60);
+    let mut last_ws_msg = Instant::now();
+    let mut watchdog = tokio::time::interval(Duration::from_secs(5));
+
     let program_invoke_log = format!("Program {program_id} invoke [");
-    while let Some(response) = stream.next().await {
-        if response.value.err.is_some() {
-            continue;
-        }
 
-        let logs = &response.value.logs;
-        if !has_log_starts_with(logs, &program_invoke_log) {
-            continue;
-        }
+    loop {
+        cleanup_seen_cache(&mut seen, ttl);
 
-        let Ok(signature) = Signature::from_str(&response.value.signature) else {
-            tracing::warn!("Invalid signature format");
-            continue;
-        };
-        let now = Instant::now();
-        // Periodic cleanup of expired entries in the TTL cache
-        seen.retain(|_, &mut timestamp| now.duration_since(timestamp) < ttl);
-        if seen.contains_key(&signature) {
-            continue;
-        }
-        seen.insert(signature, now);
+        tokio::select! {
+            maybe = stream.next() => {
+                match maybe {
+                    Some(response) => {
+                        last_ws_msg = Instant::now();
 
-        let Ok((respond_bidirectional_events, respond_events)) =
-            parse_cpi_respond_events(&rpc_client, &signature, &program_id).await
-        else {
-            continue;
-        };
-        for ev in respond_bidirectional_events {
-            if let Err(err) = crate::indexer_common::process_respond_bidirectional_event(
-                crate::indexer_common::RespondBidirectionalEvent::Solana(ev),
-                sign_tx.clone(),
-                &backlog,
-            )
-            .await
-            {
-                tracing::error!(?err, "failed to process respond bidirectional event");
+                        if response.value.err.is_some() {
+                            continue;
+                        }
+
+                        let logs = &response.value.logs;
+                        if !has_log_starts_with(logs, &program_invoke_log) {
+                            continue;
+                        }
+
+                        let Ok(signature) = Signature::from_str(&response.value.signature) else {
+                            tracing::warn!("Invalid signature format");
+                            continue;
+                        };
+
+                        if seen.contains_key(&signature) {
+                            continue;
+                        }
+
+                        let tx = match get_tx_with_timeout_retry(&rpc_client, &signature, TxFetchRetryConfig::default()).await {
+                            Ok(tx) => tx,
+                            Err(e) => {
+                                tracing::warn!("Failed to fetch transaction {}: {}", signature, e);
+                                continue;
+                            }
+                        };
+
+                        let now = Instant::now();
+                        seen.insert(signature, now);
+
+                        let (respond_bidirectional_events, respond_events) = match parse_cpi_respond_events(tx, &program_id) {
+                            Ok(v) => v,
+                            Err(err) => {
+                                tracing::warn!(?err, sig = %signature, "failed to parse respond events (will skip this signature)");
+                                continue;
+                            }
+                        };
+
+                        for ev in respond_bidirectional_events {
+                            if let Err(err) = crate::indexer_common::process_respond_bidirectional_event(
+                                crate::indexer_common::RespondBidirectionalEvent::Solana(ev),
+                                sign_tx.clone(),
+                                &backlog,
+                            ).await {
+                                tracing::error!(?err, "failed to process respond bidirectional event");
+                            }
+                        }
+
+                        for ev in respond_events {
+                            if let Err(err) = crate::indexer_common::process_respond_event(
+                                crate::indexer_common::SignatureRespondedEvent::Solana(ev),
+                                sign_tx.clone(),
+                                &mut contract_watcher,
+                                &backlog,
+                            ).await {
+                                tracing::error!(?err, "failed to process respond event");
+                            }
+                        }
+                    }
+                    None => {
+                        anyhow::bail!("solana respond logs stream ended (None), reconnecting");
+                    }
+                }
             }
-        }
 
-        for ev in respond_events {
-            if let Err(err) = crate::indexer_common::process_respond_event(
-                crate::indexer_common::SignatureRespondedEvent::Solana(ev),
-                sign_tx.clone(),
-                &mut contract_watcher,
-                &backlog,
-            )
-            .await
-            {
-                tracing::error!(?err, "failed to process respond event");
+            _ = watchdog.tick() => {
+                if last_ws_msg.elapsed() > stall_timeout {
+                    anyhow::bail!("solana respond logs subscription stalled: no ws message for {:?}", stall_timeout);
+                }
             }
         }
     }
+}
 
-    Ok(())
+// Clean up seen cache based on TTL
+fn cleanup_seen_cache(seen: &mut HashMap<Signature, Instant>, ttl: Duration) {
+    let now = Instant::now();
+    seen.retain(|_, &mut t| now.duration_since(t) < ttl);
 }
 
 pub fn to_mpc_signature(
@@ -928,4 +1009,91 @@ pub fn to_mpc_signature(
         s,
         recovery_id: sig.recovery_id,
     })
+}
+
+/// Fetch transaction with timeout + retry.
+/// Returns the same type as `RpcClient::get_transaction_with_config`.
+async fn get_tx_with_timeout_retry(
+    rpc_client: &RpcClient,
+    signature: &Signature,
+    cfg: TxFetchRetryConfig,
+) -> anyhow::Result<solana_transaction_status::EncodedConfirmedTransactionWithStatusMeta> {
+    let mut last_err: Option<anyhow::Error> = None;
+    if cfg.max_attempts == 0 {
+        anyhow::bail!("max_attempts must be at least 1");
+    }
+
+    for attempt in 1..=cfg.max_attempts {
+        let fut = rpc_client.get_transaction_with_config(
+            signature,
+            solana_client::rpc_config::RpcTransactionConfig {
+                encoding: Some(solana_transaction_status::UiTransactionEncoding::JsonParsed),
+                commitment: Some(CommitmentConfig::confirmed()),
+                max_supported_transaction_version: Some(0),
+            },
+        );
+        match timeout(cfg.per_attempt_timeout, fut).await {
+            Ok(Ok(tx)) => return Ok(tx),
+
+            Ok(Err(e)) => {
+                // On any RPC error, retry until max_attempts is reached.
+                let e_anyhow = anyhow::anyhow!(e).context(format!(
+                    "getTransaction failed (attempt {attempt}/{}) for {}",
+                    cfg.max_attempts, signature
+                ));
+
+                if attempt == cfg.max_attempts {
+                    return Err(e_anyhow);
+                }
+                last_err = Some(e_anyhow);
+            }
+
+            Err(_elapsed) => {
+                let e_anyhow = anyhow::anyhow!(
+                    "getTransaction timed out after {:?} (attempt {attempt}/{}) for {}",
+                    cfg.per_attempt_timeout,
+                    cfg.max_attempts,
+                    signature
+                );
+
+                if attempt == cfg.max_attempts {
+                    return Err(e_anyhow);
+                }
+                last_err = Some(e_anyhow);
+            }
+        }
+
+        // Backoff before next attempt (exponential + jitter).
+        let backoff = compute_backoff_with_jitter(
+            cfg.backoff_base,
+            cfg.backoff_max,
+            attempt,
+            cfg.jitter_max_ms,
+        );
+        tokio::time::sleep(backoff).await;
+    }
+
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("getTransaction failed without error details")))
+}
+
+/// Exponential backoff with jitter.
+///
+/// attempt: 1-based attempt count (1,2,3,...)
+fn compute_backoff_with_jitter(
+    base: Duration,
+    cap: Duration,
+    attempt: usize,
+    jitter_max_ms: u64,
+) -> Duration {
+    // Exponential: base * 2^(attempt-1)
+    let pow = (attempt.saturating_sub(1)).min(16) as u32;
+    let exp_ms = base.as_millis().saturating_mul(1u128 << pow);
+
+    let mut delay = Duration::from_millis(exp_ms.min(cap.as_millis()) as u64);
+
+    if jitter_max_ms > 0 {
+        let jitter = rand::thread_rng().gen_range(0..=jitter_max_ms);
+        delay += Duration::from_millis(jitter);
+    }
+    delay
 }

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -23,6 +23,7 @@ use mpc_keys::hpke;
 use mpc_primitives::SignId;
 use mpc_primitives::Signature;
 
+use crate::util::retry::{retry_async, Backoff, RetryConfig, RetryError, RetryReason};
 use alloy::contract::{ContractInstance, Interface};
 use alloy::dyn_abi::DynSolValue;
 use alloy::network::EthereumWallet;
@@ -94,7 +95,6 @@ pub struct PublishAction {
     output: FullSignature<Secp256k1>,
     pub participants: Vec<Participant>,
     timestamp: Instant,
-    retry_count: usize,
 }
 
 pub enum RpcAction {
@@ -124,7 +124,6 @@ impl RpcChannel {
                     output,
                     participants,
                     timestamp: Instant::now(),
-                    retry_count: 0,
                 }))
                 .await
             {
@@ -903,19 +902,20 @@ async fn update_config(near: NearClient, config: watch::Sender<Config>) {
 }
 
 /// Publish the signature and retry if it fails
-async fn execute_publish(client: ChainClient, mut action: PublishAction, backlog: Backlog) {
+async fn execute_publish(client: ChainClient, action: PublishAction, backlog: Backlog) {
     let chain = action.indexed.chain;
     let sign_id = action.indexed.id;
+
     tracing::info!(
         ?sign_id,
         ?chain,
         started_at = ?action.timestamp.elapsed(),
         "trying to publish signature",
     );
+
     let expected_public_key =
         mpc_crypto::derive_key(action.public_key, action.indexed.args.epsilon);
 
-    // We do this here, rather than on the client side, so we can use the ecrecover system function on NEAR to validate our signature
     let Ok(signature) = crate::kdf::into_eth_sig(
         &expected_public_key,
         &action.output.big_r,
@@ -929,55 +929,66 @@ async fn execute_publish(client: ChainClient, mut action: PublishAction, backlog
         return;
     };
 
-    let publish_result = loop {
-        let publish = match &client {
-            ChainClient::Near(near) => {
-                try_publish_near(near, &action, &action.timestamp, &signature)
-                    .await
-                    .map_err(|_| ())
-            }
-            ChainClient::Ethereum(eth) => {
-                try_publish_eth(eth, &action, &action.timestamp, &signature).await
-            }
-            ChainClient::Solana(sol) => {
-                try_publish_sol(sol, &action, &action.timestamp, &signature)
-                    .await
-                    .map_err(|_| ())
-            }
-            ChainClient::Hydration(hyd) => {
-                try_publish_hydration(hyd, &action, &action.timestamp, &signature)
-                    .await
-                    .map_err(|_| ())
-            }
-            ChainClient::Err(msg) => {
-                tracing::error!(msg, "no client for chain");
-                Ok(())
-            }
-        };
-        if publish.is_ok() {
-            break publish;
-        }
-
-        action.retry_count += 1;
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        if action.retry_count >= MAX_PUBLISH_RETRY {
-            tracing::info!(
-                ?sign_id,
-                elapsed = ?action.timestamp.elapsed(),
-                "exceeded max retries, trashing publish request",
-            );
-            break publish;
-        } else {
-            tracing::info!(
-                ?sign_id,
-                retry_count = action.retry_count,
-                elapsed = ?action.timestamp.elapsed(),
-                "failed to publish, retrying"
-            );
-        }
+    let retry_cfg = RetryConfig {
+        max_attempts: MAX_PUBLISH_RETRY,
+        per_attempt_timeout: Duration::from_secs(30),
+        backoff: Backoff::Fixed(Duration::from_millis(100)),
     };
 
-    if publish_result.is_ok() {
+    let publish_res: Result<(), RetryError<()>> = retry_async(
+        retry_cfg,
+        |_attempt| async {
+            match &client {
+                ChainClient::Near(near) => {
+                    try_publish_near(near, &action, &action.timestamp, &signature)
+                        .await
+                        .map_err(|_| ())
+                }
+                ChainClient::Ethereum(eth) => {
+                    try_publish_eth(eth, &action, &action.timestamp, &signature).await
+                }
+                ChainClient::Solana(sol) => {
+                    try_publish_sol(sol, &action, &action.timestamp, &signature)
+                        .await
+                        .map_err(|_| ())
+                }
+                ChainClient::Hydration(hyd) => {
+                    try_publish_hydration(hyd, &action, &action.timestamp, &signature)
+                        .await
+                        .map_err(|_| ())
+                }
+                ChainClient::Err(msg) => {
+                    tracing::error!(msg, "no client for chain");
+                    Ok(())
+                }
+            }
+        },
+        |_attempt, _reason| true,
+        |attempt, reason, sleep| match reason {
+            RetryReason::Error(e) => {
+                tracing::warn!(
+                    ?sign_id,
+                    retry_count = attempt.saturating_sub(1),
+                    elapsed = ?action.timestamp.elapsed(),
+                    error = ?e,
+                    "failed to publish, retrying in {sleep:?}"
+                );
+            }
+            RetryReason::Timeout(t) => {
+                tracing::warn!(
+                    ?sign_id,
+                    retry_count = attempt.saturating_sub(1),
+                    elapsed = ?action.timestamp.elapsed(),
+                    "publish timed out after {t:?}, retrying in {sleep:?}"
+                );
+            }
+        },
+    )
+    .await;
+
+    let publish_ok = publish_res.is_ok();
+
+    if publish_ok {
         let elapsed_secs =
             crate::util::unix_elapsed(action.indexed.unix_timestamp_indexed).as_secs();
         if elapsed_secs <= chain.expected_response_time_secs() {
@@ -996,15 +1007,19 @@ async fn execute_publish(client: ChainClient, mut action: PublishAction, backlog
             );
         }
         record_request_latency(chain, SignRequestStep::Responding, "ok", action.timestamp);
+    } else {
+        tracing::info!(
+            ?sign_id,
+            elapsed = ?action.timestamp.elapsed(),
+            "exceeded max retries, trashing publish request"
+        );
     }
 
-    // Mark completion in Backlog for SignBidirectional requests
     if matches!(
         action.indexed.sign_request_type,
         SignRequestType::SignBidirectional(_)
     ) {
-        let success = publish_result.is_ok();
-        if let Err(err) = backlog.mark_published(chain, &sign_id, success).await {
+        if let Err(err) = backlog.mark_published(chain, &sign_id, publish_ok).await {
             tracing::warn!(?sign_id, ?err, "failed to mark publish status in backlog");
         }
     }
@@ -1073,23 +1088,10 @@ async fn try_publish_near(
     Ok(())
 }
 
-/// Retry with exponential backoff starting at the specified `initial_delay`
-async fn handle_wait_for_polling_retry(
-    attempt: &mut usize,
-    max_attempts: usize,
-    sign_ids: &[SignId],
-    error_msg: &str,
-    initial_delay: Duration,
-) -> Result<(), ()> {
-    *attempt += 1;
-    tracing::error!(?sign_ids, attempt = *attempt, "{}", error_msg);
-    if *attempt >= max_attempts {
-        tracing::error!(?sign_ids, "exceeded max attempts");
-        return Err(());
-    }
-    let backoff = initial_delay * 2u64.pow((*attempt - 1) as u32) as u32;
-    tokio::time::sleep(backoff).await;
-    Ok(())
+#[derive(Debug)]
+enum PollErr {
+    NotReady,
+    Rpc(anyhow::Error),
 }
 
 // wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
@@ -1099,51 +1101,60 @@ async fn wait_for_pending_tx(
     sign_ids: Vec<SignId>,
     max_attempts: usize,
 ) -> Result<Transaction, ()> {
-    let mut attempt = 0;
-    let initial_delay = Duration::from_secs(5);
-    loop {
-        match tokio::time::timeout(
-            Duration::from_secs(10),
-            provider.get_transaction_by_hash(tx_hash),
-        )
-        .await
-        {
-            Ok(result) => match result {
+    let sign_ids_ref = &sign_ids;
+
+    let cfg = RetryConfig {
+        max_attempts,
+        per_attempt_timeout: Duration::from_secs(10), // 你原来 timeout 10s
+        backoff: Backoff::ExponentialJitter {
+            base: Duration::from_secs(5), // 你原来 initial_delay 5s + exponential
+            cap: Duration::from_secs(60),
+            jitter_max_ms: 0,
+        },
+    };
+
+    let res: Result<Transaction, RetryError<PollErr>> = retry_async(
+        cfg,
+        |_attempt| async {
+            match provider.get_transaction_by_hash(tx_hash).await {
                 Ok(Some(tx)) => {
-                    tracing::info!(?sign_ids, "eth signature respond pending transaction found");
-                    return Ok(tx);
+                    tracing::info!(?sign_ids_ref, "eth signature respond pending transaction found");
+                    Ok(tx)
                 }
-                Ok(None) => {
-                    handle_wait_for_polling_retry(
-                        &mut attempt,
-                        max_attempts,
-                        &sign_ids,
-                        "eth signature respond pending transaction not found, retrying",
-                        initial_delay,
-                    )
-                    .await?;
-                }
-                Err(err) => {
-                    handle_wait_for_polling_retry(
-                        &mut attempt,
-                        max_attempts,
-                        &sign_ids,
-                        &format!("failed to get eth signature respond pending transaction, retrying: {err:?}"),
-                        initial_delay,
-                    ).await?;
-                }
-            },
-            Err(_) => {
-                handle_wait_for_polling_retry(
-                    &mut attempt,
-                    max_attempts,
-                    &sign_ids,
-                    "timeout while getting eth signature respond pending transaction, retrying",
-                    initial_delay,
-                )
-                .await?;
+                Ok(None) => Err(PollErr::NotReady),
+                Err(e) => Err(PollErr::Rpc(anyhow::anyhow!(e))),
             }
-        }
+        },
+        |_attempt, _reason| true,
+        |attempt, reason, sleep| match reason {
+            RetryReason::Error(PollErr::NotReady) => {
+                tracing::error!(
+                    ?sign_ids_ref,
+                    attempt,
+                    "eth signature respond pending transaction not found, retrying in {sleep:?}"
+                );
+            }
+            RetryReason::Error(PollErr::Rpc(e)) => {
+                tracing::error!(
+                    ?sign_ids_ref,
+                    attempt,
+                    "failed to get eth signature respond pending transaction, retrying in {sleep:?}: {e:?}"
+                );
+            }
+            RetryReason::Timeout(_t) => {
+                tracing::error!(
+                    ?sign_ids_ref,
+                    attempt,
+                    "timeout while getting eth signature respond pending transaction, retrying in {sleep:?}"
+                );
+            }
+        },
+    )
+    .await;
+
+    match res {
+        Ok(tx) => Ok(tx),
+        Err(_) => Err(()),
     }
 }
 
@@ -1154,50 +1165,86 @@ async fn wait_for_transaction_receipt(
     sign_ids: Vec<SignId>,
     max_attempts: usize,
 ) -> Result<TransactionReceipt, ()> {
-    let mut attempt = 0;
-    let initial_delay = Duration::from_secs(5);
-    loop {
-        match tokio::time::timeout(
-            Duration::from_secs(10),
-            provider.get_transaction_receipt(tx_hash),
-        )
-        .await
-        {
-            Ok(result) => match result {
+    let sign_ids_ref = &sign_ids;
+
+    let retry_config = RetryConfig {
+        max_attempts,
+        per_attempt_timeout: Duration::from_secs(10),
+        backoff: Backoff::ExponentialJitter {
+            base: Duration::from_secs(5),
+            cap: Duration::from_secs(60),
+            jitter_max_ms: 0,
+        },
+    };
+
+    let res: Result<TransactionReceipt, RetryError<PollErr>> = retry_async(
+        retry_config,
+        |_attempt| async {
+            match provider.get_transaction_receipt(tx_hash).await {
                 Ok(Some(receipt)) => {
-                    tracing::info!(?sign_ids, "eth signature respond transaction receipt found");
-                    return Ok(receipt);
+                    tracing::info!(?sign_ids_ref, "eth signature respond transaction receipt found");
+                    Ok(receipt)
                 }
-                Ok(None) => {
-                    handle_wait_for_polling_retry(
-                        &mut attempt,
-                        max_attempts,
-                        &sign_ids,
-                        "eth signature respond transaction receipt not found, retrying",
-                        initial_delay,
-                    )
-                    .await?;
-                }
-                Err(err) => {
-                    handle_wait_for_polling_retry(
-                        &mut attempt,
-                        max_attempts,
-                        &sign_ids,
-                        &format!("failed to get eth signature respond transaction receipt, retrying: {err:?}"),
-                        initial_delay,
-                    ).await?;
-                }
-            },
-            Err(_) => {
-                handle_wait_for_polling_retry(
-                    &mut attempt,
-                    max_attempts,
-                    &sign_ids,
-                    "timeout while getting eth signature respond transaction receipt, retrying",
-                    initial_delay,
-                )
-                .await?;
+                Ok(None) => Err(PollErr::NotReady),
+                Err(e) => Err(PollErr::Rpc(anyhow::anyhow!(e))),
             }
+        },
+        |_attempt, _reason| true,
+        |attempt, reason, sleep| match reason {
+            RetryReason::Error(PollErr::NotReady) => {
+                tracing::error!(
+                    ?sign_ids_ref,
+                    attempt,
+                    "eth signature respond transaction receipt not found, retrying in {sleep:?}"
+                );
+            }
+            RetryReason::Error(PollErr::Rpc(e)) => {
+                tracing::error!(
+                    ?sign_ids_ref,
+                    attempt,
+                    "failed to get eth signature respond transaction receipt, retrying in {sleep:?}: {e:?}"
+                );
+            }
+            RetryReason::Timeout(_t) => {
+                tracing::error!(
+                    ?sign_ids_ref,
+                    attempt,
+                    "timeout while getting eth signature respond transaction receipt, retrying in {sleep:?}"
+                );
+            }
+        },
+    )
+    .await;
+
+    match res {
+        Ok(r) => Ok(r),
+        Err(_) => Err(()),
+    }
+}
+
+fn log_retry_err(ctx: &str, sign_ids: &[SignId], err: RetryError<anyhow::Error>) {
+    match err {
+        RetryError::Exhausted {
+            attempts,
+            last_error,
+        } => {
+            tracing::error!(
+                ?sign_ids,
+                attempts,
+                ?last_error,
+                "{ctx}: retry attempts exhausted"
+            );
+        }
+        RetryError::TimeoutExhausted {
+            attempts,
+            last_timeout,
+        } => {
+            tracing::error!(
+                ?sign_ids,
+                attempts,
+                ?last_timeout,
+                "{ctx}: timeout exhausted"
+            );
         }
     }
 }
@@ -1208,56 +1255,114 @@ async fn send_eth_transaction(
     gas: u64,
     sign_ids: &[SignId],
 ) -> Result<alloy::primitives::B256, ()> {
-    // fetch nonce manually since the automatic nonce management in ContractInstance is lagging
-    let nonce = match tokio::time::timeout(
-        Duration::from_secs(10),
-        contract
-            .provider()
-            .get_transaction_count(contract.provider().default_signer_address())
-            .pending(),
+    let cfg_nonce = RetryConfig {
+        max_attempts: 3,
+        per_attempt_timeout: Duration::from_secs(10),
+        backoff: Backoff::ExponentialJitter {
+            base: Duration::from_millis(500),
+            cap: Duration::from_secs(5),
+            jitter_max_ms: 200,
+        },
+    };
+
+    let nonce_res: Result<u64, RetryError<anyhow::Error>> = retry_async(
+        cfg_nonce,
+        |_attempt| async {
+            contract
+                .provider()
+                .get_transaction_count(contract.provider().default_signer_address())
+                .pending()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))
+        },
+        |_attempt, _reason| true,
+        |attempt, reason, sleep| match reason {
+            RetryReason::Error(e) => {
+                tracing::warn!(
+                    ?sign_ids,
+                    attempt,
+                    ?e,
+                    "get_nonce failed, retrying in {sleep:?}"
+                );
+            }
+            RetryReason::Timeout(t) => {
+                tracing::warn!(
+                    ?sign_ids,
+                    attempt,
+                    "get_nonce timed out after {t:?}, retrying in {sleep:?}"
+                );
+            }
+        },
     )
-    .await
-    {
-        Ok(Ok(nonce)) => {
+    .await;
+
+    let nonce = match nonce_res {
+        Ok(nonce) => {
             tracing::info!(nonce, "will send eth tx with nonce");
             nonce
         }
-        Ok(Err(err)) => {
-            tracing::error!(?err, "failed to get nonce");
-            return Err(());
-        }
         Err(err) => {
-            tracing::error!(?err, "timeout to get nonce");
+            log_retry_err("failed to get nonce", sign_ids, err);
             return Err(());
         }
     };
 
-    let result = tokio::time::timeout(
-        Duration::from_secs(30),
-        contract
-            .function("respond", params)
-            .unwrap()
-            .gas(gas)
-            // setting nonce manually since the automatic nonce management in ContractInstance is lagging
-            .nonce(nonce)
-            .send(),
-    )
-    .await
-    .map_err(|_| {
-        tracing::error!(
-            ?sign_ids,
-            "timeout while sending ethereum signature transaction"
-        );
-    })?
-    .map_err(|err| {
-        tracing::error!(
-            ?sign_ids,
-            ?err,
-            "failed to send ethereum signature transaction"
-        );
-    })?;
+    let cfg_send = RetryConfig {
+        max_attempts: 3,
+        per_attempt_timeout: Duration::from_secs(30),
+        backoff: Backoff::ExponentialJitter {
+            base: Duration::from_millis(500),
+            cap: Duration::from_secs(10),
+            jitter_max_ms: 200,
+        },
+    };
 
-    Ok(*result.tx_hash())
+    let send_res: Result<alloy::primitives::B256, RetryError<anyhow::Error>> = retry_async(
+        cfg_send,
+        |_attempt| async {
+            let pending = contract
+                .function("respond", params)
+                .unwrap()
+                .gas(gas)
+                .nonce(nonce) // 保持你原来的逻辑：手动 nonce
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?;
+
+            Ok(*pending.tx_hash())
+        },
+        |_attempt, _reason| true,
+        |attempt, reason, sleep| match reason {
+            RetryReason::Error(e) => {
+                tracing::warn!(
+                    ?sign_ids,
+                    attempt,
+                    ?e,
+                    "send eth tx failed, retrying in {sleep:?}"
+                );
+            }
+            RetryReason::Timeout(t) => {
+                tracing::warn!(
+                    ?sign_ids,
+                    attempt,
+                    "send eth tx timed out after {t:?}, retrying in {sleep:?}"
+                );
+            }
+        },
+    )
+    .await;
+
+    match send_res {
+        Ok(tx_hash) => Ok(tx_hash),
+        Err(err) => {
+            log_retry_err(
+                "failed to send ethereum signature transaction",
+                sign_ids,
+                err,
+            );
+            Err(())
+        }
+    }
 }
 
 async fn try_publish_eth(
@@ -1418,65 +1523,79 @@ async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAc
         signatures.insert(sign_id, signature);
     }
 
-    let mut retry_count = 0;
-    loop {
-        let publish = match client {
-            ChainClient::Near(_) => {
-                tracing::error!("near has no batch publish");
-                Ok(())
-            }
-            ChainClient::Solana(_) => {
-                tracing::error!("Solana has no batch publish");
-                Ok(())
-            }
-            ChainClient::Ethereum(eth) => try_batch_publish_eth(eth, actions, &signatures).await,
-            ChainClient::Hydration(_) => {
-                tracing::error!("Hydration has no batch publish");
-                Ok(())
-            }
-            ChainClient::Err(msg) => {
-                tracing::error!(msg, "no client for chain");
-                Ok(())
-            }
-        };
-        if publish.is_ok() {
-            // Record metrics for successful batch publish
-            for action in actions.iter() {
-                let chain = action.indexed.chain;
-                let elapsed = crate::util::unix_elapsed(action.indexed.unix_timestamp_indexed);
-                if elapsed.as_secs() <= chain.expected_response_time_secs() {
-                    record_request_latency(
-                        chain,
-                        SignRequestStep::Total,
-                        "in_time",
-                        action.indexed.unix_timestamp_indexed,
-                    );
-                } else {
-                    record_request_latency(
-                        chain,
-                        SignRequestStep::Total,
-                        "expired",
-                        action.indexed.unix_timestamp_indexed,
-                    );
-                }
-                record_request_latency(chain, SignRequestStep::Responding, "ok", action.timestamp);
-            }
-            actions.clear();
-            break;
-        }
+    let cfg = RetryConfig {
+        max_attempts: MAX_PUBLISH_RETRY,
+        per_attempt_timeout: Duration::from_secs(5),
+        backoff: Backoff::Fixed(Duration::from_millis(100)),
+    };
 
-        tracing::warn!("batch publish failed, {publish:?}");
-        retry_count += 1;
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        if retry_count >= MAX_PUBLISH_RETRY {
-            tracing::info!("exceeded max retries, trashing publish request",);
-            // clearing actions to avoid retrying
-            actions.clear();
-            break;
-        } else {
-            tracing::info!("failed to publish, retrying");
+    // 只借用 actions/signatures/client，避免 move
+    let res: Result<(), RetryError<()>> = retry_async(
+        cfg,
+        |_attempt| async {
+            match client {
+                ChainClient::Near(_) => {
+                    tracing::error!("near has no batch publish");
+                    Ok(())
+                }
+                ChainClient::Solana(_) => {
+                    tracing::error!("Solana has no batch publish");
+                    Ok(())
+                }
+                ChainClient::Ethereum(eth) => {
+                    try_batch_publish_eth(eth, actions, &signatures).await
+                }
+                ChainClient::Hydration(_) => {
+                    tracing::error!("Hydration has no batch publish");
+                    Ok(())
+                }
+                ChainClient::Err(msg) => {
+                    tracing::error!(msg, "no client for chain");
+                    Ok(())
+                }
+            }
+        },
+        |_attempt, _reason| true,
+        |attempt, reason, sleep| match reason {
+            RetryReason::Error(_e) => {
+                tracing::warn!("batch publish failed (attempt {attempt}), retrying in {sleep:?}");
+            }
+            RetryReason::Timeout(t) => {
+                tracing::warn!(
+                    "batch publish timed out after {t:?} (attempt {attempt}), retrying in {sleep:?}"
+                );
+            }
+        },
+    )
+    .await;
+
+    if res.is_ok() {
+        for action in actions.iter() {
+            let chain = action.indexed.chain;
+            let elapsed = crate::util::unix_elapsed(action.indexed.unix_timestamp_indexed);
+            if elapsed.as_secs() <= chain.expected_response_time_secs() {
+                record_request_latency(
+                    chain,
+                    SignRequestStep::Total,
+                    "in_time",
+                    action.indexed.unix_timestamp_indexed,
+                );
+            } else {
+                record_request_latency(
+                    chain,
+                    SignRequestStep::Total,
+                    "expired",
+                    action.indexed.unix_timestamp_indexed,
+                );
+            }
+            record_request_latency(chain, SignRequestStep::Responding, "ok", action.timestamp);
         }
+        actions.clear();
+        return;
     }
+
+    tracing::info!("exceeded max retries, trashing publish request");
+    actions.clear();
 }
 
 use signet_program::accounts::Respond as SolanaRespondAccount;

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -16,7 +16,7 @@ use alloy::primitives::Address;
 use alloy::providers::fillers::{FillProvider, JoinFill, WalletFiller};
 use alloy::providers::{Provider, RootProvider, WalletProvider};
 use alloy::rpc::types::{Transaction, TransactionReceipt};
-use cait_sith::protocol::Participant;
+use cait_sith::protocol::{Action, Participant};
 use cait_sith::FullSignature;
 use k256::{AffinePoint, Secp256k1};
 use mpc_keys::hpke;
@@ -970,6 +970,7 @@ async fn execute_publish(client: ChainClient, action: PublishAction, backlog: Ba
                     ?sign_id,
                     retry_count = attempt.saturating_sub(1),
                     elapsed = ?action.timestamp.elapsed(),
+                    chain = ?action.indexed.chain,
                     "failed to publish, retrying in {sleep:?}"
                 );
             }
@@ -978,6 +979,7 @@ async fn execute_publish(client: ChainClient, action: PublishAction, backlog: Ba
                     ?sign_id,
                     retry_count = attempt.saturating_sub(1),
                     elapsed = ?action.timestamp.elapsed(),
+                    chain = ?action.indexed.chain,
                     "publish timed out after {t:?}, retrying in {sleep:?}"
                 );
             }

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -931,8 +931,8 @@ async fn execute_publish(client: ChainClient, action: PublishAction, backlog: Ba
 
     let retry_cfg = RetryConfig {
         max_attempts: MAX_PUBLISH_RETRY,
-        per_attempt_timeout: Duration::from_secs(30),
-        backoff: Backoff::Fixed(Duration::from_millis(100)),
+        per_attempt_timeout: Duration::from_secs(120),
+        backoff: Backoff::Fixed(Duration::from_secs(5)),
     };
 
     let publish_res: Result<(), RetryError<()>> = retry_async(
@@ -1104,10 +1104,10 @@ async fn wait_for_pending_tx(
 
     let cfg = RetryConfig {
         max_attempts,
-        per_attempt_timeout: Duration::from_secs(10),
+        per_attempt_timeout: Duration::from_secs(5),
         backoff: Backoff::ExponentialJitter {
-            base: Duration::from_secs(5),
-            cap: Duration::from_secs(60),
+            base: Duration::from_secs(1),
+            cap: Duration::from_secs(10),
             jitter_max_ms: 0,
         },
     };
@@ -1168,10 +1168,10 @@ async fn wait_for_transaction_receipt(
 
     let retry_config = RetryConfig {
         max_attempts,
-        per_attempt_timeout: Duration::from_secs(10),
+        per_attempt_timeout: Duration::from_secs(2),
         backoff: Backoff::ExponentialJitter {
-            base: Duration::from_secs(5),
-            cap: Duration::from_secs(60),
+            base: Duration::from_secs(1),
+            cap: Duration::from_secs(20),
             jitter_max_ms: 0,
         },
     };
@@ -1256,7 +1256,7 @@ async fn send_eth_transaction(
 ) -> Result<alloy::primitives::B256, ()> {
     let cfg_nonce = RetryConfig {
         max_attempts: 3,
-        per_attempt_timeout: Duration::from_secs(10),
+        per_attempt_timeout: Duration::from_secs(2),
         backoff: Backoff::ExponentialJitter {
             base: Duration::from_millis(500),
             cap: Duration::from_secs(5),
@@ -1308,7 +1308,7 @@ async fn send_eth_transaction(
 
     let cfg_send = RetryConfig {
         max_attempts: 3,
-        per_attempt_timeout: Duration::from_secs(30),
+        per_attempt_timeout: Duration::from_secs(5),
         backoff: Backoff::ExponentialJitter {
             base: Duration::from_millis(500),
             cap: Duration::from_secs(10),
@@ -1524,8 +1524,12 @@ async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAc
 
     let cfg = RetryConfig {
         max_attempts: MAX_PUBLISH_RETRY,
-        per_attempt_timeout: Duration::from_secs(5),
-        backoff: Backoff::Fixed(Duration::from_millis(100)),
+        per_attempt_timeout: Duration::from_secs(120),
+        backoff: Backoff::ExponentialJitter {
+            base: Duration::from_secs(1),
+            cap: Duration::from_secs(10),
+            jitter_max_ms: 0,
+        },
     };
 
     let res: Result<(), RetryError<()>> = retry_async(

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -965,12 +965,11 @@ async fn execute_publish(client: ChainClient, action: PublishAction, backlog: Ba
         },
         |_attempt, _reason| true,
         |attempt, reason, sleep| match reason {
-            RetryReason::Error(e) => {
+            RetryReason::Error(_) => {
                 tracing::warn!(
                     ?sign_id,
                     retry_count = attempt.saturating_sub(1),
                     elapsed = ?action.timestamp.elapsed(),
-                    error = ?e,
                     "failed to publish, retrying in {sleep:?}"
                 );
             }

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -1105,9 +1105,9 @@ async fn wait_for_pending_tx(
 
     let cfg = RetryConfig {
         max_attempts,
-        per_attempt_timeout: Duration::from_secs(10), // 你原来 timeout 10s
+        per_attempt_timeout: Duration::from_secs(10),
         backoff: Backoff::ExponentialJitter {
-            base: Duration::from_secs(5), // 你原来 initial_delay 5s + exponential
+            base: Duration::from_secs(5),
             cap: Duration::from_secs(60),
             jitter_max_ms: 0,
         },
@@ -1324,7 +1324,7 @@ async fn send_eth_transaction(
                 .function("respond", params)
                 .unwrap()
                 .gas(gas)
-                .nonce(nonce) // 保持你原来的逻辑：手动 nonce
+                .nonce(nonce)
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!(e))?;
@@ -1529,7 +1529,6 @@ async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAc
         backoff: Backoff::Fixed(Duration::from_millis(100)),
     };
 
-    // 只借用 actions/signatures/client，避免 move
     let res: Result<(), RetryError<()>> = retry_async(
         cfg,
         |_attempt| async {

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -16,7 +16,7 @@ use alloy::primitives::Address;
 use alloy::providers::fillers::{FillProvider, JoinFill, WalletFiller};
 use alloy::providers::{Provider, RootProvider, WalletProvider};
 use alloy::rpc::types::{Transaction, TransactionReceipt};
-use cait_sith::protocol::{Action, Participant};
+use cait_sith::protocol::Participant;
 use cait_sith::FullSignature;
 use k256::{AffinePoint, Secp256k1};
 use mpc_keys::hpke;

--- a/chain-signatures/node/src/util/mod.rs
+++ b/chain-signatures/node/src/util/mod.rs
@@ -10,6 +10,8 @@ use std::future::Future;
 use std::hash::Hash;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+pub mod retry;
+
 pub trait NearPublicKeyExt {
     fn into_affine_point(self) -> PublicKey;
 }

--- a/chain-signatures/node/src/util/retry.rs
+++ b/chain-signatures/node/src/util/retry.rs
@@ -1,0 +1,165 @@
+use rand::Rng;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[derive(Clone)]
+pub enum Backoff {
+    /// Sleep a fixed duration between retries.
+    Fixed(Duration),
+
+    /// Exponential backoff with jitter:
+    /// delay = min(cap, base * 2^(attempt-1)) + rand(0..=jitter_max_ms)
+    ExponentialJitter {
+        base: Duration,
+        cap: Duration,
+        jitter_max_ms: u64,
+    },
+
+    /// Provide a custom function: attempt (1-based) -> delay
+    Custom(Arc<dyn Fn(usize) -> Duration + Send + Sync>),
+}
+
+impl Backoff {
+    pub fn delay(&self, attempt: usize) -> Duration {
+        match self {
+            Backoff::Fixed(d) => *d,
+            Backoff::ExponentialJitter {
+                base,
+                cap,
+                jitter_max_ms,
+            } => compute_backoff_with_jitter(*base, *cap, attempt, *jitter_max_ms),
+            Backoff::Custom(f) => (f)(attempt),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RetryConfig {
+    /// Total attempts including the first one. Must be >= 1.
+    pub max_attempts: usize,
+    /// timeout applied per attempt.
+    pub per_attempt_timeout: Duration,
+    /// Backoff strategy (default: exponential + jitter).
+    pub backoff: Backoff,
+}
+
+impl RetryConfig {
+    pub fn new(max_attempts: usize, per_attempt_timeout: Duration, backoff: Backoff) -> Self {
+        assert!(max_attempts >= 1, "max_attempts must be at least 1");
+        Self {
+            max_attempts,
+            per_attempt_timeout,
+            backoff,
+        }
+    }
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: 5,
+            per_attempt_timeout: Duration::from_secs(2),
+            backoff: Backoff::ExponentialJitter {
+                base: Duration::from_millis(500),
+                cap: Duration::from_secs(10),
+                jitter_max_ms: 0,
+            },
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum RetryError<E> {
+    Exhausted {
+        attempts: usize,
+        last_error: E,
+    },
+    TimeoutExhausted {
+        attempts: usize,
+        last_timeout: Duration,
+    },
+}
+
+/// Reason for a retry attempt (passed to hooks).
+#[derive(Debug)]
+pub enum RetryReason<'a, E> {
+    Error(&'a E),
+    Timeout(Duration),
+}
+
+pub fn compute_backoff_with_jitter(
+    base: Duration,
+    cap: Duration,
+    attempt: usize,
+    jitter_max_ms: u64,
+) -> Duration {
+    // Exponential: base * 2^(attempt-1)
+    let pow = (attempt.saturating_sub(1)).min(16) as u32;
+    let exp_ms = base.as_millis().saturating_mul(1u128 << pow);
+
+    let mut delay = Duration::from_millis(exp_ms.min(cap.as_millis()) as u64);
+
+    if jitter_max_ms > 0 {
+        let jitter = rand::thread_rng().gen_range(0..=jitter_max_ms);
+        delay += Duration::from_millis(jitter);
+    }
+    delay
+}
+
+/// Generic retry for async ops returning Result<T, E>.
+///
+/// - attempt is 1..=max_attempts
+/// - should_retry decides whether to continue retrying
+/// - on_retry is invoked before sleeping (log/metrics/tracing)
+pub async fn retry_async<T, E, Fut, Op, ShouldRetry, OnRetry>(
+    cfg: RetryConfig,
+    mut op: Op,
+    mut should_retry: ShouldRetry,
+    mut on_retry: OnRetry,
+) -> Result<T, RetryError<E>>
+where
+    Fut: Future<Output = Result<T, E>>,
+    Op: FnMut(usize) -> Fut,
+    ShouldRetry: FnMut(usize, RetryReason<'_, E>) -> bool,
+    OnRetry: FnMut(usize, RetryReason<'_, E>, Duration),
+{
+    assert!(cfg.max_attempts >= 1, "max_attempts must be at least 1");
+
+    for attempt in 1..=cfg.max_attempts {
+        match tokio::time::timeout(cfg.per_attempt_timeout, op(attempt)).await {
+            Ok(Ok(v)) => return Ok(v),
+            Ok(Err(e)) => {
+                let is_last = attempt == cfg.max_attempts;
+                if is_last || !should_retry(attempt, RetryReason::Error(&e)) {
+                    return Err(RetryError::Exhausted {
+                        attempts: attempt,
+                        last_error: e,
+                    });
+                }
+                let sleep_duration = cfg.backoff.delay(attempt);
+                on_retry(attempt, RetryReason::Error(&e), sleep_duration);
+                tokio::time::sleep(sleep_duration).await;
+            }
+            Err(_elapsed) => {
+                let is_last = attempt == cfg.max_attempts;
+                if is_last || !should_retry(attempt, RetryReason::Timeout(cfg.per_attempt_timeout))
+                {
+                    return Err(RetryError::TimeoutExhausted {
+                        attempts: attempt,
+                        last_timeout: cfg.per_attempt_timeout,
+                    });
+                }
+                let sleep_duration = cfg.backoff.delay(attempt);
+                on_retry(
+                    attempt,
+                    RetryReason::Timeout(cfg.per_attempt_timeout),
+                    sleep_duration,
+                );
+                tokio::time::sleep(sleep_duration).await;
+            }
+        }
+    }
+
+    unreachable!("loop returns on success or exhausted");
+}

--- a/chain-signatures/node/src/util/retry.rs
+++ b/chain-signatures/node/src/util/retry.rs
@@ -40,7 +40,7 @@ pub struct RetryConfig {
     pub max_attempts: usize,
     /// timeout applied per attempt.
     pub per_attempt_timeout: Duration,
-    /// Backoff strategy (default: exponential + jitter).
+    /// Backoff strategy (default: exponential + 0 jitter).
     pub backoff: Backoff,
 }
 
@@ -98,7 +98,11 @@ pub fn compute_backoff_with_jitter(
     let pow = (attempt.saturating_sub(1)).min(16) as u32;
     let exp_ms = base.as_millis().saturating_mul(1u128 << pow);
 
-    let mut delay = Duration::from_millis(exp_ms.min(cap.as_millis()) as u64);
+    let bounded_ms = exp_ms.min(cap.as_millis());
+    let mut delay = match u64::try_from(bounded_ms) {
+        Ok(ms) => Duration::from_millis(ms),
+        Err(_) => cap.min(Duration::from_millis(u64::MAX)),
+    };
 
     if jitter_max_ms > 0 {
         let jitter = rand::thread_rng().gen_range(0..=jitter_max_ms);


### PR DESCRIPTION
the reason why solana indexer block height stuck could be: 
1) get_transaction_with_config hangs, not getting response and hangs there forever
2) stream.next() hangs forever

in this PR, both will result in the function returning Err, then the solana client will resubscribe.

fix this issue:  https://github.com/sig-net/mpc/issues/648