### PR TITLE
Bidirectional State Sync

### DIFF
--- a/chain-signatures/node/src/node_client.rs
+++ b/chain-signatures/node/src/node_client.rs
@@ -127,6 +127,31 @@ impl NodeClient {
         }
     }
 
+    pub async fn post_cbor_response<T: Serialize + ?Sized, R: DeserializeOwned>(
+        &self,
+        url: &Url,
+        payload: &T,
+    ) -> Result<R, RequestError> {
+        let resp = self
+            .http
+            .post(url.clone())
+            .header("content-type", "application/cbor")
+            .body(cbor_to_bytes(payload).map_err(|err| RequestError::Conversion(err.to_string()))?)
+            .send()
+            .await?;
+
+        let status = resp.status();
+        if status.is_success() {
+            let body = resp.bytes().await.map_err(RequestError::MalformedBody)?;
+            ciborium::from_reader(body.as_ref())
+                .map_err(|err| RequestError::Conversion(err.to_string()))
+        } else {
+            let bytes = resp.bytes().await.map_err(RequestError::MalformedBody)?;
+            let resp = std::str::from_utf8(&bytes).map_err(RequestError::MalformedResponse)?;
+            Err(RequestError::Unsuccessful(status, resp.into()))
+        }
+    }
+
     async fn post_msg(&self, url: &Url, msg: &[&Ciphered]) -> Result<(), RequestError> {
         self.post_cbor(url, msg).await
     }
@@ -165,11 +190,14 @@ impl NodeClient {
         Ok(resp.json().await?)
     }
 
-    pub async fn sync(&self, base: impl IntoUrl, update: &SyncUpdate) -> Result<(), RequestError> {
+    pub async fn sync(
+        &self,
+        base: impl IntoUrl,
+        update: &SyncUpdate,
+    ) -> Result<SyncUpdate, RequestError> {
         let mut url = base.into_url()?;
         url.set_path("sync");
-
-        self.post_cbor(&url, update).await
+        self.post_cbor_response(&url, update).await
     }
 
     pub async fn checkpoint(

--- a/chain-signatures/node/src/protocol/sync/mod.rs
+++ b/chain-signatures/node/src/protocol/sync/mod.rs
@@ -77,7 +77,6 @@ impl SyncRequest {
             {
                 Ok(result) => result,
                 Err(err) => {
-                    tracing::error!(?err, "failed to remove outdated triples");
                     let _ = self.response_tx.send(Err(err));
                     return;
                 }
@@ -92,7 +91,6 @@ impl SyncRequest {
             {
                 Ok(result) => result,
                 Err(err) => {
-                    tracing::error!(?err, "failed to remove outdated presignatures");
                     let _ = self.response_tx.send(Err(err));
                     return;
                 }
@@ -365,24 +363,23 @@ impl SyncChannel {
             response_tx,
         };
 
-        if let Err(err) = self.request_update.send(request).await {
-            tracing::error!(?err, "failed to queue sync request");
+        if let Err(_err) = self.request_update.send(request).await {
             return Err(SyncError::QueueFailed);
         }
 
         let result = tokio::time::timeout(SYNC_RESPONSE_TIMEOUT, response_rx)
             .await
-            .map_err(|err| {
-                tracing::error!(?err, "sync response timeout");
+            .map_err(|_err| {
+                tracing::debug!("sync response timeout");
                 SyncError::ResponseFailed
             })?
-            .map_err(|err| {
-                tracing::error!(?err, "failed to receive sync response");
+            .map_err(|_err| {
+                tracing::debug!("failed to receive sync response from channel");
                 SyncError::ResponseFailed
             })?;
 
         result.map_err(|err| {
-            tracing::error!(?err, "sync processing failed");
+            tracing::debug!(?err, "sync processing failed in storage layer");
             SyncError::ResponseFailed
         })
     }

--- a/chain-signatures/node/src/protocol/sync/mod.rs
+++ b/chain-signatures/node/src/protocol/sync/mod.rs
@@ -318,7 +318,13 @@ async fn broadcast_sync(
         .await
         .into_iter()
         .filter_map(|(p, view)| {
-            if let Some(Ok(())) = view {
+            if let Some(Ok(_response)) = view {
+                tracing::debug!(
+                    ?p,
+                    not_found_triples = _response.triples.len(),
+                    not_found_presignatures = _response.presignatures.len(),
+                    "received sync response"
+                );
                 Some(p)
             } else {
                 None

--- a/chain-signatures/node/src/protocol/sync/mod.rs
+++ b/chain-signatures/node/src/protocol/sync/mod.rs
@@ -9,7 +9,7 @@ use tokio::task::{JoinHandle, JoinSet};
 use crate::mesh::MeshState;
 use crate::node_client::NodeClient;
 use crate::rpc::ContractStateWatcher;
-use crate::storage::{PresignatureStorage, TripleStorage};
+use crate::storage::{PresignatureStorage, StorageError, TripleStorage};
 
 use super::contract::primitives::ParticipantInfo;
 use super::presignature::PresignatureId;
@@ -58,39 +58,65 @@ impl SyncUpdate {
 
 pub struct SyncRequest {
     pub update: SyncUpdate,
-    pub response_tx: oneshot::Sender<SyncUpdate>,
+    pub response_tx: oneshot::Sender<Result<SyncUpdate, StorageError>>,
 }
 
 impl SyncRequest {
-    async fn process(self, triples: TripleStorage, presignatures: PresignatureStorage) {
+    async fn process(
+        self,
+        triples: TripleStorage,
+        presignatures: PresignatureStorage,
+        me: Participant,
+    ) {
         let start = Instant::now();
 
         let outdated_triples = if !self.update.triples.is_empty() {
-            triples
+            match triples
                 .remove_outdated(self.update.from, &self.update.triples)
                 .await
+            {
+                Ok(result) => result,
+                Err(err) => {
+                    tracing::error!(?err, "failed to remove outdated triples");
+                    let _ = self.response_tx.send(Err(err));
+                    return;
+                }
+            }
         } else {
-            Vec::new()
+            Default::default()
         };
         let outdated_presignatures = if !self.update.presignatures.is_empty() {
-            presignatures
+            match presignatures
                 .remove_outdated(self.update.from, &self.update.presignatures)
                 .await
+            {
+                Ok(result) => result,
+                Err(err) => {
+                    tracing::error!(?err, "failed to remove outdated presignatures");
+                    let _ = self.response_tx.send(Err(err));
+                    return;
+                }
+            }
         } else {
-            Vec::new()
+            Default::default()
         };
 
-        if !outdated_triples.is_empty() || !outdated_presignatures.is_empty() {
-            tracing::info!(
-                outdated_triples = outdated_triples.len(),
-                outdated_presignatures = outdated_presignatures.len(),
-                elapsed = ?start.elapsed(),
-                "removed outdated",
-            );
-        }
+        tracing::info!(
+            removed_triples = outdated_triples.removed.len(),
+            removed_presignatures = outdated_presignatures.removed.len(),
+            not_found_triples = outdated_triples.not_found.len(),
+            not_found_presignatures = outdated_presignatures.not_found.len(),
+            elapsed = ?start.elapsed(),
+            "processed sync update",
+        );
 
-        // TODO: Send back a response (currently echoing the update, but this need be chaned)
-        let _ = self.response_tx.send(self.update);
+        let response = SyncUpdate {
+            from: me,
+            triples: outdated_triples.not_found,
+            presignatures: outdated_presignatures.not_found,
+        };
+
+        let _ = self.response_tx.send(Ok(response));
     }
 }
 
@@ -217,7 +243,7 @@ impl SyncTask {
                     }
                 }
                 Some(sync_req) = self.requests.updates.recv() => {
-                    tokio::spawn(sync_req.process(self.triples.clone(), self.presignatures.clone()));
+                    tokio::spawn(sync_req.process(self.triples.clone(), self.presignatures.clone(), me));
                 }
             }
         }
@@ -338,7 +364,7 @@ impl SyncChannel {
             return Err(SyncError::QueueFailed);
         }
 
-        tokio::time::timeout(SYNC_RESPONSE_TIMEOUT, response_rx)
+        let result = tokio::time::timeout(SYNC_RESPONSE_TIMEOUT, response_rx)
             .await
             .map_err(|err| {
                 tracing::error!(?err, "sync response timeout");
@@ -347,7 +373,12 @@ impl SyncChannel {
             .map_err(|err| {
                 tracing::error!(?err, "failed to receive sync response");
                 SyncError::ResponseFailed
-            })
+            })?;
+
+        result.map_err(|err| {
+            tracing::error!(?err, "sync processing failed");
+            SyncError::ResponseFailed
+        })
     }
 }
 

--- a/chain-signatures/node/src/protocol/sync/mod.rs
+++ b/chain-signatures/node/src/protocol/sync/mod.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use cait_sith::protocol::Participant;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::{JoinHandle, JoinSet};
 
 use crate::mesh::MeshState;
@@ -23,6 +23,17 @@ const MAX_SYNC_UPDATE_REQUESTS: usize = 1024;
 /// The interval which we will try to sync with other nodes to see if they have lost track
 /// of anything.
 pub const RECURRING_SYNC_INTERVAL: Duration = Duration::from_secs(3600 * 24);
+
+/// Timeout for waiting for a sync response from the sync task
+const SYNC_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, thiserror::Error)]
+pub enum SyncError {
+    #[error("failed to queue sync request")]
+    QueueFailed,
+    #[error("failed to receive sync response")]
+    ResponseFailed,
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SyncUpdate {
@@ -45,8 +56,46 @@ impl SyncUpdate {
     }
 }
 
+pub struct SyncRequest {
+    pub update: SyncUpdate,
+    pub response_tx: oneshot::Sender<SyncUpdate>,
+}
+
+impl SyncRequest {
+    async fn process(self, triples: TripleStorage, presignatures: PresignatureStorage) {
+        let start = Instant::now();
+
+        let outdated_triples = if !self.update.triples.is_empty() {
+            triples
+                .remove_outdated(self.update.from, &self.update.triples)
+                .await
+        } else {
+            Vec::new()
+        };
+        let outdated_presignatures = if !self.update.presignatures.is_empty() {
+            presignatures
+                .remove_outdated(self.update.from, &self.update.presignatures)
+                .await
+        } else {
+            Vec::new()
+        };
+
+        if !outdated_triples.is_empty() || !outdated_presignatures.is_empty() {
+            tracing::info!(
+                outdated_triples = outdated_triples.len(),
+                outdated_presignatures = outdated_presignatures.len(),
+                elapsed = ?start.elapsed(),
+                "removed outdated",
+            );
+        }
+
+        // TODO: Send back a response (currently echoing the update, but this need be chaned)
+        let _ = self.response_tx.send(self.update);
+    }
+}
+
 pub struct SyncRequestReceiver {
-    updates: mpsc::Receiver<SyncUpdate>,
+    updates: mpsc::Receiver<SyncRequest>,
 }
 
 pub struct SyncTask {
@@ -167,8 +216,8 @@ impl SyncTask {
                         tracing::debug!(elapsed = ?start.elapsed(), "processed broadcast");
                     }
                 }
-                Some(req) = self.requests.updates.recv() => {
-                    tokio::spawn(req.process(self.triples.clone(), self.presignatures.clone()));
+                Some(sync_req) = self.requests.updates.recv() => {
+                    tokio::spawn(sync_req.process(self.triples.clone(), self.presignatures.clone()));
                 }
             }
         }
@@ -258,37 +307,9 @@ async fn broadcast_sync(
     );
 }
 
-impl SyncUpdate {
-    async fn process(self, triples: TripleStorage, presignatures: PresignatureStorage) {
-        let start = Instant::now();
-
-        let outdated_triples = if !self.triples.is_empty() {
-            triples.remove_outdated(self.from, &self.triples).await
-        } else {
-            Vec::new()
-        };
-        let outdated_presignatures = if !self.presignatures.is_empty() {
-            presignatures
-                .remove_outdated(self.from, &self.presignatures)
-                .await
-        } else {
-            Vec::new()
-        };
-
-        if !outdated_triples.is_empty() || !outdated_presignatures.is_empty() {
-            tracing::info!(
-                outdated_triples = outdated_triples.len(),
-                outdated_presignatures = outdated_presignatures.len(),
-                elapsed = ?start.elapsed(),
-                "removed outdated",
-            );
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct SyncChannel {
-    request_update: mpsc::Sender<SyncUpdate>,
+    request_update: mpsc::Sender<SyncRequest>,
 }
 
 impl SyncChannel {
@@ -305,10 +326,28 @@ impl SyncChannel {
         (requests, channel)
     }
 
-    pub async fn request_update(&self, update: SyncUpdate) {
-        if let Err(err) = self.request_update.send(update).await {
-            tracing::warn!(?err, "failed to request update");
+    pub async fn request_update(&self, update: SyncUpdate) -> Result<SyncUpdate, SyncError> {
+        let (response_tx, response_rx) = oneshot::channel();
+        let request = SyncRequest {
+            update: update.clone(),
+            response_tx,
+        };
+
+        if let Err(err) = self.request_update.send(request).await {
+            tracing::error!(?err, "failed to queue sync request");
+            return Err(SyncError::QueueFailed);
         }
+
+        tokio::time::timeout(SYNC_RESPONSE_TIMEOUT, response_rx)
+            .await
+            .map_err(|err| {
+                tracing::error!(?err, "sync response timeout");
+                SyncError::ResponseFailed
+            })?
+            .map_err(|err| {
+                tracing::error!(?err, "failed to receive sync response");
+                SyncError::ResponseFailed
+            })
     }
 }
 

--- a/chain-signatures/node/src/storage/mod.rs
+++ b/chain-signatures/node/src/storage/mod.rs
@@ -6,6 +6,7 @@ pub mod triple_storage;
 
 use cait_sith::protocol::Participant;
 pub use presignature_storage::PresignatureStorage;
+pub use protocol_storage::StorageError;
 pub use triple_storage::TripleStorage;
 
 // Can be used to "clear" redis storage in case of a breaking change

--- a/chain-signatures/node/src/storage/protocol_storage.rs
+++ b/chain-signatures/node/src/storage/protocol_storage.rs
@@ -305,7 +305,8 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
         let Some(mut conn) = self.connect().await else {
             return Err(StorageError::ConnectionFailed);
         };
-        let result: Result<(Vec<A::Id>, Vec<A::Id>), _> = redis::Script::new(SCRIPT)
+        type RemoveOutdatedScriptResult<T> = Result<(Vec<T>, Vec<T>), redis::RedisError>;
+        let result: RemoveOutdatedScriptResult<A::Id> = redis::Script::new(SCRIPT)
             .key(&self.artifact_key)
             .key(owner_key(&self.owner_keys, owner))
             // NOTE: this encodes each entry of owner_shares as a separate ARGV[index] entry.

--- a/chain-signatures/node/src/storage/protocol_storage.rs
+++ b/chain-signatures/node/src/storage/protocol_storage.rs
@@ -11,6 +11,35 @@ use tracing;
 
 use super::{owner_key, STORAGE_VERSION};
 
+#[derive(Debug, thiserror::Error)]
+pub enum StorageError {
+    #[error("failed to connect to redis")]
+    ConnectionFailed,
+    #[error("redis operation failed: {0}")]
+    RedisFailed(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct RemoveOutdatedResult<Id> {
+    pub removed: Vec<Id>,
+    pub not_found: Vec<Id>,
+}
+
+impl<Id> RemoveOutdatedResult<Id> {
+    pub fn new(removed: Vec<Id>, not_found: Vec<Id>) -> Self {
+        Self { removed, not_found }
+    }
+}
+
+impl<Id> Default for RemoveOutdatedResult<Id> {
+    fn default() -> Self {
+        Self {
+            removed: Vec::new(),
+            not_found: Vec::new(),
+        }
+    }
+}
+
 /// Trait for protocol artifacts that can be stored in Redis.
 pub trait ProtocolArtifact:
     ToRedisArgs + FromRedisValue + fmt::Debug + Send + Sync + 'static
@@ -221,7 +250,11 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
         self.reserved.write().await.remove(&id)
     }
 
-    pub async fn remove_outdated(&self, owner: Participant, owner_shares: &[A::Id]) -> Vec<A::Id> {
+    pub async fn remove_outdated(
+        &self,
+        owner: Participant,
+        owner_shares: &[A::Id],
+    ) -> Result<RemoveOutdatedResult<A::Id>, StorageError> {
         const SCRIPT: &str = r#"
             local artifact_key = KEYS[1]
             local owner_key = KEYS[2]
@@ -256,14 +289,23 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
                 redis.call("HDEL", artifact_key, unpack(outdated))
             end
 
-            return outdated
+            -- find shares that were shared with us but not found in our storage
+            local not_found = {}
+            for _, id in ipairs(ARGV) do
+                if redis.call("HEXISTS", artifact_key, id) == 0 then
+                    table.insert(not_found, id)
+                end
+            end
+
+            -- return both outdated and not_found
+            return {outdated, not_found}
         "#;
 
         let start = Instant::now();
         let Some(mut conn) = self.connect().await else {
-            return Vec::new();
+            return Err(StorageError::ConnectionFailed);
         };
-        let result: Result<Vec<A::Id>, _> = redis::Script::new(SCRIPT)
+        let result: Result<(Vec<A::Id>, Vec<A::Id>), _> = redis::Script::new(SCRIPT)
             .key(&self.artifact_key)
             .key(owner_key(&self.owner_keys, owner))
             // NOTE: this encodes each entry of owner_shares as a separate ARGV[index] entry.
@@ -277,7 +319,7 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
             .observe(elapsed.as_millis() as f64);
 
         match result {
-            Ok(outdated) => {
+            Ok((outdated, not_found)) => {
                 if !outdated.is_empty() {
                     tracing::info!(?outdated, ?elapsed, "removed outdated artifacts");
                     // remove outdated entries from our in-memory reserved set
@@ -292,11 +334,11 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
                         used.remove(id);
                     }
                 }
-                outdated
+                Ok(RemoveOutdatedResult::new(outdated, not_found))
             }
             Err(err) => {
-                tracing::warn!(?err, ?elapsed, "failed to remove outdated artifacts");
-                Vec::new()
+                tracing::error!(?err, ?elapsed, "failed to remove outdated artifacts");
+                Err(StorageError::RedisFailed(err.to_string()))
             }
         }
     }

--- a/chain-signatures/node/src/web/error.rs
+++ b/chain-signatures/node/src/web/error.rs
@@ -49,7 +49,7 @@ impl axum::response::IntoResponse for Error {
         // Log the error server-side for debugging
         tracing::error!(?self, "request error");
 
-        // Return generic error message to client
+        // Return generic error with request ID to the caller
         (status, "An error occurred").into_response()
     }
 }

--- a/chain-signatures/node/src/web/error.rs
+++ b/chain-signatures/node/src/web/error.rs
@@ -2,6 +2,7 @@ use axum::extract::rejection::JsonRejection;
 use http::StatusCode;
 
 use crate::protocol::message::MessageError;
+use crate::protocol::sync::SyncError;
 use crate::protocol::CryptographicError;
 use crate::web::cbor::CborRejection;
 
@@ -21,6 +22,8 @@ pub enum Error {
     Message(#[from] MessageError),
     #[error(transparent)]
     Rpc(#[from] near_fetch::Error),
+    #[error(transparent)]
+    Sync(#[from] SyncError),
     #[error("invalid parameters: {0}")]
     InvalidParameters(String),
 }
@@ -34,6 +37,7 @@ impl Error {
             Error::Message(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::Rpc(_) => StatusCode::BAD_REQUEST,
             Error::InvalidParameters(_) => StatusCode::BAD_REQUEST,
+            Error::Sync(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }
@@ -41,11 +45,11 @@ impl Error {
 impl axum::response::IntoResponse for Error {
     fn into_response(self) -> axum::response::Response {
         let status = self.status();
-        let message = match self {
-            Error::JsonExtractorRejection(json_rejection) => json_rejection.body_text(),
-            err => format!("{err:?}"),
-        };
 
-        (status, axum::Json(message)).into_response()
+        // Log the error server-side for debugging
+        tracing::error!(?self, "request error");
+
+        // Return generic error message to client
+        (status, "An error occurred").into_response()
     }
 }

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -116,9 +116,7 @@ async fn request_id_middleware(mut req: Request<Body>, next: Next) -> Response {
     req.extensions_mut().insert(request_id.clone());
 
     let span = tracing::info_span!("request", %request_id);
-    let _guard = span.enter();
-
-    let mut response = next.run(req).await;
+    let mut response = next.run(req).instrument(span).await;
     if let Ok(value) = HeaderValue::from_str(&request_id) {
         response.headers_mut().insert(header_name, value);
     }

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -34,6 +34,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
+use tracing::Instrument;
 
 struct AxumState {
     node: NodeStateWatcher,

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -269,13 +269,13 @@ async fn bench_metrics() -> Json<BenchMetrics> {
 async fn sync(
     Extension(state): Extension<Arc<AxumState>>,
     WithRejection(Cbor(update), _): WithRejection<Cbor<SyncUpdate>, Error>,
-) -> Result<Json<()>> {
+) -> Result<Cbor<SyncUpdate>> {
     let start = Instant::now();
-    state.sync_channel.request_update(update).await;
+    let response = state.sync_channel.request_update(update).await?;
     WEB_ENDPOINT_LATENCY
         .with_label_values(&["sync"])
         .observe(start.elapsed().as_millis() as f64);
-    Ok(Json(()))
+    Ok(Cbor(response))
 }
 
 #[derive(Debug, Deserialize)]

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -17,8 +17,11 @@ use crate::web::cbor::Cbor;
 use crate::web::error::Result;
 
 use anyhow::Context;
+use axum::body::Body;
 use axum::extract::{DefaultBodyLimit, Query};
-use axum::http::StatusCode;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::Response;
 use axum::routing::{get, post};
 use axum::{Extension, Json, Router};
 use axum_extra::extract::WithRejection;
@@ -91,12 +94,35 @@ pub async fn run(
         router = router.route("/bench/metrics", get(bench_metrics));
     }
 
-    let app = router.layer(Extension(Arc::new(axum_state)));
+    let app = router
+        .layer(middleware::from_fn(request_id_middleware))
+        .layer(Extension(Arc::new(axum_state)));
 
     let addr = format!("0.0.0.0:{port}");
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
     tracing::info!(?addr, "starting http server");
     axum::serve(listener, app).await.unwrap();
+}
+
+async fn request_id_middleware(mut req: Request<Body>, next: Next) -> Response {
+    let header_name = HeaderName::from_static("x-request-id");
+    let request_id = req
+        .headers()
+        .get(&header_name)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| hex::encode(rand::random::<u128>().to_be_bytes()));
+
+    req.extensions_mut().insert(request_id.clone());
+
+    let span = tracing::info_span!("request", %request_id);
+    let _guard = span.enter();
+
+    let mut response = next.run(req).await;
+    if let Ok(value) = HeaderValue::from_str(&request_id) {
+        response.headers_mut().insert(header_name, value);
+    }
+    response
 }
 
 #[tracing::instrument(level = "debug", skip_all)]

--- a/integration-tests/tests/cases/store.rs
+++ b/integration-tests/tests/cases/store.rs
@@ -153,13 +153,14 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     }
 
     // Let's say Node1 somehow used up triple 10, 11, 12 so we only have 13,14,15
-    let mut outdated = triple_storage
-        .remove_outdated(node1, &[13, 14, 15])
+    let result = triple_storage
+        .remove_outdated(node1, &[13, 14, 15, 99])
         .await
-        .unwrap()
-        .removed;
+        .unwrap();
+    let mut outdated = result.removed;
     outdated.sort();
     assert_eq!(outdated, vec![10, 11, 12]);
+    assert_eq!(result.not_found, vec![99]);
 
     assert_eq!(triple_storage.len_generated().await, 8);
     assert_eq!(triple_spawner.len_mine().await, 5);
@@ -296,13 +297,14 @@ async fn test_presignature_persistence() -> anyhow::Result<()> {
     }
 
     // Let's say Node1 somehow used up triple 10, 11, 12 so we only have 13,14,15
-    let mut outdated = presignature_storage
-        .remove_outdated(node1, &[13, 14, 15])
+    let result = presignature_storage
+        .remove_outdated(node1, &[13, 14, 15, 99])
         .await
-        .unwrap()
-        .removed;
+        .unwrap();
+    let mut outdated = result.removed;
     outdated.sort();
     assert_eq!(outdated, vec![10, 11, 12]);
+    assert_eq!(result.not_found, vec![99]);
 
     assert_eq!(presignature_storage.len_generated().await, 8);
     assert_eq!(presignature_spawner.len_mine().await, 5);

--- a/integration-tests/tests/cases/store.rs
+++ b/integration-tests/tests/cases/store.rs
@@ -153,7 +153,11 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
     }
 
     // Let's say Node1 somehow used up triple 10, 11, 12 so we only have 13,14,15
-    let mut outdated = triple_storage.remove_outdated(node1, &[13, 14, 15]).await;
+    let mut outdated = triple_storage
+        .remove_outdated(node1, &[13, 14, 15])
+        .await
+        .unwrap()
+        .removed;
     outdated.sort();
     assert_eq!(outdated, vec![10, 11, 12]);
 
@@ -294,7 +298,9 @@ async fn test_presignature_persistence() -> anyhow::Result<()> {
     // Let's say Node1 somehow used up triple 10, 11, 12 so we only have 13,14,15
     let mut outdated = presignature_storage
         .remove_outdated(node1, &[13, 14, 15])
-        .await;
+        .await
+        .unwrap()
+        .removed;
     outdated.sort();
     assert_eq!(outdated, vec![10, 11, 12]);
 

--- a/integration-tests/tests/cases/store.rs
+++ b/integration-tests/tests/cases/store.rs
@@ -152,7 +152,8 @@ async fn test_triple_persistence() -> anyhow::Result<()> {
             .await;
     }
 
-    // Let's say Node1 somehow used up triple 10, 11, 12 so we only have 13,14,15
+    // Let's say Node1 somehow used up triple 10, 11, 12 so we only have 13,14,15.
+    // We also include ID 99 which doesn't exist to test the not_found tracking.
     let result = triple_storage
         .remove_outdated(node1, &[13, 14, 15, 99])
         .await
@@ -296,7 +297,8 @@ async fn test_presignature_persistence() -> anyhow::Result<()> {
             .await;
     }
 
-    // Let's say Node1 somehow used up triple 10, 11, 12 so we only have 13,14,15
+    // Let's say Node1 somehow used up triple 10, 11, 12 so we only have 13,14,15.
+    // We also include ID 99 which doesn't exist to test the not_found tracking.
     let result = presignature_storage
         .remove_outdated(node1, &[13, 14, 15, 99])
         .await

--- a/integration-tests/tests/cases/sync.rs
+++ b/integration-tests/tests/cases/sync.rs
@@ -87,7 +87,7 @@ async fn test_state_sync_update() -> anyhow::Result<()> {
         triples: valid.clone(),
         presignatures: valid.clone(),
     };
-    sync_channel.request_update(update).await;
+    let _ = sync_channel.request_update(update).await;
     // Give it some time for sync to process the update
     tokio::time::sleep(Duration::from_secs(3)).await;
 


### PR DESCRIPTION
This is a step forward towards State Sync design + improved error handling and trasing

- Updated `/sync` API, now it returns a list of not found Ts and Ps for processing by the caller
- Implemented `not_found` on the storage layer 
- Improved error handling, now we are not threatening failed `/sync` calls as successful
- Now we are not returning specific error messages to the caller for security reason, that is a bad practice
- Added request ID middleware to track each request. In case we get an error, it should be easy to go and filter for logs with a specific ID on a specific node

The next step is to process `not_found` on the caller side.