### PR TITLE
Update max Ts and Ps setup in tests

### DIFF
--- a/chain-signatures/contract/src/config/mod.rs
+++ b/chain-signatures/contract/src/config/mod.rs
@@ -53,9 +53,10 @@ pub struct ProtocolConfig {
 
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct TripleConfig {
-    /// Minimum amount of triples that is owned by each node.
+    /// Per-node minimum: each node generates triples until it owns at least this many.
     pub min_triples: u32,
-    /// Maximum amount of triples that is in the whole network.
+    /// Network-wide cap: no new triples are generated once the total potential
+    /// count across all nodes reaches this limit.
     pub max_triples: u32,
     /// Timeout for triple generation in milliseconds.
     pub generation_timeout: u64,
@@ -67,9 +68,10 @@ pub struct TripleConfig {
 
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct PresignatureConfig {
-    /// Minimum amount of presignatures that is owned by each node.
+    /// Per-node minimum: each node generates presignatures until it owns at least this many.
     pub min_presignatures: u32,
-    /// Maximum amount of presignatures that is in the whole network.
+    /// Network-wide cap: no new presignatures are generated once the total
+    /// potential count across all nodes reaches this limit.
     pub max_presignatures: u32,
     /// Timeout for presignature generation in milliseconds.
     pub generation_timeout: u64,

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -524,15 +524,16 @@ impl PresignatureSpawner {
         }
     }
 
+    /// Generate new presignatures if this node owns fewer than the per-node minimum
+    /// (`min_presignatures`) and the network-wide total hasn't reached the cap
+    /// (`max_presignatures`).
     async fn stockpile(&mut self, active: &[Participant], cfg: &ProtocolConfig) {
         let not_enough_presignatures = {
-            // Stopgap to prevent too many presignatures in the system. This should be around min_presig*nodes*2
-            // for good measure so that we have enough presignatures to do sig generation while also maintain
-            // the minimum number of presignature where a single node can't flood the system.
+            // Network-wide cap: stop generating once total potential presignatures reach max.
             if self.len_potential().await >= cfg.presignature.max_presignatures as usize {
                 false
             } else {
-                // We will always try to generate a new triple if we have less than the minimum
+                // Per-node floor: generate if this node owns fewer than min_presignatures.
                 self.len_mine().await < cfg.presignature.min_presignatures as usize
                     && self.len_introduced() < cfg.max_concurrent_introduction as usize
                     && self.ongoing.len() < cfg.max_concurrent_generation as usize

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -554,21 +554,19 @@ impl TripleSpawner {
         Ok(())
     }
 
-    /// Stockpile triples if the amount of unspent triples is below the minimum
-    /// and the maximum number of all ongoing generation protocols is below the maximum.
+    /// Generate new triples if this node owns fewer than the per-node minimum
+    /// (`min_triples`) and the network-wide total hasn't reached the cap (`max_triples`).
     async fn stockpile(&mut self, participants: &[Participant], cfg: &ProtocolConfig) {
         if participants.len() < self.threshold {
             return;
         }
 
         let not_enough_triples = {
-            // Stopgap to prevent too many triples in the system. This should be around min_triple*nodes*2
-            // for good measure so that we have enough triples to do presig generation while also maintain
-            // the minimum number of triples where a single node can't flood the system.
+            // Network-wide cap: stop generating once total potential triples reach max_triples.
             if self.len_potential().await >= cfg.triple.max_triples as usize {
                 false
             } else {
-                // We will always try to generate a new triple if we have less than the minimum
+                // Per-node floor: generate if this node owns fewer than min_triples.
                 self.len_mine().await < cfg.triple.min_triples as usize
                     && self.len_introduced() < cfg.max_concurrent_introduction as usize
                     && self.ongoing.len() < cfg.max_concurrent_generation as usize

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -59,14 +59,15 @@ struct MpcFixtureNodeBuilder {
 /// This struct is used to change settings before building the final network.
 struct FixtureConfig {
     input: FixtureInput,
+    num_nodes: u32,
 
     use_preshared_triples: bool,
     presignature_stockpile: bool,
 
-    min_triples: u32,
-    max_triples: u32,
-    min_presignatures: u32,
-    max_presignatures: u32,
+    node_min_triples: u32,
+    network_max_triples: u32,
+    node_min_presignatures: u32,
+    network_max_presignatures: u32,
 
     signature_timeout_ms: u64,
     presignature_timeout_ms: u64,
@@ -108,12 +109,13 @@ impl FixtureConfig {
     fn new(num_nodes: u32) -> Self {
         Self {
             input: FixtureInput::load(num_nodes),
+            num_nodes,
             use_preshared_triples: false,
             presignature_stockpile: false,
-            min_triples: 10,
-            max_triples: 30,
-            min_presignatures: 10,
-            max_presignatures: 30,
+            node_min_triples: 10,
+            network_max_triples: 10 * num_nodes * 2,
+            node_min_presignatures: 10,
+            network_max_presignatures: 10 * num_nodes * 2,
             signature_timeout_ms: 10_000,
             presignature_timeout_ms: 10_000,
             triple_timeout_ms: min_to_ms(10),
@@ -209,11 +211,11 @@ impl MpcFixtureBuilder {
     fn build_protocol_config(&self) -> ProtocolConfig {
         let mut config = ProtocolConfig::default();
         config.signature.generation_timeout = self.fixture_config.signature_timeout_ms;
-        config.presignature.max_presignatures = self.fixture_config.max_presignatures;
-        config.presignature.min_presignatures = self.fixture_config.min_presignatures;
+        config.presignature.max_presignatures = self.fixture_config.network_max_presignatures;
+        config.presignature.min_presignatures = self.fixture_config.node_min_presignatures;
         config.presignature.generation_timeout = self.fixture_config.presignature_timeout_ms;
-        config.triple.max_triples = self.fixture_config.max_triples;
-        config.triple.min_triples = self.fixture_config.min_triples;
+        config.triple.max_triples = self.fixture_config.network_max_triples;
+        config.triple.min_triples = self.fixture_config.node_min_triples;
         config.triple.generation_timeout = self.fixture_config.triple_timeout_ms;
         config
     }
@@ -278,27 +280,21 @@ impl MpcFixtureBuilder {
         self
     }
 
-    /// Set protocol config
-    pub fn with_min_triples_stockpile(mut self, value: u32) -> Self {
-        self.fixture_config.min_triples = value;
+    /// Set the per-node minimum number of triples to maintain.
+    /// Each node will keep generating triples until it owns at least this many.
+    /// Also updates the network-wide max
+    pub fn with_node_min_triples(mut self, value: u32) -> Self {
+        self.fixture_config.node_min_triples = value;
+        self.fixture_config.network_max_triples = value * self.fixture_config.num_nodes * 2;
         self
     }
 
-    /// Set protocol config
-    pub fn with_max_triples_stockpile(mut self, value: u32) -> Self {
-        self.fixture_config.max_triples = value;
-        self
-    }
-
-    /// Set protocol config
-    pub fn with_min_presignatures_stockpile(mut self, value: u32) -> Self {
-        self.fixture_config.min_presignatures = value;
-        self
-    }
-
-    /// Set protocol config
-    pub fn with_max_presignatures_stockpile(mut self, value: u32) -> Self {
-        self.fixture_config.max_presignatures = value;
+    /// Set the per-node minimum number of presignatures to maintain.
+    /// Each node will keep generating presignatures until it owns at least this many.
+    /// Also updates the network-wide max to `value * num_nodes * 2`.
+    pub fn with_node_min_presignatures(mut self, value: u32) -> Self {
+        self.fixture_config.node_min_presignatures = value;
+        self.fixture_config.network_max_presignatures = value * self.fixture_config.num_nodes * 2;
         self
     }
 
@@ -339,9 +335,7 @@ impl MpcFixtureBuilder {
     ///
     /// This setup will not attempt to stockpile presignatures.
     pub fn only_generate_triples(self) -> Self {
-        self.with_preshared_key()
-            .with_min_presignatures_stockpile(0)
-            .with_max_presignatures_stockpile(0)
+        self.with_preshared_key().with_node_min_presignatures(0)
     }
 
     /// Short-hand for creating an MPC setup that's prepared to produce presignatures.
@@ -350,8 +344,7 @@ impl MpcFixtureBuilder {
     pub fn only_generate_presignatures(self) -> Self {
         self.with_preshared_key()
             .with_preshared_triples()
-            .with_min_triples_stockpile(0)
-            .with_max_triples_stockpile(0)
+            .with_node_min_triples(0)
     }
 
     /// Short-hand for creating an MPC setup that's prepared to produce signatures.
@@ -360,10 +353,8 @@ impl MpcFixtureBuilder {
     pub fn only_generate_signatures(self) -> Self {
         self.with_preshared_key()
             .with_presignature_stockpile()
-            .with_min_triples_stockpile(0)
-            .with_max_triples_stockpile(0)
-            .with_min_presignatures_stockpile(0)
-            .with_max_presignatures_stockpile(0)
+            .with_node_min_triples(0)
+            .with_node_min_presignatures(0)
     }
 }
 

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -113,9 +113,9 @@ impl FixtureConfig {
             use_preshared_triples: false,
             presignature_stockpile: false,
             node_min_triples: 10,
-            network_max_triples: 10 * num_nodes * 2,
+            network_max_triples: 10 * num_nodes * 4,
             node_min_presignatures: 10,
-            network_max_presignatures: 10 * num_nodes * 2,
+            network_max_presignatures: 10 * num_nodes * 4,
             signature_timeout_ms: 10_000,
             presignature_timeout_ms: 10_000,
             triple_timeout_ms: min_to_ms(10),
@@ -282,19 +282,19 @@ impl MpcFixtureBuilder {
 
     /// Set the per-node minimum number of triples to maintain.
     /// Each node will keep generating triples until it owns at least this many.
-    /// Also updates the network-wide max
+    /// Also updates the network-wide max to `value * num_nodes * 4`.
     pub fn with_node_min_triples(mut self, value: u32) -> Self {
         self.fixture_config.node_min_triples = value;
-        self.fixture_config.network_max_triples = value * self.fixture_config.num_nodes * 2;
+        self.fixture_config.network_max_triples = value * self.fixture_config.num_nodes * 4;
         self
     }
 
     /// Set the per-node minimum number of presignatures to maintain.
     /// Each node will keep generating presignatures until it owns at least this many.
-    /// Also updates the network-wide max to `value * num_nodes * 2`.
+    /// Also updates the network-wide max to `value * num_nodes * 4`.
     pub fn with_node_min_presignatures(mut self, value: u32) -> Self {
         self.fixture_config.node_min_presignatures = value;
-        self.fixture_config.network_max_presignatures = value * self.fixture_config.num_nodes * 2;
+        self.fixture_config.network_max_presignatures = value * self.fixture_config.num_nodes * 4;
         self
     }
 

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -232,9 +232,8 @@ async fn test_presignature_timeout() {
     let network = MpcFixtureBuilder::default()
         // configure network ready to generate presignatures immediately
         .only_generate_presignatures()
-        // set exact presignature count target
-        .with_min_presignatures_stockpile(5)
-        .with_max_presignatures_stockpile(5)
+        // set presignature generation target (each node generates at least 5)
+        .with_node_min_presignatures(5)
         // apply message filter to all nodes
         .with_outgoing_message_filter(0, create_filter())
         .with_outgoing_message_filter(1, create_filter())
@@ -426,11 +425,9 @@ async fn test_sign_requests_wait_for_presignatures() {
         .with_preshared_triples()
         .with_presignature_stockpile()
         // Disable triple generation since we're using preshared triples
-        .with_min_triples_stockpile(0)
-        .with_max_triples_stockpile(0)
+        .with_node_min_triples(0)
         // Enable presignature generation for second batch
-        .with_min_presignatures_stockpile(5)
-        .with_max_presignatures_stockpile(20)
+        .with_node_min_presignatures(5)
         .build()
         .await;
 
@@ -524,8 +521,7 @@ async fn test_sign_contention_5_nodes() {
     const THRESHOLD: usize = 4;
     const NUM_SIGN_REQUESTS: u8 = 5; // Reduced from 10 to match presignature availability
     const MIN_PRESIGNATURES_PER_OWNER: usize = 3;
-    const STOCKPILE_MIN: u32 = 8;
-    const STOCKPILE_MAX: u32 = 12;
+    const NODE_MIN_ARTIFACTS: u32 = 8;
 
     tracing::info!(
         num_nodes = NUM_NODES,
@@ -537,10 +533,8 @@ async fn test_sign_contention_5_nodes() {
     // Build network with pre-shared keys, generate triples/presignatures on the fly
     let network = MpcFixtureBuilder::new(NUM_NODES, THRESHOLD)
         .with_preshared_key()
-        .with_min_triples_stockpile(STOCKPILE_MIN)
-        .with_max_triples_stockpile(STOCKPILE_MAX)
-        .with_min_presignatures_stockpile(STOCKPILE_MIN)
-        .with_max_presignatures_stockpile(STOCKPILE_MAX)
+        .with_node_min_triples(NODE_MIN_ARTIFACTS)
+        .with_node_min_presignatures(NODE_MIN_ARTIFACTS)
         .build()
         .await;
 


### PR DESCRIPTION
Max Ts and Ps setup in tests (and not only in tests) was confusing. I think sometimes we use it as per node min and max, but in reality that is min per node and max per network. That can lead to issues like:
- set min per node to 8
- set max per network to 12
- some nodes can not reach 8 predesignates, since the network already has 12

Instead, max should be set automatically based on number of nodes and min.