### PR TITLE
Avoid bad timing on posits

### DIFF
--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -345,8 +345,13 @@ impl<Id: Copy + Hash + Eq + fmt::Debug, S> Posits<Id, S> {
         timeout: Duration,
     ) -> Vec<(Id, PositInternalAction<S>)> {
         let mut expired = Vec::new();
-        for (id, (_, timestamp)) in &self.posits {
-            if timestamp.elapsed() > timeout {
+        for (id, (positor, timestamp)) in &self.posits {
+            // Deliberators need to wait longer than the proposer, otherwise
+            // they have a high chance of aborting just when the proposer
+            // decides to move forward.
+            if (positor.is_proposer() && timestamp.elapsed() > timeout)
+                || (timestamp.elapsed() > timeout * 2)
+            {
                 expired.push(*id);
             }
         }

--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -606,7 +606,8 @@ mod tests {
             threshold,
             &PositAction::Propose,
         );
-        std::thread::sleep(Duration::from_millis(1100));
+        // need to wait for more than 2 * timeout because deliberators wait for double the timeout.
+        std::thread::sleep(Duration::from_millis(2100));
         let actions = posits1.expire_and_start(threshold, Duration::from_secs(1));
         assert_eq!(actions.len(), 0);
         assert_eq!(posits1.len(), 0);

--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -339,19 +339,28 @@ impl<Id: Copy + Hash + Eq + fmt::Debug, S> Posits<Id, S> {
 
     /// Expire and start protocols on enough accepted votes. Abort protocols action will be returned
     /// if the posit has expired.
+    ///
+    /// Note on `deliberator_extra_time`:
+    ///   Deliberators need to wait longer than the proposer, otherwise
+    ///   they have a high chance of aborting just when the proposer
+    ///   decides to move forward.
+    ///   Once Ts and Ps are generated with a single task, the same way
+    ///   signatures are handled, this should be replaced with a round-based
+    ///   message buffer.
     pub fn expire_and_start(
         &mut self,
         threshold: usize,
         timeout: Duration,
+        deliberator_extra_time: Duration,
     ) -> Vec<(Id, PositInternalAction<S>)> {
         let mut expired = Vec::new();
         for (id, (positor, timestamp)) in &self.posits {
-            // Deliberators need to wait longer than the proposer, otherwise
-            // they have a high chance of aborting just when the proposer
-            // decides to move forward.
-            if (positor.is_proposer() && timestamp.elapsed() > timeout)
-                || (timestamp.elapsed() > timeout * 2)
-            {
+            let final_timeout = if positor.is_proposer() {
+                timeout
+            } else {
+                timeout + deliberator_extra_time
+            };
+            if timestamp.elapsed() > final_timeout {
                 expired.push(*id);
             }
         }
@@ -580,11 +589,13 @@ mod tests {
         // have proposer accept, and everyone else not reply at all.
         let id202 = 202;
         posits0.propose(id202, (), &participants);
-        // expire the posit after 1 second. Only the posit for id101 should return to start the protocol.
-        std::thread::sleep(Duration::from_millis(1100));
+        // expire the posit. Only the posit for id101 should return to start the protocol.
+        let base_delay = Duration::from_secs(1);
+        let deliberator_extra_delay = Duration::from_millis(200);
+        std::thread::sleep(base_delay + deliberator_extra_delay + Duration::from_millis(100));
         // add a posit that will not expire yet
         posits0.propose(303, (), &participants);
-        let mut actions = posits0.expire_and_start(threshold, Duration::from_secs(1));
+        let mut actions = posits0.expire_and_start(threshold, base_delay, deliberator_extra_delay);
         actions.sort_by_key(|(id, _)| *id);
         assert_eq!(posits0.len(), 1);
         assert_eq!(actions.len(), 2);
@@ -606,9 +617,9 @@ mod tests {
             threshold,
             &PositAction::Propose,
         );
-        // need to wait for more than 2 * timeout because deliberators wait for double the timeout.
-        std::thread::sleep(Duration::from_millis(2100));
-        let actions = posits1.expire_and_start(threshold, Duration::from_secs(1));
+
+        std::thread::sleep(base_delay + deliberator_extra_delay + Duration::from_millis(100));
+        let actions = posits1.expire_and_start(threshold, base_delay, deliberator_extra_delay);
         assert_eq!(actions.len(), 0);
         assert_eq!(posits1.len(), 0);
     }

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -683,7 +683,7 @@ impl PresignatureSpawner {
         ongoing_gen_tx: watch::Sender<usize>,
     ) {
         let mut stockpile_interval = time::interval(Duration::from_millis(100));
-        let mut expiration_interval = tokio::time::interval(Duration::from_secs(20));
+        let mut expiration_interval = tokio::time::interval(Duration::from_secs(1));
         let mut posits = self.msg.subscribe_presignature_posit().await;
 
         let mut protocol = cfg.borrow().protocol.clone();
@@ -692,7 +692,7 @@ impl PresignatureSpawner {
         loop {
             tokio::select! {
                 _ = expiration_interval.tick() => {
-                    for (id, action) in self.posits.expire_and_start(self.threshold, Duration::from_secs(60)) {
+                    for (id, action) in self.posits.expire_and_start(self.threshold, Duration::from_secs(10)) {
                         let PositInternalAction::StartProtocol(participants, positor) = action else {
                             tracing::warn!(
                                 ?id,

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -692,7 +692,7 @@ impl PresignatureSpawner {
         loop {
             tokio::select! {
                 _ = expiration_interval.tick() => {
-                    for (id, action) in self.posits.expire_and_start(self.threshold, Duration::from_secs(10)) {
+                    for (id, action) in self.posits.expire_and_start(self.threshold, Duration::from_secs(10), Duration::from_secs(2)) {
                         let PositInternalAction::StartProtocol(participants, positor) = action else {
                             tracing::warn!(
                                 ?id,

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -557,7 +557,7 @@ impl TripleSpawner {
         ongoing_gen_tx: watch::Sender<usize>,
     ) {
         let mut stockpile_interval = tokio::time::interval(Duration::from_millis(100));
-        let mut expiration_interval = tokio::time::interval(Duration::from_secs(60));
+        let mut expiration_interval = tokio::time::interval(Duration::from_secs(1));
         let mut posits = self.msg.subscribe_triple_posit().await;
 
         let mut active = mesh_state.borrow().active().keys_vec();
@@ -566,7 +566,7 @@ impl TripleSpawner {
         loop {
             tokio::select! {
                 _ = expiration_interval.tick() => {
-                    for action in self.posits.expire_and_start(self.threshold, Duration::from_secs(60)) {
+                    for action in self.posits.expire_and_start(self.threshold, Duration::from_secs(10)) {
                         let (id, PositInternalAction::StartProtocol(participants, positor)) = action else {
                             continue;
                         };

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -566,7 +566,7 @@ impl TripleSpawner {
         loop {
             tokio::select! {
                 _ = expiration_interval.tick() => {
-                    for action in self.posits.expire_and_start(self.threshold, Duration::from_secs(10)) {
+                    for action in self.posits.expire_and_start(self.threshold, Duration::from_secs(10), Duration::from_secs(2)) {
                         let (id, PositInternalAction::StartProtocol(participants, positor)) = action else {
                             continue;
                         };


### PR DESCRIPTION
For presignature and triple generation, the proposer and deliberator roles time out at the same time.

The proposer tries to move forward on a timeout, if the threshold has been met. But a deliberator will simply abort. This leads to bad timing and non-determinism if even just a single node is not responding.

Increasing the deliberator timeout resolves the problem.

This also increases the frequency for checking the expiration, to speed up the process.