### PR TITLE
feat: limit concurrent sign tasks

### DIFF
--- a/chain-signatures/contract/src/config/impls.rs
+++ b/chain-signatures/contract/src/config/impls.rs
@@ -1,8 +1,8 @@
-use borsh::{self, BorshDeserialize, BorshSerialize};
-
 use super::{
-    Config, DynamicValue, PresignatureConfig, ProtocolConfig, SignatureConfig, TripleConfig,
+    default_max_concurrent_proposers, Config, DynamicValue, PresignatureConfig, ProtocolConfig,
+    SignatureConfig, TripleConfig,
 };
+use borsh::{self, BorshDeserialize, BorshSerialize};
 
 /// This is maximum expected participants we aim to support right now. This can be different
 /// in the future as we scale the network further.
@@ -70,6 +70,7 @@ impl Default for SignatureConfig {
             generation_timeout: secs_to_ms(45),
             generation_timeout_total: secs_to_ms(200),
             garbage_timeout: hours_to_ms(24),
+            max_concurrent_proposers: default_max_concurrent_proposers(),
 
             other: Default::default(),
         }

--- a/chain-signatures/contract/src/config/mod.rs
+++ b/chain-signatures/contract/src/config/mod.rs
@@ -91,15 +91,22 @@ pub struct SignatureConfig {
     pub generation_timeout_total: u64,
     /// Garbage collection timeout in milliseconds for signatures generated.
     pub garbage_timeout: u64,
+    /// Maximum number of concurrent signature tasks where this node acts as proposer.
+    #[serde(default = "default_max_concurrent_proposers")]
+    pub max_concurrent_proposers: u32,
 
     /// The remaining entries that can be present in future forms of the configuration.
     #[serde(flatten)]
     pub other: HashMap<String, DynamicValue>,
 }
 
+pub const fn default_max_concurrent_proposers() -> u32 {
+    4
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::config::Config;
+    use crate::config::{default_max_concurrent_proposers, Config};
 
     #[test]
     fn test_load_config() {
@@ -133,6 +140,10 @@ mod tests {
 
         let config: Config = serde_json::from_value(config_macro).unwrap();
         assert_eq!(config.protocol.message_timeout, 10000);
+        assert_eq!(
+            config.protocol.signature.max_concurrent_proposers,
+            default_max_concurrent_proposers()
+        );
         assert_eq!(config.get("integer").unwrap(), serde_json::json!(20));
         assert_eq!(config.get("string").unwrap(), serde_json::json!("value2"));
     }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -220,6 +220,16 @@ impl SignLimiter {
             state: Arc::clone(&self.state),
         })
     }
+
+    fn limits(&self) -> usize {
+        match self.state.read() {
+            Ok(state) => state.limit,
+            Err(err) => {
+                tracing::error!(?err, "failed to acquire lock in SignLimiter::limits");
+                0
+            }
+        }
+    }
 }
 
 impl Drop for SignPermit {
@@ -460,7 +470,7 @@ impl SignOrganizer {
                 ?sign_id,
                 round = ?state.round,
                 timeout = ?remaining,
-                limit = ctx.cfg.signature.max_concurrent_proposers,
+                limit = ctx.limiter.limits(),
                 "proposer waiting for concurrency slot"
             );
 

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -138,38 +138,39 @@ enum SignError {
 }
 
 #[derive(Debug)]
-enum ProposerAcquireError {
+enum SignLimitError {
     Timeout,
     Closed,
 }
 
 #[derive(Debug)]
-struct ProposerSemaphoreState {
+struct SignLimitState {
     limit: usize,
     debt: usize,
 }
 
 #[derive(Clone, Debug)]
-struct ProposerSemaphore {
+struct SignLimiter {
     semaphore: Arc<Semaphore>,
-    state: Arc<Mutex<ProposerSemaphoreState>>,
+    state: Arc<Mutex<SignLimitState>>,
 }
 
 #[derive(Debug)]
-struct ProposerPermit {
+struct SignPermit {
     permit: Option<OwnedSemaphorePermit>,
-    state: Arc<Mutex<ProposerSemaphoreState>>,
+    state: Arc<Mutex<SignLimitState>>,
 }
 
-impl ProposerSemaphore {
+impl SignLimiter {
     fn new(limit: usize) -> Self {
         Self {
             semaphore: Arc::new(Semaphore::new(limit)),
-            state: Arc::new(Mutex::new(ProposerSemaphoreState { limit, debt: 0 })),
+            state: Arc::new(Mutex::new(SignLimitState { limit, debt: 0 })),
         }
     }
 
-    fn update_limit(&self, new_limit: usize) {
+    /// Updates the limits for concurrent slots
+    fn update(&self, new_limit: usize) {
         let old_limit = {
             let mut state = self.state.lock().unwrap();
             let old_limit = state.limit;
@@ -177,23 +178,20 @@ impl ProposerSemaphore {
             old_limit
         };
 
+        // add more permits if the limit increased
         if new_limit > old_limit {
             let mut permits_to_add = new_limit - old_limit;
-
             if permits_to_add > 0 {
                 let mut state = self.state.lock().unwrap();
                 let forgiven = permits_to_add.min(state.debt);
                 state.debt -= forgiven;
                 permits_to_add -= forgiven;
-            }
-
-            if permits_to_add > 0 {
                 self.semaphore.add_permits(permits_to_add);
             }
-
             return;
         }
 
+        // remove permits or add to a debt where when the permit is dropped, we forget it.
         let permits_to_remove = old_limit - new_limit;
         if permits_to_remove == 0 {
             return;
@@ -206,22 +204,25 @@ impl ProposerSemaphore {
         }
     }
 
-    async fn acquire(&self, timeout: Duration) -> Result<ProposerPermit, ProposerAcquireError> {
+    /// Try to acquire a spot with a timeout just in case we do not receive the slot in time.
+    /// Returns a permit if successful, error otherwise.
+    async fn acquire(&self, timeout: Duration) -> Result<SignPermit, SignLimitError> {
         let permit =
             match tokio::time::timeout(timeout, self.semaphore.clone().acquire_owned()).await {
                 Ok(Ok(permit)) => permit,
-                Ok(Err(_)) => return Err(ProposerAcquireError::Closed),
-                Err(_) => return Err(ProposerAcquireError::Timeout),
+                // note, acquire error is effectively the same as closed.
+                Ok(Err(_acquire_err)) => return Err(SignLimitError::Closed),
+                Err(_timeout) => return Err(SignLimitError::Timeout),
             };
 
-        Ok(ProposerPermit {
+        Ok(SignPermit {
             permit: Some(permit),
             state: Arc::clone(&self.state),
         })
     }
 }
 
-impl Drop for ProposerPermit {
+impl Drop for SignPermit {
     fn drop(&mut self) {
         let Some(permit) = self.permit.take() else {
             return;
@@ -246,7 +247,7 @@ struct SignState {
     mesh_state: watch::Receiver<MeshState>,
     /// Budget for the current organizing+posit attempt.
     budget: TimeoutBudget,
-    proposer_permit: Option<ProposerPermit>,
+    permit: Option<SignPermit>,
     /// The highest round sent by a peer
     highest_seen_round: usize,
     /// Posit message for `highest_seen_round` round.
@@ -267,7 +268,7 @@ impl SignState {
             indexed,
             mesh_state,
             budget: TimeoutBudget::new(ORGANIZE_POSIT_TIMEOUT),
-            proposer_permit: None,
+            permit: None,
             highest_seen_round: 0,
             buffered_messages: VecDeque::new(),
         }
@@ -282,7 +283,7 @@ impl SignState {
         self.round = std::cmp::max(self.round + 1, self.highest_seen_round);
         // Reset the budget for the new attempt
         self.budget.reset(ORGANIZE_POSIT_TIMEOUT);
-        self.proposer_permit = None;
+        self.permit = None;
         tracing::debug!(prev_round, new_round = self.round, "bumped round");
     }
 
@@ -463,9 +464,9 @@ impl SignOrganizer {
                 "proposer waiting for concurrency slot"
             );
 
-            let permit = match ctx.proposer_semaphore.acquire(remaining).await {
+            let permit = match ctx.limiter.acquire(remaining).await {
                 Ok(permit) => permit,
-                Err(ProposerAcquireError::Timeout) => {
+                Err(SignLimitError::Timeout) => {
                     tracing::warn!(
                         ?sign_id,
                         round = ?state.round,
@@ -474,15 +475,15 @@ impl SignOrganizer {
                     state.bump_round();
                     return SignPhase::Organizing(SignOrganizer);
                 }
-                Err(ProposerAcquireError::Closed) => {
+                Err(SignLimitError::Closed) => {
                     tracing::error!(?sign_id, "proposer semaphore closed");
                     return SignPhase::Complete(Err(SignError::Aborted));
                 }
             };
 
-            state.proposer_permit = Some(permit);
+            state.permit = Some(permit);
         } else {
-            state.proposer_permit = None;
+            state.permit = None;
         }
 
         let (presignature_id, presignature, active) = if is_proposer {
@@ -1298,7 +1299,7 @@ struct SignTask {
     cfg: ProtocolConfig,
     contract: ContractStateWatcher,
     is_proposer: Arc<AtomicBool>,
-    proposer_semaphore: ProposerSemaphore,
+    limiter: SignLimiter,
     node_account_id: near_account_id::AccountId,
 }
 
@@ -1379,7 +1380,9 @@ pub struct SignatureSpawner {
     /// Tracks delay watcher tasks that will increment the delayed metric when response time exceeds expected
     delayed_watchers: HashMap<SignId, JoinHandle<()>>,
     mesh_state: watch::Receiver<MeshState>,
-    proposer_semaphore: ProposerSemaphore,
+    /// Limiter that limits the amount of sign tasks from progressing and utilizing
+    /// too much compute otherwise the whole system will be flooded with requests.
+    limiter: SignLimiter,
 
     msg: MessageChannel,
     rpc: RpcChannel,
@@ -1447,7 +1450,7 @@ impl SignatureSpawner {
             cfg,
             contract: self.contract.clone(),
             is_proposer,
-            proposer_semaphore: self.proposer_semaphore.clone(),
+            limiter: self.limiter.clone(),
             node_account_id: self.node_account_id.clone(),
         };
 
@@ -1584,8 +1587,8 @@ impl SignatureSpawner {
                 }
                 Ok(()) = cfg.changed() => {
                     protocol = cfg.borrow().protocol.clone();
-                    self.proposer_semaphore
-                        .update_limit(protocol.signature.max_concurrent_proposers as usize);
+                    self.limiter
+                        .update(protocol.signature.max_concurrent_proposers as usize);
                 }
                 Some(state) = contract_watcher.next_state() => {
                     if let Some(new_governance) = state.governance(&self.node_account_id) {
@@ -1629,7 +1632,7 @@ impl SignatureSpawnerTask {
             delayed_watchers: HashMap::new(),
             presignatures: presignature_storage,
             mesh_state,
-            proposer_semaphore: ProposerSemaphore::new(max_concurrent_proposers as usize),
+            limiter: SignLimiter::new(max_concurrent_proposers as usize),
             msg: msg_channel,
             rpc: rpc_channel,
             backlog,
@@ -1750,7 +1753,7 @@ mod tests {
             cfg: ProtocolConfig::default(),
             contract,
             is_proposer: Arc::new(AtomicBool::new(false)),
-            proposer_semaphore: ProposerSemaphore::new(1),
+            limiter: SignLimiter::new(1),
             node_account_id: account_id.clone(),
         };
 
@@ -1798,15 +1801,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn proposer_semaphore_times_out_at_limit() {
-        let semaphore = ProposerSemaphore::new(1);
+    async fn sign_limiter_times_out_at_limit() {
+        let semaphore = SignLimiter::new(1);
         let permit = semaphore
             .acquire(Duration::from_millis(10))
             .await
             .expect("first acquire should succeed");
 
         let second = semaphore.acquire(Duration::from_millis(10)).await;
-        assert!(matches!(second, Err(ProposerAcquireError::Timeout)));
+        assert!(matches!(second, Err(SignLimitError::Timeout)));
 
         drop(permit);
 
@@ -1815,8 +1818,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn proposer_semaphore_applies_reduced_limit_on_release() {
-        let semaphore = ProposerSemaphore::new(2);
+    async fn sign_limiter_applies_reduced_limit_on_release() {
+        let semaphore = SignLimiter::new(2);
         let first = semaphore
             .acquire(Duration::from_millis(10))
             .await
@@ -1826,12 +1829,12 @@ mod tests {
             .await
             .expect("second acquire should succeed");
 
-        semaphore.update_limit(1);
+        semaphore.update(1);
 
         drop(first);
 
         let third = semaphore.acquire(Duration::from_millis(10)).await;
-        assert!(matches!(third, Err(ProposerAcquireError::Timeout)));
+        assert!(matches!(third, Err(SignLimitError::Timeout)));
 
         drop(second);
 

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -9,6 +9,7 @@ use crate::protocol::message::{
 };
 use crate::protocol::posit::{PositAction, SinglePositCounter};
 use crate::protocol::presignature::PresignatureId;
+use crate::protocol::SignKind;
 use crate::protocol::{Chain, ProtocolState};
 use crate::rpc::{ContractStateWatcher, GovernanceInfo, RpcChannel};
 use crate::storage::presignature_storage::{PresignatureTaken, PresignatureTakenDropper};
@@ -18,7 +19,6 @@ use crate::stream::ops::SignBidirectionalEvent;
 use crate::types::SignatureProtocol;
 use crate::util::{AffinePointExt, JoinMap, TimeoutBudget};
 
-use crate::protocol::SignKind;
 use cait_sith::protocol::{Action, InitializationError, Participant};
 use cait_sith::PresignOutput;
 use chrono::Utc;
@@ -31,7 +31,7 @@ use rand::seq::IteratorRandom;
 use rand::SeedableRng;
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, watch, OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinHandle;
@@ -152,26 +152,26 @@ struct SignLimitState {
 #[derive(Clone, Debug)]
 struct SignLimiter {
     semaphore: Arc<Semaphore>,
-    state: Arc<Mutex<SignLimitState>>,
+    state: Arc<RwLock<SignLimitState>>,
 }
 
 #[derive(Debug)]
 struct SignPermit {
     permit: Option<OwnedSemaphorePermit>,
-    state: Arc<Mutex<SignLimitState>>,
+    state: Arc<RwLock<SignLimitState>>,
 }
 
 impl SignLimiter {
     fn new(limit: usize) -> Self {
         Self {
             semaphore: Arc::new(Semaphore::new(limit)),
-            state: Arc::new(Mutex::new(SignLimitState { limit, debt: 0 })),
+            state: Arc::new(RwLock::new(SignLimitState { limit, debt: 0 })),
         }
     }
 
     /// Updates the limits for concurrent slots
     fn update(&self, new_limit: usize) {
-        let mut state = match self.state.lock() {
+        let mut state = match self.state.write() {
             Ok(state) => state,
             Err(err) => {
                 tracing::error!(new_limit, ?err, "unable to update SignLimiter limits");
@@ -227,10 +227,10 @@ impl Drop for SignPermit {
         let Some(permit) = self.permit.take() else {
             return;
         };
-        let mut state = match self.state.lock() {
+        let mut state = match self.state.write() {
             Ok(state) => state,
             Err(err) => {
-                tracing::error!(?err, "failed to acquire lock in ProposerPermit drop");
+                tracing::error!(?err, "failed to acquire lock in SignPermit drop");
                 return;
             }
         };

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -31,9 +31,9 @@ use rand::seq::IteratorRandom;
 use rand::SeedableRng;
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{mpsc, watch, OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinHandle;
 
 /// The round interval to search for a proposer in the organizing phase.
@@ -137,12 +137,116 @@ enum SignError {
     Aborted,
 }
 
+#[derive(Debug)]
+enum ProposerAcquireError {
+    Timeout,
+    Closed,
+}
+
+#[derive(Debug)]
+struct ProposerSemaphoreState {
+    limit: usize,
+    debt: usize,
+}
+
+#[derive(Clone, Debug)]
+struct ProposerSemaphore {
+    semaphore: Arc<Semaphore>,
+    state: Arc<Mutex<ProposerSemaphoreState>>,
+}
+
+#[derive(Debug)]
+struct ProposerPermit {
+    permit: Option<OwnedSemaphorePermit>,
+    state: Arc<Mutex<ProposerSemaphoreState>>,
+}
+
+impl ProposerSemaphore {
+    fn new(limit: usize) -> Self {
+        Self {
+            semaphore: Arc::new(Semaphore::new(limit)),
+            state: Arc::new(Mutex::new(ProposerSemaphoreState { limit, debt: 0 })),
+        }
+    }
+
+    fn update_limit(&self, new_limit: usize) {
+        let old_limit = {
+            let mut state = self.state.lock().unwrap();
+            let old_limit = state.limit;
+            state.limit = new_limit;
+            old_limit
+        };
+
+        if new_limit > old_limit {
+            let mut permits_to_add = new_limit - old_limit;
+
+            if permits_to_add > 0 {
+                let mut state = self.state.lock().unwrap();
+                let forgiven = permits_to_add.min(state.debt);
+                state.debt -= forgiven;
+                permits_to_add -= forgiven;
+            }
+
+            if permits_to_add > 0 {
+                self.semaphore.add_permits(permits_to_add);
+            }
+
+            return;
+        }
+
+        let permits_to_remove = old_limit - new_limit;
+        if permits_to_remove == 0 {
+            return;
+        }
+
+        let forgotten = self.semaphore.forget_permits(permits_to_remove);
+        if forgotten < permits_to_remove {
+            let mut state = self.state.lock().unwrap();
+            state.debt += permits_to_remove - forgotten;
+        }
+    }
+
+    async fn acquire(&self, timeout: Duration) -> Result<ProposerPermit, ProposerAcquireError> {
+        let permit =
+            match tokio::time::timeout(timeout, self.semaphore.clone().acquire_owned()).await {
+                Ok(Ok(permit)) => permit,
+                Ok(Err(_)) => return Err(ProposerAcquireError::Closed),
+                Err(_) => return Err(ProposerAcquireError::Timeout),
+            };
+
+        Ok(ProposerPermit {
+            permit: Some(permit),
+            state: Arc::clone(&self.state),
+        })
+    }
+}
+
+impl Drop for ProposerPermit {
+    fn drop(&mut self) {
+        let Some(permit) = self.permit.take() else {
+            return;
+        };
+        let mut state = match self.state.lock() {
+            Ok(state) => state,
+            Err(err) => {
+                tracing::error!(?err, "failed to acquire lock in ProposerPermit drop");
+                return;
+            }
+        };
+        if state.debt > 0 {
+            state.debt -= 1;
+            permit.forget();
+        }
+    }
+}
+
 struct SignState {
     round: usize,
     indexed: IndexedSignRequest,
     mesh_state: watch::Receiver<MeshState>,
     /// Budget for the current organizing+posit attempt.
     budget: TimeoutBudget,
+    proposer_permit: Option<ProposerPermit>,
     /// The highest round sent by a peer
     highest_seen_round: usize,
     /// Posit message for `highest_seen_round` round.
@@ -163,6 +267,7 @@ impl SignState {
             indexed,
             mesh_state,
             budget: TimeoutBudget::new(ORGANIZE_POSIT_TIMEOUT),
+            proposer_permit: None,
             highest_seen_round: 0,
             buffered_messages: VecDeque::new(),
         }
@@ -177,6 +282,7 @@ impl SignState {
         self.round = std::cmp::max(self.round + 1, self.highest_seen_round);
         // Reset the budget for the new attempt
         self.budget.reset(ORGANIZE_POSIT_TIMEOUT);
+        self.proposer_permit = None;
         tracing::debug!(prev_round, new_round = self.round, "bumped round");
     }
 
@@ -346,6 +452,38 @@ impl SignOrganizer {
 
             (active, proposer, is_proposer)
         };
+
+        if is_proposer {
+            let remaining = state.budget.remaining();
+            tracing::info!(
+                ?sign_id,
+                round = ?state.round,
+                timeout = ?remaining,
+                limit = ctx.cfg.signature.max_concurrent_proposers,
+                "proposer waiting for concurrency slot"
+            );
+
+            let permit = match ctx.proposer_semaphore.acquire(remaining).await {
+                Ok(permit) => permit,
+                Err(ProposerAcquireError::Timeout) => {
+                    tracing::warn!(
+                        ?sign_id,
+                        round = ?state.round,
+                        "proposer timeout waiting for concurrency slot, reorganizing"
+                    );
+                    state.bump_round();
+                    return SignPhase::Organizing(SignOrganizer);
+                }
+                Err(ProposerAcquireError::Closed) => {
+                    tracing::error!(?sign_id, "proposer semaphore closed");
+                    return SignPhase::Complete(Err(SignError::Aborted));
+                }
+            };
+
+            state.proposer_permit = Some(permit);
+        } else {
+            state.proposer_permit = None;
+        }
 
         let (presignature_id, presignature, active) = if is_proposer {
             tracing::info!(?sign_id, round = ?state.round, "proposer waiting for presignature");
@@ -1160,6 +1298,7 @@ struct SignTask {
     cfg: ProtocolConfig,
     contract: ContractStateWatcher,
     is_proposer: Arc<AtomicBool>,
+    proposer_semaphore: ProposerSemaphore,
     node_account_id: near_account_id::AccountId,
 }
 
@@ -1240,6 +1379,7 @@ pub struct SignatureSpawner {
     /// Tracks delay watcher tasks that will increment the delayed metric when response time exceeds expected
     delayed_watchers: HashMap<SignId, JoinHandle<()>>,
     mesh_state: watch::Receiver<MeshState>,
+    proposer_semaphore: ProposerSemaphore,
 
     msg: MessageChannel,
     rpc: RpcChannel,
@@ -1307,6 +1447,7 @@ impl SignatureSpawner {
             cfg,
             contract: self.contract.clone(),
             is_proposer,
+            proposer_semaphore: self.proposer_semaphore.clone(),
             node_account_id: self.node_account_id.clone(),
         };
 
@@ -1443,6 +1584,8 @@ impl SignatureSpawner {
                 }
                 Ok(()) = cfg.changed() => {
                     protocol = cfg.borrow().protocol.clone();
+                    self.proposer_semaphore
+                        .update_limit(protocol.signature.max_concurrent_proposers as usize);
                 }
                 Some(state) = contract_watcher.next_state() => {
                     if let Some(new_governance) = state.governance(&self.node_account_id) {
@@ -1478,6 +1621,7 @@ impl SignatureSpawnerTask {
         rpc_channel: RpcChannel,
         backlog: Backlog,
     ) -> Self {
+        let max_concurrent_proposers = config.borrow().protocol.signature.max_concurrent_proposers;
         let spawner = SignatureSpawner {
             contract,
             tasks: JoinMap::new(),
@@ -1485,6 +1629,7 @@ impl SignatureSpawnerTask {
             delayed_watchers: HashMap::new(),
             presignatures: presignature_storage,
             mesh_state,
+            proposer_semaphore: ProposerSemaphore::new(max_concurrent_proposers as usize),
             msg: msg_channel,
             rpc: rpc_channel,
             backlog,
@@ -1605,6 +1750,7 @@ mod tests {
             cfg: ProtocolConfig::default(),
             contract,
             is_proposer: Arc::new(AtomicBool::new(false)),
+            proposer_semaphore: ProposerSemaphore::new(1),
             node_account_id: account_id.clone(),
         };
 
@@ -1649,5 +1795,47 @@ mod tests {
         assert_eq!(sign_task.governance.epoch, 1);
         assert_eq!(sign_task.governance.threshold, 1);
         assert_eq!(sign_task.governance.me, Participant::from(0));
+    }
+
+    #[tokio::test]
+    async fn proposer_semaphore_times_out_at_limit() {
+        let semaphore = ProposerSemaphore::new(1);
+        let permit = semaphore
+            .acquire(Duration::from_millis(10))
+            .await
+            .expect("first acquire should succeed");
+
+        let second = semaphore.acquire(Duration::from_millis(10)).await;
+        assert!(matches!(second, Err(ProposerAcquireError::Timeout)));
+
+        drop(permit);
+
+        let third = semaphore.acquire(Duration::from_millis(10)).await;
+        assert!(third.is_ok());
+    }
+
+    #[tokio::test]
+    async fn proposer_semaphore_applies_reduced_limit_on_release() {
+        let semaphore = ProposerSemaphore::new(2);
+        let first = semaphore
+            .acquire(Duration::from_millis(10))
+            .await
+            .expect("first acquire should succeed");
+        let second = semaphore
+            .acquire(Duration::from_millis(10))
+            .await
+            .expect("second acquire should succeed");
+
+        semaphore.update_limit(1);
+
+        drop(first);
+
+        let third = semaphore.acquire(Duration::from_millis(10)).await;
+        assert!(matches!(third, Err(ProposerAcquireError::Timeout)));
+
+        drop(second);
+
+        let fourth = semaphore.acquire(Duration::from_millis(10)).await;
+        assert!(fourth.is_ok());
     }
 }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -171,18 +171,19 @@ impl SignLimiter {
 
     /// Updates the limits for concurrent slots
     fn update(&self, new_limit: usize) {
-        let old_limit = {
-            let mut state = self.state.lock().unwrap();
-            let old_limit = state.limit;
-            state.limit = new_limit;
-            old_limit
+        let mut state = match self.state.lock() {
+            Ok(state) => state,
+            Err(err) => {
+                tracing::error!(new_limit, ?err, "unable to update SignLimiter limits");
+                return;
+            }
         };
+        let old_limit = std::mem::replace(&mut state.limit, new_limit);
 
         // add more permits if the limit increased
         if new_limit > old_limit {
             let mut permits_to_add = new_limit - old_limit;
             if permits_to_add > 0 {
-                let mut state = self.state.lock().unwrap();
                 let forgiven = permits_to_add.min(state.debt);
                 state.debt -= forgiven;
                 permits_to_add -= forgiven;
@@ -199,7 +200,6 @@ impl SignLimiter {
 
         let forgotten = self.semaphore.forget_permits(permits_to_remove);
         if forgotten < permits_to_remove {
-            let mut state = self.state.lock().unwrap();
             state.debt += permits_to_remove - forgotten;
         }
     }


### PR DESCRIPTION
Should resolve https://github.com/sig-net/mpc/issues/731 partially.

Instead of doing whatever I mentioned with the SignPool in https://github.com/sig-net/mpc/issues/731, this is simpler and introduces minimal code changes. This introduces a `SignLimiter` and `SignPermit` that behaves like a semaphore in `SignTask` where if the sign task is a proposer, then it will try to acquire a permit. If it acquires a permit, then it is able to proceed and do posit+generation work. If it's a deliberator, it just continues to watchdog or receive posit messages as normal. So nodes can be deliberators as much as possible, while it limits itself from doing too much proposer related work.

This makes it so we do not need to take out the organization step of the SignTask because a SignPool that does the organization is effectively the same as this since it would constantly reorganize all requests as it too needs to watchdog over them. Also, we can just extend `SignLimiter` to be a scheduler or priority queue where we can only acquire a permit if we meet certain conditions.

Default max concurrent proposer set is 4. With 8 nodes, that's 32 sign tasks working at the same time. With 12 nodes, that's 48. It's not bad and we can set the default lower as we add more nodes.