### PR TITLE
Derive Delta discussion

### DIFF
--- a/chain-signatures/node/src/indexer.rs
+++ b/chain-signatures/node/src/indexer.rs
@@ -103,8 +103,8 @@ impl NearIndexer {
         let payload = pending_request.payload;
         let epsilon = pending_request.epsilon;
 
-        // no longer taking entropy from logs, but this is merely for integration tests, so
-        // it doesn't matter as much as long as the IT nodes agree on the entropy.
+        // No longer taking entropy from logs, but this is merely for integration tests, so
+        // it doesn't matter as much as long as the integration tests nodes agree on the entropy.
         let entropy = self.derive_entropy_from_sign_id(&sign_id);
         // NOTE: path is not used at all currently in signature.rs during signing, so hardcoding
         // it here won't matter.

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -363,8 +363,11 @@ fn sign_request_from_filtered_log(log: Log) -> Option<IndexedSignRequest> {
         &event.path,
     );
 
-    // Use transaction hash as entropy
-    let entropy = log.transaction_hash.unwrap_or_default();
+    // Use Ethereum transaction hash as entropy
+    let Some(entropy) = log.transaction_hash else {
+        tracing::error!("log missing transaction hash, skipping sign request");
+        return None;
+    };
 
     let sign_id = SignId::new(event.generate_request_id());
     tracing::info!(?sign_id, "eth signature requested");

--- a/chain-signatures/node/src/indexer_hydration.rs
+++ b/chain-signatures/node/src/indexer_hydration.rs
@@ -480,7 +480,7 @@ pub async fn run(
                     event
                 );
 
-                let entropy = sp_core::hashing::blake2_256(ev.bytes());
+                let entropy = entropy_hydration(&ev);
 
                 if let Err(e) = crate::stream::ops::process_sign_event(
                     Box::new(event),
@@ -533,8 +533,7 @@ pub async fn run(
                     "Hydration::Signet::SignBidirectionalRequested in block #{number} ({hash:?}): {:?}",
                 event
                 );
-
-                let entropy = sp_core::hashing::blake2_256(ev.bytes());
+                let entropy = entropy_hydration(&ev);
 
                 if let Err(e) = crate::stream::ops::process_sign_event(
                     Box::new(event),
@@ -593,6 +592,11 @@ pub fn spawn_runtime_updater(api: OnlineClient<SubstrateConfig>) {
             tracing::error!("runtime updater stopped: {e}");
         }
     });
+}
+
+/// Blake2-256 hash of the raw Substrate event bytes.
+fn entropy_hydration(ev: &EventDetails<SubstrateConfig>) -> [u8; 32] {
+    sp_core::hashing::blake2_256(ev.bytes())
 }
 
 fn decode_signature_requested(

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -487,6 +487,8 @@ fn build_sign_request(
     sign_event: SignatureEventBox,
     tx_sig: Vec<u8>,
 ) -> anyhow::Result<IndexedSignRequest> {
+    // First 32 bytes of the Solana transaction signature,
+    // which serves as Solana's unique transaction identifier.
     let mut entropy = [0u8; 32];
     entropy.copy_from_slice(&tx_sig[..32]);
     sign_event.generate_sign_request(entropy)

--- a/chain-signatures/node/src/kdf.rs
+++ b/chain-signatures/node/src/kdf.rs
@@ -6,9 +6,11 @@ use mpc_primitives::Signature;
 use near_primitives::hash::CryptoHash;
 use sha3::Sha3_256;
 
-// In case there are multiple requests in the same block (hence same entropy), we need to ensure
-// that we generate different random scalars as delta tweaks.
-// Receipt ID should be unique inside of a block, so it serves us as the request identifier.
+/// # Parameters
+/// - `request_id`: unique identifier of the sign request (hash of the event fields).
+/// - `entropy`: chain-specific, unique per-request data
+/// - `presignature_big_r`: the R point from the presignature, mixed into the
+///   derivation so delta is also bound to the specific presignature used.
 pub fn derive_delta(
     request_id: [u8; 32],
     entropy: [u8; 32],


### PR DESCRIPTION
@scafuro could you please clarify the requirements for the delta computation?

We’re integrating more chains, and each of them relies on a different entropy source, so it would be helpful to have a clear definition.

My understanding is that delta must be unique. To achieve this, we include `presignature_big_r`, which is unique per signature generation since pre-signatures are not reused. Because the requester does not know which presignature will be selected, the resulting delta should not be predictable.

However, node providers can still choose which presignature they own to use for generation. To mitigate this, we add an additional source of randomness that is specific to each chain - entropy. Let's discuss if what we have is sufficient.