### PR TITLE
fix: fetch_owned should not include reserved

### DIFF
--- a/chain-signatures/node/src/storage/protocol_storage.rs
+++ b/chain-signatures/node/src/storage/protocol_storage.rs
@@ -171,7 +171,7 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
             })
             .unwrap_or_default();
 
-        owned.union(&*self.reserved.read().await).copied().collect()
+        owned.into_iter().collect()
     }
 
     pub async fn reserve(&self, id: A::Id) -> Option<ArtifactSlot<A>> {


### PR DESCRIPTION
Reserved triple ids are not assigned to a owner, yet. Including them is inconsistent.

There is also a race condition, where a triple is already stored with another owner but `unreserve` has not been called, yet. during that time, a triple will be returned for two different owners.

For Presignatures, the owner is known ahead of time. But it is still wrong to assume that all reserved ids will be owned by this node.