### PR TITLE
feat: solana catchup + livestream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tmp
 **/*-secret-manager-*
 integration-tests/.project
 integration-tests/test-ledger/
+test-ledger/
 
 node_modules/
 chain-signatures/contract-eth/artifacts

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -427,7 +427,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 }
             };
 
-            if let Some(sol_stream) = SolanaStream::new(sol.clone()) {
+            if let Some(sol_stream) = SolanaStream::new(sol.clone(), backlog.clone()) {
                 tokio::spawn(run_stream(
                     sol_stream,
                     sign_tx.clone(),

--- a/chain-signatures/node/src/indexer_canton/stream.rs
+++ b/chain-signatures/node/src/indexer_canton/stream.rs
@@ -2,11 +2,10 @@ use crate::backlog::Backlog;
 use crate::protocol::Chain;
 use crate::rpc::CantonClient;
 use crate::stream::ops::{RespondBidirectionalEvent, SignatureEvent, SignatureRespondedEvent};
-use crate::stream::{ChainEvent, ChainStream, DisabledChainIndexer};
+use crate::stream::{ChainEvent, ChainIndexer, ChainStream};
 
 use alloy::primitives::keccak256;
 use async_trait::async_trait;
-
 use futures_util::{SinkExt, StreamExt};
 use mpc_primitives::{ScalarExt, Signature};
 use std::collections::HashSet;
@@ -67,8 +66,7 @@ impl CantonStream {
 
 #[async_trait]
 impl ChainStream for CantonStream {
-    const CHAIN: Chain = Chain::Canton;
-    type Indexer = DisabledChainIndexer;
+    type Indexer = CantonIndexer;
 
     async fn start(&mut self) -> anyhow::Result<Self::Indexer> {
         let Some(state) = self.start_state.take() else {
@@ -81,11 +79,43 @@ impl ChainStream for CantonStream {
 
         // Canton stream manages its own catchup signaling from the websocket loop.
         // Return a silent indexer so generic catchup_then_livestream stays inert.
-        Ok(DisabledChainIndexer::silent())
+        Ok(Self::Indexer::silent())
     }
 
     async fn next_event(&mut self) -> Option<ChainEvent> {
         self.events_rx.recv().await
+    }
+}
+
+pub struct CantonIndexer {
+    events_tx: Option<mpsc::Sender<ChainEvent>>,
+}
+
+impl CantonIndexer {
+    pub fn silent() -> Self {
+        Self { events_tx: None }
+    }
+}
+
+#[async_trait]
+impl ChainIndexer for CantonIndexer {
+    const CHAIN: Chain = Chain::Canton;
+    type Block = ();
+    type Iter = std::iter::Empty<Self::Block>;
+
+    async fn next(&mut self) -> Option<Self::Block> {
+        None
+    }
+
+    async fn catchup_range(&self, _anchor_height: u64) -> Self::Iter {
+        std::iter::empty()
+    }
+
+    async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {
+        if let Some(events_tx) = &self.events_tx {
+            events_tx.send(ChainEvent::CatchupCompleted).await?;
+        }
+        Ok(())
     }
 }
 

--- a/chain-signatures/node/src/indexer_eth/indexer_eth_direct_rpc.rs
+++ b/chain-signatures/node/src/indexer_eth/indexer_eth_direct_rpc.rs
@@ -1,3 +1,4 @@
+use crate::indexer_eth::MaybeBlock;
 use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::hex::{self, ToHexExt};
 use alloy::primitives::{Address, Bytes, B256};
@@ -34,17 +35,15 @@ impl RpcEthereumClient {
         self.block(block_id).await
     }
 
-    pub async fn get_blocks(&self, block_ids: &[BlockId]) -> anyhow::Result<Vec<Option<Block>>> {
+    pub async fn get_blocks(&self, block_ids: &[BlockId]) -> anyhow::Result<Vec<MaybeBlock>> {
         if block_ids.is_empty() {
             return Ok(Vec::new());
         }
 
-        let mut request_ids = Vec::with_capacity(block_ids.len());
         let requests = block_ids
             .iter()
             .map(|block_id| {
                 let request_id = self.next_id();
-                request_ids.push(request_id);
                 let params = match block_id {
                     BlockId::Number(_) => {
                         vec![json!(to_hex_block_id(*block_id)), json!(false)]
@@ -54,21 +53,34 @@ impl RpcEthereumClient {
                     }
                 };
 
-                json!({
-                    "jsonrpc": "2.0",
-                    "id": request_id,
-                    "method": match block_id {
-                        BlockId::Number(_) => "eth_getBlockByNumber",
-                        BlockId::Hash(_) => "eth_getBlockByHash",
-                    },
-                    "params": params,
-                })
+                (
+                    request_id,
+                    *block_id,
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "method": match block_id {
+                            BlockId::Number(_) => "eth_getBlockByNumber",
+                            BlockId::Hash(_) => "eth_getBlockByHash",
+                        },
+                        "params": params,
+                    }),
+                )
             })
             .collect::<Vec<_>>();
 
-        let response = self.http.post(&self.url).json(&requests).send().await?;
+        let request_ids = requests
+            .iter()
+            .map(|(request_id, block_id, _)| (*request_id, *block_id))
+            .collect::<Vec<_>>();
+        let payload = requests
+            .into_iter()
+            .map(|(_, _, request)| request)
+            .collect::<Vec<_>>();
+
+        let response = self.http.post(&self.url).json(&payload).send().await?;
         let value: serde_json::Value = response.json().await?;
-        let Some(items) = value.as_array() else {
+        let serde_json::Value::Array(items) = value else {
             anyhow::bail!("batch rpc response was not an array: {value}");
         };
 
@@ -79,21 +91,33 @@ impl RpcEthereumClient {
             error: Option<serde_json::Value>,
         }
 
-        let mut blocks_by_id = HashMap::new();
+        let requested_blocks = request_ids.iter().copied().collect::<HashMap<_, _>>();
+        let mut blocks_by_id = HashMap::with_capacity(request_ids.len());
         for item in items {
-            let response: BatchResponse<Block> = serde_json::from_value(item.clone())?;
+            let response: BatchResponse<Block> = serde_json::from_value(item)?;
             if let Some(error) = response.error {
                 anyhow::bail!("batch rpc call failed for id {}: {error}", response.id);
             }
-            blocks_by_id.insert(response.id, response.result);
+
+            let Some(block_id) = requested_blocks.get(&response.id).copied() else {
+                anyhow::bail!("batch rpc response contained unknown id {}", response.id);
+            };
+
+            let block = match response.result {
+                Some(block) => MaybeBlock::Block(block),
+                None => missing_block(block_id),
+            };
+            blocks_by_id.insert(response.id, block);
         }
 
-        let mut blocks = Vec::with_capacity(block_ids.len());
-        for request_id in request_ids {
-            let block = blocks_by_id.remove(&request_id).unwrap_or(None);
-            blocks.push(block);
-        }
-
+        let blocks = request_ids
+            .into_iter()
+            .map(|(request_id, block_id)| {
+                blocks_by_id
+                    .remove(&request_id)
+                    .unwrap_or_else(|| missing_block(block_id))
+            })
+            .collect();
         Ok(blocks)
     }
 
@@ -213,6 +237,16 @@ impl RpcEthereumClient {
             vec![json!(format!("{:#x}", tx_hash))],
         )
         .await
+    }
+}
+
+fn missing_block(block_id: BlockId) -> MaybeBlock {
+    match block_id {
+        BlockId::Number(BlockNumberOrTag::Number(block_number)) => {
+            MaybeBlock::Missing(block_number)
+        }
+        BlockId::Number(tag) => panic!("expected numbered block id, got {tag:?}"),
+        BlockId::Hash(hash) => panic!("expected numbered block id, got hash {hash:?}"),
     }
 }
 

--- a/chain-signatures/node/src/indexer_eth/indexer_eth_direct_rpc.rs
+++ b/chain-signatures/node/src/indexer_eth/indexer_eth_direct_rpc.rs
@@ -105,7 +105,7 @@ impl RpcEthereumClient {
 
             let block = match response.result {
                 Some(block) => MaybeBlock::Block(block),
-                None => missing_block(block_id),
+                None => MaybeBlock::Missing(block_id),
             };
             blocks_by_id.insert(response.id, block);
         }
@@ -115,7 +115,7 @@ impl RpcEthereumClient {
             .map(|(request_id, block_id)| {
                 blocks_by_id
                     .remove(&request_id)
-                    .unwrap_or_else(|| missing_block(block_id))
+                    .unwrap_or_else(|| MaybeBlock::Missing(block_id))
             })
             .collect();
         Ok(blocks)
@@ -240,16 +240,6 @@ impl RpcEthereumClient {
     }
 }
 
-fn missing_block(block_id: BlockId) -> MaybeBlock {
-    match block_id {
-        BlockId::Number(BlockNumberOrTag::Number(block_number)) => {
-            MaybeBlock::Missing(block_number)
-        }
-        BlockId::Number(tag) => panic!("expected numbered block id, got {tag:?}"),
-        BlockId::Hash(hash) => panic!("expected numbered block id, got hash {hash:?}"),
-    }
-}
-
 fn format_address(address: Address) -> String {
     format!("0x{}", address.encode_hex())
 }
@@ -284,5 +274,78 @@ fn to_hex_block_id(block_id: BlockId) -> String {
         BlockId::Number(BlockNumberOrTag::Earliest) => "earliest".to_string(),
         BlockId::Number(BlockNumberOrTag::Pending) => "pending".to_string(),
         BlockId::Hash(hash) => format!("{:#x}", hash.block_hash),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RpcEthereumClient;
+    use crate::indexer_eth::MaybeBlock;
+    use alloy::eips::BlockNumberOrTag;
+    use alloy::rpc::types::BlockId;
+    use mockito::{Matcher, Server};
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn get_blocks_keeps_request_order_when_rpc_responses_are_reordered() {
+        let mut server = Server::new_async().await;
+        let client = RpcEthereumClient::new(&server.url());
+        let block_ids = vec![
+            BlockId::Number(BlockNumberOrTag::Number(7)),
+            BlockId::Number(BlockNumberOrTag::Number(8)),
+        ];
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex("eth_getBlockByNumber".to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!([
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "result": null
+                    },
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "result": {
+                            "number": "0x7",
+                            "hash": format!("0x{:064x}", 7),
+                            "parentHash": format!("0x{:064x}", 6),
+                            "sha3Uncles": format!("0x{:064x}", 1),
+                            "logsBloom": format!("0x{}", "0".repeat(512)),
+                            "transactionsRoot": format!("0x{:064x}", 2),
+                            "stateRoot": format!("0x{:064x}", 3),
+                            "receiptsRoot": format!("0x{:064x}", 4),
+                            "miner": format!("0x{:040x}", 5),
+                            "difficulty": "0x0",
+                            "totalDifficulty": "0x0",
+                            "extraData": "0x",
+                            "size": "0x1",
+                            "gasLimit": "0x1c9c380",
+                            "gasUsed": "0x0",
+                            "timestamp": "0x1",
+                            "uncles": [],
+                            "nonce": "0x0000000000000000",
+                            "mixHash": format!("0x{:064x}", 9),
+                            "baseFeePerGas": "0x1",
+                            "transactions": []
+                        }
+                    }
+                ])
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let blocks = client
+            .get_blocks(&block_ids)
+            .await
+            .expect("batch fetch should succeed");
+
+        assert!(matches!(&blocks[0], MaybeBlock::Block(block) if block.header.number == 7));
+        assert!(matches!(&blocks[1], MaybeBlock::Missing(BlockId::Number(BlockNumberOrTag::Number(8)))));
     }
 }

--- a/chain-signatures/node/src/indexer_eth/indexer_eth_direct_rpc.rs
+++ b/chain-signatures/node/src/indexer_eth/indexer_eth_direct_rpc.rs
@@ -1,9 +1,11 @@
 use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::hex::{self, ToHexExt};
-use alloy::primitives::{Address, Bytes};
-use alloy::rpc::types::Transaction;
+use alloy::primitives::{Address, Bytes, B256};
+use alloy::rpc::types::{Block, BlockId, Transaction, TransactionReceipt};
 use serde::de::DeserializeOwned;
 use serde_json::json;
+
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -28,25 +30,81 @@ impl RpcEthereumClient {
         }
     }
 
-    pub async fn get_block(
-        &self,
-        block_id: alloy::rpc::types::BlockId,
-    ) -> anyhow::Result<Option<alloy::rpc::types::Block>> {
+    pub async fn get_block(&self, block_id: BlockId) -> anyhow::Result<Option<Block>> {
         self.block(block_id).await
+    }
+
+    pub async fn get_blocks(&self, block_ids: &[BlockId]) -> anyhow::Result<Vec<Option<Block>>> {
+        if block_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut request_ids = Vec::with_capacity(block_ids.len());
+        let requests = block_ids
+            .iter()
+            .map(|block_id| {
+                let request_id = self.next_id();
+                request_ids.push(request_id);
+                let params = match block_id {
+                    BlockId::Number(_) => {
+                        vec![json!(to_hex_block_id(*block_id)), json!(false)]
+                    }
+                    BlockId::Hash(hash) => {
+                        vec![json!(format!("{:#x}", hash.block_hash)), json!(false)]
+                    }
+                };
+
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": match block_id {
+                        BlockId::Number(_) => "eth_getBlockByNumber",
+                        BlockId::Hash(_) => "eth_getBlockByHash",
+                    },
+                    "params": params,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let response = self.http.post(&self.url).json(&requests).send().await?;
+        let value: serde_json::Value = response.json().await?;
+        let Some(items) = value.as_array() else {
+            anyhow::bail!("batch rpc response was not an array: {value}");
+        };
+
+        #[derive(serde::Deserialize)]
+        struct BatchResponse<T> {
+            id: u64,
+            result: Option<T>,
+            error: Option<serde_json::Value>,
+        }
+
+        let mut blocks_by_id = HashMap::new();
+        for item in items {
+            let response: BatchResponse<Block> = serde_json::from_value(item.clone())?;
+            if let Some(error) = response.error {
+                anyhow::bail!("batch rpc call failed for id {}: {error}", response.id);
+            }
+            blocks_by_id.insert(response.id, response.result);
+        }
+
+        let mut blocks = Vec::with_capacity(block_ids.len());
+        for request_id in request_ids {
+            let block = blocks_by_id.remove(&request_id).unwrap_or(None);
+            blocks.push(block);
+        }
+
+        Ok(blocks)
     }
 
     pub async fn get_block_receipts(
         &self,
-        block_id: alloy::rpc::types::BlockId,
-    ) -> anyhow::Result<Option<Vec<alloy::rpc::types::TransactionReceipt>>> {
+        block_id: BlockId,
+    ) -> anyhow::Result<Option<Vec<TransactionReceipt>>> {
         self.block_receipts(block_id).await
     }
 
-    pub async fn get_nonce(
-        &self,
-        address: Address,
-        block_id: alloy::rpc::types::BlockId,
-    ) -> anyhow::Result<u64> {
+    pub async fn get_nonce(&self, address: Address, block_id: BlockId) -> anyhow::Result<u64> {
         self.rpc_call::<String>(
             "eth_getTransactionCount",
             vec![
@@ -62,8 +120,8 @@ impl RpcEthereumClient {
 
     pub async fn get_transaction_by_hash(
         &self,
-        tx_hash: alloy::primitives::B256,
-    ) -> anyhow::Result<Option<alloy::rpc::types::Transaction>> {
+        tx_hash: B256,
+    ) -> anyhow::Result<Option<Transaction>> {
         self.transaction_by_hash(tx_hash).await
     }
 
@@ -119,19 +177,16 @@ impl RpcEthereumClient {
         Ok(serde_json::from_value(result)?)
     }
 
-    async fn block(
-        &self,
-        block_id: alloy::rpc::types::BlockId,
-    ) -> anyhow::Result<Option<alloy::rpc::types::Block>> {
+    async fn block(&self, block_id: BlockId) -> anyhow::Result<Option<Block>> {
         match block_id {
-            alloy::rpc::types::BlockId::Number(_) => {
+            BlockId::Number(_) => {
                 self.rpc_call(
                     "eth_getBlockByNumber",
                     vec![json!(to_hex_block_id(block_id)), json!(false)],
                 )
                 .await
             }
-            alloy::rpc::types::BlockId::Hash(hash) => {
+            BlockId::Hash(hash) => {
                 self.rpc_call(
                     "eth_getBlockByHash",
                     vec![json!(format!("{:#x}", hash.block_hash))],
@@ -143,8 +198,8 @@ impl RpcEthereumClient {
 
     async fn block_receipts(
         &self,
-        block_id: alloy::rpc::types::BlockId,
-    ) -> anyhow::Result<Option<Vec<alloy::rpc::types::TransactionReceipt>>> {
+        block_id: BlockId,
+    ) -> anyhow::Result<Option<Vec<TransactionReceipt>>> {
         self.rpc_call(
             "eth_getBlockReceipts",
             vec![json!(to_hex_block_id(block_id))],
@@ -152,10 +207,7 @@ impl RpcEthereumClient {
         .await
     }
 
-    async fn transaction_by_hash(
-        &self,
-        tx_hash: alloy::primitives::B256,
-    ) -> anyhow::Result<Option<Transaction>> {
+    async fn transaction_by_hash(&self, tx_hash: B256) -> anyhow::Result<Option<Transaction>> {
         self.rpc_call(
             "eth_getTransactionByHash",
             vec![json!(format!("{:#x}", tx_hash))],
@@ -189,14 +241,14 @@ fn hex_to_u64(value: &str) -> anyhow::Result<u64> {
         .map_err(|err| anyhow::anyhow!("failed to parse hex value '{value}': {err}"))
 }
 
-fn to_hex_block_id(block_id: alloy::rpc::types::BlockId) -> String {
+fn to_hex_block_id(block_id: BlockId) -> String {
     match block_id {
-        alloy::rpc::types::BlockId::Number(BlockNumberOrTag::Number(number)) => to_hex_u64(number),
-        alloy::rpc::types::BlockId::Number(BlockNumberOrTag::Latest) => "latest".to_string(),
-        alloy::rpc::types::BlockId::Number(BlockNumberOrTag::Finalized) => "finalized".to_string(),
-        alloy::rpc::types::BlockId::Number(BlockNumberOrTag::Safe) => "safe".to_string(),
-        alloy::rpc::types::BlockId::Number(BlockNumberOrTag::Earliest) => "earliest".to_string(),
-        alloy::rpc::types::BlockId::Number(BlockNumberOrTag::Pending) => "pending".to_string(),
-        alloy::rpc::types::BlockId::Hash(hash) => format!("{:#x}", hash.block_hash),
+        BlockId::Number(BlockNumberOrTag::Number(number)) => to_hex_u64(number),
+        BlockId::Number(BlockNumberOrTag::Latest) => "latest".to_string(),
+        BlockId::Number(BlockNumberOrTag::Finalized) => "finalized".to_string(),
+        BlockId::Number(BlockNumberOrTag::Safe) => "safe".to_string(),
+        BlockId::Number(BlockNumberOrTag::Earliest) => "earliest".to_string(),
+        BlockId::Number(BlockNumberOrTag::Pending) => "pending".to_string(),
+        BlockId::Hash(hash) => format!("{:#x}", hash.block_hash),
     }
 }

--- a/chain-signatures/node/src/indexer_eth/indexer_eth_direct_rpc.rs
+++ b/chain-signatures/node/src/indexer_eth/indexer_eth_direct_rpc.rs
@@ -346,6 +346,9 @@ mod tests {
             .expect("batch fetch should succeed");
 
         assert!(matches!(&blocks[0], MaybeBlock::Block(block) if block.header.number == 7));
-        assert!(matches!(&blocks[1], MaybeBlock::Missing(BlockId::Number(BlockNumberOrTag::Number(8)))));
+        assert!(matches!(
+            &blocks[1],
+            MaybeBlock::Missing(BlockId::Number(BlockNumberOrTag::Number(8)))
+        ));
     }
 }

--- a/chain-signatures/node/src/indexer_eth/indexer_eth_helios.rs
+++ b/chain-signatures/node/src/indexer_eth/indexer_eth_helios.rs
@@ -1,4 +1,4 @@
-use crate::indexer_eth::EthConfig;
+use crate::indexer_eth::{EthConfig, MaybeBlock};
 use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::primitives::Address;
 use alloy::primitives::Bytes;
@@ -31,11 +31,11 @@ impl HeliosEthereumClient {
         self.fetch_block(block_id).await
     }
 
-    /// Fetch multiple blocks in parallel. If any block fetch fails, it will be logged and returned as None.
+    /// Fetch multiple blocks in parallel. Missing blocks stay associated with requested height.
     pub async fn get_blocks(
         &self,
         block_ids: &[alloy::rpc::types::BlockId],
-    ) -> anyhow::Result<Vec<Option<alloy::rpc::types::Block>>> {
+    ) -> anyhow::Result<Vec<MaybeBlock>> {
         if block_ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -44,15 +44,16 @@ impl HeliosEthereumClient {
             block_ids
                 .iter()
                 .copied()
-                .map(|block_id| self.get_block(block_id)),
+                .map(|block_id| async move { (block_id, self.get_block(block_id).await) }),
         )
         .await
         .into_iter()
-        .map(|result| match result {
-            Ok(block) => block,
+        .map(|(block_id, result)| match result {
+            Ok(Some(block)) => MaybeBlock::Block(block),
+            Ok(None) => missing_block(block_id),
             Err(err) => {
                 tracing::warn!(?err, "helios batch block fetch failed");
-                None
+                missing_block(block_id)
             }
         })
         .collect::<Vec<_>>();
@@ -138,6 +139,14 @@ impl HeliosEthereumClient {
         self.client.get_block(block_id, false).await.map_err(|err| {
             anyhow::anyhow!("Failed to fetch block for block id {block_id:?}: {:?}", err)
         })
+    }
+}
+
+fn missing_block(block_id: BlockId) -> MaybeBlock {
+    match block_id {
+        BlockId::Number(BlockNumberOrTag::Number(block_number)) => MaybeBlock::Missing(block_number),
+        BlockId::Number(tag) => panic!("expected numbered block id, got {tag:?}"),
+        BlockId::Hash(hash) => panic!("expected numbered block id, got hash {hash:?}"),
     }
 }
 

--- a/chain-signatures/node/src/indexer_eth/indexer_eth_helios.rs
+++ b/chain-signatures/node/src/indexer_eth/indexer_eth_helios.rs
@@ -50,10 +50,10 @@ impl HeliosEthereumClient {
         .into_iter()
         .map(|(block_id, result)| match result {
             Ok(Some(block)) => MaybeBlock::Block(block),
-            Ok(None) => missing_block(block_id),
+            Ok(None) => MaybeBlock::Missing(block_id),
             Err(err) => {
                 tracing::warn!(?err, "helios batch block fetch failed");
-                missing_block(block_id)
+                MaybeBlock::Missing(block_id)
             }
         })
         .collect::<Vec<_>>();
@@ -139,14 +139,6 @@ impl HeliosEthereumClient {
         self.client.get_block(block_id, false).await.map_err(|err| {
             anyhow::anyhow!("Failed to fetch block for block id {block_id:?}: {:?}", err)
         })
-    }
-}
-
-fn missing_block(block_id: BlockId) -> MaybeBlock {
-    match block_id {
-        BlockId::Number(BlockNumberOrTag::Number(block_number)) => MaybeBlock::Missing(block_number),
-        BlockId::Number(tag) => panic!("expected numbered block id, got {tag:?}"),
-        BlockId::Hash(hash) => panic!("expected numbered block id, got hash {hash:?}"),
     }
 }
 

--- a/chain-signatures/node/src/indexer_eth/indexer_eth_helios.rs
+++ b/chain-signatures/node/src/indexer_eth/indexer_eth_helios.rs
@@ -3,6 +3,7 @@ use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::primitives::Address;
 use alloy::primitives::Bytes;
 use alloy::rpc::types::TransactionRequest;
+use futures_util::future::join_all;
 use helios::ethereum::{config::networks::Network, EthereumClient, EthereumClientBuilder};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -28,6 +29,35 @@ impl HeliosEthereumClient {
         block_id: alloy::rpc::types::BlockId,
     ) -> anyhow::Result<Option<alloy::rpc::types::Block>> {
         self.fetch_block(block_id).await
+    }
+
+    /// Fetch multiple blocks in parallel. If any block fetch fails, it will be logged and returned as None.
+    pub async fn get_blocks(
+        &self,
+        block_ids: &[alloy::rpc::types::BlockId],
+    ) -> anyhow::Result<Vec<Option<alloy::rpc::types::Block>>> {
+        if block_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let blocks = join_all(
+            block_ids
+                .iter()
+                .copied()
+                .map(|block_id| self.get_block(block_id)),
+        )
+        .await
+        .into_iter()
+        .map(|result| match result {
+            Ok(block) => block,
+            Err(err) => {
+                tracing::warn!(?err, "helios batch block fetch failed");
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+        Ok(blocks)
     }
 
     pub async fn get_block_receipts(

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -1352,6 +1352,7 @@ impl EthereumIndexer {
 
 #[async_trait]
 impl ChainIndexer for EthereumIndexer {
+    const CHAIN: Chain = Chain::Ethereum;
     type Block = MaybeBlock;
     type Iter = CatchupIter;
 
@@ -1482,7 +1483,6 @@ impl EthereumStream {
 
 #[async_trait]
 impl ChainStream for EthereumStream {
-    const CHAIN: Chain = Chain::Ethereum;
     type Indexer = EthereumIndexer;
 
     async fn start(&mut self) -> anyhow::Result<Self::Indexer> {

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -732,7 +732,7 @@ impl EthereumClient {
                     num_blocks = block_ids.len(),
                     "get_blocks failed: {last_error:#}; exhausted after {attempts} attempts"
                 );
-                block_ids.iter().copied().map(Self::missing_block).collect()
+                block_ids.iter().copied().map(MaybeBlock::Missing).collect()
             }
             Err(retry::RetryError::TimeoutExhausted { attempts, last_timeout }) => {
                 tracing::warn!(
@@ -740,7 +740,7 @@ impl EthereumClient {
                     num_blocks = block_ids.len(),
                     "get_blocks timed out (last timeout {last_timeout:?}); exhausted after {attempts} attempts"
                 );
-                block_ids.iter().copied().map(Self::missing_block).collect()
+                block_ids.iter().copied().map(MaybeBlock::Missing).collect()
             }
         }
     }
@@ -762,11 +762,7 @@ impl EthereumClient {
         }
     }
 
-    fn missing_block(block_id: BlockId) -> MaybeBlock {
-        MaybeBlock::Missing(block_id)
-    }
-
-    fn block_number_from_id(block_id: BlockId) -> BlockNumber {
+    pub fn block_number_from_id(block_id: BlockId) -> BlockNumber {
         match block_id {
             BlockId::Number(BlockNumberOrTag::Number(block_number)) => block_number,
             BlockId::Number(tag) => panic!("expected numbered block id, got {tag:?}"),
@@ -1403,16 +1399,24 @@ impl ChainIndexer for EthereumIndexer {
     }
 
     async fn process_catchup(&mut self, block: &Self::Block) -> anyhow::Result<()> {
-        let MaybeBlock::Block(block) = block else {
-            let &MaybeBlock::Missing(block_id) = block else {
-                unreachable!();
-            };
-            tracing::warn!(?block_id, "ethereum catchup block not yet available");
-            return Ok(());
+        // NOTE: oh rust: needed otherwise the block gets dropped before we can use
+        // it, since it `block` is of reference type. Maybe the language will let
+        // us elide this in the future, but for now we need to introduce a new var.
+        let _block;
+
+        let block = match block {
+            MaybeBlock::Block(block) => block,
+            MaybeBlock::Missing(block_id) => {
+                tracing::warn!(?block_id, "ethereum catchup block missing from batch; refetching");
+                let Some(block) = self.client.get_block(*block_id).await else {
+                    anyhow::bail!("ethereum catchup block {block_id:?} is still unavailable after refetch")
+                };
+                _block = block;
+                &_block
+            }
         };
 
         let height = block.header.number;
-
         if height.is_multiple_of(10) {
             tracing::info!(height, "processed ethereum catchup block attempt");
         }
@@ -1523,7 +1527,103 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn missing_catchup_block_is_skipped() {
+    async fn missing_catchup_block_is_refetched() {
+        let mut server = Server::new_async().await;
+        let backlog = Backlog::new();
+        let (events_tx, mut events_rx) = mpsc::channel(1);
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockByNumber",
+                "params": ["0xc", false]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "number": "0xc",
+                        "hash": format!("0x{:064x}", 12),
+                        "parentHash": format!("0x{:064x}", 11),
+                        "sha3Uncles": format!("0x{:064x}", 1),
+                        "logsBloom": format!("0x{}", "0".repeat(512)),
+                        "transactionsRoot": format!("0x{:064x}", 2),
+                        "stateRoot": format!("0x{:064x}", 3),
+                        "receiptsRoot": format!("0x{:064x}", 4),
+                        "miner": format!("0x{:040x}", 5),
+                        "difficulty": "0x0",
+                        "totalDifficulty": "0x0",
+                        "extraData": "0x",
+                        "size": "0x1",
+                        "gasLimit": "0x1c9c380",
+                        "gasUsed": "0x0",
+                        "timestamp": "0x1",
+                        "uncles": [],
+                        "nonce": "0x0000000000000000",
+                        "mixHash": format!("0x{:064x}", 9),
+                        "baseFeePerGas": "0x1",
+                        "transactions": []
+                    }
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockReceipts",
+                "params": ["0xc"]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "result": null,
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let mut indexer = EthereumIndexer {
+            eth: EthConfig {
+                account_sk: String::new(),
+                consensus_rpc_http_url: server.url(),
+                execution_rpc_http_url: server.url(),
+                contract_address: format!("{:x}", Address::ZERO),
+                network: "sepolia".to_string(),
+                helios_data_path: "/tmp/helios-test".to_string(),
+                refresh_finalized_interval: 100,
+                optimistic_requests: true,
+                light_client: false,
+            },
+            backlog,
+            client: Arc::new(EthereumClient::DirectRpc(
+                super::indexer_eth_direct_rpc::RpcEthereumClient::new(&server.url()),
+            )),
+            events_tx,
+            contract_address: Address::ZERO,
+            catchup_complete: Arc::new(Notify::new()),
+            live_blocks_rx: None,
+        };
+
+        indexer
+            .process_catchup(&MaybeBlock::Missing(BlockId::Number(BlockNumberOrTag::Number(12))))
+            .await
+            .expect("missing catchup block should be refetched successfully");
+
+        assert!(matches!(events_rx.recv().await, Some(ChainEvent::Block(12))));
+    }
+
+    #[tokio::test]
+    async fn missing_catchup_block_returns_error_when_refetch_fails() {
         let backlog = Backlog::new();
         let (events_tx, mut events_rx) = mpsc::channel(1);
         let mut indexer = EthereumIndexer {
@@ -1548,12 +1648,15 @@ mod tests {
             live_blocks_rx: None,
         };
 
-        indexer
+        let err = indexer
             .process_catchup(&MaybeBlock::Missing(BlockId::Number(BlockNumberOrTag::Number(12))))
             .await
-            .expect("missing catchup block should not fail");
+            .expect_err("missing catchup block should fail when refetch cannot recover it");
 
         assert!(events_rx.try_recv().is_err());
+        assert!(err
+            .to_string()
+            .contains("still unavailable after refetch"));
     }
 
     #[tokio::test]

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -6,7 +6,7 @@ use crate::metrics::requests::{record_request_latency, SignRequestStep};
 use crate::protocol::{Chain, IndexedSignRequest};
 use crate::respond_bidirectional::CompletedTx;
 use crate::stream::ops::{EthereumSignatureRespondedEvent, SignatureRespondedEvent};
-use crate::stream::{ChainEvent, ChainIndexer, ChainStream, ExecutionOutcome};
+use crate::stream::{AsyncCatchupIter, ChainEvent, ChainIndexer, ChainStream, ExecutionOutcome};
 use crate::util::retry;
 
 use alloy::eips::BlockNumberOrTag;
@@ -38,6 +38,60 @@ fn live_blocks_channel() -> (mpsc::Sender<MaybeBlock>, mpsc::Receiver<MaybeBlock
 }
 
 type BlockNumber = u64;
+
+pub struct CatchupIter {
+    client: Arc<EthereumClient>,
+    next_block: BlockNumber,
+    end_block: BlockNumber,
+    buffered_blocks: std::vec::IntoIter<MaybeBlock>,
+}
+
+impl CatchupIter {
+    fn new(client: Arc<EthereumClient>, start_block: BlockNumber, end_block: BlockNumber) -> Self {
+        Self {
+            client,
+            next_block: start_block,
+            end_block,
+            buffered_blocks: Vec::new().into_iter(),
+        }
+    }
+
+    async fn fetch_next_batch(&mut self) {
+        if self.next_block >= self.end_block {
+            return;
+        }
+
+        let batch_end = self
+            .next_block
+            .saturating_add(CATCHUP_BLOCK_BATCH_SIZE)
+            .min(self.end_block);
+        let batch_block_ids = (self.next_block..batch_end)
+            .map(|block_number| BlockId::Number(BlockNumberOrTag::Number(block_number)))
+            .collect::<Vec<_>>();
+
+        self.buffered_blocks = self.client.get_blocks(&batch_block_ids).await.into_iter();
+        self.next_block = batch_end;
+    }
+}
+
+#[async_trait]
+impl AsyncCatchupIter for CatchupIter {
+    type Item = MaybeBlock;
+
+    async fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(block) = Iterator::next(&mut self.buffered_blocks) {
+                return Some(block);
+            }
+
+            if self.next_block >= self.end_block {
+                return None;
+            }
+
+            self.fetch_next_batch().await;
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
@@ -1303,7 +1357,7 @@ impl EthereumIndexer {
 #[async_trait]
 impl ChainIndexer for EthereumIndexer {
     type Block = MaybeBlock;
-    type Iter = std::vec::IntoIter<Self::Block>;
+    type Iter = CatchupIter;
 
     async fn livestream(&mut self) -> anyhow::Result<Option<u64>> {
         let start_block_number = loop {
@@ -1345,33 +1399,15 @@ impl ChainIndexer for EthereumIndexer {
             .client
             .clamp_oldest_supported(current_block, anchor_height);
 
-        let mut blocks = Vec::new();
-        let mut batch_start = catchup_start;
-
-        while batch_start < anchor_height {
-            let batch_end = batch_start
-                .saturating_add(CATCHUP_BLOCK_BATCH_SIZE)
-                .min(anchor_height);
-            let batch_block_ids = (batch_start..batch_end)
-                .map(|block_number| BlockId::Number(BlockNumberOrTag::Number(block_number)))
-                .collect::<Vec<_>>();
-
-            for block in self.client.get_blocks(&batch_block_ids).await {
-                blocks.push(block);
-            }
-
-            batch_start = batch_end;
-        }
-
-        blocks.into_iter()
+        CatchupIter::new(self.client.clone(), catchup_start, anchor_height)
     }
 
     async fn process_catchup(&mut self, block: &Self::Block) -> anyhow::Result<()> {
         let MaybeBlock::Block(block) = block else {
-            let &MaybeBlock::Missing(height) = block else {
+            let &MaybeBlock::Missing(block_id) = block else {
                 unreachable!();
             };
-            tracing::warn!(height, "ethereum catchup block not yet available");
+            tracing::warn!(?block_id, "ethereum catchup block not yet available");
             return Ok(());
         };
 
@@ -1455,13 +1491,15 @@ impl ChainStream for EthereumStream {
 }
 #[cfg(test)]
 mod tests {
-    use super::{EthConfig, EthereumClient, EthereumIndexer, MaybeBlock};
+    use super::{CatchupIter, EthConfig, EthereumClient, EthereumIndexer, MaybeBlock};
     use crate::backlog::Backlog;
     use crate::indexer_eth::indexer_eth_helios;
     use crate::protocol::Chain;
     use crate::sign_bidirectional::{BidirectionalTx, BidirectionalTxId};
-    use crate::stream::{ChainEvent, ChainIndexer, ExecutionOutcome};
+    use crate::stream::{AsyncCatchupIter, ChainEvent, ChainIndexer, ExecutionOutcome};
+    use alloy::eips::BlockNumberOrTag;
     use alloy::primitives::{address, b256, Address};
+    use alloy::rpc::types::BlockId;
     use mockito::{Matcher, Server};
     use mpc_primitives::{SignId, LATEST_MPC_KEY_VERSION};
     use serde_json::json;
@@ -1516,6 +1554,88 @@ mod tests {
             .expect("missing catchup block should not fail");
 
         assert!(events_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn catchup_iter_fetches_batches_lazily() {
+        let mut server = Server::new_async().await;
+
+        fn block_response(request_id: u64, number: u64) -> serde_json::Value {
+            json!({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {
+                    "number": format!("0x{number:x}"),
+                    "hash": format!("0x{:064x}", number),
+                    "parentHash": format!("0x{:064x}", number.saturating_sub(1)),
+                    "sha3Uncles": format!("0x{:064x}", 1),
+                    "logsBloom": format!("0x{}", "0".repeat(512)),
+                    "transactionsRoot": format!("0x{:064x}", 2),
+                    "stateRoot": format!("0x{:064x}", 3),
+                    "receiptsRoot": format!("0x{:064x}", 4),
+                    "miner": format!("0x{:040x}", 5),
+                    "difficulty": "0x0",
+                    "totalDifficulty": "0x0",
+                    "extraData": "0x",
+                    "size": "0x1",
+                    "gasLimit": "0x1c9c380",
+                    "gasUsed": "0x0",
+                    "timestamp": "0x1",
+                    "uncles": [],
+                    "nonce": "0x0000000000000000",
+                    "mixHash": format!("0x{:064x}", 9),
+                    "baseFeePerGas": "0x1",
+                    "transactions": []
+                }
+            })
+        }
+
+        let first_batch = (10..42)
+            .enumerate()
+            .map(|(index, block_number)| block_response(index as u64 + 1, block_number))
+            .collect::<Vec<_>>();
+        let second_batch = vec![block_response(33, 42)];
+
+        let second_batch_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex(r#"\"0x2a\""#.to_string()))
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!(second_batch).to_string())
+            .create_async()
+            .await;
+
+        let first_batch_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex(r#"\"0xa\""#.to_string()))
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!(first_batch).to_string())
+            .create_async()
+            .await;
+
+        let client = Arc::new(EthereumClient::DirectRpc(
+            super::indexer_eth_direct_rpc::RpcEthereumClient::new(&server.url()),
+        ));
+        let mut iter = CatchupIter::new(client, 10, 43);
+
+        for expected_number in 10..42 {
+            let next = iter.next().await;
+            assert!(matches!(
+                next,
+                Some(MaybeBlock::Block(block)) if block.header.number == expected_number
+            ));
+        }
+
+        assert!(first_batch_mock.matched_async().await);
+        assert!(!second_batch_mock.matched_async().await);
+
+        let next = iter.next().await;
+        assert!(matches!(next, Some(MaybeBlock::Block(block)) if block.header.number == 42));
+        assert!(second_batch_mock.matched_async().await);
+        assert!(iter.next().await.is_none());
     }
 
     #[tokio::test]

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -33,11 +33,18 @@ use tokio::time::Duration;
 const MAX_LIVE_BLOCK_BUFFER: usize = 16384;
 const CATCHUP_BLOCK_BATCH_SIZE: u64 = 32;
 
-fn live_blocks_channel() -> (mpsc::Sender<Block>, mpsc::Receiver<Block>) {
+fn live_blocks_channel() -> (mpsc::Sender<MaybeBlock>, mpsc::Receiver<MaybeBlock>) {
     mpsc::channel(MAX_LIVE_BLOCK_BUFFER)
 }
 
 type BlockNumber = u64;
+
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum MaybeBlock {
+    Block(Block),
+    Missing(BlockNumber),
+}
 
 pub struct BlockAndRequests {
     block_number: u64,
@@ -624,7 +631,7 @@ impl EthereumClient {
         }
     }
 
-    async fn get_blocks(&self, block_ids: &[BlockId]) -> Vec<Option<Block>> {
+    async fn get_blocks(&self, block_ids: &[BlockId]) -> Vec<MaybeBlock> {
         if block_ids.is_empty() {
             return Vec::new();
         }
@@ -671,9 +678,7 @@ impl EthereumClient {
                     num_blocks = block_ids.len(),
                     "get_blocks failed: {last_error:#}; exhausted after {attempts} attempts"
                 );
-                std::iter::repeat_with(|| None)
-                    .take(block_ids.len())
-                    .collect()
+                block_ids.iter().copied().map(Self::missing_block).collect()
             }
             Err(retry::RetryError::TimeoutExhausted { attempts, last_timeout }) => {
                 tracing::warn!(
@@ -681,9 +686,7 @@ impl EthereumClient {
                     num_blocks = block_ids.len(),
                     "get_blocks timed out (last timeout {last_timeout:?}); exhausted after {attempts} attempts"
                 );
-                std::iter::repeat_with(|| None)
-                    .take(block_ids.len())
-                    .collect()
+                block_ids.iter().copied().map(Self::missing_block).collect()
             }
         }
     }
@@ -702,6 +705,17 @@ impl EthereumClient {
         match self {
             EthereumClient::Helios(client) => client.get_nonce(address, block_id).await,
             EthereumClient::DirectRpc(client) => client.get_nonce(address, block_id).await,
+        }
+    }
+    fn missing_block(block_id: BlockId) -> MaybeBlock {
+        MaybeBlock::Missing(Self::block_number_from_id(block_id))
+    }
+
+    fn block_number_from_id(block_id: BlockId) -> BlockNumber {
+        match block_id {
+            BlockId::Number(BlockNumberOrTag::Number(block_number)) => block_number,
+            BlockId::Number(tag) => panic!("expected numbered block id, got {tag:?}"),
+            BlockId::Hash(hash) => panic!("expected numbered block id, got hash {hash:?}"),
         }
     }
 
@@ -775,7 +789,7 @@ pub struct EthereumIndexer {
     events_tx: mpsc::Sender<ChainEvent>,
     contract_address: Address,
     catchup_complete: Arc<Notify>,
-    live_blocks_rx: Option<mpsc::Receiver<Block>>,
+    live_blocks_rx: Option<mpsc::Receiver<MaybeBlock>>,
 }
 
 impl EthereumIndexer {
@@ -805,7 +819,7 @@ impl EthereumIndexer {
         client: Arc<EthereumClient>,
         catchup_complete: Arc<Notify>,
         start_block_number: u64,
-        live_blocks: mpsc::Sender<Block>,
+        live_blocks: mpsc::Sender<MaybeBlock>,
     ) {
         tracing::info!("indexing ethereum live blocks");
 
@@ -838,7 +852,7 @@ impl EthereumIndexer {
                     break;
                 };
 
-                if let Err(err) = live_blocks.send(block).await {
+                if let Err(err) = live_blocks.send(MaybeBlock::Block(block)).await {
                     tracing::warn!(
                         ?err,
                         current_block_number,
@@ -1287,7 +1301,7 @@ impl EthereumIndexer {
 
 #[async_trait]
 impl ChainIndexer for EthereumIndexer {
-    type Block = Block;
+    type Block = MaybeBlock;
     type Iter = std::vec::IntoIter<Self::Block>;
 
     async fn livestream(&mut self) -> anyhow::Result<Option<u64>> {
@@ -1341,15 +1355,8 @@ impl ChainIndexer for EthereumIndexer {
                 .map(|block_number| BlockId::Number(BlockNumberOrTag::Number(block_number)))
                 .collect::<Vec<_>>();
 
-            for (block_number, block) in
-                (batch_start..batch_end).zip(self.client.get_blocks(&batch_block_ids).await)
-            {
-                match block {
-                    Some(block) => blocks.push(block),
-                    None => {
-                        tracing::warn!(block_number, "ethereum catchup block not yet available")
-                    }
-                }
+            for block in self.client.get_blocks(&batch_block_ids).await {
+                blocks.push(block);
             }
 
             batch_start = batch_end;
@@ -1359,6 +1366,14 @@ impl ChainIndexer for EthereumIndexer {
     }
 
     async fn process_catchup(&mut self, block: &Self::Block) -> anyhow::Result<()> {
+        let MaybeBlock::Block(block) = block else {
+            let &MaybeBlock::Missing(height) = block else {
+                unreachable!();
+            };
+            tracing::warn!(height, "ethereum catchup block not yet available");
+            return Ok(());
+        };
+
         let height = block.header.number;
 
         if height.is_multiple_of(10) {
@@ -1369,6 +1384,10 @@ impl ChainIndexer for EthereumIndexer {
     }
 
     async fn process(&mut self, block: &Self::Block) -> anyhow::Result<()> {
+        let MaybeBlock::Block(block) = block else {
+            anyhow::bail!("ethereum live stream yielded missing block")
+        };
+
         self.process_block(block).await?;
         Ok(())
     }
@@ -1435,12 +1454,12 @@ impl ChainStream for EthereumStream {
 }
 #[cfg(test)]
 mod tests {
-    use super::{EthConfig, EthereumClient, EthereumIndexer};
+    use super::{EthConfig, EthereumClient, EthereumIndexer, MaybeBlock};
     use crate::backlog::Backlog;
     use crate::indexer_eth::indexer_eth_helios;
     use crate::protocol::Chain;
     use crate::sign_bidirectional::{BidirectionalTx, BidirectionalTxId};
-    use crate::stream::{ChainEvent, ExecutionOutcome};
+    use crate::stream::{ChainEvent, ChainIndexer, ExecutionOutcome};
     use alloy::primitives::{address, b256, Address};
     use mockito::{Matcher, Server};
     use mpc_primitives::{SignId, LATEST_MPC_KEY_VERSION};
@@ -1462,6 +1481,40 @@ mod tests {
 
         let heights: Vec<u64> = vec![2, 3, 4].into_iter().collect();
         assert_eq!(heights, vec![2, 3, 4]);
+    }
+
+    #[tokio::test]
+    async fn missing_catchup_block_is_skipped() {
+        let backlog = Backlog::new();
+        let (events_tx, mut events_rx) = mpsc::channel(1);
+        let mut indexer = EthereumIndexer {
+            eth: EthConfig {
+                account_sk: String::new(),
+                consensus_rpc_http_url: String::new(),
+                execution_rpc_http_url: String::new(),
+                contract_address: format!("{:x}", Address::ZERO),
+                network: "sepolia".to_string(),
+                helios_data_path: "/tmp/helios-test".to_string(),
+                refresh_finalized_interval: 100,
+                optimistic_requests: true,
+                light_client: false,
+            },
+            backlog,
+            client: Arc::new(EthereumClient::DirectRpc(
+                super::indexer_eth_direct_rpc::RpcEthereumClient::new("http://127.0.0.1:1"),
+            )),
+            events_tx,
+            contract_address: Address::ZERO,
+            catchup_complete: Arc::new(Notify::new()),
+            live_blocks_rx: None,
+        };
+
+        indexer
+            .process_catchup(&MaybeBlock::Missing(42))
+            .await
+            .expect("missing catchup block should not fail");
+
+        assert!(events_rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -7,6 +7,7 @@ use crate::protocol::{Chain, IndexedSignRequest};
 use crate::respond_bidirectional::CompletedTx;
 use crate::stream::ops::{EthereumSignatureRespondedEvent, SignatureRespondedEvent};
 use crate::stream::{ChainEvent, ChainIndexer, ChainStream, ExecutionOutcome};
+use crate::util::retry;
 
 use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::hex::{self, ToHexExt};
@@ -24,13 +25,13 @@ use mpc_primitives::{
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
-use std::ops::Range;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Notify};
 use tokio::time::Duration;
 
 const MAX_LIVE_BLOCK_BUFFER: usize = 16384;
+const CATCHUP_BLOCK_BATCH_SIZE: u64 = 32;
 
 fn live_blocks_channel() -> (mpsc::Sender<Block>, mpsc::Receiver<Block>) {
     mpsc::channel(MAX_LIVE_BLOCK_BUFFER)
@@ -565,7 +566,7 @@ impl EthereumClient {
 
     async fn get_block(&self, block_id: BlockId) -> Option<Block> {
         // Configure retry behaviour and delegate to shared retry_async helper.
-        let retry_config = crate::util::retry::RetryConfig::default();
+        let retry_config = retry::RetryConfig::default();
         let get_block_op = |_attempt: usize| async {
             match self {
                 EthereumClient::Helios(client) => client.get_block(block_id).await,
@@ -573,18 +574,18 @@ impl EthereumClient {
             }
         };
 
-        let res = crate::util::retry::retry_async(
+        let res = retry::retry_async(
             retry_config,
             get_block_op,
             |_attempt, _reason| true,
             |attempt, reason, sleep_duration| match reason {
-                crate::util::retry::RetryReason::Error(e) => {
+                retry::RetryReason::Error(e) => {
                     tracing::warn!(
                         client = self.client_name(),
                         "get_block failed (attempt {attempt}) for {block_id:?}: {e:#}; retrying in {sleep_duration:?}"
                     );
                 }
-                crate::util::retry::RetryReason::Timeout(t) => {
+                retry::RetryReason::Timeout(t) => {
                     tracing::warn!(
                         client = self.client_name(),
                         "get_block timed out after {t:?} (attempt {attempt}) for {block_id:?}; retrying in {sleep_duration:?}"
@@ -600,7 +601,7 @@ impl EthereumClient {
                 tracing::warn!(client = self.client_name(), "Block {block_id:?} not found");
                 None
             }
-            Err(crate::util::retry::RetryError::Exhausted {
+            Err(retry::RetryError::Exhausted {
                 attempts,
                 last_error,
             }) => {
@@ -610,7 +611,7 @@ impl EthereumClient {
                 );
                 None
             }
-            Err(crate::util::retry::RetryError::TimeoutExhausted {
+            Err(retry::RetryError::TimeoutExhausted {
                 attempts,
                 last_timeout,
             }) => {
@@ -619,6 +620,70 @@ impl EthereumClient {
                     "get_block timed out for {block_id:?} (last timeout {last_timeout:?}); exhausted after {attempts} attempts"
                 );
                 None
+            }
+        }
+    }
+
+    async fn get_blocks(&self, block_ids: &[BlockId]) -> Vec<Option<Block>> {
+        if block_ids.is_empty() {
+            return Vec::new();
+        }
+
+        let retry_config = retry::RetryConfig::default();
+        let block_ids = block_ids.to_vec();
+        let get_blocks_op = |_attempt: usize| {
+            let block_ids = block_ids.clone();
+            async move {
+                match self {
+                    EthereumClient::Helios(client) => client.get_blocks(&block_ids).await,
+                    EthereumClient::DirectRpc(client) => client.get_blocks(&block_ids).await,
+                }
+            }
+        };
+
+        match retry::retry_async(
+            retry_config,
+            get_blocks_op,
+            |_attempt, _reason| true,
+            |attempt, reason, sleep_duration| match reason {
+                retry::RetryReason::Error(e) => {
+                    tracing::warn!(
+                        client = self.client_name(),
+                        num_blocks = block_ids.len(),
+                        "get_blocks failed (attempt {attempt}): {e:#}; retrying in {sleep_duration:?}"
+                    );
+                }
+                retry::RetryReason::Timeout(t) => {
+                    tracing::warn!(
+                        client = self.client_name(),
+                        num_blocks = block_ids.len(),
+                        "get_blocks timed out after {t:?} (attempt {attempt}); retrying in {sleep_duration:?}"
+                    );
+                }
+            },
+        )
+        .await
+        {
+            Ok(blocks) => blocks,
+            Err(retry::RetryError::Exhausted { attempts, last_error }) => {
+                tracing::warn!(
+                    client = self.client_name(),
+                    num_blocks = block_ids.len(),
+                    "get_blocks failed: {last_error:#}; exhausted after {attempts} attempts"
+                );
+                std::iter::repeat_with(|| None)
+                    .take(block_ids.len())
+                    .collect()
+            }
+            Err(retry::RetryError::TimeoutExhausted { attempts, last_timeout }) => {
+                tracing::warn!(
+                    client = self.client_name(),
+                    num_blocks = block_ids.len(),
+                    "get_blocks timed out (last timeout {last_timeout:?}); exhausted after {attempts} attempts"
+                );
+                std::iter::repeat_with(|| None)
+                    .take(block_ids.len())
+                    .collect()
             }
         }
     }
@@ -785,18 +850,6 @@ impl EthereumIndexer {
                 current_block_number = current_block_number.saturating_add(1);
             }
         }
-    }
-
-    async fn process_height(&self, block_number: u64) -> anyhow::Result<()> {
-        let Some(block) = self
-            .client
-            .get_block(BlockId::Number(BlockNumberOrTag::Number(block_number)))
-            .await
-        else {
-            anyhow::bail!("ethereum block {block_number} not found");
-        };
-
-        self.process_block(&block).await
     }
 
     /// Process the block and emit relevant ChainEvents from the block.
@@ -1235,6 +1288,7 @@ impl EthereumIndexer {
 #[async_trait]
 impl ChainIndexer for EthereumIndexer {
     type Block = Block;
+    type Iter = std::vec::IntoIter<Self::Block>;
 
     async fn livestream(&mut self) -> anyhow::Result<Option<u64>> {
         let start_block_number = loop {
@@ -1261,7 +1315,7 @@ impl ChainIndexer for EthereumIndexer {
         rx.recv().await
     }
 
-    async fn catchup_range(&mut self, anchor_height: u64) -> Range<u64> {
+    async fn catchup_range(&self, anchor_height: u64) -> Self::Iter {
         // TODO: start from genesis block of contract deployment instead of
         // anchor_height so that we can start from the very beginning of
         // the history of the network in case where we do not have a checkpoint.
@@ -1276,15 +1330,42 @@ impl ChainIndexer for EthereumIndexer {
             .client
             .clamp_oldest_supported(current_block, anchor_height);
 
-        catchup_start..anchor_height
-    }
+        let mut blocks = Vec::new();
+        let mut batch_start = catchup_start;
 
-    async fn process_catchup_on_height(&mut self, height: u64) -> anyhow::Result<()> {
-        if height.is_multiple_of(10) {
-            tracing::info!(height, "processed ethereum catchup height attempt");
+        while batch_start < anchor_height {
+            let batch_end = batch_start
+                .saturating_add(CATCHUP_BLOCK_BATCH_SIZE)
+                .min(anchor_height);
+            let batch_block_ids = (batch_start..batch_end)
+                .map(|block_number| BlockId::Number(BlockNumberOrTag::Number(block_number)))
+                .collect::<Vec<_>>();
+
+            for (block_number, block) in
+                (batch_start..batch_end).zip(self.client.get_blocks(&batch_block_ids).await)
+            {
+                match block {
+                    Some(block) => blocks.push(block),
+                    None => {
+                        tracing::warn!(block_number, "ethereum catchup block not yet available")
+                    }
+                }
+            }
+
+            batch_start = batch_end;
         }
 
-        self.process_height(height).await
+        blocks.into_iter()
+    }
+
+    async fn process_catchup(&mut self, block: &Self::Block) -> anyhow::Result<()> {
+        let height = block.header.number;
+
+        if height.is_multiple_of(10) {
+            tracing::info!(height, "processed ethereum catchup block attempt");
+        }
+
+        self.process_block(block).await
     }
 
     async fn process(&mut self, block: &Self::Block) -> anyhow::Result<()> {
@@ -1378,6 +1459,9 @@ mod tests {
             EthereumClient::clamp_oldest_supported_with(1, anchor_height, max_catchup_blocks),
             expected_oldest,
         );
+
+        let heights: Vec<u64> = vec![2, 3, 4].into_iter().collect();
+        assert_eq!(heights, vec![2, 3, 4]);
     }
 
     #[tokio::test]

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -1515,6 +1515,44 @@ mod tests {
     use std::sync::Arc;
     use tokio::sync::{mpsc, Notify};
 
+    fn block_response(request_id: u64, number: u64) -> serde_json::Value {
+        json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "number": format!("0x{number:x}"),
+                "hash": format!("0x{:064x}", number),
+                "parentHash": format!("0x{:064x}", number.saturating_sub(1)),
+                "sha3Uncles": format!("0x{:064x}", 1),
+                "logsBloom": format!("0x{}", "0".repeat(512)),
+                "transactionsRoot": format!("0x{:064x}", 2),
+                "stateRoot": format!("0x{:064x}", 3),
+                "receiptsRoot": format!("0x{:064x}", 4),
+                "miner": format!("0x{:040x}", 5),
+                "difficulty": "0x0",
+                "totalDifficulty": "0x0",
+                "extraData": "0x",
+                "size": "0x1",
+                "gasLimit": "0x1c9c380",
+                "gasUsed": "0x0",
+                "timestamp": "0x1",
+                "uncles": [],
+                "nonce": "0x0000000000000000",
+                "mixHash": format!("0x{:064x}", 9),
+                "baseFeePerGas": "0x1",
+                "transactions": []
+            }
+        })
+    }
+
+    fn missing_block_response(request_id: u64) -> serde_json::Value {
+        json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": null
+        })
+    }
+
     #[test]
     fn catchup_start_is_clamped_to_supported_window() {
         let max_catchup_blocks = indexer_eth_helios::MAX_CATCHUP_BLOCKS;
@@ -1542,36 +1580,7 @@ mod tests {
             })))
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(
-                json!({
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "result": {
-                        "number": "0xc",
-                        "hash": format!("0x{:064x}", 12),
-                        "parentHash": format!("0x{:064x}", 11),
-                        "sha3Uncles": format!("0x{:064x}", 1),
-                        "logsBloom": format!("0x{}", "0".repeat(512)),
-                        "transactionsRoot": format!("0x{:064x}", 2),
-                        "stateRoot": format!("0x{:064x}", 3),
-                        "receiptsRoot": format!("0x{:064x}", 4),
-                        "miner": format!("0x{:040x}", 5),
-                        "difficulty": "0x0",
-                        "totalDifficulty": "0x0",
-                        "extraData": "0x",
-                        "size": "0x1",
-                        "gasLimit": "0x1c9c380",
-                        "gasUsed": "0x0",
-                        "timestamp": "0x1",
-                        "uncles": [],
-                        "nonce": "0x0000000000000000",
-                        "mixHash": format!("0x{:064x}", 9),
-                        "baseFeePerGas": "0x1",
-                        "transactions": []
-                    }
-                })
-                .to_string(),
-            )
+            .with_body(block_response(1, 12).to_string())
             .create_async()
             .await;
 
@@ -1583,14 +1592,7 @@ mod tests {
             })))
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(
-                json!({
-                    "jsonrpc": "2.0",
-                    "id": 2,
-                    "result": null,
-                })
-                .to_string(),
-            )
+            .with_body(missing_block_response(2).to_string())
             .create_async()
             .await;
 
@@ -1667,38 +1669,100 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn catchup_iter_fetches_batches_lazily() {
+    async fn ethereum_client_get_blocks_preserves_request_order() {
         let mut server = Server::new_async().await;
 
-        fn block_response(request_id: u64, number: u64) -> serde_json::Value {
-            json!({
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "result": {
-                    "number": format!("0x{number:x}"),
-                    "hash": format!("0x{:064x}", number),
-                    "parentHash": format!("0x{:064x}", number.saturating_sub(1)),
-                    "sha3Uncles": format!("0x{:064x}", 1),
-                    "logsBloom": format!("0x{}", "0".repeat(512)),
-                    "transactionsRoot": format!("0x{:064x}", 2),
-                    "stateRoot": format!("0x{:064x}", 3),
-                    "receiptsRoot": format!("0x{:064x}", 4),
-                    "miner": format!("0x{:040x}", 5),
-                    "difficulty": "0x0",
-                    "totalDifficulty": "0x0",
-                    "extraData": "0x",
-                    "size": "0x1",
-                    "gasLimit": "0x1c9c380",
-                    "gasUsed": "0x0",
-                    "timestamp": "0x1",
-                    "uncles": [],
-                    "nonce": "0x0000000000000000",
-                    "mixHash": format!("0x{:064x}", 9),
-                    "baseFeePerGas": "0x1",
-                    "transactions": []
-                }
-            })
-        }
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex("eth_getBlockByNumber".to_string()))
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!([
+                    block_response(3, 9),
+                    block_response(1, 7),
+                    missing_block_response(2),
+                ])
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let client = EthereumClient::DirectRpc(
+            super::indexer_eth_direct_rpc::RpcEthereumClient::new(&server.url()),
+        );
+        let block_ids = vec![
+            BlockId::Number(BlockNumberOrTag::Number(7)),
+            BlockId::Number(BlockNumberOrTag::Number(8)),
+            BlockId::Number(BlockNumberOrTag::Number(9)),
+        ];
+
+        let blocks = client.get_blocks(&block_ids).await;
+
+        assert_eq!(blocks.len(), 3);
+        assert!(matches!(&blocks[0], MaybeBlock::Block(block) if block.header.number == 7));
+        assert!(matches!(
+            &blocks[1],
+            MaybeBlock::Missing(BlockId::Number(BlockNumberOrTag::Number(8)))
+        ));
+        assert!(matches!(&blocks[2], MaybeBlock::Block(block) if block.header.number == 9));
+    }
+
+    #[tokio::test]
+    async fn ethereum_client_get_blocks_retries_and_keeps_positions() {
+        let mut server = Server::new_async().await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex("eth_getBlockByNumber".to_string()))
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({ "jsonrpc": "2.0", "result": "invalid-shape" }).to_string())
+            .create_async()
+            .await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex("eth_getBlockByNumber".to_string()))
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!([
+                    block_response(4, 20),
+                    missing_block_response(5),
+                    block_response(6, 22),
+                ])
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let client = EthereumClient::DirectRpc(
+            super::indexer_eth_direct_rpc::RpcEthereumClient::new(&server.url()),
+        );
+        let block_ids = vec![
+            BlockId::Number(BlockNumberOrTag::Number(20)),
+            BlockId::Number(BlockNumberOrTag::Number(21)),
+            BlockId::Number(BlockNumberOrTag::Number(22)),
+        ];
+
+        let blocks = client.get_blocks(&block_ids).await;
+
+        assert_eq!(blocks.len(), 3);
+        assert!(matches!(&blocks[0], MaybeBlock::Block(block) if block.header.number == 20));
+        assert!(matches!(
+            &blocks[1],
+            MaybeBlock::Missing(BlockId::Number(BlockNumberOrTag::Number(21)))
+        ));
+        assert!(matches!(&blocks[2], MaybeBlock::Block(block) if block.header.number == 22));
+    }
+
+    #[tokio::test]
+    async fn catchup_iter_fetches_batches_lazily() {
+        let mut server = Server::new_async().await;
 
         let first_batch = (10..42)
             .enumerate()
@@ -1746,6 +1810,69 @@ mod tests {
         assert!(matches!(next, Some(MaybeBlock::Block(block)) if block.header.number == 42));
         assert!(second_batch_mock.matched_async().await);
         assert!(iter.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn catchup_iter_splits_requests_into_32_32_1_batches() {
+        let mut server = Server::new_async().await;
+
+        let first_batch = (0..32)
+            .enumerate()
+            .map(|(idx, block_number)| block_response(idx as u64 + 1, block_number))
+            .collect::<Vec<_>>();
+        let second_batch = (32..64)
+            .enumerate()
+            .map(|(idx, block_number)| block_response((idx + 33) as u64, block_number))
+            .collect::<Vec<_>>();
+        let third_batch = vec![block_response(65, 64)];
+
+        let first_batch_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex(r#"\"id\":32"#.to_string()))
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!(first_batch).to_string())
+            .create_async()
+            .await;
+
+        let second_batch_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex(r#"\"id\":64"#.to_string()))
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!(second_batch).to_string())
+            .create_async()
+            .await;
+
+        let third_batch_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex(r#"\"id\":65"#.to_string()))
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!(third_batch).to_string())
+            .create_async()
+            .await;
+
+        let client = Arc::new(EthereumClient::DirectRpc(
+            super::indexer_eth_direct_rpc::RpcEthereumClient::new(&server.url()),
+        ));
+        let mut iter = CatchupIter::new(client, 0, 65);
+
+        for expected_number in 0..65 {
+            let next = iter.next().await;
+            assert!(matches!(
+                next,
+                Some(MaybeBlock::Block(block)) if block.header.number == expected_number
+            ));
+        }
+
+        assert!(iter.next().await.is_none());
+        assert!(first_batch_mock.matched_async().await);
+        assert!(second_batch_mock.matched_async().await);
+        assert!(third_batch_mock.matched_async().await);
     }
 
     #[tokio::test]

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -1407,9 +1407,14 @@ impl ChainIndexer for EthereumIndexer {
         let block = match block {
             MaybeBlock::Block(block) => block,
             MaybeBlock::Missing(block_id) => {
-                tracing::warn!(?block_id, "ethereum catchup block missing from batch; refetching");
+                tracing::warn!(
+                    ?block_id,
+                    "ethereum catchup block missing from batch; refetching"
+                );
                 let Some(block) = self.client.get_block(*block_id).await else {
-                    anyhow::bail!("ethereum catchup block {block_id:?} is still unavailable after refetch")
+                    anyhow::bail!(
+                        "ethereum catchup block {block_id:?} is still unavailable after refetch"
+                    )
                 };
                 _block = block;
                 &_block
@@ -1521,9 +1526,6 @@ mod tests {
             EthereumClient::clamp_oldest_supported_with(1, anchor_height, max_catchup_blocks),
             expected_oldest,
         );
-
-        let heights: Vec<u64> = vec![2, 3, 4].into_iter().collect();
-        assert_eq!(heights, vec![2, 3, 4]);
     }
 
     #[tokio::test]
@@ -1615,11 +1617,16 @@ mod tests {
         };
 
         indexer
-            .process_catchup(&MaybeBlock::Missing(BlockId::Number(BlockNumberOrTag::Number(12))))
+            .process_catchup(&MaybeBlock::Missing(BlockId::Number(
+                BlockNumberOrTag::Number(12),
+            )))
             .await
             .expect("missing catchup block should be refetched successfully");
 
-        assert!(matches!(events_rx.recv().await, Some(ChainEvent::Block(12))));
+        assert!(matches!(
+            events_rx.recv().await,
+            Some(ChainEvent::Block(12))
+        ));
     }
 
     #[tokio::test]
@@ -1649,14 +1656,14 @@ mod tests {
         };
 
         let err = indexer
-            .process_catchup(&MaybeBlock::Missing(BlockId::Number(BlockNumberOrTag::Number(12))))
+            .process_catchup(&MaybeBlock::Missing(BlockId::Number(
+                BlockNumberOrTag::Number(12),
+            )))
             .await
             .expect_err("missing catchup block should fail when refetch cannot recover it");
 
         assert!(events_rx.try_recv().is_err());
-        assert!(err
-            .to_string()
-            .contains("still unavailable after refetch"));
+        assert!(err.to_string().contains("still unavailable after refetch"));
     }
 
     #[tokio::test]

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -43,7 +43,7 @@ type BlockNumber = u64;
 #[allow(clippy::large_enum_variant)]
 pub enum MaybeBlock {
     Block(Block),
-    Missing(BlockNumber),
+    Missing(BlockId),
 }
 
 pub struct BlockAndRequests {
@@ -707,8 +707,9 @@ impl EthereumClient {
             EthereumClient::DirectRpc(client) => client.get_nonce(address, block_id).await,
         }
     }
+
     fn missing_block(block_id: BlockId) -> MaybeBlock {
-        MaybeBlock::Missing(Self::block_number_from_id(block_id))
+        MaybeBlock::Missing(block_id)
     }
 
     fn block_number_from_id(block_id: BlockId) -> BlockNumber {
@@ -1510,7 +1511,7 @@ mod tests {
         };
 
         indexer
-            .process_catchup(&MaybeBlock::Missing(42))
+            .process_catchup(&MaybeBlock::Missing(BlockId::Number(BlockNumberOrTag::Number(12))))
             .await
             .expect("missing catchup block should not fail");
 

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -1,11 +1,11 @@
+use crate::backlog::Backlog;
 use crate::protocol::{Chain, IndexedSignRequest};
 use crate::sign_bidirectional::hash_rlp_data;
 use crate::stream::ops::{SignatureEvent, SignatureEventBox};
-use crate::stream::{ChainEvent, ChainStream, DisabledChainIndexer};
+use crate::stream::{ChainEvent, ChainIndexer, ChainStream};
 use crate::util::retry::{retry_async, RetryConfig, RetryError, RetryReason};
 
-use async_trait::async_trait;
-use std::collections::HashMap;
+use std::collections::{btree_map, BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 use std::str::FromStr;
 use std::time::{Duration, Instant};
@@ -14,6 +14,7 @@ use alloy_sol_types::SolValue;
 use anchor_client::anchor_lang::AnchorDeserialize;
 use anchor_lang::solana_program::keccak;
 use anchor_lang::Discriminator;
+use async_trait::async_trait;
 use ethabi::{encode, Token};
 use futures_util::StreamExt;
 use k256::elliptic_curve::sec1::FromEncodedPoint;
@@ -29,9 +30,15 @@ use signet_program::{
 };
 use solana_client::{
     nonblocking::{pubsub_client::PubsubClient, rpc_client::RpcClient},
+    rpc_client::GetConfirmedSignaturesForAddress2Config,
     rpc_config::{RpcTransactionLogsConfig, RpcTransactionLogsFilter},
 };
 use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey, signature::Signature};
+use solana_transaction_status::option_serializer::OptionSerializer;
+use solana_transaction_status::{
+    EncodedConfirmedBlock, EncodedConfirmedTransactionWithStatusMeta, EncodedTransaction,
+    EncodedTransactionWithStatusMeta, UiTransactionEncoding,
+};
 use tokio::sync::mpsc;
 
 const CPI_EVENT_HINTS: &[&str] = &[
@@ -286,6 +293,8 @@ impl SignatureEvent for SignBidirectionalEvent {
 
 type Result<T> = anyhow::Result<T>;
 
+const MAX_SIGNATURES_FOR_FAST_CATCHUP: usize = 1000;
+
 /// Solana stream that implements the new ChainStream abstraction
 pub struct SolanaStream {
     rx: Option<mpsc::Receiver<ChainEvent>>,
@@ -293,10 +302,21 @@ pub struct SolanaStream {
     tasks: Vec<tokio::task::JoinHandle<()>>,
 }
 
+pub struct SolanaIndexer {
+    program_id: Pubkey,
+    rpc_client: RpcClient,
+    rpc_http_url: String,
+    rpc_ws_url: String,
+    events_tx: mpsc::Sender<ChainEvent>,
+    backlog: Backlog,
+    live_rx: Option<mpsc::Receiver<ChainEvent>>,
+}
+
 struct SolanaStreamStartState {
     program_id: Pubkey,
     rpc_http_url: String,
     rpc_ws_url: String,
+    backlog: Backlog,
     tx: mpsc::Sender<ChainEvent>,
 }
 
@@ -309,7 +329,7 @@ impl Drop for SolanaStream {
 }
 
 impl SolanaStream {
-    pub fn new(sol: Option<SolConfig>) -> Option<Self> {
+    pub fn new(sol: Option<SolConfig>, backlog: Backlog) -> Option<Self> {
         let Some(sol) = sol else {
             tracing::warn!("solana indexer is disabled");
             return None;
@@ -328,6 +348,7 @@ impl SolanaStream {
                 program_id,
                 rpc_http_url: sol.rpc_http_url.clone(),
                 rpc_ws_url: sol.rpc_ws_url.clone(),
+                backlog,
                 tx,
             }),
             tasks: Vec::new(),
@@ -338,20 +359,24 @@ impl SolanaStream {
 #[async_trait]
 impl ChainStream for SolanaStream {
     const CHAIN: Chain = Chain::Solana;
-    type Indexer = DisabledChainIndexer;
+    type Indexer = SolanaIndexer;
 
     async fn start(&mut self) -> anyhow::Result<Self::Indexer> {
         let Some(start_state) = self.start_state.take() else {
             anyhow::bail!("solana stream already started");
         };
 
-        self.tasks.push(spawn_events(
-            start_state.program_id,
-            start_state.rpc_http_url.clone(),
-            start_state.rpc_ws_url.clone(),
-            start_state.tx.clone(),
-        ));
-        Ok(DisabledChainIndexer::new(start_state.tx))
+        let indexer = SolanaIndexer {
+            program_id: start_state.program_id,
+            rpc_client: RpcClient::new(start_state.rpc_http_url.clone()),
+            rpc_http_url: start_state.rpc_http_url.clone(),
+            rpc_ws_url: start_state.rpc_ws_url.clone(),
+            events_tx: start_state.tx.clone(),
+            backlog: start_state.backlog.clone(),
+            live_rx: None,
+        };
+
+        Ok(indexer)
     }
 
     async fn next_event(&mut self) -> Option<ChainEvent> {
@@ -362,18 +387,204 @@ impl ChainStream for SolanaStream {
     }
 }
 
-fn spawn_events(
-    program_id: Pubkey,
-    rpc_url: String,
-    ws_url: String,
-    events_tx: mpsc::Sender<ChainEvent>,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(subscribe_and_process_events(
-        program_id,
-        rpc_url.clone(),
-        ws_url.clone(),
-        events_tx.clone(),
-    ))
+#[async_trait]
+impl ChainIndexer for SolanaIndexer {
+    type Block = (u64, EncodedConfirmedBlock);
+    type Iter = btree_map::IntoIter<u64, EncodedConfirmedBlock>;
+
+    async fn livestream(&mut self) -> anyhow::Result<Option<u64>> {
+        let (live_tx, live_rx) = crate::stream::channel();
+        self.live_rx = Some(live_rx);
+
+        let program_id = self.program_id;
+        let rpc_http_url = self.rpc_http_url.clone();
+        let rpc_ws_url = self.rpc_ws_url.clone();
+
+        // Oneshot to receive the first observed slot from the live subscription.
+        let (anchor_tx, anchor_rx) = tokio::sync::oneshot::channel::<u64>();
+
+        tokio::spawn(subscribe_and_buffer_live_events(
+            program_id,
+            rpc_http_url,
+            rpc_ws_url,
+            live_tx,
+            anchor_tx,
+        ));
+
+        // Wait for the first slot observed on the live feed to use as anchor.
+        Ok(Some(anchor_rx.await?))
+    }
+
+    async fn catchup_range(&self, anchor_height: u64) -> Self::Iter {
+        // Get the last persisted processed block height from backlog
+        let last_processed = self
+            .backlog
+            .processed_block(Chain::Solana)
+            .await
+            .map(|n| n.saturating_add(1))
+            .unwrap_or(0);
+        // TODO: https://github.com/sig-net/mpc/issues/777
+        let start_slot = last_processed.max(1); // Ensure we start from at least slot 1
+        let end_slot = anchor_height.saturating_sub(1); // We want to catch up to just before the anchor
+
+        // This fetches a sparse list of transactions based on whether our program received
+        // a transaction in that specific slot. This is the most optimized and cheapest path.
+        let signatures = match self
+            .rpc_client
+            .get_signatures_for_address_with_config(
+                &self.program_id,
+                GetConfirmedSignaturesForAddress2Config {
+                    before: None,
+                    until: None,
+                    limit: Some(MAX_SIGNATURES_FOR_FAST_CATCHUP),
+                    commitment: Some(CommitmentConfig::confirmed()),
+                },
+            )
+            .await
+        {
+            Ok(signatures) => signatures,
+            Err(err) => {
+                tracing::warn!(
+                    ?err,
+                    "failed to query solana signature history; falling back to sparse catchup"
+                );
+                return self
+                    .fetch_sparse_blocks(start_slot, end_slot)
+                    .await
+                    .into_iter();
+            }
+        };
+
+        let signatures_len = signatures.len();
+        let mut mid_slot = None;
+        let mut slots = BTreeSet::new();
+        for sig in signatures {
+            if sig.slot < start_slot || sig.slot >= end_slot {
+                continue;
+            }
+            mid_slot = Some(mid_slot.unwrap_or(sig.slot).min(sig.slot));
+            slots.insert(sig.slot);
+        }
+        let mid_slot = mid_slot.map(|n| n.saturating_sub(1)).unwrap_or(start_slot);
+        let mut items = self.fetch_blocks_for_slots(slots).await;
+
+        // NOTE: since we can only do fast catchup for up to 1000 signatures,
+        // if we hit that limit and the earliest signature is significantly
+        // ahead of our start slot, we do one additional fetch for the
+        // sparse blocks between start_slot and the earliest signature (mid_slot).
+        if signatures_len == MAX_SIGNATURES_FOR_FAST_CATCHUP && mid_slot > start_slot {
+            tracing::info!(
+                start_slot,
+                mid_slot,
+                "solana signature history hit the 1000-signature limit; combining sparse blocks with signatures"
+            );
+            items.extend(self.fetch_sparse_blocks(start_slot, mid_slot).await);
+        }
+
+        items.into_iter()
+    }
+
+    async fn process_catchup(&mut self, (height, block): &Self::Block) -> anyhow::Result<()> {
+        self.process_block(*height, block).await
+    }
+
+    async fn process_next_block(&mut self) -> bool {
+        let Some(rx) = self.live_rx.as_mut() else {
+            return false;
+        };
+        let Some(event) = rx.recv().await else {
+            return false;
+        };
+        if let Err(err) = self.events_tx.send(event).await {
+            tracing::warn!(?err, "failed to forward live solana event");
+            return false;
+        }
+        true
+    }
+
+    async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {
+        self.events_tx.send(ChainEvent::CatchupCompleted).await?;
+        Ok(())
+    }
+}
+
+impl SolanaIndexer {
+    async fn fetch_blocks_for_slots(
+        &self,
+        slots: BTreeSet<u64>,
+    ) -> BTreeMap<u64, EncodedConfirmedBlock> {
+        let mut blocks_by_height = BTreeMap::new();
+
+        for slot in slots {
+            match self.rpc_client.get_block(slot).await {
+                Ok(block) => {
+                    blocks_by_height.insert(slot, block);
+                }
+                Err(err) => {
+                    tracing::warn!(?err, slot, "failed to fetch Solana block for catchup slot");
+                }
+            }
+        }
+
+        blocks_by_height
+    }
+
+    async fn process_block(
+        &mut self,
+        height: u64,
+        block: &EncodedConfirmedBlock,
+    ) -> anyhow::Result<()> {
+        for tx in &block.transactions {
+            let Some(logs) = tx
+                .meta
+                .as_ref()
+                .and_then(|meta| match meta.log_messages.as_ref() {
+                    OptionSerializer::Some(logs) => Some(logs.clone()),
+                    _ => None,
+                })
+            else {
+                continue;
+            };
+
+            let signature = extract_tx_signature(&tx.transaction)?;
+            emit_events(&self.events_tx, &self.program_id, signature, tx, &logs).await?;
+        }
+
+        self.events_tx.send(ChainEvent::Block(height)).await?;
+        Ok(())
+    }
+
+    /// Fetches blocks from start_slot to end_slot. The range is inclusive `[start_slot, endslot]`
+    async fn fetch_sparse_blocks(
+        &self,
+        start_slot: u64,
+        end_slot: u64,
+    ) -> BTreeMap<u64, EncodedConfirmedBlock> {
+        let mut blocks_by_height = BTreeMap::new();
+
+        // Fetch all blocks in the range from start_slot to end_slot
+        let Ok(block_slots) = self.rpc_client.get_blocks(start_slot, Some(end_slot)).await else {
+            tracing::warn!(start_slot, end_slot, "failed to fetch blocks for range");
+            return BTreeMap::new();
+        };
+
+        for slot in block_slots {
+            if slot >= end_slot {
+                continue;
+            }
+
+            match self.rpc_client.get_block(slot).await {
+                Ok(block) => {
+                    blocks_by_height.insert(slot, block);
+                }
+                Err(err) => {
+                    tracing::warn!(?err, slot, "failed to cache Solana block for catchup");
+                }
+            }
+        }
+
+        blocks_by_height
+    }
 }
 
 fn build_sign_request(
@@ -385,38 +596,43 @@ fn build_sign_request(
     sign_event.generate_sign_request(entropy)
 }
 
-// Reference: https://github.com/solana-foundation/anchor/blob/a5df519319ac39cff21191f2b09d54eda42c5716/client/src/lib.rs#L31
-async fn subscribe_and_process_events(
+/// Subscribe to the live WS feed, preprocess events into `ChainEvent`s, and buffer them
+/// in `live_tx`. The anchor slot (current confirmed slot + 1 at subscription time) is sent
+/// via `anchor_tx` so that `livestream()` can return it to the catchup logic.
+///
+/// Events accumulate in the channel while catchup runs; `process_next_block` drains them
+/// only after catchup completes (enforced by `catchup_then_livestream`).
+async fn subscribe_and_buffer_live_events(
     program_id: Pubkey,
     rpc_url: String,
     ws_url: String,
-    events_tx: mpsc::Sender<ChainEvent>,
+    live_tx: mpsc::Sender<ChainEvent>,
+    anchor_tx: tokio::sync::oneshot::Sender<u64>,
 ) {
+    // Get anchor slot immediately so livestream() can return without waiting for an event.
+    let anchor = {
+        let rpc = RpcClient::new(rpc_url.clone());
+        loop {
+            match rpc
+                .get_slot_with_commitment(CommitmentConfig::confirmed())
+                .await
+            {
+                Ok(slot) => break slot.saturating_add(1),
+                Err(err) => {
+                    tracing::warn!(?err, "failed to get anchor slot; retrying");
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+    };
+    let _ = anchor_tx.send(anchor);
+
     loop {
-        let events_tx_clone = events_tx.clone();
-        let result = subscribe_to_program_events(
-            program_id,
-            &rpc_url,
-            &ws_url,
-            events_tx.clone(),
-            move |event, signature: solana_sdk::signature::Signature, _slot| {
-                tracing::info!("got event: {:?}", event);
-                let tx_sig: Vec<u8> = signature.as_ref().to_vec();
-                let events_tx = events_tx_clone.clone();
-                tokio::spawn(async move {
-                    match build_sign_request(event, tx_sig) {
-                        Ok(req) => {
-                            let _ = events_tx.send(ChainEvent::SignRequest(req)).await;
-                        }
-                        Err(err) => tracing::warn!("Failed to process event: {:?}", err),
-                    }
-                });
-            },
-        )
-        .await;
+        let result =
+            subscribe_to_program_events(program_id, &rpc_url, &ws_url, live_tx.clone()).await;
 
         if let Err(err) = result {
-            tracing::warn!("Failed to subscribe to solana events: {:?}", err);
+            tracing::warn!("Live solana subscription failed: {:?}", err);
         }
 
         tokio::time::sleep(Duration::from_secs(1)).await;
@@ -424,12 +640,12 @@ async fn subscribe_and_process_events(
 }
 
 fn parse_cpi_events(
-    tx: solana_transaction_status::EncodedConfirmedTransactionWithStatusMeta,
+    tx: EncodedTransactionWithStatusMeta,
     target_program_id: &Pubkey,
 ) -> Result<Vec<SignatureEventBox>> {
     use solana_transaction_status::{UiInstruction, UiParsedInstruction};
 
-    let Some(meta) = tx.transaction.meta else {
+    let Some(meta) = tx.meta else {
         return Ok(Vec::new());
     };
 
@@ -481,7 +697,7 @@ fn parse_cpi_events(
 
     // Look into inner instructions for CPI calls
     let inner_ixs = match meta.inner_instructions {
-        solana_transaction_status::option_serializer::OptionSerializer::Some(ixs) => ixs,
+        OptionSerializer::Some(ixs) => ixs,
         _ => return Ok(Vec::new()),
     };
 
@@ -516,16 +732,12 @@ fn parse_cpi_events(
     Ok(out)
 }
 
-async fn subscribe_to_program_events<F>(
+async fn subscribe_to_program_events(
     program_id: Pubkey,
     rpc_url: &str,
     ws_url: &str,
     events_tx: mpsc::Sender<ChainEvent>,
-    mut sign_event_handler: F,
-) -> Result<()>
-where
-    F: FnMut(SignatureEventBox, Signature, u64) + Send,
-{
+) -> Result<()> {
     let rpc_client = RpcClient::new(rpc_url.to_string());
     let pubsub_client = PubsubClient::new(ws_url).await?;
 
@@ -585,35 +797,17 @@ where
                         let now = Instant::now();
                         seen.insert(signature, now);
 
-                        // Reference: https://github.com/solana-foundation/anchor/blob/a5df519319ac39cff21191f2b09d54eda42c5716/client/src/lib.rs#L311
-                        if looks_like_cpi_sign_event(logs) {
-                            match parse_cpi_events(tx_res, &program_id) {
-                                Ok(events) => {
-                                    for ev in events {
-                                        sign_event_handler(ev, signature, response.context.slot);
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::warn!("Failed to parse cpi events for {}: {}", signature, e);
-                                    continue;
-                                }
-                            }
-                        } else if looks_like_respond_event(logs) {
-                            let (respond_bidirectional_events, respond_events) = match parse_cpi_respond_events(tx_res, &program_id) {
-                                Ok(v) => v,
-                                Err(err) => {
-                                    tracing::warn!(?err, sig = %signature, "failed to parse respond events (will skip this signature)");
-                                    continue;
-                                }
-                            };
-
-                            for ev in respond_bidirectional_events {
-                                let _ = events_tx.send(ChainEvent::RespondBidirectional(crate::stream::ops::RespondBidirectionalEvent::Solana(ev))).await;
-                            }
-
-                            for ev in respond_events {
-                                let _ = events_tx.send(ChainEvent::Respond(crate::stream::ops::SignatureRespondedEvent::Solana(ev))).await;
-                            }
+                        if let Err(err) = emit_events(
+                            &events_tx,
+                            &program_id,
+                            signature,
+                            &tx_res.transaction,
+                            logs,
+                        )
+                        .await
+                        {
+                            tracing::warn!(?err, sig = %signature, "failed to parse solana tx events");
+                            continue;
                         }
 
                         // Emit block event for every observed slot
@@ -656,12 +850,12 @@ fn has_log_starts_with(logs: &[String], start_with: &str) -> bool {
 }
 
 fn parse_cpi_respond_events(
-    tx: solana_transaction_status::EncodedConfirmedTransactionWithStatusMeta,
+    tx: EncodedTransactionWithStatusMeta,
     target_program_id: &Pubkey,
 ) -> Result<(Vec<RespondBidirectionalEvent>, Vec<SignatureRespondedEvent>)> {
     use solana_transaction_status::{UiInstruction, UiParsedInstruction};
 
-    let Some(meta) = tx.transaction.meta else {
+    let Some(meta) = tx.meta else {
         return Ok((Vec::new(), Vec::new()));
     };
 
@@ -713,7 +907,7 @@ fn parse_cpi_respond_events(
 
     // Look into inner instructions for CPI calls
     let inner_ixs = match meta.inner_instructions {
-        solana_transaction_status::option_serializer::OptionSerializer::Some(ixs) => ixs,
+        OptionSerializer::Some(ixs) => ixs,
         _ => return Ok((Vec::new(), Vec::new())),
     };
 
@@ -757,6 +951,90 @@ fn parse_cpi_respond_events(
     Ok((respond_bidirectional_events, signature_responded_events))
 }
 
+enum SolanaEvents {
+    Sign(Vec<SignatureEventBox>),
+    Respond {
+        bidirectional: Vec<RespondBidirectionalEvent>,
+        responded: Vec<SignatureRespondedEvent>,
+    },
+    None,
+}
+
+impl SolanaEvents {
+    fn parse(
+        tx: EncodedTransactionWithStatusMeta,
+        target_program_id: &Pubkey,
+        logs: &[String],
+    ) -> Result<Self> {
+        if looks_like_cpi_sign_event(logs) {
+            Ok(SolanaEvents::Sign(parse_cpi_events(tx, target_program_id)?))
+        } else if looks_like_respond_event(logs) {
+            let (bidirectional, responded) = parse_cpi_respond_events(tx, target_program_id)?;
+            Ok(SolanaEvents::Respond {
+                bidirectional,
+                responded,
+            })
+        } else {
+            Ok(SolanaEvents::None)
+        }
+    }
+}
+
+async fn emit_events(
+    events_tx: &mpsc::Sender<ChainEvent>,
+    program_id: &Pubkey,
+    signature: Signature,
+    tx: &EncodedTransactionWithStatusMeta,
+    logs: &[String],
+) -> Result<()> {
+    match SolanaEvents::parse(tx.clone(), program_id, logs)? {
+        SolanaEvents::Sign(events) => {
+            for ev in events {
+                let req = build_sign_request(ev, signature.as_ref().to_vec())?;
+                events_tx.send(ChainEvent::SignRequest(req)).await?;
+            }
+        }
+        SolanaEvents::Respond {
+            bidirectional,
+            responded,
+        } => {
+            for ev in bidirectional {
+                let _ = events_tx
+                    .send(ChainEvent::RespondBidirectional(
+                        crate::stream::ops::RespondBidirectionalEvent::Solana(ev),
+                    ))
+                    .await;
+            }
+
+            for ev in responded {
+                let _ = events_tx
+                    .send(ChainEvent::Respond(
+                        crate::stream::ops::SignatureRespondedEvent::Solana(ev),
+                    ))
+                    .await;
+            }
+        }
+        SolanaEvents::None => {}
+    }
+    Ok(())
+}
+
+fn extract_tx_signature(tx: &EncodedTransaction) -> anyhow::Result<Signature> {
+    match tx {
+        EncodedTransaction::Json(ui_tx) => {
+            let signature = ui_tx
+                .signatures
+                .first()
+                .ok_or_else(|| anyhow::anyhow!("missing signature in block transaction"))?;
+            Signature::from_str(signature)
+                .map_err(|err| anyhow::anyhow!(err).context("failed to parse block signature"))
+        }
+        other => Err(anyhow::anyhow!(
+            "unsupported encoded transaction variant in block catchup: {other:?}"
+        )),
+    }
+}
+
 // Clean up seen cache based on TTL
 fn cleanup_seen_cache(seen: &mut HashMap<Signature, Instant>, ttl: Duration) {
     let now = Instant::now();
@@ -795,7 +1073,7 @@ async fn get_tx(
     rpc_client: &RpcClient,
     signature: &Signature,
     retry_cfg: RetryConfig,
-) -> anyhow::Result<solana_transaction_status::EncodedConfirmedTransactionWithStatusMeta> {
+) -> anyhow::Result<EncodedConfirmedTransactionWithStatusMeta> {
     let max_attempts = retry_cfg.max_attempts;
 
     let res = retry_async(
@@ -805,7 +1083,7 @@ async fn get_tx(
                 .get_transaction_with_config(
                     signature,
                     solana_client::rpc_config::RpcTransactionConfig {
-                        encoding: Some(solana_transaction_status::UiTransactionEncoding::JsonParsed),
+                        encoding: Some(UiTransactionEncoding::JsonParsed),
                         commitment: Some(CommitmentConfig::confirmed()),
                         max_supported_transaction_version: Some(0),
                     },

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -541,7 +541,7 @@ impl SolanaIndexer {
                 .meta
                 .as_ref()
                 .and_then(|meta| match meta.log_messages.as_ref() {
-                    OptionSerializer::Some(logs) => Some(logs.clone()),
+                    OptionSerializer::Some(logs) => Some(logs),
                     _ => None,
                 })
             else {
@@ -549,7 +549,7 @@ impl SolanaIndexer {
             };
 
             let signature = extract_tx_signature(&tx.transaction)?;
-            emit_events(&self.events_tx, &self.program_id, signature, tx, &logs).await?;
+            emit_events(&self.events_tx, &self.program_id, signature, tx, logs).await?;
         }
 
         self.events_tx.send(ChainEvent::Block(height)).await?;
@@ -642,12 +642,12 @@ async fn subscribe_and_buffer_live_events(
 }
 
 fn parse_cpi_events(
-    tx: EncodedTransactionWithStatusMeta,
+    tx: &EncodedTransactionWithStatusMeta,
     target_program_id: &Pubkey,
 ) -> Result<Vec<SignatureEventBox>> {
     use solana_transaction_status::{UiInstruction, UiParsedInstruction};
 
-    let Some(meta) = tx.meta else {
+    let Some(meta) = &tx.meta else {
         return Ok(Vec::new());
     };
 
@@ -698,7 +698,7 @@ fn parse_cpi_events(
     };
 
     // Look into inner instructions for CPI calls
-    let inner_ixs = match meta.inner_instructions {
+    let inner_ixs = match &meta.inner_instructions {
         OptionSerializer::Some(ixs) => ixs,
         _ => return Ok(Vec::new()),
     };
@@ -852,12 +852,12 @@ fn has_log_starts_with(logs: &[String], start_with: &str) -> bool {
 }
 
 fn parse_cpi_respond_events(
-    tx: EncodedTransactionWithStatusMeta,
+    tx: &EncodedTransactionWithStatusMeta,
     target_program_id: &Pubkey,
 ) -> Result<(Vec<RespondBidirectionalEvent>, Vec<SignatureRespondedEvent>)> {
     use solana_transaction_status::{UiInstruction, UiParsedInstruction};
 
-    let Some(meta) = tx.meta else {
+    let Some(meta) = &tx.meta else {
         return Ok((Vec::new(), Vec::new()));
     };
 
@@ -908,7 +908,7 @@ fn parse_cpi_respond_events(
         };
 
     // Look into inner instructions for CPI calls
-    let inner_ixs = match meta.inner_instructions {
+    let inner_ixs = match &meta.inner_instructions {
         OptionSerializer::Some(ixs) => ixs,
         _ => return Ok((Vec::new(), Vec::new())),
     };
@@ -964,7 +964,7 @@ enum SolanaEvents {
 
 impl SolanaEvents {
     fn parse(
-        tx: EncodedTransactionWithStatusMeta,
+        tx: &EncodedTransactionWithStatusMeta,
         target_program_id: &Pubkey,
         logs: &[String],
     ) -> Result<Self> {
@@ -989,7 +989,7 @@ async fn emit_events(
     tx: &EncodedTransactionWithStatusMeta,
     logs: &[String],
 ) -> Result<()> {
-    match SolanaEvents::parse(tx.clone(), program_id, logs)? {
+    match SolanaEvents::parse(tx, program_id, logs)? {
         SolanaEvents::Sign(events) => {
             for ev in events {
                 let req = build_sign_request(ev, signature.as_ref().to_vec())?;

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -358,7 +358,6 @@ impl SolanaStream {
 
 #[async_trait]
 impl ChainStream for SolanaStream {
-    const CHAIN: Chain = Chain::Solana;
     type Indexer = SolanaIndexer;
 
     async fn start(&mut self) -> anyhow::Result<Self::Indexer> {
@@ -389,6 +388,7 @@ impl ChainStream for SolanaStream {
 
 #[async_trait]
 impl ChainIndexer for SolanaIndexer {
+    const CHAIN: Chain = Chain::Solana;
     type Block = (u64, EncodedConfirmedBlock);
     type Iter = btree_map::IntoIter<u64, EncodedConfirmedBlock>;
 
@@ -599,7 +599,7 @@ fn build_sign_request(
 }
 
 /// Subscribe to the live WS feed, preprocess events into `ChainEvent`s, and buffer them
-/// in `live_tx`. The anchor slot (current confirmed slot + 1 at subscription time) is sent
+/// in `live_tx`. The anchor slot (current confirmed slot at subscription time) is sent
 /// via `anchor_tx` so that `livestream()` can return it to the catchup logic.
 ///
 /// Events accumulate in the channel while catchup runs; `process_next_block` drains them
@@ -612,26 +612,12 @@ async fn subscribe_and_buffer_live_events(
     anchor_tx: oneshot::Sender<u64>,
 ) {
     // Get anchor slot immediately so livestream() can return without waiting for an event.
-    let anchor = {
-        let rpc = RpcClient::new(rpc_url.clone());
-        loop {
-            match rpc
-                .get_slot_with_commitment(CommitmentConfig::confirmed())
-                .await
-            {
-                Ok(slot) => break slot.saturating_add(1),
-                Err(err) => {
-                    tracing::warn!(?err, "failed to get anchor slot; retrying");
-                    tokio::time::sleep(Duration::from_secs(1)).await;
-                }
-            }
-        }
-    };
-    let _ = anchor_tx.send(anchor);
-
+    let rpc = RpcClient::new(rpc_url);
+    let mut anchor_tx = Some(anchor_tx);
     loop {
         let result =
-            subscribe_to_program_events(program_id, &rpc_url, &ws_url, live_tx.clone()).await;
+            subscribe_to_program_events(program_id, &rpc, &ws_url, live_tx.clone(), &mut anchor_tx)
+                .await;
 
         if let Err(err) = result {
             tracing::warn!("Live solana subscription failed: {:?}", err);
@@ -736,11 +722,11 @@ fn parse_cpi_events(
 
 async fn subscribe_to_program_events(
     program_id: Pubkey,
-    rpc_url: &str,
+    rpc_client: &RpcClient,
     ws_url: &str,
     events_tx: mpsc::Sender<ChainEvent>,
+    anchor_tx: &mut Option<oneshot::Sender<u64>>,
 ) -> Result<()> {
-    let rpc_client = RpcClient::new(rpc_url.to_string());
     let pubsub_client = PubsubClient::new(ws_url).await?;
 
     let filter = RpcTransactionLogsFilter::Mentions(vec![program_id.to_string()]);
@@ -770,12 +756,19 @@ async fn subscribe_to_program_events(
                     Some(response) => {
                         last_ws_msg = Instant::now();
 
-                        if response.value.err.is_some() {
-                            continue;
+                        let slot = response.context.slot;
+                        if let Some(anchor_tx) = anchor_tx.take() {
+                            // Send the anchor slot back to livestream() on the first received message
+                            let _ = anchor_tx.send(slot);
                         }
 
                         let logs = &response.value.logs;
-                        if !has_log_starts_with(logs, &program_invoke_log) {
+                        if response.value.err.is_some() || !has_log_starts_with(logs, &program_invoke_log) {
+                            // block is not relevant to our program, skip but still
+                            // emit block event for progress tracking
+                            if let Err(err) = events_tx.send(ChainEvent::Block(slot)).await {
+                                tracing::warn!(?err, "failed to send block event");
+                            }
                             continue;
                         }
 
@@ -788,7 +781,7 @@ async fn subscribe_to_program_events(
                             continue;
                         }
 
-                        let tx_res = match get_tx(&rpc_client, &signature, RetryConfig::default()).await {
+                        let tx_res = match get_tx(rpc_client, &signature, RetryConfig::default()).await {
                             Ok(tx) => tx,
                             Err(e) => {
                                 tracing::warn!("Failed to fetch transaction {}: {}", signature, e);
@@ -813,7 +806,7 @@ async fn subscribe_to_program_events(
                         }
 
                         // Emit block event for every observed slot
-                        if let Err(err) = events_tx.send(ChainEvent::Block(response.context.slot)).await {
+                        if let Err(err) = events_tx.send(ChainEvent::Block(slot)).await {
                             tracing::warn!(?err, "failed to send block event");
                         }
                     }

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -615,6 +615,9 @@ async fn subscribe_and_buffer_live_events(
     let rpc = RpcClient::new(rpc_url);
     let mut anchor_tx = Some(anchor_tx);
     loop {
+        // TODO: if solana ever fails and needs to retry, we actually need to do catchup
+        // again. This requires potentially complicating the coordination we have on the
+        // high level of run_stream. Issue: https://github.com/sig-net/mpc/issues/811
         let result =
             subscribe_to_program_events(program_id, &rpc, &ws_url, live_tx.clone(), &mut anchor_tx)
                 .await;

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -417,14 +417,13 @@ impl ChainIndexer for SolanaIndexer {
 
     async fn catchup_range(&self, anchor_height: u64) -> Self::Iter {
         // Get the last persisted processed block height from backlog
-        let last_processed = self
+        // TODO: https://github.com/sig-net/mpc/issues/777
+        let start_slot = self
             .backlog
             .processed_block(Chain::Solana)
             .await
             .map(|n| n.saturating_add(1))
-            .unwrap_or(0);
-        // TODO: https://github.com/sig-net/mpc/issues/777
-        let start_slot = last_processed.max(1); // Ensure we start from at least slot 1
+            .unwrap_or(anchor_height);
         let end_slot = anchor_height.saturating_sub(1); // We want to catch up to just before the anchor
 
         // This fetches a sparse list of transactions based on whether our program received

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -39,7 +39,7 @@ use solana_transaction_status::{
     EncodedConfirmedBlock, EncodedConfirmedTransactionWithStatusMeta, EncodedTransaction,
     EncodedTransactionWithStatusMeta, UiTransactionEncoding,
 };
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 const CPI_EVENT_HINTS: &[&str] = &[
     "Program log: Instruction: Sign",
@@ -401,7 +401,7 @@ impl ChainIndexer for SolanaIndexer {
         let rpc_ws_url = self.rpc_ws_url.clone();
 
         // Oneshot to receive the first observed slot from the live subscription.
-        let (anchor_tx, anchor_rx) = tokio::sync::oneshot::channel::<u64>();
+        let (anchor_tx, anchor_rx) = oneshot::channel::<u64>();
 
         tokio::spawn(subscribe_and_buffer_live_events(
             program_id,
@@ -459,7 +459,7 @@ impl ChainIndexer for SolanaIndexer {
         let mut mid_slot = None;
         let mut slots = BTreeSet::new();
         for sig in signatures {
-            if sig.slot < start_slot || sig.slot >= end_slot {
+            if sig.slot < start_slot || sig.slot > end_slot {
                 continue;
             }
             mid_slot = Some(mid_slot.unwrap_or(sig.slot).min(sig.slot));
@@ -607,7 +607,7 @@ async fn subscribe_and_buffer_live_events(
     rpc_url: String,
     ws_url: String,
     live_tx: mpsc::Sender<ChainEvent>,
-    anchor_tx: tokio::sync::oneshot::Sender<u64>,
+    anchor_tx: oneshot::Sender<u64>,
 ) {
     // Get anchor slot immediately so livestream() can return without waiting for an event.
     let anchor = {
@@ -1029,9 +1029,9 @@ fn extract_tx_signature(tx: &EncodedTransaction) -> anyhow::Result<Signature> {
             Signature::from_str(signature)
                 .map_err(|err| anyhow::anyhow!(err).context("failed to parse block signature"))
         }
-        other => Err(anyhow::anyhow!(
-            "unsupported encoded transaction variant in block catchup: {other:?}"
-        )),
+        other => {
+            anyhow::bail!("unsupported encoded transaction variant in block catchup: {other:?}")
+        }
     }
 }
 

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -568,7 +568,7 @@ impl SolanaIndexer {
         };
 
         for slot in block_slots {
-            if slot >= end_slot {
+            if slot > end_slot {
                 continue;
             }
 

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -425,6 +425,9 @@ impl ChainIndexer for SolanaIndexer {
             .map(|n| n.saturating_add(1))
             .unwrap_or(anchor_height);
         let end_slot = anchor_height.saturating_sub(1); // We want to catch up to just before the anchor
+        if start_slot >= end_slot {
+            return BTreeMap::new().into_iter();
+        }
 
         // This fetches a sparse list of transactions based on whether our program received
         // a transaction in that specific slot. This is the most optimized and cheapest path.

--- a/chain-signatures/node/src/storage/checkpoint_storage.rs
+++ b/chain-signatures/node/src/storage/checkpoint_storage.rs
@@ -10,7 +10,7 @@ use tokio::sync::RwLock;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-const CHECKPOINT_VERSION: &str = "v4";
+const CHECKPOINT_VERSION: &str = "v5";
 
 #[derive(Clone, Debug)]
 pub enum CheckpointStorage {

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -94,9 +94,29 @@ pub enum ExecutionOutcome {
 }
 
 #[async_trait]
+pub trait AsyncCatchupIter: Send + 'static {
+    type Item: Send;
+
+    async fn next(&mut self) -> Option<Self::Item>;
+}
+
+#[async_trait]
+impl<I> AsyncCatchupIter for I
+where
+    I: Iterator + Send + 'static,
+    I::Item: Send,
+{
+    type Item = I::Item;
+
+    async fn next(&mut self) -> Option<Self::Item> {
+        Iterator::next(self)
+    }
+}
+
+#[async_trait]
 pub trait ChainIndexer: Send + 'static {
     type Block: Send;
-    type Iter: Iterator<Item = Self::Block> + Send + 'static;
+    type Iter: AsyncCatchupIter<Item = Self::Block> + Send + 'static;
 
     const RETRY_DELAY: Duration = Duration::from_millis(500);
 
@@ -170,7 +190,8 @@ pub async fn catchup_then_livestream<I: ChainIndexer>(chain: Chain, mut indexer:
         return;
     };
 
-    for catchup_item in indexer.catchup_range(anchor_height).await {
+    let mut catchup_iter = indexer.catchup_range(anchor_height).await;
+    while let Some(catchup_item) = catchup_iter.next().await {
         while let Err(err) = indexer.process_catchup(&catchup_item).await {
             tracing::warn!(?err, %chain, "catchup item processing failed; retrying");
             tokio::time::sleep(I::RETRY_DELAY).await;

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -115,6 +115,7 @@ where
 
 #[async_trait]
 pub trait ChainIndexer: Send + 'static {
+    const CHAIN: Chain;
     type Block: Send;
     type Iter: AsyncCatchupIter<Item = Self::Block> + Send + 'static;
 
@@ -160,14 +161,14 @@ pub trait ChainIndexer: Send + 'static {
 
 #[async_trait]
 pub trait ChainStream: Send + 'static {
-    const CHAIN: Chain;
     type Indexer: ChainIndexer + Send;
 
     async fn start(&mut self) -> anyhow::Result<Self::Indexer>;
     async fn next_event(&mut self) -> Option<ChainEvent>;
 }
 
-pub async fn catchup_then_livestream<I: ChainIndexer>(chain: Chain, mut indexer: I) {
+pub async fn catchup_then_livestream<I: ChainIndexer>(mut indexer: I) {
+    let chain = I::CHAIN;
     tracing::info!(%chain, "starting ChainStream catchup then livestream");
 
     // TODO: on failure, we currently send catchup_completed due to some streams not enabling
@@ -190,6 +191,7 @@ pub async fn catchup_then_livestream<I: ChainIndexer>(chain: Chain, mut indexer:
         return;
     };
 
+    tracing::info!(%chain, anchor_height, "livestream initialized => starting catchup");
     let mut catchup_iter = indexer.catchup_range(anchor_height).await;
     while let Some(catchup_item) = catchup_iter.next().await {
         while let Err(err) = indexer.process_catchup(&catchup_item).await {
@@ -198,6 +200,7 @@ pub async fn catchup_then_livestream<I: ChainIndexer>(chain: Chain, mut indexer:
         }
     }
 
+    tracing::info!(%chain, "catchup completed => processing livestream");
     if let Err(err) = indexer.notify_catchup_completed().await {
         tracing::warn!(?err, %chain, "failed to signal catchup completion");
         return;
@@ -215,7 +218,7 @@ pub async fn run_stream<S: ChainStream>(
     mut mesh_state: watch::Receiver<MeshState>,
     node_client: NodeClient,
 ) {
-    let chain = S::CHAIN;
+    let chain = S::Indexer::CHAIN;
     tracing::info!(%chain, "starting stream");
 
     recover_backlog(
@@ -234,7 +237,7 @@ pub async fn run_stream<S: ChainStream>(
             return;
         }
     };
-    let indexer_task = tokio::spawn(catchup_then_livestream(chain, indexer));
+    let indexer_task = tokio::spawn(catchup_then_livestream(indexer));
 
     let mut caught_up = false;
     while let Some(event) = stream.next_event().await {
@@ -276,11 +279,11 @@ pub async fn run_stream<S: ChainStream>(
                 }
             }
             ChainEvent::Block(block) => {
-                if let Some(checkpoint) = backlog.set_processed_block(S::CHAIN, block).await {
+                if let Some(checkpoint) = backlog.set_processed_block(chain, block).await {
                     tracing::info!(block, ?checkpoint, %chain, "created checkpoint");
                 }
                 crate::metrics::indexers::LATEST_BLOCK_NUMBER
-                    .with_label_values(&[S::CHAIN.as_str(), "finalized"])
+                    .with_label_values(&[chain.as_str(), "finalized"])
                     .set(block as i64);
             }
             ChainEvent::ExecutionConfirmed {
@@ -298,7 +301,7 @@ pub async fn run_stream<S: ChainStream>(
                     result,
                     &backlog,
                     sign_tx.clone(),
-                    S::CHAIN,
+                    chain,
                     caught_up,
                 )
                 .await
@@ -327,6 +330,7 @@ impl DisabledChainIndexer {
 
 #[async_trait]
 impl ChainIndexer for DisabledChainIndexer {
+    const CHAIN: Chain = Chain::Bitcoin;
     type Block = ();
     type Iter = std::iter::Empty<Self::Block>;
 
@@ -398,8 +402,6 @@ mod tests {
 
             #[async_trait]
             impl ChainStream for $name {
-                const CHAIN: Chain = $chain;
-
                 type Indexer = DisabledChainIndexer;
 
                 async fn start(&mut self) -> anyhow::Result<Self::Indexer> {
@@ -483,6 +485,7 @@ mod tests {
 
     #[async_trait]
     impl ChainIndexer for TestLinearIndexer {
+        const CHAIN: Chain = Chain::Ethereum;
         type Block = u64;
         type Iter = std::vec::IntoIter<Self::Block>;
 
@@ -536,7 +539,6 @@ mod tests {
 
     #[async_trait]
     impl ChainStream for TestLinearStream {
-        const CHAIN: Chain = Chain::Ethereum;
         type Indexer = TestLinearIndexer;
 
         async fn start(&mut self) -> anyhow::Result<Self::Indexer> {
@@ -557,7 +559,7 @@ mod tests {
     async fn test_run_linearized_source_orders_catchup_before_live() {
         let mut stream = TestLinearStream::new(TestLinearControl::new(Some(1), vec![4, 5]));
         let indexer = stream.start().await.unwrap();
-        catchup_then_livestream(Chain::Ethereum, indexer).await;
+        catchup_then_livestream(indexer).await;
 
         let mut observed = Vec::new();
         while let Some(event) = timeout(Duration::from_millis(20), stream.next_event())
@@ -582,7 +584,7 @@ mod tests {
                 .fail_live_once(4),
         );
         let indexer = stream.start().await.unwrap();
-        catchup_then_livestream(Chain::Ethereum, indexer).await;
+        catchup_then_livestream(indexer).await;
 
         let mut observed = Vec::new();
         while let Some(event) = timeout(Duration::from_millis(20), stream.next_event())
@@ -702,7 +704,6 @@ mod tests {
 
         #[async_trait]
         impl ChainStream for LocalStream {
-            const CHAIN: Chain = Chain::Solana;
             type Indexer = DisabledChainIndexer;
 
             async fn start(&mut self) -> anyhow::Result<Self::Indexer> {

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -11,13 +11,12 @@ use crate::stream::ops::{
     RespondBidirectionalEvent, SignatureRespondedEvent,
 };
 
+pub mod ops;
+
 use async_trait::async_trait;
-use std::ops::Range;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
-
-pub mod ops;
 
 pub const CHAIN_EVENT_STREAM_SIZE: usize = 16384;
 
@@ -96,7 +95,8 @@ pub enum ExecutionOutcome {
 
 #[async_trait]
 pub trait ChainIndexer: Send + 'static {
-    type Block: Send + 'static;
+    type Block: Send;
+    type Iter: Iterator<Item = Self::Block> + Send + 'static;
 
     const RETRY_DELAY: Duration = Duration::from_millis(500);
 
@@ -108,20 +108,16 @@ pub trait ChainIndexer: Send + 'static {
         Ok(())
     }
 
-    async fn catchup_range(&mut self, anchor_height: u64) -> Range<u64> {
-        let _ = anchor_height;
-        // TODO: this disables the catchup range, will be removed in the future once
-        // all chains like solana support catchup & livestream.
-        // https://github.com/sig-net/mpc/issues/778
-        0..0
-    }
+    async fn catchup_range(&self, anchor_height: u64) -> Self::Iter;
 
-    async fn process_catchup_on_height(&mut self, height: u64) -> anyhow::Result<()> {
-        let _ = height;
+    async fn process_catchup(&mut self, item: &Self::Block) -> anyhow::Result<()> {
+        let _ = item;
         Ok(())
     }
 
-    async fn next(&mut self) -> Option<Self::Block>;
+    async fn next(&mut self) -> Option<Self::Block> {
+        None
+    }
 
     async fn process(&mut self, block: &Self::Block) -> anyhow::Result<()> {
         let _ = block;
@@ -142,44 +138,10 @@ pub trait ChainIndexer: Send + 'static {
     }
 }
 
-/// Type used to denote a disabled stream (i.e. Solana, Hydration) that does
-/// not yet support the flow for general catchup & livestream.
-pub struct DisabledChainIndexer {
-    events_tx: Option<mpsc::Sender<ChainEvent>>,
-}
-
-impl DisabledChainIndexer {
-    pub fn new(events_tx: mpsc::Sender<ChainEvent>) -> Self {
-        Self {
-            events_tx: Some(events_tx),
-        }
-    }
-
-    pub fn silent() -> Self {
-        Self { events_tx: None }
-    }
-}
-
-#[async_trait]
-impl ChainIndexer for DisabledChainIndexer {
-    type Block = ();
-
-    async fn next(&mut self) -> Option<Self::Block> {
-        None
-    }
-
-    async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {
-        if let Some(events_tx) = &self.events_tx {
-            events_tx.send(ChainEvent::CatchupCompleted).await?;
-        }
-        Ok(())
-    }
-}
-
 #[async_trait]
 pub trait ChainStream: Send + 'static {
     const CHAIN: Chain;
-    type Indexer: ChainIndexer;
+    type Indexer: ChainIndexer + Send;
 
     async fn start(&mut self) -> anyhow::Result<Self::Indexer>;
     async fn next_event(&mut self) -> Option<ChainEvent>;
@@ -208,10 +170,9 @@ pub async fn catchup_then_livestream<I: ChainIndexer>(chain: Chain, mut indexer:
         return;
     };
 
-    let catchup_range = indexer.catchup_range(anchor_height).await;
-    for height in catchup_range {
-        while let Err(err) = indexer.process_catchup_on_height(height).await {
-            tracing::warn!(?err, %chain, height, "catchup height processing failed; retrying");
+    for catchup_item in indexer.catchup_range(anchor_height).await {
+        while let Err(err) = indexer.process_catchup(&catchup_item).await {
+            tracing::warn!(?err, %chain, "catchup item processing failed; retrying");
             tokio::time::sleep(I::RETRY_DELAY).await;
         }
     }
@@ -357,6 +318,39 @@ mod tests {
     use tokio::sync::mpsc;
     use tokio::time::timeout;
 
+    /// Type used to denote a disabled stream (i.e. Solana, Hydration) that does
+    /// not yet support the flow for general catchup & livestream.
+    pub struct DisabledChainIndexer {
+        events_tx: Option<mpsc::Sender<ChainEvent>>,
+    }
+
+    impl DisabledChainIndexer {
+        pub fn silent() -> Self {
+            Self { events_tx: None }
+        }
+    }
+
+    #[async_trait]
+    impl ChainIndexer for DisabledChainIndexer {
+        type Block = ();
+        type Iter = std::iter::Empty<Self::Block>;
+
+        async fn next(&mut self) -> Option<Self::Block> {
+            None
+        }
+
+        async fn catchup_range(&self, _anchor_height: u64) -> Self::Iter {
+            std::iter::empty()
+        }
+
+        async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {
+            if let Some(events_tx) = &self.events_tx {
+                events_tx.send(ChainEvent::CatchupCompleted).await?;
+            }
+            Ok(())
+        }
+    }
+
     struct VecEventStreamState {
         started: bool,
         events: Vec<Option<ChainEvent>>,
@@ -469,6 +463,7 @@ mod tests {
     #[async_trait]
     impl ChainIndexer for TestLinearIndexer {
         type Block = u64;
+        type Iter = std::vec::IntoIter<Self::Block>;
 
         const RETRY_DELAY: Duration = Duration::from_millis(1);
 
@@ -487,16 +482,17 @@ mod tests {
             Some(block)
         }
 
-        async fn catchup_range(&mut self, anchor_height: u64) -> Range<u64> {
+        async fn catchup_range(&self, anchor_height: u64) -> Self::Iter {
             let start = self
                 .control
                 .persisted_height
                 .map(|height| height + 1)
                 .unwrap_or(anchor_height);
-            start..anchor_height
+            let items: Vec<Self::Block> = (start..anchor_height).collect();
+            items.into_iter()
         }
 
-        async fn process_catchup_on_height(&mut self, height: u64) -> anyhow::Result<()> {
+        async fn process_catchup(&mut self, &height: &Self::Block) -> anyhow::Result<()> {
             if TestLinearControl::consume_failure(&self.control.catchup_failures, height) {
                 anyhow::bail!("synthetic catchup failure at height {height}");
             }

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -292,6 +292,39 @@ pub async fn run_stream<S: ChainStream>(
     indexer_task.abort();
 }
 
+/// Type used to denote a disabled stream (i.e. Solana, Hydration) that does
+/// not yet support the flow for general catchup & livestream.
+pub struct DisabledChainIndexer {
+    events_tx: Option<mpsc::Sender<ChainEvent>>,
+}
+
+impl DisabledChainIndexer {
+    pub fn silent() -> Self {
+        Self { events_tx: None }
+    }
+}
+
+#[async_trait]
+impl ChainIndexer for DisabledChainIndexer {
+    type Block = ();
+    type Iter = std::iter::Empty<Self::Block>;
+
+    async fn next(&mut self) -> Option<Self::Block> {
+        None
+    }
+
+    async fn catchup_range(&self, _anchor_height: u64) -> Self::Iter {
+        std::iter::empty()
+    }
+
+    async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {
+        if let Some(events_tx) = &self.events_tx {
+            events_tx.send(ChainEvent::CatchupCompleted).await?;
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -317,39 +350,6 @@ mod tests {
     use std::time::Duration;
     use tokio::sync::mpsc;
     use tokio::time::timeout;
-
-    /// Type used to denote a disabled stream (i.e. Solana, Hydration) that does
-    /// not yet support the flow for general catchup & livestream.
-    pub struct DisabledChainIndexer {
-        events_tx: Option<mpsc::Sender<ChainEvent>>,
-    }
-
-    impl DisabledChainIndexer {
-        pub fn silent() -> Self {
-            Self { events_tx: None }
-        }
-    }
-
-    #[async_trait]
-    impl ChainIndexer for DisabledChainIndexer {
-        type Block = ();
-        type Iter = std::iter::Empty<Self::Block>;
-
-        async fn next(&mut self) -> Option<Self::Block> {
-            None
-        }
-
-        async fn catchup_range(&self, _anchor_height: u64) -> Self::Iter {
-            std::iter::empty()
-        }
-
-        async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {
-            if let Some(events_tx) = &self.events_tx {
-                events_tx.send(ChainEvent::CatchupCompleted).await?;
-            }
-            Ok(())
-        }
-    }
 
     struct VecEventStreamState {
         started: bool,

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -316,40 +316,6 @@ pub async fn run_stream<S: ChainStream>(
     indexer_task.abort();
 }
 
-/// Type used to denote a disabled stream (i.e. Solana, Hydration) that does
-/// not yet support the flow for general catchup & livestream.
-pub struct DisabledChainIndexer {
-    events_tx: Option<mpsc::Sender<ChainEvent>>,
-}
-
-impl DisabledChainIndexer {
-    pub fn silent() -> Self {
-        Self { events_tx: None }
-    }
-}
-
-#[async_trait]
-impl ChainIndexer for DisabledChainIndexer {
-    const CHAIN: Chain = Chain::Bitcoin;
-    type Block = ();
-    type Iter = std::iter::Empty<Self::Block>;
-
-    async fn next(&mut self) -> Option<Self::Block> {
-        None
-    }
-
-    async fn catchup_range(&self, _anchor_height: u64) -> Self::Iter {
-        std::iter::empty()
-    }
-
-    async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {
-        if let Some(events_tx) = &self.events_tx {
-            events_tx.send(ChainEvent::CatchupCompleted).await?;
-        }
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -391,36 +357,71 @@ mod tests {
     }
 
     macro_rules! impl_vec_event_stream {
-        ($name:ident, $chain:expr) => {
-            struct $name(VecEventStreamState);
+        ($stream:ident, $indexer:ident, $chain:expr) => {
+            struct $stream(VecEventStreamState);
 
-            impl $name {
+            impl $stream {
                 pub fn new(events: Vec<Option<ChainEvent>>) -> Self {
                     Self(VecEventStreamState::new(events))
                 }
             }
 
+            struct $indexer {
+                events_tx: Option<mpsc::Sender<ChainEvent>>,
+            }
+
+            impl $indexer {
+                pub fn silent() -> Self {
+                    Self { events_tx: None }
+                }
+            }
+
             #[async_trait]
-            impl ChainStream for $name {
-                type Indexer = DisabledChainIndexer;
+            impl ChainIndexer for $indexer {
+                const CHAIN: Chain = $chain;
+
+                type Block = ();
+                type Iter = std::iter::Empty<Self::Block>;
+
+                async fn next(&mut self) -> Option<Self::Block> {
+                    None
+                }
+
+                async fn catchup_range(&self, _anchor_height: u64) -> Self::Iter {
+                    std::iter::empty()
+                }
+
+                async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {
+                    if let Some(events_tx) = &self.events_tx {
+                        events_tx.send(ChainEvent::CatchupCompleted).await?;
+                    }
+
+                    Ok(())
+                }
+            }
+
+            #[async_trait]
+            impl ChainStream for $stream {
+                type Indexer = $indexer;
 
                 async fn start(&mut self) -> anyhow::Result<Self::Indexer> {
                     self.0.started = true;
-                    Ok(DisabledChainIndexer::silent())
+                    Ok($indexer::silent())
                 }
 
                 async fn next_event(&mut self) -> Option<ChainEvent> {
                     if self.0.events.is_empty() {
                         return None;
                     }
+
                     self.0.events.remove(0)
                 }
             }
         };
     }
 
-    impl_vec_event_stream!(SolanaTestStream, Chain::Solana);
-    impl_vec_event_stream!(EthereumTestStream, Chain::Ethereum);
+    impl_vec_event_stream!(SolanaTestStream, DisabledSolanaIndexer, Chain::Solana);
+    impl_vec_event_stream!(EthereumTestStream, DisabledEthereumIndexer, Chain::Ethereum);
 
     #[derive(Clone)]
     struct TestLinearControl {
@@ -712,6 +713,38 @@ mod tests {
 
             async fn next_event(&mut self) -> Option<ChainEvent> {
                 self.rx.recv().await
+            }
+        }
+
+        pub struct DisabledChainIndexer {
+            events_tx: Option<mpsc::Sender<ChainEvent>>,
+        }
+
+        impl DisabledChainIndexer {
+            pub fn silent() -> Self {
+                Self { events_tx: None }
+            }
+        }
+
+        #[async_trait]
+        impl ChainIndexer for DisabledChainIndexer {
+            const CHAIN: Chain = Chain::Solana;
+            type Block = ();
+            type Iter = std::iter::Empty<Self::Block>;
+
+            async fn next(&mut self) -> Option<Self::Block> {
+                None
+            }
+
+            async fn catchup_range(&self, _anchor_height: u64) -> Self::Iter {
+                std::iter::empty()
+            }
+
+            async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {
+                if let Some(events_tx) = &self.events_tx {
+                    events_tx.send(ChainEvent::CatchupCompleted).await?;
+                }
+                Ok(())
             }
         }
 

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -363,7 +363,7 @@ async fn stream_ethereum(
 ) -> Result<StartedEthereumStream> {
     let mut stream = EthereumStream::new(Some(ctx.config(true)), backlog).await?;
     let indexer = stream.start().await?;
-    let indexer_task = tokio::spawn(catchup_then_livestream(EthereumStream::CHAIN, indexer));
+    let indexer_task = tokio::spawn(catchup_then_livestream(indexer));
 
     Ok(StartedEthereumStream {
         stream,

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -12,6 +12,7 @@ use mpc_primitives::LATEST_MPC_KEY_VERSION;
 use solana_sdk::signer::Signer;
 use tokio::sync::watch;
 use tokio::time::timeout;
+use tokio::time::Instant;
 
 use std::time::Duration;
 
@@ -29,7 +30,13 @@ fn test_dependencies() -> (Backlog, watch::Receiver<MeshState>, NodeClient) {
 }
 
 async fn stream_solana(config: SolConfig) -> Result<SolanaStream> {
-    let mut stream = SolanaStream::new(Some(config)).context("failed to create SolanaStream")?;
+    let (backlog, _, _) = test_dependencies();
+    stream_solana_with_backlog(config, backlog).await
+}
+
+async fn stream_solana_with_backlog(config: SolConfig, backlog: Backlog) -> Result<SolanaStream> {
+    let mut stream =
+        SolanaStream::new(Some(config), backlog).context("failed to create SolanaStream")?;
     let _ = ChainStream::start(&mut stream).await?;
     Ok(stream)
 }
@@ -286,7 +293,7 @@ async fn test_solana_stream_checkpoint_persistence() -> Result<()> {
     let program_address = solana.program_keypair.pubkey().to_string();
     let (backlog, _, _) = test_dependencies();
     let config = solana.get_config(program_address.clone());
-    let mut stream1 = stream_solana(config.clone()).await?;
+    let mut stream1 = stream_solana_with_backlog(config.clone(), backlog.clone()).await?;
 
     // Submit request and wait for a block marker
     solana
@@ -300,23 +307,34 @@ async fn test_solana_stream_checkpoint_persistence() -> Result<()> {
         )
         .await?;
 
+    let deadline = Instant::now() + Duration::from_secs(30);
     let mut checkpoint_block = None;
-    for _ in 0..10 {
-        if let Ok(Some(ChainEvent::Block(block))) =
-            timeout(Duration::from_secs(1), stream1.next_event()).await
-        {
-            checkpoint_block = Some(block);
-            // Set checkpoint in backlog
-            backlog.set_processed_block(Chain::Solana, block).await;
-            break;
+    while Instant::now() < deadline {
+        match timeout(Duration::from_secs(1), stream1.next_event()).await {
+            Ok(Some(ChainEvent::Block(block))) => {
+                checkpoint_block = Some(block);
+                backlog.set_processed_block(Chain::Solana, block).await;
+                break;
+            }
+            Ok(Some(_)) | Ok(None) | Err(_) => continue,
         }
     }
 
-    assert!(checkpoint_block.is_some(), "did not receive block event");
+    assert!(
+        checkpoint_block.is_some(),
+        "did not receive block event within 30 seconds"
+    );
     drop(stream1);
 
     // Create new client with same backlog - should resume from checkpoint
-    let mut stream2 = stream_solana(config).await?;
+    let mut stream2 = stream_solana_with_backlog(config, backlog.clone()).await?;
+
+    // Verify the backlog was persisted
+    let persisted_block = backlog.processed_block(Chain::Solana).await;
+    assert_eq!(
+        persisted_block, checkpoint_block,
+        "backlog did not persist the checkpoint block"
+    );
 
     // Submit new request
     solana

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -316,7 +316,8 @@ async fn test_solana_stream_checkpoint_persistence() -> Result<()> {
                 backlog.set_processed_block(Chain::Solana, block).await;
                 break;
             }
-            Ok(Some(_)) | Ok(None) | Err(_) => continue,
+            Ok(Some(_)) | Err(_) => continue,
+            Ok(None) => break,
         }
     }
 

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -7,7 +7,7 @@ use mpc_node::indexer_sol::{SolConfig, SolanaStream};
 use mpc_node::mesh::MeshState;
 use mpc_node::node_client::NodeClient;
 use mpc_node::protocol::{Chain, IndexedSignRequest};
-use mpc_node::stream::{ChainEvent, ChainStream};
+use mpc_node::stream::{catchup_then_livestream, ChainEvent, ChainStream};
 use mpc_primitives::LATEST_MPC_KEY_VERSION;
 use solana_sdk::signer::Signer;
 use tokio::sync::watch;
@@ -37,8 +37,8 @@ async fn stream_solana(config: SolConfig) -> Result<SolanaStream> {
 async fn stream_solana_with_backlog(config: SolConfig, backlog: Backlog) -> Result<SolanaStream> {
     let mut stream =
         SolanaStream::new(Some(config), backlog).context("failed to create SolanaStream")?;
-    let _ = ChainStream::start(&mut stream).await?;
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    let indexer = ChainStream::start(&mut stream).await?;
+    tokio::spawn(catchup_then_livestream(indexer));
     Ok(stream)
 }
 
@@ -258,7 +258,7 @@ async fn test_solana_stream_concurrent_events() -> Result<()> {
     // Collect all sign request events
     let mut sign_events = Vec::new();
 
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     while sign_events.len() < num_requests {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
@@ -275,7 +275,7 @@ async fn test_solana_stream_concurrent_events() -> Result<()> {
     assert_eq!(
         sign_events.len(),
         num_requests,
-        "did not receive all sign requests"
+        "did not receive all sign requests {sign_events:?}"
     );
 
     // Verify all payloads are unique
@@ -312,23 +312,28 @@ async fn test_solana_stream_checkpoint_persistence() -> Result<()> {
         )
         .await?;
 
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + Duration::from_secs(5);
     let mut checkpoint_block = None;
     while Instant::now() < deadline {
         match timeout(Duration::from_secs(1), stream1.next_event()).await {
             Ok(Some(ChainEvent::Block(block))) => {
+                tracing::info!(block, "received block event");
                 checkpoint_block = Some(block);
                 backlog.set_processed_block(Chain::Solana, block).await;
                 break;
             }
-            Ok(Some(_)) | Err(_) => continue,
+            Ok(Some(event)) => {
+                tracing::info!(?event, "received non-block event");
+                continue;
+            }
+            Err(_) => continue,
             Ok(None) => break,
         }
     }
 
     assert!(
         checkpoint_block.is_some(),
-        "did not receive block event within 30 seconds"
+        "did not receive block event within time"
     );
     drop(stream1);
 
@@ -355,16 +360,21 @@ async fn test_solana_stream_checkpoint_persistence() -> Result<()> {
         .await?;
 
     // New client should pick up new events
-    let event = timeout(Duration::from_secs(5), stream2.next_event())
-        .await
-        .context("timeout waiting for event")?
-        .context("client returned None")?;
-
-    // Should get sign request or block marker
-    assert!(
-        matches!(event, ChainEvent::SignRequest(_) | ChainEvent::Block(_)),
-        "expected SignRequest or Block after restart"
-    );
+    timeout(Duration::from_secs(5), async {
+        loop {
+            match stream2.next_event().await {
+                Some(ChainEvent::SignRequest(req)) => break Ok(req),
+                Some(other) => {
+                    tracing::info!(?other, "received non-sign/block event");
+                    continue;
+                }
+                None => anyhow::bail!("stream returned None"),
+            }
+        }
+    })
+    .await
+    .context("timeout waiting for event")?
+    .context("client returned None")?;
 
     Ok(())
 }

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -48,6 +48,10 @@ async fn wait_for_sign_request(stream: &mut SolanaStream) -> Result<IndexedSignR
         match timeout(Duration::from_secs(6), stream.next_event()).await {
             Ok(Some(ChainEvent::SignRequest(req))) => return Ok(req),
             Ok(Some(ChainEvent::Block(_))) => continue,
+            Ok(Some(ChainEvent::CatchupCompleted)) => {
+                tracing::info!("received CatchupCompleted event while waiting for SignRequest");
+                continue;
+            }
             Ok(Some(other)) => anyhow::bail!("Expected SignRequest, got {:?}", other),
             Ok(None) => anyhow::bail!("stream returned None"),
             Err(_) => anyhow::bail!("timeout waiting for SignRequest event"),


### PR DESCRIPTION
This implements the catchup + livestream for solana.

Some noticeable differences between the ethereum one:
- catchup logic has some nuances:
   - fetch signatures to do fast catchup
   - if fail, fetch all sparse set of blocks from start to anchor
   - if exceeds max fast catchup (1000 slots), then sparse fetch from start to mid where mid is the furthest fast catchup can go back to.
 - the livestream task preprocesses blocks so we are only left with ChainEvents instead of the whole history of blocks that might not be relevant to us.

Resolves https://github.com/sig-net/mpc/issues/778
 