### PR TITLE
ci: run component tests in parallel

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,20 @@
+# Always limit cluster tests to a single thread
+[test-groups]
+cluster = { max-threads = 1 }
+fixture = { max-threads = "num-cpus" }
+
+[[profile.default.overrides]]
+filter = 'test(cases::mpc) | test(cases::state_sync)'
+test-group = 'fixture'
+
+[[profile.default.overrides]]
+filter = 'not (test(cases::mpc) | test(cases::state_sync))'
+test-group = 'cluster'
+
+# Usage: cargo nextest run -p integration-tests --profile fixture
+[profile.fixture]
+default-filter = 'test(cases::mpc) | test(cases::state_sync)'
+
+# Usage: cargo nextest run -p integration-tests --profile cluster
+[profile.cluster]
+default-filter = 'not (test(cases::mpc) | test(cases::state_sync))'

--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -43,12 +43,6 @@ jobs:
           export PATH="$HOME/.dpm/bin:$PATH"
           dpm --version
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
       - name: Install Rust (1.81.0)
         uses: actions-rs/toolchain@v1
         with:
@@ -120,12 +114,6 @@ jobs:
           echo "$HOME/.dpm/bin" >> $GITHUB_PATH
           export PATH="$HOME/.dpm/bin:$PATH"
           dpm --version
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
 
       - name: Install Rust (1.81.0)
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/deploy-dev-contract.yml
+++ b/.github/workflows/deploy-dev-contract.yml
@@ -23,12 +23,6 @@ jobs:
       - name: Install near-cli
         run: 'npm install -g near-cli'
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
       - name: Install Rust (1.81.0)
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,12 +57,6 @@ jobs:
         run: |
           docker pull redis:7.4.2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
       - name: Install Rust (1.81.0)
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           profile: minimal
           toolchain: 1.81.0
+          target: wasm32-unknown-unknown
 
       - uses: WarpBuilds/cache@v1
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -62,17 +62,16 @@ jobs:
           key: "${{ runner.os }}-cargo-${{ hashFiles('chain-signatures/Cargo.lock') }}"
           restore-keys: ${{ runner.os }}-cargo-
 
+      - name: Install cargo-nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+
       # Build the tests before actually running them to see how long the tests take to run by itself
       # instead of including the build time in the test time report on Github.
       - name: Build Chain-Signatures Integration Tests
         run: cargo build -p integration-tests --tests
 
       - name: Test
-        # Using two separate commands for easy test selection.
-        # We could use cargo nextest to make it one clean command but this works, too.
-        run: |
-          cargo test -p integration-tests -- cases::mpc --test-threads 4
-          cargo test -p integration-tests -- cases::state_sync --test-threads 4
+        run: cargo nextest run -p integration-tests --profile fixture
         env:
           RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1
@@ -160,13 +159,16 @@ jobs:
         working-directory: ./chain-signatures/contract-eth
         run: npm i && npx hardhat compile
 
+      - name: Install cargo-nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+
       # Build the tests before actually running them to see how long the tests take to run by itself
       # instead of including the build time in the test time report on Github.
       - name: Build Chain-Signatures Integration Tests
         run: cargo build -p integration-tests --tests
 
       - name: Test
-        run: cargo test -p integration-tests --jobs 1 -- --test-threads 1 --skip cases::mpc --skip cases::state_sync
+        run: cargo nextest run -p integration-tests --profile cluster
         env:
           RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,74 @@ on:
 env:
   RUSTFLAGS: -D warnings
 jobs:
-  test:
+  # Light-weight component tests using the MPC fixture, these can run in parallel.
+  component-test:
+    name: Component Test
+    runs-on: warp-ubuntu-latest-x64-4x
+
+    steps:
+      - name: Comment on PR if this is a re-run
+        if: github.run_attempt > 1 && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `⚠️ Component tests (MPC fixture) were re-run (attempt ${process.env.RUN_ATTEMPT})`,
+            });
+
+      - uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull Relayer, Sandbox, Redis Docker Images
+        run: |
+          docker pull redis:7.4.2
+
+      - name: Install Rust (1.81.0)
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.81.0
+
+      - uses: WarpBuilds/cache@v1
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: "${{ runner.os }}-cargo-${{ hashFiles('chain-signatures/Cargo.lock') }}"
+          restore-keys: ${{ runner.os }}-cargo-
+
+      # Build the tests before actually running them to see how long the tests take to run by itself
+      # instead of including the build time in the test time report on Github.
+      - name: Build Chain-Signatures Integration Tests
+        run: cargo build -p integration-tests --tests
+
+      - name: Test
+        # Using two separate commands for easy test selection.
+        # We could use cargo nextest to make it one clean command but this works, too.
+        run: |
+          cargo test -p integration-tests -- cases::mpc --test-threads 4
+          cargo test -p integration-tests -- cases::state_sync --test-threads 4
+        env:
+          RUST_LOG: info,workspaces=warn
+          RUST_BACKTRACE: 1
+
+  # Integration tests that share the mpc_it_network Docker network and thus must run sequentially.
+  # This also requires additional Solana/Anchor setup.
+  sequential-integration-test:
     name: Integration Test
     strategy:
       matrix:
@@ -93,16 +160,13 @@ jobs:
         working-directory: ./chain-signatures/contract-eth
         run: npm i && npx hardhat compile
 
-      - name: Build Chain-Signatures Node
-        run: cargo build -p mpc-node --release
-
       # Build the tests before actually running them to see how long the tests take to run by itself
       # instead of including the build time in the test time report on Github.
       - name: Build Chain-Signatures Integration Tests
         run: cargo build -p integration-tests --tests
 
       - name: Test
-        run: cargo test -p integration-tests --jobs 1 -- --test-threads 1
+        run: cargo test -p integration-tests --jobs 1 -- --test-threads 1 --skip cases::mpc --skip cases::state_sync
         env:
           RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,12 +60,6 @@ jobs:
           solana-cli-version: '2.3.9'
           anchor-version: '0.30.1'
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
       - name: Install Rust (1.81.0)
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/prod-compatibility.yml
+++ b/.github/workflows/prod-compatibility.yml
@@ -33,12 +33,6 @@ jobs:
       - name: Pull Redis image
         run: docker pull redis:7.4.2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
       - name: Install Rust (1.81.0)
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.81.0
       - name: Install Rust (1.81.0)
         uses: actions-rs/toolchain@v1
         with:
@@ -52,8 +52,6 @@ jobs:
         run: cd chain-signatures/contract-eth && npm i && npx hardhat compile
       - name: Eth contract unit tests
         run: cd chain-signatures/contract-eth && npx hardhat test
-      - name: Compile
-        run: cargo check
       - name: Test format
         run: cargo fmt -- --check
       - name: Test clippy
@@ -66,11 +64,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install stable toolchain
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.81.0
       - name: Install Audit
         run: cargo install cargo-audit
       - name: Run Audit

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,5 +1,18 @@
 # Integration tests
 
+## Prerequisites
+
+Install [cargo-nextest](https://nexte.st) for race-free parallelization:
+
+```bash
+# Linux
+curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ~/.cargo/bin
+# macOS:
+curl -LsSf https://get.nexte.st/latest/mac | tar zxf - -C ~/.cargo/bin
+```
+
+Alternatively, you may run all tests sequentially with `cargo test -p integration-tests --jobs 1 -- --test-threads 1`.
+
 ## Basic guide
 
 Running integration tests requires you to have redis and sandbox docker images present on your machine:
@@ -13,10 +26,23 @@ In case of authorization issues make sure you have logged into docker using your
 Then run the integration tests:
 
 ```BASH
-cargo test -p integration-tests --jobs 1 -- --test-threads 1
-# or if you want to run tests in docker
-cargo test -p integration-tests --features docker-test
+cargo nextest run -p integration-tests
 ```
+
+For a faster iteration loop during development, run only the lightweight MPC fixture tests
+(no full cluster or Docker containers needed beyond Redis):
+
+```BASH
+cargo nextest run -p integration-tests --profile fixture
+```
+
+To run only the full cluster tests:
+
+```BASH
+cargo nextest run -p integration-tests --profile cluster
+```
+
+The available profiles and their concurrency settings are defined in [`.config/nextest.toml`](../.config/nextest.toml).
 
 ## Logging and Tracing
 We have three types of logging available:
@@ -83,7 +109,7 @@ artifacts into git.
 You can pass environment variable `TESTCONTAINERS=keep` to keep all of the docker containers. For example:
 
 ```bash
-$ TESTCONTAINERS=keep cargo test -p integration-tests --jobs 1 -- --test-threads 1
+$ TESTCONTAINERS=keep cargo nextest run -p integration-tests
 ```
 
 ### There are no logs anymore, how do I debug?
@@ -91,7 +117,7 @@ $ TESTCONTAINERS=keep cargo test -p integration-tests --jobs 1 -- --test-threads
 The easiest way is to run one isolated test of your choosing while keeping the containers (see above):
 
 ```bash
-$ TESTCONTAINERS=keep cargo test -p integration-tests test_basic_action
+$ TESTCONTAINERS=keep cargo nextest run -p integration-tests -E 'test(test_basic_action)'
 ```
 
 Now, you can do `docker ps` and it should list all of containers related to your test (the most recent ones are always at the top, so lookout for those). For example:
@@ -112,7 +138,7 @@ Now, you can inspect each container's logs according to your needs using `docker
 
 ### How to see all the logs in terminal
 ```bash
-RUST_BACKTRACE=full RUST_LOG=debug cargo test test_name -- --nocapture
+RUST_BACKTRACE=full RUST_LOG=debug cargo nextest run -p integration-tests -E 'test(test_name)' --no-capture
 ```
 
 ### Re-building Docker image is way too slow, is there a way I can do a faster development feedback loop?

--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -238,11 +238,6 @@ impl DockerClient {
     }
 
     pub async fn create_network(&self, network: &str) -> anyhow::Result<()> {
-        let list = self.docker.list_networks::<&str>(None).await?;
-        if list.iter().any(|n| n.name == Some(network.to_string())) {
-            return Ok(());
-        }
-
         let create_network_options = CreateNetworkOptions {
             name: network,
             check_duplicate: true,
@@ -257,9 +252,15 @@ impl DockerClient {
             },
             ..Default::default()
         };
-        let _response = &self.docker.create_network(create_network_options).await?;
-
-        Ok(())
+        // Concurrent test threads have a race condition on creating this!
+        // => Treat 409 Conflict (network already exists) as success and continue.
+        match self.docker.create_network(create_network_options).await {
+            Ok(_) => Ok(()),
+            Err(bollard::errors::Error::DockerResponseServerError {
+                status_code: 409, ..
+            }) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
     }
 
     pub async fn continuously_print_logs(&self, id: &str) -> anyhow::Result<()> {

--- a/setup.sh
+++ b/setup.sh
@@ -15,6 +15,13 @@ if [ "${MPC_SETUP_ALWAYS:-}" != "1" ] && [ "${CARGO_PKG_NAME:-}" != "integration
     exec "$@"
 fi
 
+# Special case for cargo nextest, which needs to be able to list tests without building
+for arg in "$@"; do
+    case "$arg" in
+        --list) exec "$@" ;;
+    esac
+done
+
 CARGO_CMD_ARGS="$@"
 CARGO_BUILD_INDENT="            "
 echo "${CARGO_BUILD_INDENT} running MPC build script"


### PR DESCRIPTION
1. Create two different jobs for (slow and sequential) cluster-based integration tests vs (parallel and hopefully faster) fixture-based tests.
2. Add `cargo nextest` as the test runner to make this easier to set up in CI as well as for running tests locally

If there are reasons not to use `cargo nextest`, I can revert the second commit and just split it into two jobs.

But I recommend `cargo nextest` for anyone running tests locally.