### PR TITLE
feat: only run setup.sh for integration-tests

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,16 @@ export ROOT_DIR=$(dirname -- "$0")
 # Use CARGO_TARGET_DIR if it is set, or the default ./target location otherwise
 export TARGET_DIR=${CARGO_TARGET_DIR:-$ROOT_DIR/target}
 
+# Only run the prebuild for integration tests unless explicitly forced.
+# Set MPC_SETUP_SKIP=1 to skip running setup.sh
+# Set MPC_SETUP_ALWAYS=1 to run setup.sh regardless of package
+if [ "${MPC_SETUP_SKIP:-}" = "1" ]; then
+    exec "$@"
+fi
+if [ "${MPC_SETUP_ALWAYS:-}" != "1" ] && [ "${CARGO_PKG_NAME:-}" != "integration-tests" ]; then
+    exec "$@"
+fi
+
 CARGO_CMD_ARGS="$@"
 CARGO_BUILD_INDENT="            "
 echo "${CARGO_BUILD_INDENT} running MPC build script"


### PR DESCRIPTION
When running unit tests, setup.sh will always run right now. So this will make it so that the binaries do not get unnecessarily built if we are only doing unit testing.