### PR TITLE
fix: bidirectional requeue

### DIFF
--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -1024,14 +1024,29 @@ mod tests {
 
         match status {
             SignStatus::AwaitingResponse => {}
-            SignStatus::AwaitingResponseBidirectional => {}
+            SignStatus::AwaitingResponseBidirectional => {
+                let completion_request = IndexedSignRequest::respond_bidirectional(
+                    sign_id,
+                    create_test_args(sign_id.request_id[0]),
+                    chain,
+                    0,
+                    RespondBidirectionalTx {
+                        tx_id: tx.id,
+                        output: vec![],
+                    },
+                );
+                backlog
+                    .set_request(chain, &sign_id, completion_request)
+                    .await
+                    .unwrap();
+            }
             SignStatus::PendingExecution => {
                 backlog.advance(chain, sign_id, tx).await.unwrap();
             }
-            SignStatus::Success | SignStatus::Failed => {
-                backlog.advance(chain, sign_id, tx).await.unwrap();
-                backlog.set_status(chain, &sign_id, status).await;
-            }
+        }
+
+        if status == SignStatus::AwaitingResponseBidirectional {
+            backlog.set_status(chain, &sign_id, status).await;
         }
     }
 
@@ -1103,7 +1118,7 @@ mod tests {
             &backlog,
             Chain::Ethereum,
             tx2,
-            SignStatus::Success,
+            SignStatus::AwaitingResponseBidirectional,
             "ethereum",
         )
         .await;
@@ -1138,11 +1153,11 @@ mod tests {
             .await;
         assert_eq!(eth_awaiting.len(), 1);
 
-        // Filter Ethereum by Success
-        let eth_success = backlog
-            .get_by_status(Chain::Ethereum, SignStatus::Success)
+        // Filter Ethereum by bidirectional completion awaiting final respond
+        let eth_completion = backlog
+            .get_by_status(Chain::Ethereum, SignStatus::AwaitingResponseBidirectional)
             .await;
-        assert_eq!(eth_success.len(), 1);
+        assert_eq!(eth_completion.len(), 1);
 
         // Filter Solana by Pending
         let sol_pending = backlog
@@ -1245,7 +1260,7 @@ mod tests {
             &backlog,
             Chain::Ethereum,
             tx2.clone(),
-            SignStatus::Success,
+            SignStatus::AwaitingResponseBidirectional,
             "ethereum",
         )
         .await;
@@ -1442,10 +1457,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_recovered_completed_bidirectional_requests_are_requeued_for_final_respond() {
-        for (offset, status) in [SignStatus::Success, SignStatus::Failed]
-            .into_iter()
-            .enumerate()
-        {
+        let status = SignStatus::AwaitingResponseBidirectional;
+        for offset in 0..2 {
             let backlog = Backlog::new();
             let tx = create_test_tx(8 + offset as u8);
             let sign_id = SignId::new(tx.request_id);
@@ -1583,10 +1596,14 @@ mod tests {
 
         // set_status should update the sign request status
         backlog
-            .set_status(tx.source_chain, &sign_id, SignStatus::Success)
+            .set_status(
+                tx.source_chain,
+                &sign_id,
+                SignStatus::AwaitingResponseBidirectional,
+            )
             .await;
         let successes = backlog
-            .get_by_status(tx.source_chain, SignStatus::Success)
+            .get_by_status(tx.source_chain, SignStatus::AwaitingResponseBidirectional)
             .await;
         assert!(successes.contains_key(&sign_id));
     }

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -325,9 +325,16 @@ impl Backlog {
         recovered_sign_ids
             .into_iter()
             .filter_map(|sign_id| pending.get(&sign_id))
-            .filter(|entry| entry.status() == SignStatus::AwaitingResponse)
-            .filter(|entry| entry.execution_tx().is_none())
-            .map(|entry| entry.request.clone())
+            .filter_map(|entry| {
+                if entry.status() == SignStatus::AwaitingResponseBidirectional
+                    || (entry.status() == SignStatus::AwaitingResponse
+                        && entry.execution_tx().is_none())
+                {
+                    Some(entry.request.clone())
+                } else {
+                    None
+                }
+            })
             .collect()
     }
 
@@ -362,6 +369,27 @@ impl Backlog {
         _success: bool,
     ) -> Result<(), BacklogError> {
         // TODO: implement
+        Ok(())
+    }
+
+    // TODO: the backlog is a bit bloated with transition functions, so we need to do a proper cleanup
+    // where we can have proper typestate on a set of types. With these types, we can easily guide
+    // ourselves into the right transitions. For now, this is used to set the request in
+    // `execution_confirmed` to transition from PendingExecution to AwaitingResponseBidirectional.
+    pub async fn set_request(
+        &self,
+        chain: Chain,
+        id: &SignId,
+        request: IndexedSignRequest,
+    ) -> Result<(), BacklogError> {
+        let mut requests = self.requests.write().await;
+        let Some(pending) = requests.get_mut(&chain) else {
+            return Err(BacklogError::ChainNotFound);
+        };
+        let Some(entry) = pending.requests.get_mut(id) else {
+            return Err(BacklogError::NotFound { chain, id: *id });
+        };
+        entry.set_request(request);
         Ok(())
     }
 
@@ -775,6 +803,10 @@ impl BacklogEntry {
         self.status = status;
     }
 
+    pub fn set_request(&mut self, request: IndexedSignRequest) {
+        self.request = request;
+    }
+
     pub fn advance_to_execution(
         &mut self,
         bidirectional_tx: BidirectionalTx,
@@ -816,11 +848,17 @@ impl BacklogEntry {
     }
 
     pub fn typename(&self) -> &'static str {
-        match (&self.request.kind, self.execution.is_some()) {
-            (SignKind::Sign, _) => "Sign",
-            (SignKind::SignBidirectional(_), true) => "BidirectionalExecution",
-            (SignKind::SignBidirectional(_), false) => "BidirectionalPending",
-            (SignKind::RespondBidirectional(_), _) => "RespondBidirectional",
+        match (&self.request.kind, self.execution.is_some(), self.status) {
+            (SignKind::Sign, _, _) => "Sign",
+            (SignKind::SignBidirectional(_), true, _) => "BidirectionalExecution",
+            (SignKind::SignBidirectional(_), false, SignStatus::AwaitingResponse) => {
+                "BidirectionalPending"
+            }
+            (SignKind::SignBidirectional(_), false, _) => "BidirectionalPending",
+            (SignKind::RespondBidirectional(_), _, SignStatus::AwaitingResponseBidirectional) => {
+                "BidirectionalRespondPending"
+            }
+            (SignKind::RespondBidirectional(_), _, _) => "RespondBidirectional",
         }
     }
 }
@@ -869,6 +907,7 @@ mod tests {
     use super::*;
     use crate::{
         protocol::SignKind,
+        respond_bidirectional::RespondBidirectionalTx,
         sign_bidirectional::{BidirectionalTx, BidirectionalTxId, SignStatus},
         stream::ops::SignBidirectionalEvent,
     };
@@ -985,6 +1024,7 @@ mod tests {
 
         match status {
             SignStatus::AwaitingResponse => {}
+            SignStatus::AwaitingResponseBidirectional => {}
             SignStatus::PendingExecution => {
                 backlog.advance(chain, sign_id, tx).await.unwrap();
             }
@@ -1397,6 +1437,109 @@ mod tests {
         assert!(matches!(
             recovered_entry.request.kind,
             SignKind::SignBidirectional(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_recovered_completed_bidirectional_requests_are_requeued_for_final_respond() {
+        for (offset, status) in [SignStatus::Success, SignStatus::Failed]
+            .into_iter()
+            .enumerate()
+        {
+            let backlog = Backlog::new();
+            let tx = create_test_tx(8 + offset as u8);
+            let sign_id = SignId::new(tx.request_id);
+
+            insert_bidirectional_with_status(
+                &backlog,
+                Chain::Solana,
+                tx.clone(),
+                status,
+                "ethereum",
+            )
+            .await;
+            backlog.set_processed_block(Chain::Solana, 10).await;
+
+            let checkpoint = backlog.checkpoint(Chain::Solana).await;
+
+            let recovered = Backlog::new();
+            recovered
+                .recover_by_checkpoint(checkpoint)
+                .await
+                .expect("failed to recover");
+
+            let completion_request = IndexedSignRequest::respond_bidirectional(
+                sign_id,
+                create_test_args(sign_id.request_id[0]),
+                Chain::Solana,
+                0,
+                RespondBidirectionalTx {
+                    tx_id: tx.id,
+                    output: vec![],
+                },
+            );
+            recovered
+                .set_request(Chain::Solana, &sign_id, completion_request)
+                .await
+                .expect("failed to store completion request");
+            recovered
+                .set_status(
+                    Chain::Solana,
+                    &sign_id,
+                    SignStatus::AwaitingResponseBidirectional,
+                )
+                .await;
+            recovered
+                .set_recovered_requests(Chain::Solana, HashSet::from([sign_id]))
+                .await;
+
+            let requeued = recovered.take_requeueable_requests(Chain::Solana).await;
+            assert_eq!(
+                requeued.len(),
+                1,
+                "completed bidirectional request should be requeued for final respond"
+            );
+            assert!(matches!(
+                requeued[0].kind,
+                SignKind::RespondBidirectional(_)
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_awaiting_response_bidirectional_requeues() {
+        let backlog = Backlog::new();
+        let tx = create_test_tx(42);
+        let sign_id = SignId::new(tx.request_id);
+
+        let completion_request = IndexedSignRequest::respond_bidirectional(
+            sign_id,
+            create_test_args(sign_id.request_id[0]),
+            Chain::Solana,
+            0,
+            RespondBidirectionalTx {
+                tx_id: tx.id,
+                output: vec![1, 2, 3],
+            },
+        );
+
+        backlog.insert(completion_request).await;
+        backlog
+            .set_status(
+                Chain::Solana,
+                &sign_id,
+                SignStatus::AwaitingResponseBidirectional,
+            )
+            .await;
+        backlog
+            .set_recovered_requests(Chain::Solana, HashSet::from([sign_id]))
+            .await;
+
+        let requeued = backlog.take_requeueable_requests(Chain::Solana).await;
+        assert_eq!(requeued.len(), 1);
+        assert!(matches!(
+            requeued[0].kind,
+            SignKind::RespondBidirectional(_)
         ));
     }
 

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -7,7 +7,6 @@ use crate::stream::ops::{EthereumSignatureRespondedEvent, SignatureRespondedEven
 use crate::metrics::requests::{record_request_latency, SignRequestStep};
 use crate::protocol::{Chain, IndexedSignRequest};
 use crate::respond_bidirectional::CompletedTx;
-use crate::sign_bidirectional::SignStatus;
 use crate::stream::{ChainEvent, ChainStream, ExecutionOutcome};
 
 use alloy::eips::BlockNumberOrTag;
@@ -1057,22 +1056,19 @@ impl EthereumIndexer {
                 continue;
             };
 
-            let status = if receipt.status() {
-                SignStatus::Success
-            } else {
-                SignStatus::Failed
-            };
+            let receipt_succeeded = receipt.status();
 
             tracing::info!(
                 ?tx_id,
                 ?sign_id,
                 block_number,
+                receipt_succeeded,
                 "bidirectional execution observed via rpc"
             );
 
             let source_chain = pending_tx.source_chain;
 
-            let result = if status == SignStatus::Success {
+            let result = if receipt_succeeded {
                 let completed_tx = CompletedTx::new(pending_tx.clone(), block_number);
                 match completed_tx.extract_success_tx_output(client).await {
                     Ok(serialized_output) => {

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -41,8 +41,6 @@ pub enum SignStatus {
     PendingExecution,
     /// Execution was confirmed and final respond request is waiting to be signed.
     AwaitingResponseBidirectional,
-    Failed,
-    Success,
 }
 
 #[derive(Debug, Clone, Hash, serde::Serialize, serde::Deserialize)]

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -39,6 +39,8 @@ pub enum SignStatus {
     /// Request has been responded to and the derived transaction is now waiting to
     /// execute on the destination chain.
     PendingExecution,
+    /// Execution was confirmed and final respond request is waiting to be signed.
+    AwaitingResponseBidirectional,
     Failed,
     Success,
 }

--- a/chain-signatures/node/src/storage/checkpoint_storage.rs
+++ b/chain-signatures/node/src/storage/checkpoint_storage.rs
@@ -10,7 +10,7 @@ use tokio::sync::RwLock;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-const CHECKPOINT_VERSION: &str = "v3";
+const CHECKPOINT_VERSION: &str = "v4";
 
 #[derive(Clone, Debug)]
 pub enum CheckpointStorage {

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -458,6 +458,7 @@ pub(crate) async fn process_respond_bidirectional_event(
         tracing::info!(?sign_id, "bidirectional tx completed");
     } else {
         tracing::warn!(?sign_id, "bidirectional tx not found on completion");
+        return Ok(());
     }
 
     sign_tx
@@ -578,12 +579,16 @@ mod tests {
     use crate::node_client::NodeClient;
     use crate::protocol::contract::primitives::{ParticipantInfo, Participants};
     use crate::protocol::SignKind;
+    use crate::respond_bidirectional::RespondBidirectionalTx;
+    use crate::storage::checkpoint_storage::CheckpointStorage;
     use crate::stream::ops::process_execution_confirmed;
     use crate::util::current_unix_timestamp;
+    use alloy::primitives::{Address, B256};
     use cait_sith::protocol::Participant;
     use k256::{ProjectivePoint, Scalar};
     use mpc_primitives::SignArgs;
     use near_primitives::types::AccountId;
+    use solana_sdk::pubkey::Pubkey;
     use std::time::Duration;
     use tokio::sync::mpsc;
     use tokio::time::timeout;
@@ -596,6 +601,45 @@ mod tests {
         kind: SignKind,
     ) -> IndexedSignRequest {
         IndexedSignRequest::new(sign_id, args, chain, unix_timestamp_indexed, kind)
+    }
+
+    fn test_bidirectional_tx(id: u8, source_chain: Chain, target_chain: Chain) -> BidirectionalTx {
+        BidirectionalTx {
+            id: BidirectionalTxId(B256::from([id; 32])),
+            sender: [0u8; 32],
+            serialized_transaction: vec![1, 2, 3],
+            source_chain,
+            target_chain,
+            caip2_id: "test_caip2_id".to_string(),
+            key_version: 1,
+            deposit: 1000,
+            path: "test_path".to_string(),
+            algo: "ECDSA".to_string(),
+            dest: "0x1234567890123456789012345678901234567890".to_string(),
+            params: "{}".to_string(),
+            output_deserialization_schema: vec![],
+            respond_serialization_schema: vec![],
+            request_id: [id; 32],
+            from_address: Address::ZERO,
+            nonce: 0,
+        }
+    }
+
+    fn test_sign_bidirectional_event(dest: &str) -> SignBidirectionalEvent {
+        SignBidirectionalEvent::Solana(signet_program::SignBidirectionalEvent {
+            sender: Default::default(),
+            serialized_transaction: vec![1, 2, 3, 4],
+            dest: dest.to_string(),
+            caip2_id: "eip155:1".to_string(),
+            key_version: 0,
+            deposit: 0,
+            path: "m/0".to_string(),
+            algo: "ECDSA".to_string(),
+            params: "{}".to_string(),
+            program_id: Pubkey::new_unique(),
+            output_deserialization_schema: vec![],
+            respond_serialization_schema: vec![],
+        })
     }
 
     #[test]
@@ -692,28 +736,7 @@ mod tests {
     #[tokio::test]
     async fn process_execution_confirmed_success_creates_respond_request() {
         let backlog = Backlog::new();
-
-        // Create a bidirectional tx and watch it on the target chain
-        use alloy::primitives::{Address, B256};
-        let tx = BidirectionalTx {
-            id: BidirectionalTxId(B256::from([1u8; 32])),
-            sender: [0u8; 32],
-            serialized_transaction: vec![1, 2, 3],
-            source_chain: Chain::Solana,
-            target_chain: Chain::Ethereum,
-            caip2_id: "test_caip2_id".to_string(),
-            key_version: 1,
-            deposit: 1000,
-            path: "test_path".to_string(),
-            algo: "ECDSA".to_string(),
-            dest: "0x1234567890123456789012345678901234567890".to_string(),
-            params: "{}".to_string(),
-            output_deserialization_schema: vec![],
-            respond_serialization_schema: vec![],
-            request_id: [1u8; 32],
-            from_address: Address::ZERO,
-            nonce: 0,
-        };
+        let tx = test_bidirectional_tx(1, Chain::Solana, Chain::Ethereum);
         let sign_id = SignId::new(tx.request_id);
 
         // Insert a pending Sign request on the source chain
@@ -795,6 +818,340 @@ mod tests {
             }
             _ => panic!("Expected Sign::Request"),
         }
+    }
+
+    #[tokio::test]
+    async fn process_execution_confirmed_is_idempotent_after_first_processing() {
+        let backlog = Backlog::new();
+        let tx = test_bidirectional_tx(7, Chain::Solana, Chain::Ethereum);
+        let sign_id = SignId::new(tx.request_id);
+        let args = SignArgs {
+            entropy: [7u8; 32],
+            epsilon: Scalar::from(1u64),
+            payload: Scalar::from(2u64),
+            path: "test".to_string(),
+            key_version: 1,
+        };
+        backlog
+            .insert(test_indexed_request(
+                sign_id,
+                tx.source_chain,
+                args,
+                current_unix_timestamp(),
+                SignKind::Sign,
+            ))
+            .await;
+        backlog
+            .watch_execution(tx.target_chain, sign_id, tx.clone())
+            .await;
+
+        let (sign_tx, mut sign_rx) = mpsc::channel(4);
+
+        process_execution_confirmed(
+            tx.id,
+            sign_id,
+            tx.source_chain,
+            123u64,
+            ExecutionOutcome::Success { output: vec![] },
+            &backlog,
+            sign_tx.clone(),
+            tx.target_chain,
+        )
+        .await
+        .unwrap();
+
+        process_execution_confirmed(
+            tx.id,
+            sign_id,
+            tx.source_chain,
+            124u64,
+            ExecutionOutcome::Success { output: vec![] },
+            &backlog,
+            sign_tx,
+            tx.target_chain,
+        )
+        .await
+        .unwrap();
+
+        let first = timeout(Duration::from_secs(1), sign_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        match first {
+            Sign::Request(req) => assert!(matches!(req.kind, SignKind::RespondBidirectional(_))),
+            other => panic!("expected one sign request, got {other:?}"),
+        }
+
+        let no_second = timeout(Duration::from_millis(100), sign_rx.recv()).await;
+        assert!(matches!(no_second, Err(_) | Ok(None)));
+
+        assert!(backlog.pending_execution(tx.target_chain).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn process_execution_confirmed_warns_but_still_uses_watcher_sign_id() {
+        let backlog = Backlog::new();
+        let tx = test_bidirectional_tx(8, Chain::Solana, Chain::Ethereum);
+        let sign_id = SignId::new(tx.request_id);
+        let mismatched_sign_id = SignId::new([88u8; 32]);
+        let args = SignArgs {
+            entropy: [8u8; 32],
+            epsilon: Scalar::from(1u64),
+            payload: Scalar::from(2u64),
+            path: "test".to_string(),
+            key_version: 1,
+        };
+        backlog
+            .insert(test_indexed_request(
+                sign_id,
+                tx.source_chain,
+                args,
+                current_unix_timestamp(),
+                SignKind::Sign,
+            ))
+            .await;
+        backlog
+            .watch_execution(tx.target_chain, sign_id, tx.clone())
+            .await;
+
+        let (sign_tx, mut sign_rx) = mpsc::channel(4);
+
+        process_execution_confirmed(
+            tx.id,
+            mismatched_sign_id,
+            tx.source_chain,
+            321u64,
+            ExecutionOutcome::Failed,
+            &backlog,
+            sign_tx,
+            tx.target_chain,
+        )
+        .await
+        .unwrap();
+
+        let tx_after = backlog.get(tx.source_chain, &sign_id).await.unwrap();
+        assert_eq!(tx_after.status(), SignStatus::AwaitingResponseBidirectional);
+        assert!(matches!(
+            tx_after.request.kind,
+            SignKind::RespondBidirectional(_)
+        ));
+        assert!(backlog.pending_execution(tx.target_chain).await.is_empty());
+
+        let msg = timeout(Duration::from_secs(1), sign_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        match msg {
+            Sign::Request(req) => assert_eq!(req.id, sign_id),
+            other => panic!("expected sign request, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn process_execution_confirmed_recovery_requeues_final_respond_after_send_failure() {
+        let storage = CheckpointStorage::in_memory();
+        let backlog = Backlog::persisted(storage.clone());
+        let tx = test_bidirectional_tx(9, Chain::Solana, Chain::Ethereum);
+        let sign_id = SignId::new(tx.request_id);
+        let args = SignArgs {
+            entropy: [9u8; 32],
+            epsilon: Scalar::from(1u64),
+            payload: Scalar::from(2u64),
+            path: "test".to_string(),
+            key_version: 1,
+        };
+        backlog
+            .insert(test_indexed_request(
+                sign_id,
+                tx.source_chain,
+                args.clone(),
+                current_unix_timestamp(),
+                SignKind::Sign,
+            ))
+            .await;
+        backlog
+            .watch_execution(tx.target_chain, sign_id, tx.clone())
+            .await;
+
+        let (sign_tx, sign_rx) = mpsc::channel(4);
+        drop(sign_rx);
+
+        process_execution_confirmed(
+            tx.id,
+            sign_id,
+            tx.source_chain,
+            444u64,
+            ExecutionOutcome::Success { output: vec![] },
+            &backlog,
+            sign_tx,
+            tx.target_chain,
+        )
+        .await
+        .unwrap();
+
+        backlog.set_processed_block(tx.source_chain, 10).await;
+        backlog.checkpoint(tx.source_chain).await;
+
+        let threshold = 1;
+        let mut mesh_state = MeshState::default();
+        let participant = Participant::from(0u32);
+        mesh_state.update(participant, NodeStatus::Active, ParticipantInfo::new(0));
+        let (_mesh_tx, mut mesh_rx) = watch::channel(mesh_state);
+        wait_threshold_active(&mut mesh_rx, threshold).await;
+
+        let account_id: AccountId = "test.near".parse().unwrap();
+        let public_key = ProjectivePoint::GENERATOR.to_affine();
+        let participants = Participants::default();
+        let (mut contract_watcher, _tx) =
+            ContractStateWatcher::with_running(&account_id, public_key, threshold, participants);
+
+        let (sign_tx, mut sign_rx) = mpsc::channel(4);
+        let node_client = NodeClient::new(&Default::default());
+        let recovered = Backlog::persisted(storage.clone());
+
+        recover_backlog(
+            &recovered,
+            &mut contract_watcher,
+            &mut mesh_rx,
+            &node_client,
+            tx.source_chain,
+            sign_tx,
+        )
+        .await;
+
+        let msg = timeout(Duration::from_secs(1), sign_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        match msg {
+            Sign::Request(req) => {
+                assert_eq!(req.id, sign_id);
+                assert!(matches!(req.kind, SignKind::RespondBidirectional(_)));
+            }
+            other => panic!("expected recovered final respond request, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn process_respond_event_rejects_invalid_bidirectional_target_chain() {
+        let backlog = Backlog::new();
+        let sign_id = SignId::new([11u8; 32]);
+        let args = SignArgs {
+            entropy: [11u8; 32],
+            epsilon: Scalar::from(1u64),
+            payload: Scalar::from(2u64),
+            path: "test".to_string(),
+            key_version: 1,
+        };
+
+        backlog
+            .insert(IndexedSignRequest::sign_bidirectional(
+                sign_id,
+                args,
+                Chain::Ethereum,
+                current_unix_timestamp(),
+                test_sign_bidirectional_event("not-a-chain"),
+            ))
+            .await;
+
+        let event = SignatureRespondedEvent::Ethereum(EthereumSignatureRespondedEvent {
+            request_id: sign_id.request_id,
+            responder: alloy::primitives::Address::from_slice(&[0u8; 20]),
+            signature: Signature::new(ProjectivePoint::GENERATOR.to_affine(), Scalar::ONE, 0),
+        });
+
+        let account_id: AccountId = "test.near".parse().unwrap();
+        let public_key = ProjectivePoint::GENERATOR.to_affine();
+        let (mut contract_watcher, _tx) =
+            ContractStateWatcher::with_running(&account_id, public_key, 1, Default::default());
+
+        let (sign_tx, _sign_rx) = mpsc::channel(4);
+
+        let err = process_respond_event(event, sign_tx, &mut contract_watcher, &backlog)
+            .await
+            .expect_err("invalid chain should fail");
+        assert!(err.to_string().contains("unable to parse target chain"));
+    }
+
+    #[tokio::test]
+    async fn process_sign_request_rejects_respond_bidirectional_kind() {
+        let backlog = Backlog::new();
+        let sign_id = SignId::new([12u8; 32]);
+        let args = SignArgs {
+            entropy: [12u8; 32],
+            epsilon: Scalar::from(1u64),
+            payload: Scalar::from(2u64),
+            path: "test".to_string(),
+            key_version: 1,
+        };
+
+        let request = IndexedSignRequest::respond_bidirectional(
+            sign_id,
+            args,
+            Chain::Solana,
+            current_unix_timestamp(),
+            RespondBidirectionalTx {
+                tx_id: BidirectionalTxId(B256::from([12u8; 32])),
+                output: vec![],
+            },
+        );
+
+        let (sign_tx, _sign_rx) = mpsc::channel(4);
+        let err = process_sign_request(request, sign_tx, backlog)
+            .await
+            .expect_err("RespondBidirectional should be rejected from the sign queue path");
+        assert!(err.to_string().contains("Unexpected sign request kind"));
+    }
+
+    #[tokio::test]
+    async fn process_respond_bidirectional_event_duplicate_is_idempotent() {
+        let backlog = Backlog::new();
+        let sign_id = SignId::new([13u8; 32]);
+        let args = SignArgs {
+            entropy: [13u8; 32],
+            epsilon: Scalar::from(1u64),
+            payload: Scalar::from(2u64),
+            path: "test".to_string(),
+            key_version: 1,
+        };
+
+        backlog
+            .insert(IndexedSignRequest::respond_bidirectional(
+                sign_id,
+                args,
+                Chain::Solana,
+                current_unix_timestamp(),
+                RespondBidirectionalTx {
+                    tx_id: BidirectionalTxId(B256::from([13u8; 32])),
+                    output: vec![1, 2, 3],
+                },
+            ))
+            .await;
+
+        let duplicate_event0 = respond_event(sign_id);
+        let duplicate_event1 = respond_event(sign_id);
+
+        let (sign_tx, mut sign_rx) = mpsc::channel(4);
+
+        process_respond_bidirectional_event(duplicate_event0, sign_tx.clone(), &backlog)
+            .await
+            .expect("first completion should succeed");
+
+        process_respond_bidirectional_event(duplicate_event1, sign_tx, &backlog)
+            .await
+            .expect("duplicate completion should be ignored");
+
+        let first = timeout(Duration::from_secs(1), sign_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        match first {
+            Sign::Completion(id) => assert_eq!(id, sign_id),
+            other => panic!("expected completion, got {other:?}"),
+        }
+
+        let no_second = timeout(Duration::from_millis(100), sign_rx.recv()).await;
+        assert!(matches!(no_second, Err(_) | Ok(None)));
     }
 
     #[tokio::test]
@@ -969,5 +1326,21 @@ mod tests {
             }
             _ => panic!("Expected Sign::Request"),
         }
+    }
+
+    fn respond_event(sign_id: SignId) -> RespondBidirectionalEvent {
+        RespondBidirectionalEvent::Solana(signet_program::RespondBidirectionalEvent {
+            request_id: sign_id.request_id,
+            responder: Pubkey::new_unique(),
+            serialized_output: vec![1, 2, 3],
+            signature: signet_program::Signature {
+                big_r: signet_program::AffinePoint {
+                    x: [0u8; 32],
+                    y: [0u8; 32],
+                },
+                s: [1u8; 32],
+                recovery_id: 0,
+            },
+        })
     }
 }

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -504,25 +504,7 @@ pub async fn process_execution_confirmed(
         tracing::warn!(?tx_id, expected = ?unwatched_sign_id, actual = ?sign_id, "sign_id mismatch between event and watcher");
     }
 
-    // Update the status on the source chain
-    let status = match result {
-        ExecutionOutcome::Success { .. } => SignStatus::Success,
-        ExecutionOutcome::Failed => SignStatus::Failed,
-    };
-
-    let set_res = backlog
-        .set_status(pending_tx.source_chain, &unwatched_sign_id, status)
-        .await;
-    let updated_tx = match set_res {
-        Some(tx) => tx,
-        None => {
-            tracing::error!(?tx_id, ?unwatched_sign_id, source_chain = ?pending_tx.source_chain, "failed to set status on pending tx");
-            anyhow::bail!("failed to set status for sign id: {unwatched_sign_id:?}");
-        }
-    };
-    tracing::info!(?tx_id, ?unwatched_sign_id, updated_status = ?updated_tx.status(), "set_status returned transaction");
-
-    let completed_tx = CompletedTx::new(pending_tx, block_height);
+    let completed_tx = CompletedTx::new(pending_tx.clone(), block_height);
 
     let sign_request = match result {
         ExecutionOutcome::Success { output } => {
@@ -534,6 +516,40 @@ pub async fn process_execution_confirmed(
                 .await?
         }
     };
+
+    if let Err(err) = backlog
+        .set_request(
+            pending_tx.source_chain,
+            &unwatched_sign_id,
+            sign_request.clone(),
+        )
+        .await
+    {
+        tracing::error!(
+            ?tx_id,
+            ?unwatched_sign_id,
+            ?source_chain,
+            ?err,
+            "failed to persist completion request on pending tx"
+        );
+        anyhow::bail!("failed to persist completion request for sign id: {unwatched_sign_id:?}");
+    }
+
+    let set_res = backlog
+        .set_status(
+            pending_tx.source_chain,
+            &unwatched_sign_id,
+            SignStatus::AwaitingResponseBidirectional,
+        )
+        .await;
+    let updated_tx = match set_res {
+        Some(tx) => tx,
+        None => {
+            tracing::error!(?tx_id, ?unwatched_sign_id, source_chain = ?pending_tx.source_chain, "failed to set status on pending tx");
+            anyhow::bail!("failed to set status for sign id: {unwatched_sign_id:?}");
+        }
+    };
+    tracing::info!(?tx_id, ?unwatched_sign_id, updated_status = ?updated_tx.status(), "set_status returned transaction");
 
     let chain = sign_request.chain;
     if let Err(err) = sign_tx.send(Sign::Request(sign_request)).await {
@@ -748,14 +764,21 @@ mod tests {
         tracing::info!(?watchers, "watchers after execution confirmed");
         assert!(watchers.is_empty());
 
-        // Source chain request should be marked Success
+        // Source chain request should now wait for final bidirectional response.
         // inspect the transaction to provide more debugging info on failure
         let maybe_tx = backlog.get(tx.source_chain, &sign_id).await;
         assert!(maybe_tx.is_some(), "expected sign tx to still exist");
         let tx_after = maybe_tx.unwrap();
-        if tx_after.status() != SignStatus::Success {
-            panic!("expected Success but found status: {:?}", tx_after.status());
-        }
+        assert_eq!(
+            tx_after.status(),
+            SignStatus::AwaitingResponseBidirectional,
+            "expected AwaitingResponseBidirectional but found status: {:?}",
+            tx_after.status()
+        );
+        assert!(matches!(
+            tx_after.request.kind,
+            SignKind::RespondBidirectional(_)
+        ));
 
         // A sign request should have been sent to the sign queue
         let msg = timeout(Duration::from_secs(1), sign_rx.recv())
@@ -917,11 +940,17 @@ mod tests {
         let watchers = backlog.pending_execution(tx.target_chain).await;
         assert!(watchers.is_empty());
 
-        // Source chain should be marked Failed
-        let failed = backlog
-            .get_by_status(tx.source_chain, SignStatus::Failed)
+        // Source chain should now wait for final bidirectional response.
+        let waiting = backlog
+            .get_by_status(tx.source_chain, SignStatus::AwaitingResponseBidirectional)
             .await;
-        assert!(failed.contains_key(&sign_id));
+        assert!(waiting.contains_key(&sign_id));
+
+        let tx_after = backlog.get(tx.source_chain, &sign_id).await.unwrap();
+        assert!(matches!(
+            tx_after.request.kind,
+            SignKind::RespondBidirectional(_)
+        ));
 
         // A sign request should have been sent
         let msg = timeout(Duration::from_secs(1), sign_rx.recv())


### PR DESCRIPTION
Bidirectional requests were not getting requeued properly. This fixes it by persisting additional state that requeueing would need.

Changes:
- Added `SignStatus::AwaitingResponseBidirectional` for requests that have already had execution confirmed and are waiting on the final respond signature.
- Removed `SignStatus::{Success, Failed}` backlog states since they're not needed anymore with the addition of AwaitingResponseBidirectional.
- Persisted the final `RespondBidirectional` request directly in backlog.
- Updated recovery logic to requeue based on the dedicated bidirectional awaiting status.
- **Breaking Change** Bumped checkpoint storage version to v4