### PR TITLE
log: add more info about posit rounds

### DIFF
--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -410,11 +410,21 @@ impl SignPositor {
                 // not immediately jump to that higher round. Otherwise, any peer
                 // could force themselves to be the proposer every time.
                 if state.round < *peer_round {
+                    tracing::info!(
+                        peer_round,
+                        my_round = state.round,
+                        "Storing message for future round, as deliberator",
+                    );
                     state.store_future_posit_message(task_msg);
                     continue;
                 }
 
                 if !matches!(action, PositAction::Propose) {
+                    tracing::warn!(
+                        round = peer_round,
+                        ?action,
+                        "Got unexpected posit message while waiting for propose"
+                    );
                     continue;
                 }
 
@@ -574,6 +584,11 @@ impl SignPositor {
                     // not immediately jump to that higher round. Otherwise, any peer
                     // could force themselves to be the proposer every time.
                     if state.round < peer_round {
+                        tracing::info!(
+                            peer_round,
+                            my_round = state.round,
+                            "Storing message for future round",
+                        );
                         state.store_future_posit_message(task_msg);
                         continue;
                     }
@@ -646,6 +661,7 @@ impl SignPositor {
                             ?sign_id,
                             accepts = counter.accepts.len(),
                             threshold = ctx.threshold,
+                            ?round,
                             "proposer posit deadline reached, expiring round"
                         );
                         if let Some(taken) = presignature {
@@ -653,7 +669,7 @@ impl SignPositor {
                             ctx.presignatures.recycle_mine(ctx.me, taken).await;
                         }
                     } else {
-                        tracing::warn!(?sign_id, "deliberator posit timeout waiting for Start, reorganizing");
+                        tracing::warn!(?sign_id, me=?ctx.me, ?proposer, "deliberator posit timeout waiting for Start, reorganizing");
                     }
 
                     state.bump_round();

--- a/integration-tests/src/actions/sign.rs
+++ b/integration-tests/src/actions/sign.rs
@@ -852,7 +852,10 @@ impl SignAction<'_> {
                 .await?;
             let err = wait_for::rogue_message_responded(rogue_status).await?;
 
-            assert!(err.contains(&errors::RespondError::InvalidSignature.to_string()));
+            assert!(
+                err.contains(&errors::RespondError::InvalidSignature.to_string()),
+                "Response instead was {err}"
+            );
             Some(rogue)
         } else {
             None


### PR DESCRIPTION
When debugging posit round problems, it is hard to read from logs which round and sometimes which
participant a message refers to.

This adds the posit round to already logged messages, it adds information about delayed and dropped messages, and it includes the `me` participant in some cases.

Also, `test_signature_rogue` is unstable, likely due to the documented race-condition. This PR also improves the assertion message to show the problem there whenever it fails.