### PR TITLE
ci: remove redundant steps

### DIFF
--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -43,12 +43,6 @@ jobs:
           export PATH="$HOME/.dpm/bin:$PATH"
           dpm --version
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
       - name: Install Rust (1.81.0)
         uses: actions-rs/toolchain@v1
         with:
@@ -120,12 +114,6 @@ jobs:
           echo "$HOME/.dpm/bin" >> $GITHUB_PATH
           export PATH="$HOME/.dpm/bin:$PATH"
           dpm --version
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
 
       - name: Install Rust (1.81.0)
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/deploy-dev-contract.yml
+++ b/.github/workflows/deploy-dev-contract.yml
@@ -23,12 +23,6 @@ jobs:
       - name: Install near-cli
         run: 'npm install -g near-cli'
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
       - name: Install Rust (1.81.0)
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,12 +57,6 @@ jobs:
         run: |
           docker pull redis:7.4.2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
       - name: Install Rust (1.81.0)
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,12 +60,6 @@ jobs:
           solana-cli-version: '2.3.9'
           anchor-version: '0.30.1'
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
       - name: Install Rust (1.81.0)
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/prod-compatibility.yml
+++ b/.github/workflows/prod-compatibility.yml
@@ -33,12 +33,6 @@ jobs:
       - name: Pull Redis image
         run: docker pull redis:7.4.2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
       - name: Install Rust (1.81.0)
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.81.0
       - name: Install Rust (1.81.0)
         uses: actions-rs/toolchain@v1
         with:
@@ -52,8 +52,6 @@ jobs:
         run: cd chain-signatures/contract-eth && npm i && npx hardhat compile
       - name: Eth contract unit tests
         run: cd chain-signatures/contract-eth && npx hardhat test
-      - name: Compile
-        run: cargo check
       - name: Test format
         run: cargo fmt -- --check
       - name: Test clippy
@@ -66,11 +64,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install stable toolchain
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.81.0
       - name: Install Audit
         run: cargo install cargo-audit
       - name: Run Audit


### PR DESCRIPTION
Installing rust stable and also 1.81.0 doesn't
seem to have a specific purpose, it's just extra
work.

This also now uses 1.81.0 everywhere, which
means we will no longer have unplanned
Rust version updates in CI checks, which leads
to new clippy warnings popping up without
us changing anything.

Lastly, I removed the `cargo check` step.
`cargo clippy` does the same and more,
and even `cargo test` would catch the same
errors.