### PR TITLE
feat: only fetch artifacts after posit succeeds

### DIFF
--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -11,8 +11,9 @@ use crate::protocol::posit::{PositAction, SinglePositCounter};
 use crate::protocol::presignature::PresignatureId;
 use crate::protocol::{Chain, ProtocolState};
 use crate::rpc::{ContractStateWatcher, GovernanceInfo, RpcChannel};
-use crate::storage::presignature_storage::{PresignatureTaken, PresignatureTakenDropper};
-use crate::storage::protocol_storage::ProtocolArtifact;
+use crate::storage::presignature_storage::{
+    PresignatureReserved, PresignatureTaken, PresignatureTakenDropper,
+};
 use crate::storage::PresignatureStorage;
 use crate::stream::ops::SignBidirectionalEvent;
 use crate::types::SignatureProtocol;
@@ -212,7 +213,7 @@ struct SignPositor {
     proposer: Participant,
     active: BTreeSet<Participant>,
     presignature_id: PresignatureId,
-    presignature: Option<PresignatureTaken>,
+    presignature: Option<PresignatureReserved>,
 }
 
 struct SignGenerating {
@@ -353,34 +354,27 @@ impl SignOrganizer {
             let remaining = state.budget.remaining();
             let fetch = tokio::time::timeout(remaining, async {
                 loop {
-                    if let Some(taken) = ctx.presignatures.take_mine().await {
-                        let Some(holders) = taken.artifact.holders() else {
-                            tracing::error!(
-                                id = taken.artifact.id,
-                                "holders not set on taken presignature"
-                            );
-                            continue;
-                        };
-                        let participants = intersect_vec(&[holders, &active]);
+                    if let Some(reserved) = ctx.presignatures.reserve_mine().await {
+                        let participants = intersect_vec(&[&reserved.holders, &active]);
                         if participants.len() < ctx.governance.threshold {
                             tracing::warn!(
                                 ?sign_id,
-                                id = taken.artifact.id,
-                                ?holders,
+                                id = reserved.id,
+                                holders = ?reserved.holders,
                                 ?active,
-                                "discarding presignature due to inactive participants"
+                                "releasing reserved presignature due to inactive participants"
                             );
+                            // drop(reserved) releases the mine-key entry
                             continue;
                         }
-
-                        break (taken, participants);
+                        break (reserved, participants);
                     }
                     tokio::time::sleep(Duration::from_millis(500)).await;
                 }
             })
             .await;
 
-            let (taken, participants) = match fetch {
+            let (reserved, participants) = match fetch {
                 Ok(value) => value,
                 Err(_) => {
                     tracing::warn!(
@@ -393,7 +387,7 @@ impl SignOrganizer {
                 }
             };
 
-            let presignature_id = taken.artifact.id;
+            let presignature_id = reserved.id;
 
             tracing::info!(?sign_id, ?presignature_id, "proposer got presignature");
 
@@ -417,7 +411,7 @@ impl SignOrganizer {
 
             // Update active to only include participants that are in both the presignature and active set
             let active = participants.into_iter().collect::<BTreeSet<_>>();
-            (presignature_id, Some(taken), active)
+            (presignature_id, Some(reserved), active)
         } else {
             (PresignatureId::default(), None, active)
         };
@@ -704,12 +698,10 @@ impl SignPositor {
                         if !counter.process_action(from, &action) {
                             continue;
                         }
-
                         if counter.enough_rejects(ctx.governance.threshold) {
-                            tracing::warn!(?sign_id, ?round, ?from, "received enough REJECTs, reorganizing");
-                            if let Some(_taken) = presignature {
-                                tracing::warn!(?sign_id, "discarding presignature due to REJECTs");
-                            }
+                            // drop(reserved) releases the mine-key entry
+                            let released = presignature.map(|reserved|reserved.id);
+                            tracing::warn!(?sign_id, ?round, ?from, ?released, "received enough REJECTs, reorganizing");
                             state.bump_round();
                             return SignPhase::Organizing(SignOrganizer);
                         }
@@ -738,16 +730,16 @@ impl SignPositor {
                 }
                 _ = &mut posit_deadline => {
                     if is_proposer {
+                        // drop(reserved) releases the mine-key entry
+                        let released = presignature.map(|reserved|reserved.id);
                         tracing::warn!(
                             ?sign_id,
                             accepts = counter.accepts.len(),
                             threshold = ctx.governance.threshold,
                             ?round,
+                            ?released,
                             "proposer posit deadline reached, expiring round"
                         );
-                        if let Some(_taken) = presignature {
-                            tracing::warn!(?sign_id, "discarding presignature due to proposer timeout");
-                        }
                     } else {
                         tracing::warn!(?sign_id, me=?ctx.governance.me, ?proposer, "deliberator posit timeout waiting for Start, reorganizing");
                     }
@@ -772,10 +764,27 @@ impl SignPositor {
             }
         };
 
+        // Proposer: Now that posit succeeded, fetch and delete the presignature
+        // atomically. This shouldn't fail outside of corrupted db problems.
+        let presignature_taken = match presignature {
+            Some(reserved) => match reserved.commit(&ctx.presignatures).await {
+                Some(taken) => Some(taken),
+                None => {
+                    tracing::warn!(
+                        ?sign_id,
+                        "failed to commit reserved presignature, reorganizing"
+                    );
+                    state.bump_round();
+                    return SignPhase::Organizing(SignOrganizer);
+                }
+            },
+            None => None,
+        };
+
         SignPhase::Generating(SignGenerating {
             proposer,
             presignature_id,
-            presignature,
+            presignature: presignature_taken,
             accepted_participants,
         })
     }

--- a/chain-signatures/node/src/storage/presignature_storage.rs
+++ b/chain-signatures/node/src/storage/presignature_storage.rs
@@ -4,7 +4,9 @@ use redis::{FromRedisValue, RedisError, RedisWrite, ToRedisArgs};
 
 use cait_sith::protocol::Participant;
 
-use super::protocol_storage::{ArtifactSlot, ArtifactTaken, ArtifactTakenDropper, ProtocolStorage};
+use super::protocol_storage::{
+    ArtifactReserved, ArtifactSlot, ArtifactTaken, ArtifactTakenDropper, ProtocolStorage,
+};
 use crate::protocol::presignature::{Presignature, PresignatureId};
 use crate::storage::protocol_storage::ProtocolArtifact;
 
@@ -12,6 +14,7 @@ pub type PresignatureStorage = ProtocolStorage<Presignature>;
 pub type PresignatureSlot = ArtifactSlot<Presignature>;
 pub type PresignatureTaken = ArtifactTaken<Presignature>;
 pub type PresignatureTakenDropper = ArtifactTakenDropper<Presignature>;
+pub type PresignatureReserved = ArtifactReserved<Presignature>;
 
 impl Presignature {
     pub fn storage(pool: &Pool, account_id: &AccountId) -> PresignatureStorage {

--- a/chain-signatures/node/src/storage/protocol_storage.rs
+++ b/chain-signatures/node/src/storage/protocol_storage.rs
@@ -138,6 +138,9 @@ struct ReservedState<Id> {
     /// IDs taken from Redis and actively consumed by a protocol.
     /// Value is `true` if this node is the owner of the artifact.
     using: HashMap<Id, bool>,
+    /// Candidate IDs for a protocol where we are proposer. These are not in
+    /// `using`, yet.
+    mine_reserved: HashSet<Id>,
 }
 
 impl<Id: Eq + std::hash::Hash> ReservedState<Id> {
@@ -145,6 +148,7 @@ impl<Id: Eq + std::hash::Hash> ReservedState<Id> {
         Self {
             generating: HashMap::new(),
             using: HashMap::new(),
+            mine_reserved: HashSet::new(),
         }
     }
 
@@ -153,7 +157,49 @@ impl<Id: Eq + std::hash::Hash> ReservedState<Id> {
     }
 
     fn contains_reserved(&self, id: &Id) -> bool {
-        self.generating.contains_key(id) || self.using.contains_key(id)
+        self.generating.contains_key(id)
+            || self.using.contains_key(id)
+            || self.mine_reserved.contains(id)
+    }
+}
+
+/// A handle for a reserved artifact.
+///
+/// The mine-key has been removed but the artifact data remains in Redis
+/// unfetched. Dropping this without calling [`ArtifactReserved::commit`]
+/// restores the mine-key entry.
+pub struct ArtifactReserved<A: ProtocolArtifact> {
+    pub id: A::Id,
+    /// Participants that held this artifact at reserve time (fetched separately,
+    /// without loading the full artifact data).
+    pub holders: Vec<Participant>,
+    releaser: ArtifactReservedDropper<A>,
+}
+
+struct ArtifactReservedDropper<A: ProtocolArtifact> {
+    id: A::Id,
+    storage: Option<ProtocolStorage<A>>,
+}
+
+impl<A: ProtocolArtifact> Drop for ArtifactReservedDropper<A> {
+    fn drop(&mut self) {
+        if let Some(storage) = self.storage.take() {
+            let id = self.id;
+            tokio::spawn(async move {
+                let result = storage.release_reserved(id).await;
+                if let Err(err) = result {
+                    tracing::error!(?err, id, "failed to release reserved artifact");
+                }
+            });
+        }
+    }
+}
+
+impl<A: ProtocolArtifact> ArtifactReserved<A> {
+    /// Fetch a previously reserved artifact from Redis and delete it atomically.
+    pub async fn commit(mut self, storage: &ProtocolStorage<A>) -> Option<ArtifactTaken<A>> {
+        self.releaser.storage = None; // disarm: Drop must not call release_reserved
+        storage.commit_reserved(self.id).await
     }
 }
 
@@ -330,6 +376,7 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
                 .iter()
                 .filter_map(|(&id, &mine)| mine.then_some(id)),
         );
+        ids.extend(state.mine_reserved.iter().copied());
         Ok(ids)
     }
 
@@ -674,6 +721,7 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
         let mut state = self.reserved.write().await;
         state.generating.clear();
         state.using.clear();
+        state.mine_reserved.clear();
 
         // if the outcome is None, it means the script failed or there was an error.
         outcome.is_some()
@@ -683,69 +731,124 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
     /// It is very important to NOT reuse the same artifact twice for two different
     /// protocols.
     pub async fn take_mine(&self) -> Option<ArtifactTaken<A>> {
-        const SCRIPT: &str = r#"
-            local artifact_key = KEYS[1]
-            local mine_key = KEYS[2]
-
-            if redis.call("SCARD", mine_key) < 1 then
-                return nil
-            end
-
-            -- pop one artifact from the self owner set and delete it once successfully fetched
-            local id = redis.call("SPOP", mine_key)
-            local artifact = redis.call("HGET", artifact_key, id)
-            if not artifact then
-                return {err = "WARN unexpected, artifact " .. id .. " is missing"}
-            end
-
-            -- Delete the artifact from the hash map
-            redis.call("HDEL", artifact_key, id)
-            -- delete the artifact from our self owner set
-            redis.call("SREM", mine_key, id)
-
-            -- Read and delete the holders set
-            local holders_key = artifact_key .. ':holders:' .. id
-            local holders = redis.call("SMEMBERS", holders_key)
-            redis.call("DEL", holders_key)
-
-            -- Return the artifact and holders
-            return {artifact, holders}
-        "#;
-
-        let start = Instant::now();
-        let mut conn = self.connect().await?;
-        let me = self.me().ok()?;
-        let result: Result<Option<(A, Vec<u32>)>, _> = redis::Script::new(SCRIPT)
-            .key(&self.artifact_key)
-            .key(owner_key(&self.owner_keys, me))
-            .invoke_async(&mut conn)
-            .await;
-
-        let elapsed = start.elapsed();
-        crate::metrics::storage::REDIS_LATENCY
-            .with_label_values(&[A::METRIC_LABEL, "take_mine"])
-            .observe(elapsed.as_millis() as f64);
-
-        match result {
-            Ok(Some((mut artifact, holders))) => {
-                let holders = holders.into_iter().map(Participant::from).collect();
-                artifact.set_holders(holders);
-                let id = artifact.id();
-                self.reserved.write().await.using.insert(id, true);
-                let taken = ArtifactTaken::new(artifact, self.clone());
-                tracing::debug!(id, ?elapsed, "took mine artifact");
-                Some(taken)
-            }
-            Ok(None) => None,
-            Err(err) => {
-                tracing::warn!(?err, ?elapsed, "failed to take mine artifact from storage");
-                None
-            }
-        }
+        let mut reserved = self.reserve_mine().await?;
+        // removing releaser.storage stops the releasing on drop
+        let storage = reserved.releaser.storage.take()?;
+        reserved.commit(&storage).await
     }
 
     pub fn artifact_key(&self) -> &str {
         &self.artifact_key
+    }
+
+    /// Read an id but not the content of an artifact from Redis, then mark it
+    /// as used in an in-memory structure.
+    pub async fn reserve_mine(&self) -> Option<ArtifactReserved<A>> {
+        let mut conn = self.connect().await?;
+        let me = self.me().ok()?;
+        let mine_key = owner_key(&self.owner_keys, me);
+
+        let start = Instant::now();
+        let result: Result<Option<A::Id>, _> = conn.spop(&mine_key).await;
+        let elapsed = start.elapsed();
+        crate::metrics::storage::REDIS_LATENCY
+            .with_label_values(&[A::METRIC_LABEL, "reserve_mine"])
+            .observe(elapsed.as_millis() as f64);
+
+        let id = match result {
+            Ok(Some(id)) => id,
+            Ok(None) => return None,
+            Err(err) => {
+                tracing::warn!(
+                    ?err,
+                    ?elapsed,
+                    "failed to reserve mine artifact from storage"
+                );
+                return None;
+            }
+        };
+
+        let holders_key = format!("{}:holders:{}", self.artifact_key, id);
+        let raw_holders: Vec<u32> = conn.smembers(&holders_key).await.unwrap_or_default();
+        let holders = raw_holders.into_iter().map(Participant::from).collect();
+
+        self.reserved.write().await.mine_reserved.insert(id);
+        tracing::debug!(id, ?elapsed, "reserved mine artifact");
+        Some(ArtifactReserved {
+            id,
+            holders,
+            releaser: ArtifactReservedDropper {
+                id,
+                storage: Some(self.clone()),
+            },
+        })
+    }
+
+    /// Fetch and delete a previously reserved artifact from Redis.
+    async fn commit_reserved(&self, id: A::Id) -> Option<ArtifactTaken<A>> {
+        let start = Instant::now();
+        let Some(mut conn) = self.connect().await else {
+            tracing::warn!(id, "failed to commit reserved artifact: connection failed");
+            self.reserved.write().await.mine_reserved.remove(&id);
+            return None;
+        };
+
+        let artifact_result: Result<Option<A>, _> = conn.hget(&self.artifact_key, id).await;
+        let mut artifact = match artifact_result {
+            Ok(Some(a)) => a,
+            Ok(None) => {
+                tracing::warn!(id, "artifact not found for commit");
+                self.reserved.write().await.mine_reserved.remove(&id);
+                return None;
+            }
+            Err(err) => {
+                tracing::warn!(id, ?err, "failed to fetch artifact for commit");
+                self.reserved.write().await.mine_reserved.remove(&id);
+                return None;
+            }
+        };
+
+        let _: Result<i64, _> = conn.hdel(&self.artifact_key, id).await;
+        let holders_key = format!("{}:holders:{}", self.artifact_key, id);
+        let raw_holders: Vec<u32> = conn.smembers(&holders_key).await.unwrap_or_default();
+        let _: Result<i64, _> = conn.del(&holders_key).await;
+
+        let elapsed = start.elapsed();
+        crate::metrics::storage::REDIS_LATENCY
+            .with_label_values(&[A::METRIC_LABEL, "commit_reserved"])
+            .observe(elapsed.as_millis() as f64);
+
+        let holders = raw_holders.into_iter().map(Participant::from).collect();
+        artifact.set_holders(holders);
+        let mut state = self.reserved.write().await;
+        state.mine_reserved.remove(&id);
+        state.using.insert(id, true);
+        drop(state);
+        tracing::debug!(id, ?elapsed, "committed reserved artifact");
+        Some(ArtifactTaken::new(artifact, self.clone()))
+    }
+
+    /// Restore the mine-key entry for a previously reserved artifact.
+    ///
+    /// INVARIANT: Never put back an artifact once it has been removed. This is
+    /// preserved because we never read the artifact itself from redis, only the
+    /// id. Here we only put back the id.
+    async fn release_reserved(&self, id: A::Id) -> anyhow::Result<()> {
+        self.reserved.write().await.mine_reserved.remove(&id);
+        let me = self.me()?;
+        let mine_key = owner_key(&self.owner_keys, me);
+
+        let Some(mut conn) = self.connect().await else {
+            return Err(StorageError::ConnectionFailed)?;
+        };
+
+        let result: Result<i64, _> = conn.sadd(&mine_key, id).await;
+        if let Err(err) = result {
+            tracing::warn!(id, ?err, "failed to restore mine_key for reserved artifact");
+        } else {
+            tracing::debug!(id, "restored mine_key entry for reserved artifact");
+        }
+        Ok(())
     }
 
     /// Batch remove a peer from holders for a set of artifact IDs, and prune


### PR DESCRIPTION
WIP: THIS IS NOT COMPLETE. CURRENTLY IT FETCHES THE FULL ARTIFACT, NOT JUST AN ID.

Removing an artifact from redis before we know if the posit succeeds can lead to wasted triples and presignatures.

This introduces a "reserved" state, meaning that an artifact is reserved for being used. Only owned artifacts can be reserved.

This is different from the previous "reserved" state previously renamed to "generating" in https://github.com/sig-net/mpc/pull/738.

The extra state allows to avoid wasted P and T without recycling them.

For state sync, an artifact with a reserved id is still treated as AVAILABLE.