### PR TITLE
fix: correct SignatureResponded event for eth indexer

### DIFF
--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -331,9 +331,14 @@ sol! {
     );
 
     struct Signature {
-        uint8 v;
-        bytes32 r;
-        bytes32 s;
+        AffinePoint bigR;
+        uint256 s;
+        uint8 recoveryId;
+    }
+
+    struct AffinePoint {
+        uint256 x;
+        uint256 y;
     }
 
     event SignatureResponded(


### PR DESCRIPTION
While working on abstracting the indexers, I wrote a test to make sure that we are able to Sign and then get a Respond event from the ethereum indexer. This was not the case so something was wrong, and it match whatever was wrong on devnet where we weren't get completion events for responds that have transpired on sign requests that should have been completed by other nodes but not our node.

So the reason was because our indexer did not have the correct type to listen for, for the Respond event. This corrects that, but the testing for it will be left for the abstracting indexer PR.