### PR TITLE
clippy: new lints from rust 1.95

### DIFF
--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -183,7 +183,7 @@ impl TransactionOutput {
 
         // Map to named output
         let mut output_map = HashMap::new();
-        for (field, value) in schema.into_iter().zip(values.into_iter()) {
+        for (field, value) in schema.into_iter().zip(values) {
             output_map.insert(field.name, value);
         }
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -581,7 +581,7 @@ pub async fn host(spawner: &mut ClusterSpawner) -> anyhow::Result<Nodes> {
     let node_futures = spawner
         .accounts
         .iter()
-        .zip(std::mem::take(&mut spawner.node_binary_sources).into_iter())
+        .zip(std::mem::take(&mut spawner.node_binary_sources))
         .map(|(account, source)| {
             let binary_path = source.binary_path().unwrap();
             local::Node::run_with_binary(&ctx, cfg, account, binary_path)


### PR DESCRIPTION
clippy::useless_conversion on into_iter started firing with rustc 1.95.0