### PR TITLE
fix: run dev deploy workflow on pushes to develop

### DIFF
--- a/.github/workflows/deploy-dev-nodes.yml
+++ b/.github/workflows/deploy-dev-nodes.yml
@@ -1,7 +1,6 @@
 name: Build Image & Deploy Nodes to Dev
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - develop
     paths:
@@ -14,7 +13,6 @@ env:
 
 jobs:
   build:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -28,7 +26,6 @@ jobs:
           password: ${{ secrets.SIG_CREDENTIALS_DEV }}
 
       - name: Build Docker image and push to Google Artifact Registry
-        if: github.event.pull_request.merged == true
         id: docker-push-tagged
         uses: docker/build-push-action@v4
         with:
@@ -39,7 +36,6 @@ jobs:
           tags: "${{ env.IMAGE }}:${{ env.TAG }},${{ env.IMAGE }}:latest"
 
   deploy:
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
Run the dev image deploy workflow on pushes to develop instead of merged pull_request events.