### PR TITLE
request latency observability: latency metrics for organizing, posit and generating

### DIFF
--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -2,7 +2,7 @@ pub mod indexer_eth_direct_rpc;
 pub mod indexer_eth_helios;
 
 use crate::backlog::Backlog;
-use crate::metrics::requests::{record_request_latency, SignRequestStep};
+use crate::metrics::requests::{record_request_latency_since, SignRequestStep};
 use crate::protocol::{Chain, IndexedSignRequest};
 use crate::respond_bidirectional::CompletedTx;
 use crate::stream::ops::{EthereumSignatureRespondedEvent, SignatureRespondedEvent};
@@ -878,7 +878,7 @@ impl EthereumIndexer {
             .await?;
 
         for _request in &sign_requests {
-            record_request_latency(
+            record_request_latency_since(
                 Chain::Ethereum,
                 SignRequestStep::Indexing,
                 "ok",

--- a/chain-signatures/node/src/metrics/requests.rs
+++ b/chain-signatures/node/src/metrics/requests.rs
@@ -47,7 +47,7 @@ impl SignRequestStep {
     }
 }
 
-pub(crate) static SIGN_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
+static SIGN_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec_with_node_and_version(
         "multichain_sign_request_latency_sec",
         "Latency of multichain sign request processing with step and status specification.",

--- a/chain-signatures/node/src/metrics/requests.rs
+++ b/chain-signatures/node/src/metrics/requests.rs
@@ -117,7 +117,7 @@ pub(crate) static SIGN_REQUEST_DELAYED: LazyLock<CounterVec> = LazyLock::new(|| 
 /// the loop-back: organizing (self-loop on no presignature / no active peers),
 /// posit (consensus failed / timeout), or generating (generator construction
 /// or MPC run failed).
-pub static SIGN_REQUEST_LOOPS: LazyLock<CounterVec> = LazyLock::new(|| {
+pub(crate) static SIGN_REQUEST_LOOPS: LazyLock<CounterVec> = LazyLock::new(|| {
     try_create_counter_vec_with_node_and_version(
         "multichain_sign_request_loops_total",
         "Number of back-edges to organizing in the sign request state machine, by chain and source phase.",

--- a/chain-signatures/node/src/metrics/requests.rs
+++ b/chain-signatures/node/src/metrics/requests.rs
@@ -1,4 +1,5 @@
 use std::sync::LazyLock;
+use std::time::Duration;
 
 use prometheus::{exponential_buckets, CounterVec, HistogramVec, IntGauge};
 
@@ -16,7 +17,20 @@ pub enum SignRequestStep {
     Indexing,
     /// Time from indexing to signature generation start (Status: ok)
     AwaitingGeneration,
-    /// Time to generate the signature (Status: ok, error)
+    /// Cumulative time spent in the organizing phase across all attempts for
+    /// this request (Status: ok). Summed across loop iterations. In the
+    /// absence of governance pauses, Indexing + AwaitingGeneration +
+    /// Organizing + Posit + Generating + Responding == Total; resharing or
+    /// other transitions out of `Running` mid-request show up only in Total,
+    /// so the equality holds as `<=` in that case.
+    Organizing,
+    /// Cumulative time spent in the posit phase across all attempts for this
+    /// request (Status: ok). Summed across loop iterations. See `Organizing`
+    /// for the additivity caveat around governance pauses.
+    Posit,
+    /// Cumulative time spent in the generating phase across all attempts for
+    /// this request (Status: ok). Summed across loop iterations. See
+    /// `Organizing` for the additivity caveat around governance pauses.
     Generating,
     /// Time to respond to the sign request (Status: ok)
     Responding,
@@ -32,6 +46,8 @@ impl SignRequestStep {
         match self {
             Self::Indexing => "indexing",
             Self::AwaitingGeneration => "awaiting_generation",
+            Self::Organizing => "organizing",
+            Self::Posit => "posit",
             Self::Generating => "generating",
             Self::Responding => "responding",
             Self::Total => "total",
@@ -39,7 +55,7 @@ impl SignRequestStep {
     }
 }
 
-static SIGN_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
+pub(crate) static SIGN_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec_with_node_and_version(
         "multichain_sign_request_latency_sec",
         "Latency of multichain sign request processing with step and status specification.",
@@ -51,17 +67,33 @@ static SIGN_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
     .unwrap()
 });
 
+/// Observe a request latency given the elapsed duration directly. Use this
+/// when the caller already has a `Duration` — e.g. an accumulator that
+/// summed time across multiple attempts.
 pub fn record_request_latency(
+    chain: Chain,
+    step: SignRequestStep,
+    status: &str,
+    latency: Duration,
+) {
+    SIGN_REQUEST_LATENCY
+        .with_label_values(&[chain.as_str(), step.as_str(), status])
+        .observe(latency.as_secs_f64());
+}
+
+/// Observe a request latency by computing the elapsed time from a start
+/// point (Instant, unix timestamp, SystemTime). Sugar around
+/// `record_request_latency` for callers that have a start instead of a
+/// pre-computed duration.
+pub fn record_request_latency_since(
     chain: Chain,
     step: SignRequestStep,
     status: &str,
     start: impl LatencyStart,
 ) {
-    let duration = start.elapsed_seconds();
-
     SIGN_REQUEST_LATENCY
         .with_label_values(&[chain.as_str(), step.as_str(), status])
-        .observe(duration);
+        .observe(start.elapsed_seconds());
 }
 /// Some chains do not provide information about the block time.
 /// For that reason we record indexing step reached with 0.0 latency.
@@ -76,6 +108,20 @@ pub(crate) static SIGN_REQUEST_DELAYED: LazyLock<CounterVec> = LazyLock::new(|| 
         "multichain_sign_request_delayed",
         "Number of delayed requests by chain, reported by the current proposer node.",
         &["chain"],
+    )
+    .unwrap()
+});
+
+/// Counts each back-edge in the sign request state machine where a phase
+/// returns to organizing (a "loop"). `from_phase` is the phase that triggered
+/// the loop-back: organizing (self-loop on no presignature / no active peers),
+/// posit (consensus failed / timeout), or generating (generator construction
+/// or MPC run failed).
+pub static SIGN_REQUEST_LOOPS: LazyLock<CounterVec> = LazyLock::new(|| {
+    try_create_counter_vec_with_node_and_version(
+        "multichain_sign_request_loops_total",
+        "Number of back-edges to organizing in the sign request state machine, by chain and source phase.",
+        &["chain", "from_phase"],
     )
     .unwrap()
 });

--- a/chain-signatures/node/src/metrics/requests.rs
+++ b/chain-signatures/node/src/metrics/requests.rs
@@ -17,20 +17,12 @@ pub enum SignRequestStep {
     Indexing,
     /// Time from indexing to signature generation start (Status: ok)
     AwaitingGeneration,
-    /// Cumulative time spent in the organizing phase across all attempts for
-    /// this request (Status: ok). Summed across loop iterations. In the
-    /// absence of governance pauses, Indexing + AwaitingGeneration +
-    /// Organizing + Posit + Generating + Responding == Total; resharing or
-    /// other transitions out of `Running` mid-request show up only in Total,
-    /// so the equality holds as `<=` in that case.
+    /// Cumulative time in the organizing phase across all attempts (Status: ok).
+    /// See `PhaseDurations` for the additivity caveat around governance pauses.
     Organizing,
-    /// Cumulative time spent in the posit phase across all attempts for this
-    /// request (Status: ok). Summed across loop iterations. See `Organizing`
-    /// for the additivity caveat around governance pauses.
+    /// Cumulative time in the posit phase across all attempts (Status: ok).
     Posit,
-    /// Cumulative time spent in the generating phase across all attempts for
-    /// this request (Status: ok). Summed across loop iterations. See
-    /// `Organizing` for the additivity caveat around governance pauses.
+    /// Cumulative time in the generating phase across all attempts (Status: ok).
     Generating,
     /// Time to respond to the sign request (Status: ok)
     Responding,
@@ -112,11 +104,9 @@ pub(crate) static SIGN_REQUEST_DELAYED: LazyLock<CounterVec> = LazyLock::new(|| 
     .unwrap()
 });
 
-/// Counts each back-edge in the sign request state machine where a phase
-/// returns to organizing (a "loop"). `from_phase` is the phase that triggered
-/// the loop-back: organizing (self-loop on no presignature / no active peers),
-/// posit (consensus failed / timeout), or generating (generator construction
-/// or MPC run failed).
+/// Counts back-edges to organizing in the sign request state machine.
+/// `from_phase` identifies the source: organizing (self-loop), posit
+/// (consensus failed/timeout), or generating (construction or MPC failed).
 pub(crate) static SIGN_REQUEST_LOOPS: LazyLock<CounterVec> = LazyLock::new(|| {
     try_create_counter_vec_with_node_and_version(
         "multichain_sign_request_loops_total",

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -1236,8 +1236,6 @@ impl SignGenerator {
                         "completed signature generation"
                     );
 
-                    // SignRequestStep::Generating is emitted cumulatively from SignTask::run; the per-attempt protocol metrics below are unchanged.
-
                     crate::metrics::protocols::SIGNATURE_ACCRUED_WAIT_DELAY
                         .observe(total_wait.as_millis() as f64);
                     crate::metrics::protocols::SIGNATURE_POKES_CNT.observe(total_pokes as f64);
@@ -1881,14 +1879,6 @@ mod tests {
         assert_eq!(sign_task.governance.epoch, 1);
         assert_eq!(sign_task.governance.threshold, 1);
         assert_eq!(sign_task.governance.me, Participant::from(0));
-    }
-
-    #[test]
-    fn phase_durations_default_is_zero() {
-        let d = PhaseDurations::default();
-        assert_eq!(d.organizing, Duration::ZERO);
-        assert_eq!(d.posit, Duration::ZERO);
-        assert_eq!(d.generating, Duration::ZERO);
     }
 
     #[test]

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -2,7 +2,9 @@ use crate::backlog::Backlog;
 use crate::config::Config;
 use crate::kdf::derive_delta;
 use crate::mesh::MeshState;
-use crate::metrics::requests::{record_request_latency, SignRequestStep};
+use crate::metrics::requests::{
+    record_request_latency, record_request_latency_since, SignRequestStep, SIGN_REQUEST_LOOPS,
+};
 use crate::protocol::contract::primitives::intersect_vec;
 use crate::protocol::message::{
     MessageChannel, PositMessage, PositProtocolId, SignatureMessage, Subscriber,
@@ -1082,12 +1084,7 @@ impl SignGenerator {
                         "completed signature generation"
                     );
 
-                    record_request_latency(
-                        self.indexed.chain,
-                        SignRequestStep::Generating,
-                        "ok",
-                        self.created,
-                    );
+                    // SignRequestStep::Generating is emitted cumulatively from SignTask::run; the per-attempt protocol metrics below are unchanged.
 
                     crate::metrics::protocols::SIGNATURE_ACCRUED_WAIT_DELAY
                         .observe(total_wait.as_millis() as f64);
@@ -1145,6 +1142,53 @@ impl Drop for SignGenerator {
     }
 }
 
+/// Per-request accumulator for time spent in the three phases that the
+/// `SignTask::run` loop drives: Organizing, Posit, and Generating. Each
+/// phase can be entered multiple times for one request (e.g. Posit can fail
+/// consensus and loop back to Organizing), so the times are summed across
+/// every attempt.
+///
+/// In the absence of governance pauses, the emitted histograms satisfy
+/// Indexing + AwaitingGeneration + Organizing + Posit + Generating +
+/// Responding == Total. If the contract state leaves `Running` mid-request
+/// (resharing, governance churn) the run loop idles until it transitions
+/// back; that idle time is captured in Total but not in any phase, so the
+/// equality becomes `<= Total`.
+///
+/// The other `SignRequestStep` variants are not part of SignTask at all —
+/// Indexing is emitted by the indexer modules, AwaitingGeneration by
+/// `SignatureSpawner::handle_request`, and Responding/Total by `rpc.rs`.
+/// `add` ignores them so they are not double-counted.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+struct PhaseDurations {
+    organizing: Duration,
+    posit: Duration,
+    generating: Duration,
+}
+
+impl PhaseDurations {
+    fn add(&mut self, step: SignRequestStep, elapsed: Duration) {
+        match step {
+            SignRequestStep::Organizing => self.organizing += elapsed,
+            SignRequestStep::Posit => self.posit += elapsed,
+            SignRequestStep::Generating => self.generating += elapsed,
+            // Not part of SignTask — emitted elsewhere in the codebase.
+            // Listed explicitly (instead of `_`) so adding a new variant to
+            // SignRequestStep forces a compile error and a deliberate choice.
+            SignRequestStep::Indexing
+            | SignRequestStep::AwaitingGeneration
+            | SignRequestStep::Responding
+            | SignRequestStep::Total => {}
+        }
+    }
+
+    fn emit(self, chain: Chain) {
+        record_request_latency(chain, SignRequestStep::Organizing, "ok", self.organizing);
+        record_request_latency(chain, SignRequestStep::Posit, "ok", self.posit);
+        record_request_latency(chain, SignRequestStep::Generating, "ok", self.generating);
+    }
+}
+
 struct SignTask {
     governance: GovernanceInfo,
     sign_id: SignId,
@@ -1181,9 +1225,36 @@ impl SignTask {
         // since we won't in the running state
         let mut is_running = self.governance.is_running;
 
+        // Accumulate time spent in each phase across all loop iterations so
+        // that the emitted latencies sum to Total. Emitted once on
+        // Complete(Ok) further below; on failed completion we skip emission
+        // to match existing practice of recording only the ok path.
+        let mut durations = PhaseDurations::default();
+
         loop {
+            let phase_start = Instant::now();
+            let current_phase_step = match &phase {
+                SignPhase::Organizing(_) => Some(SignRequestStep::Organizing),
+                SignPhase::Posit(_) => Some(SignRequestStep::Posit),
+                SignPhase::Generating(_) => Some(SignRequestStep::Generating),
+                SignPhase::Complete(_) => None,
+            };
+
             tokio::select! {
                 Some(contract_state) = contract_watcher.next_state() => {
+                    // phase.advance was cancelled at its current await point.
+                    // If is_running was true, advance was actually running, so
+                    // attribute its partial elapsed time to the cancelled
+                    // phase to keep Organizing + Posit + Generating == Total.
+                    // If is_running was false, the advance branch was already
+                    // gated off; the iteration was idle-waiting and there is
+                    // no phase work to attribute. (Note: we check is_running
+                    // before refresh_governance mutates it below.)
+                    if is_running {
+                        if let Some(step) = current_phase_step {
+                            durations.add(step, phase_start.elapsed());
+                        }
+                    }
                     is_running = self.refresh_governance(&contract_state);
                     if is_running {
                         // we're back into running, reset to SignOrganizer
@@ -1199,9 +1270,28 @@ impl SignTask {
                 // This branch in tokio::select will get cancelled since the future for next contract
                 // state is reached first. This effectively pauses this branch from executing and
                 // further advancing the signature organization/positing/generation flow.
-                new_phase = phase.advance(&mut self, &mut state, &mut task_rx), if is_running => match new_phase {
-                    SignPhase::Complete(result) => return result,
-                    new_phase => phase = new_phase,
+                new_phase = phase.advance(&mut self, &mut state, &mut task_rx), if is_running => {
+                    if let Some(step) = current_phase_step {
+                        durations.add(step, phase_start.elapsed());
+                        if matches!(&new_phase, SignPhase::Organizing(_)) {
+                            SIGN_REQUEST_LOOPS
+                                .with_label_values(&[
+                                    state.indexed().chain.as_str(),
+                                    step.as_str(),
+                                ])
+                                .inc();
+                        }
+                    }
+
+                    match new_phase {
+                        SignPhase::Complete(result) => {
+                            if result.is_ok() {
+                                durations.emit(state.indexed().chain);
+                            }
+                            return result;
+                        }
+                        new_phase => phase = new_phase,
+                    }
                 }
             };
         }
@@ -1402,7 +1492,7 @@ impl SignatureSpawner {
                     return;
                 }
 
-                record_request_latency(
+                record_request_latency_since(
                     request.chain,
                     SignRequestStep::AwaitingGeneration,
                     "ok",
@@ -1649,5 +1739,71 @@ mod tests {
         assert_eq!(sign_task.governance.epoch, 1);
         assert_eq!(sign_task.governance.threshold, 1);
         assert_eq!(sign_task.governance.me, Participant::from(0));
+    }
+
+    #[test]
+    fn phase_durations_default_is_zero() {
+        let d = PhaseDurations::default();
+        assert_eq!(d.organizing, Duration::ZERO);
+        assert_eq!(d.posit, Duration::ZERO);
+        assert_eq!(d.generating, Duration::ZERO);
+    }
+
+    #[test]
+    fn phase_durations_sum_per_phase_across_attempts() {
+        // Simulates a request that loops Organizing -> Posit -> Organizing ->
+        // Posit -> Generating before completing. Each `add` mirrors one
+        // iteration of the SignTask::run phase loop.
+        let mut d = PhaseDurations::default();
+        d.add(SignRequestStep::Organizing, Duration::from_millis(100));
+        d.add(SignRequestStep::Posit, Duration::from_millis(200));
+        // back-edge: Posit failed and we re-entered Organizing
+        d.add(SignRequestStep::Organizing, Duration::from_millis(50));
+        d.add(SignRequestStep::Posit, Duration::from_millis(150));
+        d.add(SignRequestStep::Generating, Duration::from_millis(500));
+
+        assert_eq!(d.organizing, Duration::from_millis(150));
+        assert_eq!(d.posit, Duration::from_millis(350));
+        assert_eq!(d.generating, Duration::from_millis(500));
+    }
+
+    #[test]
+    fn phase_durations_ignore_steps_not_part_of_sign_task() {
+        // These variants are not part of SignTask: Indexing is emitted by
+        // the indexer modules, AwaitingGeneration by SignatureSpawner::
+        // handle_request, and Responding/Total by rpc.rs. Passing any to
+        // `add` must be a no-op or they would be double-counted on
+        // multichain_sign_request_latency_sec.
+        let mut d = PhaseDurations::default();
+        d.add(SignRequestStep::Indexing, Duration::from_millis(100));
+        d.add(
+            SignRequestStep::AwaitingGeneration,
+            Duration::from_millis(200),
+        );
+        d.add(SignRequestStep::Responding, Duration::from_millis(300));
+        d.add(SignRequestStep::Total, Duration::from_millis(400));
+
+        assert_eq!(d, PhaseDurations::default());
+    }
+
+    #[test]
+    fn phase_durations_preserve_additivity_invariant() {
+        // This represents the case where we have 2 attempts:
+        // 1st one fails at posit, then starts from oganizing again and finishes
+        let inputs = [
+            (SignRequestStep::Organizing, Duration::from_millis(40)),
+            (SignRequestStep::Posit, Duration::from_millis(120)),
+            (SignRequestStep::Organizing, Duration::from_millis(35)),
+            (SignRequestStep::Posit, Duration::from_millis(95)),
+            (SignRequestStep::Generating, Duration::from_millis(710)),
+        ];
+        let expected: Duration = inputs.iter().map(|(_, d)| *d).sum();
+
+        let mut d = PhaseDurations::default();
+        for (step, elapsed) in inputs {
+            d.add(step, elapsed);
+        }
+
+        assert_eq!(d.organizing + d.posit + d.generating, expected);
     }
 }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -1294,23 +1294,15 @@ impl Drop for SignGenerator {
     }
 }
 
-/// Per-request accumulator for time spent in the three phases that the
-/// `SignTask::run` loop drives: Organizing, Posit, and Generating. Each
-/// phase can be entered multiple times for one request (e.g. Posit can fail
-/// consensus and loop back to Organizing), so the times are summed across
-/// every attempt.
+/// Per-request accumulator for the three looping phases in `SignTask::run`:
+/// Organizing, Posit, Generating. Times are summed across attempts so each
+/// histogram observation covers the full request even when the state machine
+/// loops back. Indexing/AwaitingGeneration/Responding/Total are emitted
+/// elsewhere and ignored by `add`.
 ///
-/// In the absence of governance pauses, the emitted histograms satisfy
-/// Indexing + AwaitingGeneration + Organizing + Posit + Generating +
-/// Responding == Total. If the contract state leaves `Running` mid-request
-/// (resharing, governance churn) the run loop idles until it transitions
-/// back; that idle time is captured in Total but not in any phase, so the
-/// equality becomes `<= Total`.
-///
-/// The other `SignRequestStep` variants are not part of SignTask at all —
-/// Indexing is emitted by the indexer modules, AwaitingGeneration by
-/// `SignatureSpawner::handle_request`, and Responding/Total by `rpc.rs`.
-/// `add` ignores them so they are not double-counted.
+/// Additivity caveat: without governance pauses, all five stages sum to
+/// Total. Resharing or other transitions out of `Running` mid-request show
+/// idle time only in Total, so the equality holds as `<=` in that case.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 struct PhaseDurations {
     organizing: Duration,
@@ -1324,9 +1316,8 @@ impl PhaseDurations {
             SignRequestStep::Organizing => self.organizing += elapsed,
             SignRequestStep::Posit => self.posit += elapsed,
             SignRequestStep::Generating => self.generating += elapsed,
-            // Not part of SignTask — emitted elsewhere in the codebase.
-            // Listed explicitly (instead of `_`) so adding a new variant to
-            // SignRequestStep forces a compile error and a deliberate choice.
+            // Emitted elsewhere; listed explicitly so adding a new variant
+            // forces a deliberate decision here.
             SignRequestStep::Indexing
             | SignRequestStep::AwaitingGeneration
             | SignRequestStep::Responding
@@ -1378,10 +1369,7 @@ impl SignTask {
         // since we won't in the running state
         let mut is_running = self.governance.is_running;
 
-        // Accumulate time spent in each phase across all loop iterations so
-        // that the emitted latencies sum to Total. Emitted once on
-        // Complete(Ok) further below; on failed completion we skip emission
-        // to match existing practice of recording only the ok path.
+        // Sum per-phase time across loop attempts; emit on Complete(Ok) only.
         let mut durations = PhaseDurations::default();
 
         loop {
@@ -1395,12 +1383,9 @@ impl SignTask {
 
             tokio::select! {
                 Some(contract_state) = contract_watcher.next_state() => {
-                    // phase.advance was cancelled at its current await point.
-                    // If is_running was true, advance was actually running, so
-                    // attribute its partial elapsed time to the cancelled phase.
-                    // If is_running was false, the advance branch was already
-                    // gated off; the iteration was idle-waiting and there is
-                    // no phase work to attribute.
+                    // `phase.advance` was cancelled. Attribute its partial
+                    // elapsed time only if `is_running` was true; otherwise
+                    // the branch was gated off and the iteration was idle.
                     if is_running {
                         if let Some(step) = current_phase_step {
                             durations.add(step, phase_start.elapsed());

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -1244,12 +1244,10 @@ impl SignTask {
                 Some(contract_state) = contract_watcher.next_state() => {
                     // phase.advance was cancelled at its current await point.
                     // If is_running was true, advance was actually running, so
-                    // attribute its partial elapsed time to the cancelled
-                    // phase to keep Organizing + Posit + Generating == Total.
+                    // attribute its partial elapsed time to the cancelled phase.
                     // If is_running was false, the advance branch was already
                     // gated off; the iteration was idle-waiting and there is
-                    // no phase work to attribute. (Note: we check is_running
-                    // before refresh_governance mutates it below.)
+                    // no phase work to attribute.
                     if is_running {
                         if let Some(step) = current_phase_step {
                             durations.add(step, phase_start.elapsed());
@@ -1789,7 +1787,7 @@ mod tests {
     #[test]
     fn phase_durations_preserve_additivity_invariant() {
         // This represents the case where we have 2 attempts:
-        // 1st one fails at posit, then starts from oganizing again and finishes
+        // 1st one fails at posit, then starts from organizing again and finishes
         let inputs = [
             (SignRequestStep::Organizing, Duration::from_millis(40)),
             (SignRequestStep::Posit, Duration::from_millis(120)),

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -2,7 +2,7 @@ use crate::backlog::Backlog;
 use crate::config::{Config, ContractConfig, NetworkConfig};
 use crate::indexer_eth::EthConfig;
 use crate::indexer_sol::SolConfig;
-use crate::metrics::requests::{record_request_latency, SignRequestStep};
+use crate::metrics::requests::{record_request_latency_since, SignRequestStep};
 use crate::protocol::contract::primitives::{ParticipantMap, Participants};
 use crate::protocol::contract::RunningContractState;
 use crate::protocol::{Chain, Governance, IndexedSignRequest, ProtocolState, SignKind};
@@ -1233,21 +1233,21 @@ async fn execute_publish(client: ChainClient, action: PublishAction, backlog: Ba
         let elapsed_secs =
             crate::util::unix_elapsed(action.indexed.unix_timestamp_indexed).as_secs();
         if elapsed_secs <= chain.expected_response_time_secs() {
-            record_request_latency(
+            record_request_latency_since(
                 chain,
                 SignRequestStep::Total,
                 "in_time",
                 action.indexed.unix_timestamp_indexed,
             );
         } else {
-            record_request_latency(
+            record_request_latency_since(
                 chain,
                 SignRequestStep::Total,
                 "expired",
                 action.indexed.unix_timestamp_indexed,
             );
         }
-        record_request_latency(chain, SignRequestStep::Responding, "ok", action.timestamp);
+        record_request_latency_since(chain, SignRequestStep::Responding, "ok", action.timestamp);
     } else {
         tracing::info!(
             ?sign_id,
@@ -1802,21 +1802,26 @@ async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAc
             let chain = action.indexed.chain;
             let elapsed = crate::util::unix_elapsed(action.indexed.unix_timestamp_indexed);
             if elapsed.as_secs() <= chain.expected_response_time_secs() {
-                record_request_latency(
+                record_request_latency_since(
                     chain,
                     SignRequestStep::Total,
                     "in_time",
                     action.indexed.unix_timestamp_indexed,
                 );
             } else {
-                record_request_latency(
+                record_request_latency_since(
                     chain,
                     SignRequestStep::Total,
                     "expired",
                     action.indexed.unix_timestamp_indexed,
                 );
             }
-            record_request_latency(chain, SignRequestStep::Responding, "ok", action.timestamp);
+            record_request_latency_since(
+                chain,
+                SignRequestStep::Responding,
+                "ok",
+                action.timestamp,
+            );
         }
         actions.clear();
         return;


### PR DESCRIPTION
as pointed out in https://github.com/sig-net/mpc/issues/751, we need more visibility into the time spent looping between organizing and posit.

By looking at code, it turns out, besides going from posit -> organizing when posit fails, it is also possible to go from generating -> organizing when generating fails.

This change captures the possibility that organizing, posit and generating can each be happening multiple times before a sign request is completed, and sum up all the time spent in each attempt in the corresponding phase per sign request.

Example:
let's say what happened is: organizing(1s) -> posit (which failed, 2s) -> organizing(1s) -> posit(2s) -> generating (failed, 10s) -> organizing(1s) -> posit(2s) -> generating(10s) -> completed, then the request latency emitted for stage `organizing` will be the 3 organizing attempts added together = 1 + 1 +1 = 3s, the latency emitted for stage `posit` = 2 + 2 +2 = 6s, the latency metric emitted for stage `Generating` = 10 +10 = 20s.

This would better observe the requests where we had multiple attempts, and the request stages' latency would add up towards total request latency much more closely.

Caveat:
we could still lose time in idle waiting, i.e. waiting while contract state changes, we omit them for now.