### PR TITLE
fix: macos eth testing

### DIFF
--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -332,9 +332,7 @@ impl Default for DockerClient {
             }
         };
 
-        Self {
-            docker,
-        }
+        Self { docker }
     }
 }
 
@@ -645,7 +643,8 @@ impl Solana {
 
         let rpc_address = format!("http://127.0.0.1:{}", rpc_port);
         let ws_address = format!("ws://127.0.0.1:{}", ws_port);
-        let ledger_dir = std::env::temp_dir().join(format!("solana-test-ledger-{}", uuid::Uuid::new_v4()));
+        let ledger_dir =
+            std::env::temp_dir().join(format!("solana-test-ledger-{}", uuid::Uuid::new_v4()));
         // Start the solana-test-validator process
         let mut command = Command::new("solana-test-validator");
         command
@@ -666,7 +665,9 @@ impl Solana {
             .arg("--reset")
             .arg("--quiet");
 
-        let process = command.spawn().expect("failed to start solana-test-validator");
+        let process = command
+            .spawn()
+            .expect("failed to start solana-test-validator");
 
         let rpc_client = SolanaRpcClient::new_with_commitment(
             rpc_address.clone(),
@@ -708,12 +709,21 @@ impl Solana {
 
             if version_ready && blockhash_ready {
                 if !funded {
-                    tracing::warn!(attempt, "solana validator RPC is ready but payer balance is still zero");
+                    tracing::warn!(
+                        attempt,
+                        "solana validator RPC is ready but payer balance is still zero"
+                    );
                 }
                 return;
             }
 
-            tracing::debug!(attempt, version_ready, blockhash_ready, funded, "waiting for solana-test-validator readiness");
+            tracing::debug!(
+                attempt,
+                version_ready,
+                blockhash_ready,
+                funded,
+                "waiting for solana-test-validator readiness"
+            );
             sleep(Duration::from_secs(1)).await;
         }
 

--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::env;
 use std::path::Path;
 
 use crate::cluster::spawner::ClusterSpawner;
@@ -309,14 +310,30 @@ impl DockerClient {
 
 impl Default for DockerClient {
     fn default() -> Self {
+        let timeout = 600;
+        let api_version = bollard::API_DEFAULT_VERSION;
+
+        let docker = match bollard::Docker::connect_with_defaults() {
+            Ok(docker) => docker,
+            Err(default_err) => {
+                let home_socket = env::var("HOME")
+                    .ok()
+                    .map(|home| format!("unix://{home}/.docker/run/docker.sock"));
+                let Some(home_socket) = home_socket else {
+                    panic!("failed to connect to Docker using defaults: {default_err}");
+                };
+
+                bollard::Docker::connect_with_unix(&home_socket, timeout, api_version)
+                    .unwrap_or_else(|home_err| {
+                        panic!(
+                            "failed to connect to Docker using defaults ({default_err}) or Docker Desktop socket {home_socket} ({home_err})"
+                        )
+                    })
+            }
+        };
+
         Self {
-            docker: Docker::connect_with_local(
-                "unix:///var/run/docker.sock",
-                // 10 minutes timeout for all requests in case a lot of tests are being ran in parallel.
-                600,
-                bollard::API_DEFAULT_VERSION,
-            )
-            .unwrap(),
+            docker,
         }
     }
 }
@@ -458,53 +475,32 @@ impl EthereumSandbox {
 
     pub async fn run(spawner: &ClusterSpawner) -> anyhow::Result<Self> {
         let chain_id_arg = Self::DEFAULT_CHAIN_ID.to_string();
-        let command = vec![
-            "anvil".to_string(),
-            "--host".to_string(),
-            "0.0.0.0".to_string(),
-            "--chain-id".to_string(),
+        let command = format!(
+            "anvil --host 0.0.0.0 --chain-id {} --mnemonic '{}' --block-time 1",
             chain_id_arg,
-            "--mnemonic".to_string(),
-            Self::DEFAULT_MNEMONIC.to_string(),
-            "--block-time".to_string(),
-            "1".to_string(),
-        ];
+            Self::DEFAULT_MNEMONIC,
+        );
 
-        let request = if cfg!(feature = "docker-test") {
-            GenericImage::new("ghcr.io/foundry-rs/foundry", "nightly")
-                .with_exposed_port(Self::RPC_PORT.tcp())
-                .with_network(&spawner.network)
-                .with_cmd(command.clone())
-        } else {
-            GenericImage::new("ghcr.io/foundry-rs/foundry", "nightly")
-                .with_network("host")
-                .with_cmd(command)
-        };
+        let request = GenericImage::new("ghcr.io/foundry-rs/foundry", "nightly")
+            .with_exposed_port(Self::RPC_PORT.tcp())
+            .with_network(&spawner.network)
+            .with_cmd(vec![command]);
 
         let container = request.start().await?;
 
         let secret_key = derive_secret_key(Self::DEFAULT_MNEMONIC)?;
 
-        let (internal_http_endpoint, external_http_endpoint) = if cfg!(feature = "docker-test") {
-            let network_ip = spawner
-                .docker
-                .get_network_ip_address(&container, &spawner.network)
-                .await?;
+        let network_ip = spawner
+            .docker
+            .get_network_ip_address(&container, &spawner.network)
+            .await?;
+        let external_port = container
+            .get_host_port_ipv4(Self::RPC_PORT)
+            .await
+            .context("ethereum sandbox port mapping")?;
 
-            let external_port = container
-                .get_host_port_ipv4(Self::RPC_PORT)
-                .await
-                .context("ethereum sandbox port mapping")?;
-
-            let external_http_endpoint = format!("http://127.0.0.1:{external_port}");
-            (
-                format!("http://{}:{}", network_ip, Self::RPC_PORT),
-                external_http_endpoint,
-            )
-        } else {
-            let endpoint = format!("http://127.0.0.1:{}", Self::RPC_PORT);
-            (endpoint.clone(), endpoint)
-        };
+        let internal_http_endpoint = format!("http://{}:{}", network_ip, Self::RPC_PORT);
+        let external_http_endpoint = format!("http://127.0.0.1:{external_port}");
 
         wait_for_rpc(&external_http_endpoint).await?;
 

--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::cluster::spawner::ClusterSpawner;
 use crate::local::NodeEnvConfig;
@@ -592,6 +592,7 @@ pub struct Solana {
     pub ws_port: u16,
     pub faucet_port: u16,
     pub rpc_client: SolanaRpcClient,
+    ledger_dir: PathBuf,
 }
 
 impl Solana {
@@ -631,41 +632,52 @@ impl Solana {
 
         // Generate a new keypair for the test validator
         let program_keypair = Solana::program_keypair();
+        let payer_keypair = SolanaKeypair::from_seed(&[102u8; 32]).unwrap();
 
         // Find available ports for RPC and WebSocket
         // Find available ports (websocket is automatically rpc_port + 1)
         let rpc_port = pick_preferred_or_unused_port(8899).await;
         let ws_port = rpc_port + 1;
         let faucet_port = pick_preferred_or_unused_port(9900).await;
+        let gossip_port = pick_preferred_or_unused_port(8000).await;
+        let dynamic_port_start = pick_preferred_or_unused_port(gossip_port + 1).await;
+        let dynamic_port_end = dynamic_port_start + 32;
 
         let rpc_address = format!("http://127.0.0.1:{}", rpc_port);
         let ws_address = format!("ws://127.0.0.1:{}", ws_port);
-
+        let ledger_dir = std::env::temp_dir().join(format!("solana-test-ledger-{}", uuid::Uuid::new_v4()));
         // Start the solana-test-validator process
-        let process = Command::new("solana-test-validator")
+        let mut command = Command::new("solana-test-validator");
+        command
+            .arg("--ledger")
+            .arg(&ledger_dir)
             .arg("--rpc-port")
             .arg(rpc_port.to_string())
             .arg("--faucet-port")
             .arg(faucet_port.to_string())
+            .arg("--gossip-port")
+            .arg(gossip_port.to_string())
+            .arg("--dynamic-port-range")
+            .arg(format!("{dynamic_port_start}-{dynamic_port_end}"))
             .arg("--bind-address")
             .arg("127.0.0.1")
+            .arg("--mint")
+            .arg(payer_keypair.pubkey().to_string())
             .arg("--reset")
-            .arg("--quiet")
-            .spawn()
-            .expect("failed to start solana-test-validator");
+            .arg("--quiet");
 
-        // Wait a bit for the validator to start up
-        tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+        let process = command.spawn().expect("failed to start solana-test-validator");
+
+        let rpc_client = SolanaRpcClient::new_with_commitment(
+            rpc_address.clone(),
+            solana_sdk::commitment_config::CommitmentConfig::confirmed(),
+        );
+        Self::wait_for_validator_ready(&rpc_client, &payer_keypair.pubkey()).await;
+
         tracing::info!(
             rpc_address,
             ws_address,
             "solana-test-validator process is running",
-        );
-
-        let payer_keypair = SolanaKeypair::from_seed(&[102u8; 32]).unwrap();
-        let rpc_client = SolanaRpcClient::new_with_commitment(
-            rpc_address.clone(),
-            solana_sdk::commitment_config::CommitmentConfig::confirmed(),
         );
 
         Self {
@@ -678,7 +690,34 @@ impl Solana {
             ws_port,
             faucet_port,
             rpc_client,
+            ledger_dir,
         }
+    }
+
+    async fn wait_for_validator_ready(rpc_client: &SolanaRpcClient, payer: &SolanaPubkey) {
+        const MAX_ATTEMPTS: usize = 60;
+
+        for attempt in 1..=MAX_ATTEMPTS {
+            let version_ready = rpc_client.get_version().await.is_ok();
+            let blockhash_ready = rpc_client.get_latest_blockhash().await.is_ok();
+            let funded = rpc_client
+                .get_balance(payer)
+                .await
+                .ok()
+                .is_some_and(|balance| balance > 0);
+
+            if version_ready && blockhash_ready {
+                if !funded {
+                    tracing::warn!(attempt, "solana validator RPC is ready but payer balance is still zero");
+                }
+                return;
+            }
+
+            tracing::debug!(attempt, version_ready, blockhash_ready, funded, "waiting for solana-test-validator readiness");
+            sleep(Duration::from_secs(1)).await;
+        }
+
+        panic!("solana-test-validator did not become ready in time");
     }
 
     pub fn get_config(&self, program_address: String) -> mpc_node::indexer_sol::SolConfig {
@@ -742,28 +781,6 @@ impl Solana {
         self.program_keypair
             .write_to_file(&program_keypair_path)
             .unwrap();
-
-        // Request airdrop for the payer to fund deployment
-        tracing::info!(
-            ?payer_keypair_path,
-            "requesting solana airdrop for deployment..."
-        );
-        let airdrop_output = tokio::process::Command::new("solana")
-            .args([
-                "airdrop",
-                "10", // 10 SOL should be enough for whatever action
-                "--url",
-                &self.rpc_address,
-                "--keypair",
-                payer_keypair_path.to_str().unwrap(),
-            ])
-            .output()
-            .await?;
-
-        if !airdrop_output.status.success() {
-            let stderr = String::from_utf8_lossy(&airdrop_output.stderr);
-            tracing::warn!(?payer_keypair_path, "failed to airdrop SOL: {stderr}",);
-        }
 
         // Deploy the program using solana CLI
         tracing::info!("deploying solana program via CLI...");
@@ -1139,6 +1156,10 @@ impl Drop for Solana {
             tracing::warn!("failed to kill solana-test-validator process: {e}");
         } else {
             tracing::info!("solana-test-validator process terminated");
+        }
+
+        if let Err(e) = std::fs::remove_dir_all(&self.ledger_dir) {
+            tracing::debug!(?self.ledger_dir, "failed to remove solana ledger dir: {e}");
         }
     }
 }

--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -370,22 +370,40 @@ async fn test_checkpoint_recovery_after_offline() -> anyhow::Result<()> {
         "offline node has restarted and checkpoint recovery complete",
     );
 
+    anyhow::ensure!(
+        node_recovered_checkpoint.block_height >= node_active_checkpoint.block_height,
+        "restarted node should recover to at least the active checkpoint height via consensus"
+    );
+
+    let (active_checkpoint_after_restart, recovered_checkpoint_after_restart) =
+        wait_matching_node_checkpoints(
+            &cluster,
+            active_idx,
+            offline_idx,
+            Chain::Ethereum,
+            node_recovered_checkpoint
+                .block_height
+                .max(node_active_checkpoint.block_height),
+            Duration::from_secs(20),
+        )
+        .await?;
+
     assert_eq!(
-        node_active_checkpoint, node_recovered_checkpoint,
-        "restarted node should recover to same checkpoint as active node via consensus"
+        active_checkpoint_after_restart, recovered_checkpoint_after_restart,
+        "restarted node should converge to the same checkpoint as the active node via consensus"
     );
 
     let active_checkpoint_after_restart = wait_node_checkpoint(
         &cluster,
         active_idx,
         Chain::Ethereum,
-        node_active_checkpoint.block_height,
+        active_checkpoint_after_restart.block_height,
         Duration::from_secs(10),
     )
     .await?;
 
     assert_eq!(
-        node_active_checkpoint, active_checkpoint_after_restart,
+        recovered_checkpoint_after_restart, active_checkpoint_after_restart,
         "active node checkpoint should remain aligned after peer recovery"
     );
 
@@ -463,5 +481,47 @@ async fn wait_node_checkpoint(
     .await
     .unwrap_or_else(|_| {
         panic!("timed out waiting for node {node_idx} checkpoint >= {min_block_height}")
+    })
+}
+
+async fn wait_matching_node_checkpoints(
+    nodes: &Cluster,
+    left_idx: usize,
+    right_idx: usize,
+    chain: Chain,
+    min_block_height: u64,
+    timeout: Duration,
+) -> anyhow::Result<(Checkpoint, Checkpoint)> {
+    tokio::time::timeout(timeout, async {
+        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        loop {
+            interval.tick().await;
+
+            let left = nodes.fetch_checkpoints(left_idx).await?;
+            let right = nodes.fetch_checkpoints(right_idx).await?;
+
+            let Some(left_checkpoint) = left.get(&chain).cloned() else {
+                continue;
+            };
+            let Some(right_checkpoint) = right.get(&chain).cloned() else {
+                continue;
+            };
+
+            if left_checkpoint.block_height < min_block_height
+                || right_checkpoint.block_height < min_block_height
+            {
+                continue;
+            }
+
+            if left_checkpoint == right_checkpoint {
+                return Ok((left_checkpoint, right_checkpoint));
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "timed out waiting for nodes {left_idx} and {right_idx} to converge on checkpoint >= {min_block_height}"
+        )
     })
 }


### PR DESCRIPTION
Fixes testing locally on macos for ethereum integration tests.

Also fixes some flaky stuff with solana environment airdrops for integration tests. Uses `--mint` option here