### PR TITLE
fix(evm): canonicalize transaction signature scalar encoding

### DIFF
--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -292,8 +292,8 @@ pub fn sign_and_hash_eip1559_from_unsigned(
     }
     let y: u8 = if y_parity { 1 } else { 0 };
     srlp.append(&y);
-    srlp.append(&r);
-    srlp.append(&s);
+    srlp.append(&U256::from_be_slice(r).to_be_bytes_trimmed_vec());
+    srlp.append(&U256::from_be_slice(s).to_be_bytes_trimmed_vec());
 
     let srlp_body = srlp.as_raw(); // &[u8]
     let mut signed_bytes = Vec::with_capacity(1 + srlp_body.len());
@@ -325,8 +325,8 @@ pub fn sign_and_hash_legacy_from_unsigned(
     }
     let v: u64 = 35 + 2 * chain_id.unwrap_or(0) + if y_parity { 1 } else { 0 };
     out.append(&v);
-    out.append(&r);
-    out.append(&s);
+    out.append(&U256::from_be_slice(r).to_be_bytes_trimmed_vec());
+    out.append(&U256::from_be_slice(s).to_be_bytes_trimmed_vec());
 
     let signed_bytes = out.out().to_vec();
     let hash = alloy_primitives::keccak256(&signed_bytes);
@@ -503,4 +503,84 @@ pub struct SignBidirectionalSignature {
     pub public_key: mpc_crypto::PublicKey,
     pub indexed: IndexedSignRequest,
     pub signature: Signature,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::consensus::{SignableTransaction, TxEip1559, TxLegacy};
+    use alloy::eips::eip2718::Encodable2718;
+    use alloy::eips::eip2930::{AccessList, AccessListItem};
+    use alloy::primitives::{FixedBytes, Signature as AlloySignature, TxKind};
+
+    fn alloy_signature(r: [u8; 32], s: [u8; 32], y_parity: bool) -> AlloySignature {
+        AlloySignature::from_scalars_and_parity(
+            FixedBytes::from_slice(&r),
+            FixedBytes::from_slice(&s),
+            y_parity,
+        )
+    }
+
+    #[test]
+    fn sign_and_hash_eip1559_matches_alloy_for_access_list_with_leading_zero_signature_scalar() {
+        let tx = TxEip1559 {
+            chain_id: 1,
+            nonce: 7,
+            gas_limit: 100_000,
+            max_fee_per_gas: 100_000_000_000,
+            max_priority_fee_per_gas: 1_000_000_000,
+            to: TxKind::Call(Address::from([0x22; 20])),
+            value: U256::from(123u64),
+            access_list: AccessList(vec![AccessListItem {
+                address: Address::from([0x33; 20]),
+                storage_keys: vec![B256::from([0x44; 32])],
+            }]),
+            input: Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+        };
+        let unsigned = tx.encoded_for_signing();
+        let r = [
+            0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+            23, 24, 25, 26, 27, 28, 29,
+        ];
+        let s = [
+            0, 0, 0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+            23, 24, 25, 26, 27, 28, 29, 30,
+        ];
+        let expected_hash = keccak256(tx.into_signed(alloy_signature(r, s, true)).encoded_2718());
+
+        let (actual_hash, nonce) =
+            sign_and_hash_eip1559_from_unsigned(&unsigned, &r, &s, true).unwrap();
+
+        assert_eq!(nonce, 7);
+        assert_eq!(B256::from(actual_hash), expected_hash);
+    }
+
+    #[test]
+    fn sign_and_hash_legacy_matches_alloy_with_leading_zero_signature_scalar() {
+        let tx = TxLegacy {
+            chain_id: Some(1),
+            nonce: 11,
+            gas_price: 20_000_000_000,
+            gas_limit: 21_000,
+            to: TxKind::Call(Address::from([0x55; 20])),
+            value: U256::from(456u64),
+            input: Bytes::from_static(&[0xca, 0xfe]),
+        };
+        let unsigned = tx.encoded_for_signing();
+        let r = [
+            0, 0, 0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ];
+        let s = [
+            0, 0, 0, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 32,
+        ];
+        let expected_hash = keccak256(tx.into_signed(alloy_signature(r, s, false)).encoded_2718());
+
+        let (actual_hash, nonce) =
+            sign_and_hash_legacy_from_unsigned(&unsigned, Some(1), &r, &s, false).unwrap();
+
+        assert_eq!(nonce, 11);
+        assert_eq!(B256::from(actual_hash), expected_hash);
+    }
 }


### PR DESCRIPTION
## Summary
- Canonicalize EVM signed transaction RLP encoding for signature scalars in the MPC sign-and-hash path.
- Apply the same fix to EIP-1559 and legacy transaction reconstruction.
- Add Alloy-oracle regression tests for leading-zero `r`/`s` scalars, including the EIP-1559 access-list shape that exposed the issue.

## Why
Ethereum transaction signature fields `r` and `s` are RLP integers. The MPC node was appending fixed-width 32-byte scalar slices directly when manually reconstructing signed transaction bytes. If either scalar began with one or more zero bytes, the watcher hashed non-canonical bytes while Anvil hashed the canonical raw transaction, causing deterministic `BidirectionalTxId` mismatches at broadcast time.

Using the existing `U256::to_be_bytes_trimmed_vec()` conversion makes the manually encoded scalar payload match Alloy/Anvil canonical integer encoding without adding a local trimming helper.