### PR TITLE
fix: stream respond error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12563,6 +12563,7 @@ name = "signet-program"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
+ "serde",
 ]
 
 [[package]]

--- a/chain-signatures/contract-sol/Cargo.toml
+++ b/chain-signatures/contract-sol/Cargo.toml
@@ -10,3 +10,4 @@ name = "signet_program"
 
 [dependencies]
 anchor-lang = { version = "0.31.1", features = ["event-cpi"] }
+serde.workspace = true

--- a/chain-signatures/contract-sol/src/lib.rs
+++ b/chain-signatures/contract-sol/src/lib.rs
@@ -219,7 +219,7 @@ pub struct SignatureRequestedEvent {
 }
 
 #[event]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct SignBidirectionalEvent {
     pub sender: Pubkey,
     pub serialized_transaction: Vec<u8>,

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -22,7 +22,7 @@ const RETENTION_DURATION: Duration = Duration::from_secs(30 * 60);
 
 #[derive(Debug, Clone)]
 pub struct PendingRequests {
-    requests: HashMap<SignId, BacklogTransaction>,
+    requests: HashMap<SignId, BacklogEntry>,
     /// The highest block height that has been processed for this chain
     processed_block_height: Option<u64>,
 }
@@ -44,20 +44,31 @@ impl PendingRequests {
 
     /// Inserts a sign-respond transaction into the pending requests map
     /// Returns Some(old_value) if the key was already present
-    fn insert(&mut self, id: SignId, tx: BacklogTransaction) -> Option<BacklogTransaction> {
-        self.requests.insert(id, tx)
+    fn insert(
+        &mut self,
+        id: SignId,
+        tx: BacklogTransaction,
+        sign_type: Option<SignRequestType>,
+    ) -> Option<BacklogTransaction> {
+        self.requests
+            .insert(id, BacklogEntry { tx, sign_type })
+            .map(|entry| entry.tx)
     }
 
     /// Removes a sign-respond transaction from the pending requests map
     /// Returns Some(value) if the key was present
     fn remove(&mut self, id: &SignId) -> Option<BacklogTransaction> {
-        self.requests.remove(id)
+        self.requests.remove(id).map(|entry| entry.tx)
     }
 
-    /// Gets a clone of a sign-respond transaction from the pending requests map
+    /// Gets a clone of a backlog entry from the pending requests map
     /// Returns Some(value) if the key is present
-    fn get(&self, id: &SignId) -> Option<BacklogTransaction> {
+    fn get(&self, id: &SignId) -> Option<BacklogEntry> {
         self.requests.get(id).cloned()
+    }
+
+    fn sign_type(&self, id: &SignId) -> Option<SignRequestType> {
+        self.requests.get(id).and_then(|entry| entry.sign_type.clone())
     }
 
     /// Returns the number of pending requests
@@ -72,16 +83,16 @@ impl PendingRequests {
     ) -> HashMap<SignId, BacklogTransaction> {
         self.requests
             .iter()
-            .filter(|(_, tx)| tx.status() == status)
-            .map(|(id, tx)| (*id, tx.clone()))
+            .filter(|(_, entry)| entry.tx.status() == status)
+            .map(|(id, entry)| (*id, entry.tx.clone()))
             .collect()
     }
 
     fn pending_execution(&self) -> Vec<(SignId, BacklogTransaction)> {
         self.requests
             .iter()
-            .filter(|(_, tx)| tx.status() == PendingRequestStatus::PendingExecution)
-            .map(|(&id, tx)| (id, tx.clone()))
+            .filter(|(_, entry)| entry.tx.status() == PendingRequestStatus::PendingExecution)
+            .map(|(&id, entry)| (id, entry.tx.clone()))
             .collect()
     }
 
@@ -99,8 +110,8 @@ impl PendingRequests {
         let mut encoded = self
             .requests
             .iter()
-            .map(|(&sign_id, tx)| {
-                let transaction = serde_json::to_vec(&tx)
+            .map(|(&sign_id, entry)| {
+                let transaction = serde_json::to_vec(&entry.tx)
                     .expect("serialize bidirectional transaction for checkpoint");
                 PendingTx {
                     sign_id,
@@ -120,7 +131,7 @@ impl PendingRequests {
     fn from_checkpoint(checkpoint: Checkpoint) -> anyhow::Result<Self> {
         fn decode(
             pending: mpc_primitives::PendingTx,
-        ) -> anyhow::Result<(SignId, BacklogTransaction)> {
+        ) -> anyhow::Result<(SignId, BacklogEntry)> {
             let tx: BacklogTransaction = serde_json::from_slice(&pending.transaction)
                 .with_context(|| {
                     format!(
@@ -128,7 +139,13 @@ impl PendingRequests {
                         pending.sign_id
                     )
                 })?;
-            Ok((pending.sign_id, tx))
+            Ok((
+                pending.sign_id,
+                BacklogEntry {
+                    tx,
+                    sign_type: None,
+                },
+            ))
         }
 
         let mut requests = HashMap::new();
@@ -190,7 +207,6 @@ pub struct Backlog {
     storage: CheckpointStorage,
     requests: Arc<RwLock<HashMap<Chain, PendingRequests>>>,
     execution_watchers: Arc<RwLock<HashMap<Chain, ExecutionWatchers>>>,
-    sign_request_types: Arc<RwLock<HashMap<(Chain, SignId), SignRequestType>>>,
     /// Historical checkpoints kept for 30 minutes, indexed by chain
     historical_checkpoints: Arc<RwLock<HashMap<Chain, Vec<HistoricalCheckpoint>>>>,
 }
@@ -211,7 +227,6 @@ impl Backlog {
             storage,
             requests: Arc::new(RwLock::new(HashMap::new())),
             execution_watchers: Arc::new(RwLock::new(HashMap::new())),
-            sign_request_types: Arc::new(RwLock::new(HashMap::new())),
             historical_checkpoints: Arc::new(RwLock::new(HashMap::new())),
         }
     }
@@ -223,12 +238,10 @@ impl Backlog {
         tx: BacklogTransaction,
         sign_type: SignRequestType,
     ) -> Option<BacklogTransaction> {
-        self.set_sign_request_type(chain, id, sign_type).await;
-
         let (prev, len) = {
             let mut requests = self.requests.write().await;
             let pending = requests.entry(chain).or_insert_with(PendingRequests::new);
-            let p = pending.insert(id, tx);
+            let p = pending.insert(id, tx, Some(sign_type));
             (p, pending.len())
         };
 
@@ -237,9 +250,6 @@ impl Backlog {
     }
 
     pub async fn remove(&self, chain: Chain, id: &SignId) -> Option<BacklogTransaction> {
-        // Also remove the sign request type tracking
-        self.remove_sign_request_type(chain, id).await;
-
         let (removed, len) = {
             let mut requests = self.requests.write().await;
             let pending = requests.entry(chain).or_insert_with(PendingRequests::new);
@@ -251,7 +261,7 @@ impl Backlog {
         removed
     }
 
-    pub async fn get(&self, chain: Chain, id: &SignId) -> Option<BacklogTransaction> {
+    pub async fn get(&self, chain: Chain, id: &SignId) -> Option<BacklogEntry> {
         self.requests
             .read()
             .await
@@ -274,32 +284,13 @@ impl Backlog {
         self.requests.read().await.is_empty()
     }
 
-    /// Track the sign request type for a given sign ID
-    /// Store the sign request type for a given sign ID (internal only, set during insert)
-    async fn set_sign_request_type(
-        &self,
-        chain: Chain,
-        id: SignId,
-        sign_request_type: SignRequestType,
-    ) {
-        self.sign_request_types
-            .write()
-            .await
-            .insert((chain, id), sign_request_type);
-    }
-
     /// Get the sign request type for a given sign ID
     pub async fn sign_type(&self, chain: Chain, id: &SignId) -> Option<SignRequestType> {
-        self.sign_request_types
+        self.requests
             .read()
             .await
-            .get(&(chain, *id))
-            .cloned()
-    }
-
-    /// Remove the sign request type tracking for a given sign ID (internal only, removed during remove)
-    async fn remove_sign_request_type(&self, chain: Chain, id: &SignId) {
-        self.sign_request_types.write().await.remove(&(chain, *id));
+            .get(&chain)
+            .and_then(|pending_requests| pending_requests.sign_type(id))
     }
 
     fn observe_backlog_size(&self, chain: Chain, len: usize) {
@@ -404,9 +395,9 @@ impl Backlog {
             );
             return None;
         };
-        tracing::info!(?chain, ?id, before = ?tx.status(), after = ?status, "set_status: updating");
-        tx.set_status(status);
-        Some(tx.clone())
+        tracing::info!(?chain, ?id, before = ?tx.tx.status(), after = ?status, "set_status: updating");
+        tx.tx.set_status(status);
+        Some(tx.tx.clone())
     }
 
     /// Advances a `Sign` transaction to its execution phase and register execution watcher.
@@ -424,10 +415,17 @@ impl Backlog {
             .ok_or(BacklogError::ChainNotFound)?;
 
         // Replace the Sign transaction with the Bidirectional transaction
-        pending.requests.insert(
-            sign_id,
-            BacklogTransaction::Bidirectional(bidirectional_tx.clone()),
-        );
+        if let Some(entry) = pending.requests.get_mut(&sign_id) {
+            entry.tx = BacklogTransaction::Bidirectional(bidirectional_tx.clone());
+        } else {
+            pending.requests.insert(
+                sign_id,
+                BacklogEntry {
+                    tx: BacklogTransaction::Bidirectional(bidirectional_tx.clone()),
+                    sign_type: None,
+                },
+            );
+        }
 
         // Registration successful, now register the execution watcher on the target chain
         let target_chain = bidirectional_tx.target_chain;
@@ -662,7 +660,14 @@ impl Backlog {
         let mut recovered = HashMap::new();
         for &chain in chains {
             if let Some(pending) = requests.get(&chain) {
-                recovered.insert(chain, pending.requests.clone());
+                recovered.insert(
+                    chain,
+                    pending
+                        .requests
+                        .iter()
+                        .map(|(id, entry)| (*id, entry.tx.clone()))
+                        .collect(),
+                );
             }
         }
 
@@ -691,6 +696,12 @@ pub struct SignTx {
     pub status: PendingRequestStatus,
     pub args: SignArgs,
     pub unix_timestamp_indexed: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct BacklogEntry {
+    pub tx: BacklogTransaction,
+    pub sign_type: Option<SignRequestType>,
 }
 
 /// Pending transaction in the backlog - can be either a sign-only or bidirectional.
@@ -1084,10 +1095,12 @@ mod tests {
         pending1.insert(
             SignId::new(tx1.request_id),
             BacklogTransaction::Bidirectional(tx1.clone()),
+            Some(SignRequestType::Sign),
         );
         pending1.insert(
             SignId::new(tx2.request_id),
             BacklogTransaction::Bidirectional(tx2.clone()),
+            Some(SignRequestType::Sign),
         );
         pending1.set_processed_block(100);
 
@@ -1095,10 +1108,12 @@ mod tests {
         pending2.insert(
             SignId::new(tx1.request_id),
             BacklogTransaction::Bidirectional(tx1.clone()),
+            Some(SignRequestType::Sign),
         );
         pending2.insert(
             SignId::new(tx2.request_id),
             BacklogTransaction::Bidirectional(tx2.clone()),
+            Some(SignRequestType::Sign),
         );
         pending2.set_processed_block(100);
 
@@ -1121,6 +1136,7 @@ mod tests {
         pending.insert(
             SignId::new(tx1.request_id),
             BacklogTransaction::Bidirectional(tx1.clone()),
+            Some(SignRequestType::Sign),
         );
         pending.set_processed_block(100);
         let checkpoint = pending.checkpoint(Chain::Ethereum);

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -48,7 +48,7 @@ impl PendingRequests {
         &mut self,
         id: SignId,
         tx: BacklogTransaction,
-        sign_type: Option<SignRequestType>,
+        sign_type: SignRequestType,
     ) -> Option<BacklogTransaction> {
         self.requests
             .insert(id, BacklogEntry { tx, sign_type })
@@ -68,7 +68,7 @@ impl PendingRequests {
     }
 
     fn sign_type(&self, id: &SignId) -> Option<SignRequestType> {
-        self.requests.get(id).and_then(|entry| entry.sign_type.clone())
+        self.requests.get(id).map(|entry| entry.sign_type.clone())
     }
 
     /// Returns the number of pending requests
@@ -129,9 +129,7 @@ impl PendingRequests {
     }
 
     fn from_checkpoint(checkpoint: Checkpoint) -> anyhow::Result<Self> {
-        fn decode(
-            pending: mpc_primitives::PendingTx,
-        ) -> anyhow::Result<(SignId, BacklogEntry)> {
+        fn decode(pending: mpc_primitives::PendingTx) -> anyhow::Result<(SignId, BacklogEntry)> {
             let tx: BacklogTransaction = serde_json::from_slice(&pending.transaction)
                 .with_context(|| {
                     format!(
@@ -143,7 +141,7 @@ impl PendingRequests {
                 pending.sign_id,
                 BacklogEntry {
                     tx,
-                    sign_type: None,
+                    sign_type: SignRequestType::Sign,
                 },
             ))
         }
@@ -241,7 +239,7 @@ impl Backlog {
         let (prev, len) = {
             let mut requests = self.requests.write().await;
             let pending = requests.entry(chain).or_insert_with(PendingRequests::new);
-            let p = pending.insert(id, tx, Some(sign_type));
+            let p = pending.insert(id, tx, sign_type);
             (p, pending.len())
         };
 
@@ -422,7 +420,7 @@ impl Backlog {
                 sign_id,
                 BacklogEntry {
                     tx: BacklogTransaction::Bidirectional(bidirectional_tx.clone()),
-                    sign_type: None,
+                    sign_type: SignRequestType::Sign,
                 },
             );
         }
@@ -701,7 +699,7 @@ pub struct SignTx {
 #[derive(Debug, Clone)]
 pub struct BacklogEntry {
     pub tx: BacklogTransaction,
-    pub sign_type: Option<SignRequestType>,
+    pub sign_type: SignRequestType,
 }
 
 /// Pending transaction in the backlog - can be either a sign-only or bidirectional.
@@ -756,6 +754,13 @@ impl BacklogTransaction {
     /// Check if this is a bidirectional transaction
     pub fn is_bidirectional(&self) -> bool {
         matches!(self, Self::Bidirectional(_))
+    }
+
+    pub fn typename(&self) -> &'static str {
+        match self {
+            Self::Sign(_) => "Sign",
+            Self::Bidirectional(_) => "Bidirectional",
+        }
     }
 }
 
@@ -1095,12 +1100,12 @@ mod tests {
         pending1.insert(
             SignId::new(tx1.request_id),
             BacklogTransaction::Bidirectional(tx1.clone()),
-            Some(SignRequestType::Sign),
+            SignRequestType::Sign,
         );
         pending1.insert(
             SignId::new(tx2.request_id),
             BacklogTransaction::Bidirectional(tx2.clone()),
-            Some(SignRequestType::Sign),
+            SignRequestType::Sign,
         );
         pending1.set_processed_block(100);
 
@@ -1108,12 +1113,12 @@ mod tests {
         pending2.insert(
             SignId::new(tx1.request_id),
             BacklogTransaction::Bidirectional(tx1.clone()),
-            Some(SignRequestType::Sign),
+            SignRequestType::Sign,
         );
         pending2.insert(
             SignId::new(tx2.request_id),
             BacklogTransaction::Bidirectional(tx2.clone()),
-            Some(SignRequestType::Sign),
+            SignRequestType::Sign,
         );
         pending2.set_processed_block(100);
 
@@ -1136,7 +1141,7 @@ mod tests {
         pending.insert(
             SignId::new(tx1.request_id),
             BacklogTransaction::Bidirectional(tx1.clone()),
-            Some(SignRequestType::Sign),
+            SignRequestType::Sign,
         );
         pending.set_processed_block(100);
         let checkpoint = pending.checkpoint(Chain::Ethereum);

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -127,8 +127,7 @@ impl PendingRequests {
 
     fn from_checkpoint(checkpoint: Checkpoint) -> anyhow::Result<Self> {
         fn decode(pending: mpc_primitives::PendingTx) -> anyhow::Result<(SignId, BacklogEntry)> {
-            let entry: BacklogEntry =
-                ciborium::de::from_reader(pending.transaction.as_slice())
+            let entry: BacklogEntry = ciborium::de::from_reader(pending.transaction.as_slice())
                 .with_context(|| {
                     format!(
                         "failed to deserialize pending backlog entry for sign_id {:?}",

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -67,10 +67,6 @@ impl PendingRequests {
         self.requests.get(id).cloned()
     }
 
-    fn sign_type(&self, id: &SignId) -> Option<SignRequestType> {
-        self.requests.get(id).map(|entry| entry.sign_type.clone())
-    }
-
     /// Returns the number of pending requests
     fn len(&self) -> usize {
         self.requests.len()
@@ -111,8 +107,9 @@ impl PendingRequests {
             .requests
             .iter()
             .map(|(&sign_id, entry)| {
-                let transaction = serde_json::to_vec(&entry.tx)
-                    .expect("serialize bidirectional transaction for checkpoint");
+                let mut transaction = Vec::new();
+                ciborium::ser::into_writer(entry, &mut transaction)
+                    .expect("serialize backlog entry for checkpoint");
                 PendingTx {
                     sign_id,
                     transaction,
@@ -130,20 +127,15 @@ impl PendingRequests {
 
     fn from_checkpoint(checkpoint: Checkpoint) -> anyhow::Result<Self> {
         fn decode(pending: mpc_primitives::PendingTx) -> anyhow::Result<(SignId, BacklogEntry)> {
-            let tx: BacklogTransaction = serde_json::from_slice(&pending.transaction)
+            let entry: BacklogEntry =
+                ciborium::de::from_reader(pending.transaction.as_slice())
                 .with_context(|| {
                     format!(
-                        "failed to deserialize pending transaction for sign_id {:?}",
+                        "failed to deserialize pending backlog entry for sign_id {:?}",
                         pending.sign_id
                     )
                 })?;
-            Ok((
-                pending.sign_id,
-                BacklogEntry {
-                    tx,
-                    sign_type: SignRequestType::Sign,
-                },
-            ))
+            Ok((pending.sign_id, entry))
         }
 
         let mut requests = HashMap::new();
@@ -288,7 +280,8 @@ impl Backlog {
             .read()
             .await
             .get(&chain)
-            .and_then(|pending_requests| pending_requests.sign_type(id))
+            .and_then(|pending_requests| pending_requests.get(id))
+            .map(|entry| entry.sign_type)
     }
 
     fn observe_backlog_size(&self, chain: Chain, len: usize) {
@@ -696,10 +689,10 @@ pub struct SignTx {
     pub unix_timestamp_indexed: u64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BacklogEntry {
-    pub tx: BacklogTransaction,
     pub sign_type: SignRequestType,
+    pub tx: BacklogTransaction,
 }
 
 /// Pending transaction in the backlog - can be either a sign-only or bidirectional.
@@ -1152,21 +1145,22 @@ mod tests {
 
         assert_eq!(checkpoint, deserialized);
 
-        let (sign_id, restored_tx): (SignId, BidirectionalTx) = {
+        let (sign_id, restored_tx, restored_sign_type): (SignId, BidirectionalTx, SignRequestType) = {
             let pending = &checkpoint.pending_requests[0];
-            let backlog_tx: BacklogTransaction =
-                serde_json::from_slice(&pending.transaction).unwrap();
-            let tx = match backlog_tx {
+            let backlog_entry: BacklogEntry =
+                ciborium::de::from_reader(pending.transaction.as_slice()).unwrap();
+            let tx = match backlog_entry.tx {
                 BacklogTransaction::Bidirectional(tx) => tx,
                 BacklogTransaction::Sign(_) => panic!("Expected Bidirectional transaction"),
             };
-            (pending.sign_id, tx)
+            (pending.sign_id, tx, backlog_entry.sign_type)
         };
         assert_eq!(sign_id, SignId::new(tx1.request_id));
         assert_eq!(
             restored_tx.serialized_transaction,
             tx1.serialized_transaction
         );
+        assert_eq!(restored_sign_type, SignRequestType::Sign);
     }
 
     #[tokio::test]
@@ -1196,6 +1190,70 @@ mod tests {
         let watchers = recovered.pending_execution(Chain::Ethereum).await;
         assert_eq!(watchers.len(), 1);
         assert!(watchers.contains_key(&tx.id));
+    }
+
+    #[tokio::test]
+    async fn test_recover_preserves_sign_request_type() {
+        use crate::stream::ops::SignBidirectionalEvent as StreamSignBidirectionalEvent;
+
+        let backlog = Backlog::new();
+        let sign_id = SignId::new([42u8; 32]);
+        let args = SignArgs {
+            entropy: [1u8; 32],
+            epsilon: k256::Scalar::from(1u64),
+            payload: k256::Scalar::from(2u64),
+            path: "test".to_string(),
+            key_version: 1,
+        };
+
+        let program_id = Pubkey::new_unique();
+        let sign_type = SignRequestType::SignBidirectional(StreamSignBidirectionalEvent::Solana(
+            SignBidirectionalEvent {
+                sender: Default::default(),
+                serialized_transaction: vec![1, 2, 3],
+                dest: "ethereum".to_string(),
+                caip2_id: "eip155:1".to_string(),
+                key_version: 1,
+                deposit: 10,
+                path: "m/0".to_string(),
+                algo: "ECDSA".to_string(),
+                params: "{}".to_string(),
+                program_id,
+                output_deserialization_schema: vec![9],
+                respond_serialization_schema: vec![8],
+            },
+        ));
+
+        backlog
+            .insert(
+                Chain::Solana,
+                sign_id,
+                BacklogTransaction::Sign(SignTx {
+                    request_id: sign_id.request_id,
+                    source_chain: Chain::Solana,
+                    status: PendingRequestStatus::AwaitingResponse,
+                    args,
+                    unix_timestamp_indexed: 0,
+                }),
+                sign_type.clone(),
+            )
+            .await;
+        backlog.set_processed_block(Chain::Solana, 10).await;
+
+        let checkpoint = backlog.checkpoint(Chain::Solana).await;
+
+        let recovered = Backlog::new();
+        recovered
+            .recover_by_checkpoint(checkpoint)
+            .await
+            .expect("failed to recover");
+
+        let recovered_entry = recovered
+            .get(Chain::Solana, &sign_id)
+            .await
+            .expect("missing recovered entry");
+
+        assert_eq!(recovered_entry.sign_type, sign_type);
     }
 
     #[tokio::test]

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -61,10 +61,10 @@ impl PendingRequests {
         self.requests.remove(id).map(|entry| entry.tx)
     }
 
-    /// Gets a clone of a backlog entry from the pending requests map
+    /// Gets a ref of a backlog entry from the pending requests map
     /// Returns Some(value) if the key is present
-    fn get(&self, id: &SignId) -> Option<BacklogEntry> {
-        self.requests.get(id).cloned()
+    fn get(&self, id: &SignId) -> Option<&BacklogEntry> {
+        self.requests.get(id)
     }
 
     /// Returns the number of pending requests
@@ -255,7 +255,7 @@ impl Backlog {
             .read()
             .await
             .get(&chain)
-            .and_then(|pending_requests| pending_requests.get(id))
+            .and_then(|pending_requests| pending_requests.get(id).cloned())
     }
 
     /// Returns the number of pending requests in total
@@ -279,8 +279,7 @@ impl Backlog {
             .read()
             .await
             .get(&chain)
-            .and_then(|pending_requests| pending_requests.get(id))
-            .map(|entry| entry.sign_type)
+            .and_then(|pending| pending.get(id).map(|entry| entry.sign_type.clone()))
     }
 
     fn observe_backlog_size(&self, chain: Chain, len: usize) {

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -404,18 +404,13 @@ impl Backlog {
             .get_mut(&chain)
             .ok_or(BacklogError::ChainNotFound)?;
 
-        // Replace the Sign transaction with the Bidirectional transaction
-        if let Some(entry) = pending.requests.get_mut(&sign_id) {
-            entry.tx = BacklogTransaction::Bidirectional(bidirectional_tx.clone());
-        } else {
-            pending.requests.insert(
-                sign_id,
-                BacklogEntry {
-                    tx: BacklogTransaction::Bidirectional(bidirectional_tx.clone()),
-                    sign_type: SignRequestType::Sign,
-                },
-            );
-        }
+        // Replace the Sign transaction with the Bidirectional transaction while
+        // preserving the original sign_type metadata.
+        let entry = pending
+            .requests
+            .get_mut(&sign_id)
+            .ok_or(BacklogError::NotFound { chain, id: sign_id })?;
+        entry.tx = BacklogTransaction::Bidirectional(bidirectional_tx.clone());
 
         // Registration successful, now register the execution watcher on the target chain
         let target_chain = bidirectional_tx.target_chain;

--- a/chain-signatures/node/src/indexer_hydration.rs
+++ b/chain-signatures/node/src/indexer_hydration.rs
@@ -208,7 +208,7 @@ impl SignatureEvent for HydrationSignatureRequestedEvent {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct HydrationSignBidirectionalRequestedEvent {
     pub sender: [u8; 32],
     pub serialized_transaction: Vec<u8>,

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -675,7 +675,7 @@ fn parse_cpi_events(
                 Err(e) => tracing::warn!("Failed to deserialize SignatureRequestedEvent: {e}"),
             }
         } else if event_discriminator == SignBidirectionalEvent::DISCRIMINATOR {
-            match SignBidirectionalEvent::deserialize(&mut &event_data[..]) {
+            match <SignBidirectionalEvent as AnchorDeserialize>::deserialize(&mut &event_data[..]) {
                 Ok(ev) => acc.push(Box::new(ev) as SignatureEventBox),
                 Err(e) => {
                     tracing::warn!("Failed to deserialize SignBidirectionalEvent: {e}")

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -219,7 +219,7 @@ pub async fn spawn_system_metrics() -> tokio::task::JoinHandle<()> {
     })
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum SignRequestType {
     Sign,

--- a/chain-signatures/node/src/respond_bidirectional.rs
+++ b/chain-signatures/node/src/respond_bidirectional.rs
@@ -30,7 +30,7 @@ pub struct CompletedTx {
     block_number: u64,
 }
 
-#[derive(Hash, PartialEq, Eq, Clone, Debug)]
+#[derive(Hash, PartialEq, Eq, Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct RespondBidirectionalTx {
     pub tx_id: BidirectionalTxId,
     pub output: RespondBidirectionalSerializedOutput,

--- a/chain-signatures/node/src/storage/checkpoint_storage.rs
+++ b/chain-signatures/node/src/storage/checkpoint_storage.rs
@@ -10,7 +10,7 @@ use tokio::sync::RwLock;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-const CHECKPOINT_VERSION: &str = "v0";
+const CHECKPOINT_VERSION: &str = "v1";
 
 #[derive(Clone, Debug)]
 pub enum CheckpointStorage {

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -376,7 +376,7 @@ mod tests {
         let sign_bidir = SignBidirectionalEvent {
             sender: Default::default(),
             serialized_transaction: unsigned_rlp,
-            dest: "eip155:1".to_string(),
+            dest: Chain::Ethereum.to_string(),
             caip2_id: "eip155:1".to_string(),
             key_version: 0,
             deposit: 0,

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, watch};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum SignBidirectionalEvent {
     Solana(signet_program::SignBidirectionalEvent),
     Hydration(HydrationSignBidirectionalRequestedEvent),
@@ -401,9 +401,12 @@ pub(crate) async fn process_respond_event(
     let sign_id = SignId::new(respond_event.request_id());
     let source_chain = respond_event.source_chain();
     let Some(entry) = backlog.get(source_chain, &sign_id).await else {
-        anyhow::bail!(
-            "sign request not found for respond event: {sign_id:?} on chain {source_chain:?}"
+        tracing::info!(
+            ?sign_id,
+            ?source_chain,
+            "respond event is already finalized or pruned; skipping"
         );
+        return Ok(());
     };
 
     let event = match entry.sign_type {

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -421,10 +421,14 @@ pub(crate) async fn process_respond_event(
     let target_chain = Chain::from_str(&event.dest())
         .map_err(|err| anyhow::anyhow!("unable to parse target chain from dest: {err:?}"))?;
     if !matches!(entry.tx, BacklogTransaction::Sign(_)) {
-        let entry_type = entry.tx.typename();
-        anyhow::bail!(
-            "expected Sign transaction type for respond event, found different type={entry_type}: {sign_id:?}, {source_chain:?}, {target_chain:?}"
+        tracing::info!(
+            ?sign_id,
+            ?source_chain,
+            ?target_chain,
+            entry_type = %entry.tx.typename(),
+            "respond event backlog entry is already advanced; treating as processed"
         );
+        return Ok(());
     }
 
     let mpc_sig = respond_event.signature();

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -401,12 +401,9 @@ pub(crate) async fn process_respond_event(
     let sign_id = SignId::new(respond_event.request_id());
     let source_chain = respond_event.source_chain();
     let Some(entry) = backlog.get(source_chain, &sign_id).await else {
-        tracing::warn!(
-            ?sign_id,
-            ?source_chain,
-            "sign request not found for respond event (maybe already processed)"
+        anyhow::bail!(
+            "sign request not found for respond event: {sign_id:?} on chain {source_chain:?}"
         );
-        return Ok(());
     };
 
     let event = match entry.sign_type {
@@ -426,20 +423,12 @@ pub(crate) async fn process_respond_event(
 
     tracing::info!(?sign_id, "bidirectional processing initial respond event");
     let target_chain = Chain::from_str(&event.dest())
-        .map_err(|err| anyhow::anyhow!("unable to parse target chain from dest: {err:?}"));
-    let target_chain = match target_chain {
-        Ok(chain) => chain,
-        Err(_) => Chain::Ethereum,
-    };
-
+        .map_err(|err| anyhow::anyhow!("unable to parse target chain from dest: {err:?}"))?;
     if !matches!(entry.tx, BacklogTransaction::Sign(_)) {
-        tracing::warn!(
-            ?sign_id,
-            ?source_chain,
-            typename = ?entry.tx.typename(),
-            "expected Sign transaction type for initial respond event, found different type"
+        let entry_type = entry.tx.typename();
+        anyhow::bail!(
+            "expected Sign transaction type for respond event, found different type={entry_type}: {sign_id:?}, {source_chain:?}, {target_chain:?}"
         );
-        anyhow::bail!("bidirectional tx not found for advancement: {sign_id:?}");
     }
 
     let mpc_sig = respond_event.signature();

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -402,37 +402,42 @@ pub(crate) async fn process_respond_event(
 
     let source_chain = respond_event.source_chain();
 
-    let sign_type = match backlog.sign_type(source_chain, &sign_id).await {
+    let existing_entry = backlog.get(source_chain, &sign_id).await;
+
+    let sign_type = match existing_entry
+        .as_ref()
+        .and_then(|entry| entry.sign_type.clone())
+    {
         Some(sign_type) => sign_type,
-        None => {
-            let existing_tx = backlog.get(source_chain, &sign_id).await;
-            match existing_tx {
-                None => {
-                    tracing::info!(
-                        ?sign_id,
-                        ?source_chain,
-                        "ignoring duplicate respond event for already-completed request"
-                    );
-                    return Ok(());
-                }
-                // During checkpoint recovery we currently restore backlog transactions,
-                // but not their sign request type metadata. For Ethereum, requests are
-                // regular `Sign`, so we can safely continue.
-                Some(BacklogTransaction::Sign(_)) if source_chain == Chain::Ethereum => {
-                    tracing::warn!(
-                        ?sign_id,
-                        "sign type missing for ethereum respond event; defaulting to Sign"
-                    );
-                    SignRequestType::Sign
-                }
-                Some(tx) => {
-                    anyhow::bail!(
-                        "sign type missing for respond event but tx still exists: sign_id={sign_id:?}, source_chain={source_chain:?}, tx_status={:?}",
-                        tx.status()
-                    );
-                }
+        None => match existing_entry.as_ref() {
+            None => {
+                tracing::info!(
+                    ?sign_id,
+                    ?source_chain,
+                    "ignoring duplicate respond event for already-completed request"
+                );
+                return Ok(());
             }
-        }
+            // During checkpoint recovery we currently restore backlog transactions,
+            // but not their sign request type metadata. For Ethereum, requests are
+            // regular `Sign`, so we can safely continue.
+            Some(entry)
+                if source_chain == Chain::Ethereum
+                    && matches!(entry.tx, BacklogTransaction::Sign(_)) =>
+            {
+                tracing::warn!(
+                    ?sign_id,
+                    "sign type missing for ethereum respond event; defaulting to Sign"
+                );
+                SignRequestType::Sign
+            }
+            Some(entry) => {
+                anyhow::bail!(
+                    "sign type missing for respond event but tx still exists: sign_id={sign_id:?}, source_chain={source_chain:?}, tx_status={:?}",
+                    entry.tx.status()
+                );
+            }
+        },
     };
 
     let event = match sign_type {
@@ -458,9 +463,13 @@ pub(crate) async fn process_respond_event(
         Err(_) => Chain::Ethereum,
     };
 
-    let Some(BacklogTransaction::Sign(_)) = backlog.get(source_chain, &sign_id).await else {
+    let Some(existing_entry) = existing_entry.as_ref() else {
         anyhow::bail!("bidirectional tx not found for advancement: {sign_id:?}");
     };
+
+    if !matches!(existing_entry.tx, BacklogTransaction::Sign(_)) {
+        anyhow::bail!("bidirectional tx not found for advancement: {sign_id:?}");
+    }
 
     let mpc_sig = respond_event.signature();
 
@@ -845,7 +854,7 @@ mod tests {
         // inspect the transaction to provide more debugging info on failure
         let maybe_tx = backlog.get(tx.source_chain, &sign_id).await;
         assert!(maybe_tx.is_some(), "expected sign tx to still exist");
-        let tx_after = maybe_tx.unwrap();
+        let tx_after = maybe_tx.unwrap().tx;
         if tx_after.status() != PendingRequestStatus::Success {
             panic!("expected Success but found status: {:?}", tx_after.status());
         }
@@ -932,9 +941,14 @@ mod tests {
         // This mirrors production behavior where the same respond log can be
         // emitted repeatedly by the Ethereum indexer pipeline.
         for _ in 0..16 {
-            process_respond_event(event.clone(), sign_tx.clone(), &mut contract_watcher, &backlog)
-                .await
-                .expect("duplicate respond event should be idempotent");
+            process_respond_event(
+                event.clone(),
+                sign_tx.clone(),
+                &mut contract_watcher,
+                &backlog,
+            )
+            .await
+            .expect("duplicate respond event should be idempotent");
         }
 
         let no_extra = timeout(Duration::from_millis(100), sign_rx.recv()).await;

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -399,48 +399,17 @@ pub(crate) async fn process_respond_event(
     backlog: &Backlog,
 ) -> anyhow::Result<()> {
     let sign_id = SignId::new(respond_event.request_id());
-
     let source_chain = respond_event.source_chain();
-
-    let existing_entry = backlog.get(source_chain, &sign_id).await;
-
-    let sign_type = match existing_entry
-        .as_ref()
-        .and_then(|entry| entry.sign_type.clone())
-    {
-        Some(sign_type) => sign_type,
-        None => match existing_entry.as_ref() {
-            None => {
-                tracing::info!(
-                    ?sign_id,
-                    ?source_chain,
-                    "ignoring duplicate respond event for already-completed request"
-                );
-                return Ok(());
-            }
-            // During checkpoint recovery we currently restore backlog transactions,
-            // but not their sign request type metadata. For Ethereum, requests are
-            // regular `Sign`, so we can safely continue.
-            Some(entry)
-                if source_chain == Chain::Ethereum
-                    && matches!(entry.tx, BacklogTransaction::Sign(_)) =>
-            {
-                tracing::warn!(
-                    ?sign_id,
-                    "sign type missing for ethereum respond event; defaulting to Sign"
-                );
-                SignRequestType::Sign
-            }
-            Some(entry) => {
-                anyhow::bail!(
-                    "sign type missing for respond event but tx still exists: sign_id={sign_id:?}, source_chain={source_chain:?}, tx_status={:?}",
-                    entry.tx.status()
-                );
-            }
-        },
+    let Some(entry) = backlog.get(source_chain, &sign_id).await else {
+        tracing::warn!(
+            ?sign_id,
+            ?source_chain,
+            "sign request not found for respond event (maybe already processed)"
+        );
+        return Ok(());
     };
 
-    let event = match sign_type {
+    let event = match entry.sign_type {
         SignRequestType::SignBidirectional(event) => event,
         SignRequestType::Sign => {
             tracing::info!(?sign_id, "sign request completed successfully");
@@ -463,11 +432,13 @@ pub(crate) async fn process_respond_event(
         Err(_) => Chain::Ethereum,
     };
 
-    let Some(existing_entry) = existing_entry.as_ref() else {
-        anyhow::bail!("bidirectional tx not found for advancement: {sign_id:?}");
-    };
-
-    if !matches!(existing_entry.tx, BacklogTransaction::Sign(_)) {
+    if !matches!(entry.tx, BacklogTransaction::Sign(_)) {
+        tracing::warn!(
+            ?sign_id,
+            ?source_chain,
+            typename = ?entry.tx.typename(),
+            "expected Sign transaction type for initial respond event, found different type"
+        );
         anyhow::bail!("bidirectional tx not found for advancement: {sign_id:?}");
     }
 

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -402,10 +402,37 @@ pub(crate) async fn process_respond_event(
 
     let source_chain = respond_event.source_chain();
 
-    let Some(sign_type) = backlog.sign_type(source_chain, &sign_id).await else {
-        anyhow::bail!(
-            "sign type not found for respond event (may have already been processed): {sign_id:?}"
-        )
+    let sign_type = match backlog.sign_type(source_chain, &sign_id).await {
+        Some(sign_type) => sign_type,
+        None => {
+            let existing_tx = backlog.get(source_chain, &sign_id).await;
+            match existing_tx {
+                None => {
+                    tracing::info!(
+                        ?sign_id,
+                        ?source_chain,
+                        "ignoring duplicate respond event for already-completed request"
+                    );
+                    return Ok(());
+                }
+                // During checkpoint recovery we currently restore backlog transactions,
+                // but not their sign request type metadata. For Ethereum, requests are
+                // regular `Sign`, so we can safely continue.
+                Some(BacklogTransaction::Sign(_)) if source_chain == Chain::Ethereum => {
+                    tracing::warn!(
+                        ?sign_id,
+                        "sign type missing for ethereum respond event; defaulting to Sign"
+                    );
+                    SignRequestType::Sign
+                }
+                Some(tx) => {
+                    anyhow::bail!(
+                        "sign type missing for respond event but tx still exists: sign_id={sign_id:?}, source_chain={source_chain:?}, tx_status={:?}",
+                        tx.status()
+                    );
+                }
+            }
+        }
     };
 
     let event = match sign_type {
@@ -840,6 +867,81 @@ mod tests {
             }
             _ => panic!("Expected Sign::Request"),
         }
+    }
+
+    #[tokio::test]
+    async fn process_respond_event_duplicate_ethereum_is_idempotent() {
+        let backlog = Backlog::new();
+        let sign_id = SignId::new([3u8; 32]);
+        let args = SignArgs {
+            entropy: [1u8; 32],
+            epsilon: Scalar::from(1u64),
+            payload: Scalar::from(2u64),
+            path: "test".to_string(),
+            key_version: 1,
+        };
+
+        backlog
+            .insert(
+                Chain::Ethereum,
+                sign_id,
+                BacklogTransaction::Sign(SignTx {
+                    request_id: sign_id.request_id,
+                    source_chain: Chain::Ethereum,
+                    status: PendingRequestStatus::AwaitingResponse,
+                    args,
+                    unix_timestamp_indexed: current_unix_timestamp(),
+                }),
+                SignRequestType::Sign,
+            )
+            .await;
+
+        let event = SignatureRespondedEvent::Ethereum(EthereumSignatureRespondedEvent {
+            request_id: sign_id.request_id,
+            responder: alloy::primitives::Address::from_slice(&[0u8; 20]),
+            signature: Signature::new(ProjectivePoint::GENERATOR.to_affine(), Scalar::ONE, 0),
+        });
+
+        let account_id: AccountId = "test.near".parse().unwrap();
+        let public_key = ProjectivePoint::GENERATOR.to_affine();
+        let (mut contract_watcher, _tx) =
+            ContractStateWatcher::with_running(&account_id, public_key, 1, Default::default());
+
+        let (sign_tx, mut sign_rx) = mpsc::channel(4);
+
+        // First event should complete the request.
+        process_respond_event(
+            event.clone(),
+            sign_tx.clone(),
+            &mut contract_watcher,
+            &backlog,
+        )
+        .await
+        .expect("first respond event should succeed");
+
+        let msg = timeout(Duration::from_secs(1), sign_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        match msg {
+            Sign::Completion(id) => assert_eq!(id, sign_id),
+            _ => panic!("expected completion"),
+        }
+
+        // Duplicate events should be ignored, not treated as an error.
+        // This mirrors production behavior where the same respond log can be
+        // emitted repeatedly by the Ethereum indexer pipeline.
+        for _ in 0..16 {
+            process_respond_event(event.clone(), sign_tx.clone(), &mut contract_watcher, &backlog)
+                .await
+                .expect("duplicate respond event should be idempotent");
+        }
+
+        let no_extra = timeout(Duration::from_millis(100), sign_rx.recv()).await;
+        assert!(
+            matches!(no_extra, Err(_) | Ok(None)),
+            "expected no additional completion message, got: {no_extra:?}"
+        );
     }
 
     #[tokio::test]

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -543,7 +543,7 @@ async fn test_sign_contention_5_nodes() {
     // Wait for presignatures to be generated - 5-node triple generation takes ~3-4 minutes
     // We wait for a modest per-owner count since distribution is not uniform
     tracing::info!("waiting for presignatures to be generated (triple gen takes ~3-4 min)...");
-    let timeout = Duration::from_secs(480); // 8 minutes for triple + presignature generation
+    let timeout = Duration::from_secs(600); // 10 minutes for triple + presignature generation
     network
         .assert_presignatures(MIN_PRESIGNATURES_PER_OWNER, timeout)
         .await;


### PR DESCRIPTION
This fixes the issue with the following error  `failed to process respond event`: `sign type not found for respond event (may have already been processed)`.

This is due to cases like sign type not being recovered during recovery of the checkpoint so it appears blank. The non-recovered sign type then proceeds to make the `process_respond_event` skip a respond event and not clearing the sign request from the backlog. Also added an idempotent test to make sure the same respond event does not trigger any errors.

The fix here is adding the sign type to be serialized and recovered now too. This means we have to serialize the bidrectional events unfortunately. This is a storage breaking change so CHECKPOINT_VERSION is now `v1`
 