### PR TITLE
Fix k6 shadowing issue

### DIFF
--- a/infra/loadtests/k6-load-test.js
+++ b/infra/loadtests/k6-load-test.js
@@ -96,12 +96,12 @@ export default function () {
     console.error(`One or more required environment variables are not set: chain ${chain}, env ${env}, check ${checkRaw}`);
     throw new Error("Missing required environment variables. Exiting script.");
   }
-  let check = checkRaw === 'true';
+  let checkSignature = checkRaw === 'true';
 
   let params = JSON.stringify({
     chain: chain,
     env: env,
-    check: check,
+    check: checkSignature,
   });
 
   console.log(`Sending request to ${PINGER_URL} with params: ${params}`);


### PR DESCRIPTION
`check` variable was shadowing imported `check` function, that was causing red status on CI when executing k6 load tests