### PR TITLE
Remove participant id maping after removal

### DIFF
--- a/chain-signatures/contract/src/primitives.rs
+++ b/chain-signatures/contract/src/primitives.rs
@@ -143,6 +143,7 @@ impl Participants {
 
     pub fn remove(&mut self, account_id: &AccountId) {
         self.participants.remove(account_id);
+        self.account_to_participant_id.remove(account_id);
     }
 
     pub fn get(&self, account_id: &AccountId) -> Option<&ParticipantInfo> {

--- a/chain-signatures/contract/src/primitives.rs
+++ b/chain-signatures/contract/src/primitives.rs
@@ -133,17 +133,25 @@ impl Participants {
     }
 
     pub fn insert(&mut self, account_id: AccountId, participant_info: ParticipantInfo) {
-        if !self.account_to_participant_id.contains_key(&account_id) {
-            self.account_to_participant_id
-                .insert(account_id.clone(), self.next_id);
-            self.next_id += 1;
-        }
         self.participants.insert(account_id, participant_info);
+        self.reindex();
     }
 
     pub fn remove(&mut self, account_id: &AccountId) {
         self.participants.remove(account_id);
-        self.account_to_participant_id.remove(account_id);
+        self.reindex();
+    }
+
+    /// Rebuild `account_to_participant_id` so IDs are contiguous starting from 0,
+    /// following the BTreeMap's sorted order.
+    fn reindex(&mut self) {
+        self.account_to_participant_id = self
+            .participants
+            .keys()
+            .enumerate()
+            .map(|(id, account_id)| (account_id.clone(), id as u32))
+            .collect();
+        self.next_id = self.participants.len() as u32;
     }
 
     pub fn get(&self, account_id: &AccountId) -> Option<&ParticipantInfo> {

--- a/chain-signatures/contract/src/primitives.rs
+++ b/chain-signatures/contract/src/primitives.rs
@@ -133,25 +133,17 @@ impl Participants {
     }
 
     pub fn insert(&mut self, account_id: AccountId, participant_info: ParticipantInfo) {
+        if !self.account_to_participant_id.contains_key(&account_id) {
+            self.account_to_participant_id
+                .insert(account_id.clone(), self.next_id);
+            self.next_id += 1;
+        }
         self.participants.insert(account_id, participant_info);
-        self.reindex();
     }
 
     pub fn remove(&mut self, account_id: &AccountId) {
         self.participants.remove(account_id);
-        self.reindex();
-    }
-
-    /// Rebuild `account_to_participant_id` so IDs are contiguous starting from 0,
-    /// following the BTreeMap's sorted order.
-    fn reindex(&mut self) {
-        self.account_to_participant_id = self
-            .participants
-            .keys()
-            .enumerate()
-            .map(|(id, account_id)| (account_id.clone(), id as u32))
-            .collect();
-        self.next_id = self.participants.len() as u32;
+        self.account_to_participant_id.remove(account_id);
     }
 
     pub fn get(&self, account_id: &AccountId) -> Option<&ParticipantInfo> {

--- a/chain-signatures/contract/tests/vote.rs
+++ b/chain-signatures/contract/tests/vote.rs
@@ -283,8 +283,45 @@ async fn test_vote_leave() -> anyhow::Result<()> {
                 .new_participants
                 .participants
                 .contains_key(accounts[0].id()));
+            assert!(!r
+                .new_participants
+                .account_to_participant_id
+                .contains_key(accounts[0].id()));
         }
         _ => panic!("should be in resharing state"),
+    };
+
+    // Complete resharing and verify the removed participant is fully gone
+    let execution = accounts[1]
+        .call(contract.id(), "vote_reshared")
+        .args_json(json!({ "epoch": 1 }))
+        .transact()
+        .await?;
+    assert!(execution.is_success());
+
+    let execution = accounts[2]
+        .call(contract.id(), "vote_reshared")
+        .args_json(json!({ "epoch": 1 }))
+        .transact()
+        .await?;
+    assert!(execution.is_success());
+
+    let state: mpc_contract::ProtocolContractState =
+        contract.view("state").await.unwrap().json().unwrap();
+    match state {
+        mpc_contract::ProtocolContractState::Running(r) => {
+            assert!(
+                !r.participants.contains_key(accounts[0].id()),
+                "removed participant must not be in participants"
+            );
+            assert!(
+                !r.participants
+                    .account_to_participant_id
+                    .contains_key(accounts[0].id()),
+                "removed participant must not be in account_to_participant_id"
+            );
+        }
+        _ => panic!("should be in running state after resharing"),
     };
 
     Ok(())

--- a/chain-signatures/contract/tests/vote.rs
+++ b/chain-signatures/contract/tests/vote.rs
@@ -320,17 +320,6 @@ async fn test_vote_leave() -> anyhow::Result<()> {
                     .contains_key(accounts[0].id()),
                 "removed participant must not be in account_to_participant_id"
             );
-            // IDs must be contiguous 0..n
-            let mut ids: Vec<u32> = r
-                .participants
-                .account_to_participant_id
-                .values()
-                .copied()
-                .collect();
-            ids.sort();
-            let expected: Vec<u32> = (0..r.participants.len() as u32).collect();
-            assert_eq!(ids, expected, "participant IDs must be contiguous from 0");
-            assert_eq!(r.participants.next_id, r.participants.len() as u32);
         }
         _ => panic!("should be in running state after resharing"),
     };

--- a/chain-signatures/contract/tests/vote.rs
+++ b/chain-signatures/contract/tests/vote.rs
@@ -320,6 +320,17 @@ async fn test_vote_leave() -> anyhow::Result<()> {
                     .contains_key(accounts[0].id()),
                 "removed participant must not be in account_to_participant_id"
             );
+            // IDs must be contiguous 0..n
+            let mut ids: Vec<u32> = r
+                .participants
+                .account_to_participant_id
+                .values()
+                .copied()
+                .collect();
+            ids.sort();
+            let expected: Vec<u32> = (0..r.participants.len() as u32).collect();
+            assert_eq!(ids, expected, "participant IDs must be contiguous from 0");
+            assert_eq!(r.participants.next_id, r.participants.len() as u32);
         }
         _ => panic!("should be in running state after resharing"),
     };


### PR DESCRIPTION
The resharing was successful, but I've noticed that lifted was still in the list if acc -> id map. I've applied a fix, not sure why we have not seen it before.

@ChaoticTempest having lifted in the list should not be a huge harm, but we may also remove it for sanity.

I've noticed that we are not updating ids. If we had 1, 2, 3 and removed node 2, we will have 1, 3. When we add a node we will have 1, 3, 4. That should not be a problem for Cait-sith, but we need to keep that in mind.

cc @auto-mausx 