### PR TITLE
chore: update openssl dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9608,9 +9608,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if 1.0.0",
@@ -9649,9 +9649,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
update to new version that includes a fix for

- CVE-2026-41681
- CVE-2026-41678 
- CVE-2026-41676


rust-openssl security advisories:
- https://github.com/rust-openssl/rust-openssl/security/advisories/GHSA-ghm9-cr32-g9qj
- https://github.com/advisories/GHSA-8c75-8mhr-p7r9
- https://github.com/advisories/GHSA-hppc-g8h3-xhp3
- https://github.com/advisories/GHSA-pqf5-4pqq-29f5