### PR TITLE
Turn off broken CI job

### DIFF
--- a/.github/workflows/prod-compatibility.yml
+++ b/.github/workflows/prod-compatibility.yml
@@ -1,12 +1,14 @@
 name: Production Compatibility
 
 on:
-  push:
-    branches:
-      - develop
-    paths:
-      - chain-signatures/**
-  pull_request:
+  workflow_dispatch:
+  # Temporarily disabled until finalized
+  # push:
+  #   branches:
+  #     - develop
+  #   paths:
+  #     - chain-signatures/**
+  # pull_request:
 
 env:
   RUSTFLAGS: -D warnings


### PR DESCRIPTION
Let's get it back once it works. Now it is only making our CI status red, including on the main repo page.