### PR TITLE
chore: feature gate and disable helios by default

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -20,7 +20,7 @@ rustflags = [
 runner = "./setup.sh"
 
 [alias]
-build-node = "build -p mpc-node --release"
+build-node = "build -p mpc-node --release --features helios"
 build-test = "build -p integration-tests --tests"
 test-i = "test -p integration-tests -- --test-threads 4 --show-output"
 test-unit = "test --workspace --exclude integration-tests -- --show-output"

--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -71,7 +71,7 @@ jobs:
         run: npm i && npx hardhat compile
 
       - name: Presetup binaries
-        run: setup.sh
+        run: ./setup.sh
 
       - name: Build integration tests
         run: cargo build -p integration-tests --tests
@@ -140,7 +140,7 @@ jobs:
         run: npm i && npx hardhat compile
 
       - name: Presetup binaries
-        run: setup.sh
+        run: ./setup.sh
 
       - name: Build integration tests
         run: cargo build -p integration-tests --tests

--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -70,10 +70,13 @@ jobs:
         working-directory: ./chain-signatures/contract-eth
         run: npm i && npx hardhat compile
 
-      - name: Build integration tests
-        run: cargo build -p integration-tests --tests
+      - name: Presetup binaries
+        run: setup.sh
         env:
           MPC_ENABLE_HELIOS: 1
+
+      - name: Build integration tests
+        run: cargo build -p integration-tests --tests
 
       - name: Run Canton stream tests
         run: cargo test -p integration-tests --test lib -- canton_stream --ignored --nocapture --test-threads 1
@@ -134,15 +137,14 @@ jobs:
           key: "${{ runner.os }}-cargo-${{ hashFiles('chain-signatures/Cargo.lock') }}"
           restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Build Chain-Signatures Contract
-        run: ./build-contract.sh
-
       - name: Build eth contract
         working-directory: ./chain-signatures/contract-eth
         run: npm i && npx hardhat compile
 
-      - name: Build Chain-Signatures Node
-        run: cargo build -p mpc-node --release --features helios
+      - name: Presetup binaries
+        run: setup.sh
+        env:
+          MPC_ENABLE_HELIOS: 1
 
       - name: Build integration tests
         run: cargo build -p integration-tests --tests

--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -66,18 +66,14 @@ jobs:
           key: "${{ runner.os }}-cargo-${{ hashFiles('chain-signatures/Cargo.lock') }}"
           restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Build Chain-Signatures Contract
-        run: ./build-contract.sh
-
       - name: Build eth contract
         working-directory: ./chain-signatures/contract-eth
         run: npm i && npx hardhat compile
 
-      - name: Build Chain-Signatures Node
-        run: cargo build -p mpc-node --release
-
       - name: Build integration tests
         run: cargo build -p integration-tests --tests
+        env:
+          MPC_ENABLE_HELIOS: 1
 
       - name: Run Canton stream tests
         run: cargo test -p integration-tests --test lib -- canton_stream --ignored --nocapture --test-threads 1
@@ -146,7 +142,7 @@ jobs:
         run: npm i && npx hardhat compile
 
       - name: Build Chain-Signatures Node
-        run: cargo build -p mpc-node --release
+        run: cargo build -p mpc-node --release --features helios
 
       - name: Build integration tests
         run: cargo build -p integration-tests --tests

--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -72,8 +72,6 @@ jobs:
 
       - name: Presetup binaries
         run: setup.sh
-        env:
-          MPC_ENABLE_HELIOS: 1
 
       - name: Build integration tests
         run: cargo build -p integration-tests --tests
@@ -143,8 +141,6 @@ jobs:
 
       - name: Presetup binaries
         run: setup.sh
-        env:
-          MPC_ENABLE_HELIOS: 1
 
       - name: Build integration tests
         run: cargo build -p integration-tests --tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -74,10 +74,10 @@ jobs:
       # Build the tests before actually running them to see how long the tests take to run by itself
       # instead of including the build time in the test time report on Github.
       - name: Build Chain-Signatures Integration Tests
-        run: cargo build -p integration-tests --tests
+        run: cargo build -p integration-tests --tests --features helios
 
       - name: Test
-        run: cargo nextest run -p integration-tests --profile fixture
+        run: cargo nextest run -p integration-tests --features helios --profile fixture
         env:
           RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -66,12 +66,15 @@ jobs:
       - name: Install cargo-nextest
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
+      - name: Presetup binaries
+        run: setup.sh
+        env:
+          MPC_ENABLE_HELIOS: 1
+
       # Build the tests before actually running them to see how long the tests take to run by itself
       # instead of including the build time in the test time report on Github.
       - name: Build Chain-Signatures Integration Tests
         run: cargo build -p integration-tests --tests
-        env:
-          MPC_ENABLE_HELIOS: 1
 
       - name: Test
         run: cargo nextest run -p integration-tests --profile fixture

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -67,7 +67,7 @@ jobs:
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - name: Presetup binaries
-        run: setup.sh
+        run: ./setup.sh
         env:
           MPC_ENABLE_HELIOS: 1
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -70,6 +70,8 @@ jobs:
       # instead of including the build time in the test time report on Github.
       - name: Build Chain-Signatures Integration Tests
         run: cargo build -p integration-tests --tests
+        env:
+          MPC_ENABLE_HELIOS: 1
 
       - name: Test
         run: cargo nextest run -p integration-tests --profile fixture

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -83,18 +83,14 @@ jobs:
           key: "${{ runner.os }}-cargo-${{ hashFiles('chain-signatures/Cargo.lock') }}"
           restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Build Chain-Signatures Contract
-        run: ./build-contract.sh
-
       - name: Build eth contract
         working-directory: ./chain-signatures/contract-eth
         run: npm i && npx hardhat compile
 
-      - name: Build Chain-Signatures Node
-        run: cargo build -p mpc-node --release
-
       - name: Build nightly
         run: cargo build -p integration-tests --tests
+        env:
+          MPC_ENABLE_HELIOS: 1
 
       - name: Run nightly
         run: cargo test -p integration-tests --test lib -- cases::nightly --show-output --ignored

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -93,10 +93,10 @@ jobs:
           MPC_ENABLE_HELIOS: 1
 
       - name: Build nightly
-        run: cargo build -p integration-tests --tests
+        run: cargo build -p integration-tests --tests --features helios
 
       - name: Run nightly
-        run: cargo test -p integration-tests --test lib -- cases::nightly --show-output --ignored
+        run: cargo test -p integration-tests --features helios --test lib -- cases::nightly --show-output --ignored
         env:
           RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -87,10 +87,13 @@ jobs:
         working-directory: ./chain-signatures/contract-eth
         run: npm i && npx hardhat compile
 
-      - name: Build nightly
-        run: cargo build -p integration-tests --tests
+      - name: Presetup binaries
+        run: setup.sh
         env:
           MPC_ENABLE_HELIOS: 1
+
+      - name: Build nightly
+        run: cargo build -p integration-tests --tests
 
       - name: Run nightly
         run: cargo test -p integration-tests --test lib -- cases::nightly --show-output --ignored

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -88,7 +88,7 @@ jobs:
         run: npm i && npx hardhat compile
 
       - name: Presetup binaries
-        run: setup.sh
+        run: ./setup.sh
         env:
           MPC_ENABLE_HELIOS: 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY integration-tests/ ./integration-tests
 COPY Cargo.toml .
 COPY Cargo.lock .
 COPY --from=eth-builder /usr/src/app/contract-eth/artifacts chain-signatures/contract-eth/artifacts
-RUN cargo build --release --package mpc-node
+RUN cargo build --release --package mpc-node --features helios
 
 FROM debian:stable-slim AS runtime
 RUN apt-get update && apt-get install --assume-yes libssl-dev ca-certificates curl

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -38,7 +38,7 @@ opentelemetry_sdk = { version = "0.29.0", default-features = false, features = [
 opentelemetry-appender-tracing = "0.29.1"
 alloy-signer-local = "1.0.38"
 alloy-sol-types = "1.4.1"
-helios = { git = "https://github.com/a16z/helios", rev = "e1f9a50f73d7af6f6ae4acf2b663d04aab6adb19" }
+helios = { git = "https://github.com/a16z/helios", rev = "e1f9a50f73d7af6f6ae4acf2b663d04aab6adb19", optional = true }
 ed25519-zebra = { version = "4.1", default-features = false, features = ["alloc"] }
 subxt = { version = "0.44", default-features = false, features = ["jsonrpsee","native","unstable-light-client"] }
 sp-core = { version = "38.1", default-features = false, features = ["std"] }
@@ -110,6 +110,7 @@ test-log = { version = "0.2.12", features = ["log", "trace"] }
 
 [features]
 default = []
+helios = ["dep:helios"]
 # utilized for benchmarking the node:
 bench = []
 # utilized by "integration-tests" package:

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -1417,9 +1417,6 @@ mod tests {
 
     #[test]
     fn catchup_start_is_clamped_to_supported_window() {
-        #[cfg(feature = "helios")]
-        let max_catchup_blocks = indexer_eth_helios::MAX_CATCHUP_BLOCKS;
-        #[cfg(not(feature = "helios"))]
         let max_catchup_blocks = 8191;
         let anchor_height = 10_000;
         let catchup_end = anchor_height - 1;

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -133,52 +133,36 @@ pub struct EthArgs {
 
     // -- Helios light-client --
     /// Use Helios light client instead of direct RPC
-    #[cfg_attr(
-        feature = "helios",
-        clap(
-            long,
-            env("MPC_ETH_LIGHT_CLIENT"),
-            default_value = "false",
-            requires_if("true", "eth_consensus_rpc_http_url")
-        )
+    #[clap(
+        long,
+        env("MPC_ETH_LIGHT_CLIENT"),
+        default_value = "false",
+        requires_if("true", "eth_consensus_rpc_http_url")
     )]
-    #[cfg_attr(not(feature = "helios"), arg(skip))]
     pub eth_light_client: bool,
     /// Ethereum consensus RPC URL (required when --eth-light-client is set)
-    #[cfg_attr(
-        feature = "helios",
-        clap(
-            long,
-            env("MPC_ETH_CONSENSUS_RPC_HTTP_URL"),
-            requires = "eth_account_sk"
-        )
+    #[clap(
+        long,
+        env("MPC_ETH_CONSENSUS_RPC_HTTP_URL"),
+        requires = "eth_account_sk"
     )]
-    #[cfg_attr(not(feature = "helios"), arg(skip))]
     pub eth_consensus_rpc_http_url: Option<String>,
     /// The network that the eth indexer is running on. Either "sepolia"/"mainnet"
-    #[cfg_attr(
-        feature = "helios",
-        clap(
-            long,
-            env("MPC_ETH_NETWORK"),
-            requires = "eth_account_sk",
-            default_value = "sepolia",
-            value_parser = ["sepolia", "mainnet"],
-        )
+    #[clap(
+        long,
+        env("MPC_ETH_NETWORK"),
+        requires = "eth_account_sk",
+        default_value = "sepolia",
+        value_parser = ["sepolia", "mainnet"],
     )]
-    #[cfg_attr(not(feature = "helios"), arg(skip))]
     pub eth_network: Option<String>,
     /// Helios light client data path
-    #[cfg_attr(
-        feature = "helios",
-        clap(
-            long,
-            env("MPC_ETH_HELIOS_DATA_PATH"),
-            requires = "eth_account_sk",
-            default_value = "/helios/sepolia"
-        )
+    #[clap(
+        long,
+        env("MPC_ETH_HELIOS_DATA_PATH"),
+        requires = "eth_account_sk",
+        default_value = "/helios/sepolia"
     )]
-    #[cfg_attr(not(feature = "helios"), arg(skip))]
     pub eth_helios_data_path: Option<String>,
 
     // -- Behaviour --

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -1,4 +1,5 @@
 pub mod indexer_eth_direct_rpc;
+#[cfg(feature = "helios")]
 pub mod indexer_eth_helios;
 
 use crate::backlog::Backlog;
@@ -132,36 +133,52 @@ pub struct EthArgs {
 
     // -- Helios light-client --
     /// Use Helios light client instead of direct RPC
-    #[clap(
-        long,
-        env("MPC_ETH_LIGHT_CLIENT"),
-        default_value = "false",
-        requires_if("true", "eth_consensus_rpc_http_url")
+    #[cfg_attr(
+        feature = "helios",
+        clap(
+            long,
+            env("MPC_ETH_LIGHT_CLIENT"),
+            default_value = "false",
+            requires_if("true", "eth_consensus_rpc_http_url")
+        )
     )]
+    #[cfg_attr(not(feature = "helios"), arg(skip))]
     pub eth_light_client: bool,
     /// Ethereum consensus RPC URL (required when --eth-light-client is set)
-    #[clap(
-        long,
-        env("MPC_ETH_CONSENSUS_RPC_HTTP_URL"),
-        requires = "eth_account_sk"
+    #[cfg_attr(
+        feature = "helios",
+        clap(
+            long,
+            env("MPC_ETH_CONSENSUS_RPC_HTTP_URL"),
+            requires = "eth_account_sk"
+        )
     )]
+    #[cfg_attr(not(feature = "helios"), arg(skip))]
     pub eth_consensus_rpc_http_url: Option<String>,
     /// The network that the eth indexer is running on. Either "sepolia"/"mainnet"
-    #[clap(
-        long,
-        env("MPC_ETH_NETWORK"),
-        requires = "eth_account_sk",
-        default_value = "sepolia",
-        value_parser = ["sepolia", "mainnet"],
+    #[cfg_attr(
+        feature = "helios",
+        clap(
+            long,
+            env("MPC_ETH_NETWORK"),
+            requires = "eth_account_sk",
+            default_value = "sepolia",
+            value_parser = ["sepolia", "mainnet"],
+        )
     )]
+    #[cfg_attr(not(feature = "helios"), arg(skip))]
     pub eth_network: Option<String>,
     /// Helios light client data path
-    #[clap(
-        long,
-        env("MPC_ETH_HELIOS_DATA_PATH"),
-        requires = "eth_account_sk",
-        default_value = "/helios/sepolia"
+    #[cfg_attr(
+        feature = "helios",
+        clap(
+            long,
+            env("MPC_ETH_HELIOS_DATA_PATH"),
+            requires = "eth_account_sk",
+            default_value = "/helios/sepolia"
+        )
     )]
+    #[cfg_attr(not(feature = "helios"), arg(skip))]
     pub eth_helios_data_path: Option<String>,
 
     // -- Behaviour --
@@ -221,6 +238,13 @@ impl EthArgs {
     }
 
     pub fn into_config(self) -> Option<EthConfig> {
+        #[cfg(not(feature = "helios"))]
+        if self.eth_light_client {
+            tracing::warn!(
+                "ignoring ethereum light client request because mpc-node was built without helios feature"
+            );
+        }
+
         Some(EthConfig {
             account_sk: self.eth_account_sk?,
             consensus_rpc_http_url: self.eth_consensus_rpc_http_url.unwrap_or_default(),
@@ -230,7 +254,10 @@ impl EthArgs {
             helios_data_path: self.eth_helios_data_path.unwrap_or_default(),
             refresh_finalized_interval: self.eth_refresh_finalized_interval.unwrap(),
             optimistic_requests: self.eth_optimistic_requests,
+            #[cfg(feature = "helios")]
             light_client: self.eth_light_client,
+            #[cfg(not(feature = "helios"))]
+            light_client: false,
         })
     }
 
@@ -539,6 +566,7 @@ impl SignatureRequestedEvent {
 
 #[derive(Clone)]
 pub enum EthereumClient {
+    #[cfg(feature = "helios")]
     Helios(indexer_eth_helios::HeliosEthereumClient),
     DirectRpc(indexer_eth_direct_rpc::RpcEthereumClient),
 }
@@ -546,10 +574,22 @@ pub enum EthereumClient {
 impl EthereumClient {
     pub async fn new(eth: EthConfig) -> anyhow::Result<EthereumClient> {
         if eth.light_client {
-            Ok(EthereumClient::Helios(
-                indexer_eth_helios::build_client(eth.clone()).await?,
-            ))
-        } else {
+            #[cfg(feature = "helios")]
+            {
+                return Ok(EthereumClient::Helios(
+                    indexer_eth_helios::build_client(eth.clone()).await?,
+                ));
+            }
+
+            #[cfg(not(feature = "helios"))]
+            {
+                anyhow::bail!(
+                    "ethereum light client requested, but mpc-node was built without helios feature"
+                );
+            }
+        }
+
+        {
             Ok(EthereumClient::DirectRpc(
                 indexer_eth_direct_rpc::RpcEthereumClient::new(&eth.execution_rpc_http_url),
             ))
@@ -558,6 +598,7 @@ impl EthereumClient {
 
     fn client_name(&self) -> &str {
         match self {
+            #[cfg(feature = "helios")]
             EthereumClient::Helios(_) => "Helios",
             EthereumClient::DirectRpc(_) => "DirectRpc",
         }
@@ -568,6 +609,7 @@ impl EthereumClient {
         let retry_config = crate::util::retry::RetryConfig::default();
         let get_block_op = |_attempt: usize| async {
             match self {
+                #[cfg(feature = "helios")]
                 EthereumClient::Helios(client) => client.get_block(block_id).await,
                 EthereumClient::DirectRpc(client) => client.get_block(block_id).await,
             }
@@ -628,6 +670,7 @@ impl EthereumClient {
         block_id: BlockId,
     ) -> anyhow::Result<Option<Vec<alloy::rpc::types::TransactionReceipt>>> {
         match self {
+            #[cfg(feature = "helios")]
             EthereumClient::Helios(client) => client.get_block_receipts(block_id).await,
             EthereumClient::DirectRpc(client) => client.get_block_receipts(block_id).await,
         }
@@ -635,6 +678,7 @@ impl EthereumClient {
 
     async fn get_nonce(&self, address: Address, block_id: BlockId) -> anyhow::Result<u64> {
         match self {
+            #[cfg(feature = "helios")]
             EthereumClient::Helios(client) => client.get_nonce(address, block_id).await,
             EthereumClient::DirectRpc(client) => client.get_nonce(address, block_id).await,
         }
@@ -645,6 +689,7 @@ impl EthereumClient {
         tx_hash: alloy::primitives::B256,
     ) -> anyhow::Result<Option<alloy::rpc::types::Transaction>> {
         match self {
+            #[cfg(feature = "helios")]
             EthereumClient::Helios(client) => client.get_transaction_by_hash(tx_hash).await,
             EthereumClient::DirectRpc(client) => client.get_transaction_by_hash(tx_hash).await,
         }
@@ -658,6 +703,7 @@ impl EthereumClient {
         block_number: u64,
     ) -> anyhow::Result<Bytes> {
         match self {
+            #[cfg(feature = "helios")]
             EthereumClient::Helios(client) => client.call(from, to, data, block_number).await,
             EthereumClient::DirectRpc(client) => client.call(from, to, data, block_number).await,
         }
@@ -675,6 +721,7 @@ impl EthereumClient {
         anchor_height: BlockNumber,
     ) -> BlockNumber {
         let max_catchup_blocks = match self {
+            #[cfg(feature = "helios")]
             EthereumClient::Helios(_) => indexer_eth_helios::MAX_CATCHUP_BLOCKS,
             EthereumClient::DirectRpc(_) => indexer_eth_direct_rpc::MAX_CATCHUP_BLOCKS,
         };
@@ -1356,6 +1403,7 @@ impl ChainStream for EthereumStream {
 mod tests {
     use super::{EthConfig, EthereumClient, EthereumIndexer};
     use crate::backlog::Backlog;
+    #[cfg(feature = "helios")]
     use crate::indexer_eth::indexer_eth_helios;
     use crate::protocol::Chain;
     use crate::sign_bidirectional::{BidirectionalTx, BidirectionalTxId};
@@ -1369,7 +1417,10 @@ mod tests {
 
     #[test]
     fn catchup_start_is_clamped_to_supported_window() {
+        #[cfg(feature = "helios")]
         let max_catchup_blocks = indexer_eth_helios::MAX_CATCHUP_BLOCKS;
+        #[cfg(not(feature = "helios"))]
+        let max_catchup_blocks = 8191;
         let anchor_height = 10_000;
         let catchup_end = anchor_height - 1;
         let expected_oldest = catchup_end - max_catchup_blocks;

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -70,7 +70,7 @@ near-workspaces = "0.15.0"
 mpc-crypto.workspace = true
 mpc-contract.workspace = true
 mpc-keys.workspace = true
-mpc-node = { path = "../chain-signatures/node", features = ["test-feature", "debug-page"] }
+mpc-node = { path = "../chain-signatures/node", features = ["helios", "test-feature", "debug-page"] }
 mpc-primitives.workspace = true
 
 [dev-dependencies]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -70,7 +70,7 @@ near-workspaces = "0.15.0"
 mpc-crypto.workspace = true
 mpc-contract.workspace = true
 mpc-keys.workspace = true
-mpc-node = { path = "../chain-signatures/node", features = ["helios", "test-feature", "debug-page"] }
+mpc-node = { path = "../chain-signatures/node", default-features = false, features = ["test-feature", "debug-page"] }
 mpc-primitives.workspace = true
 
 [dev-dependencies]
@@ -97,3 +97,4 @@ harness = false
 [features]
 default = []
 docker-test = []
+helios = ["mpc-node/helios"]

--- a/setup.sh
+++ b/setup.sh
@@ -26,14 +26,17 @@ done
 
 CARGO_CMD_ARGS="$@"
 CARGO_BUILD_INDENT="            "
-echo "${CARGO_BUILD_INDENT} running MPC build script"
+SCRIPT_START_TEXT="${CARGO_BUILD_INDENT} running MPC build script"
 
 # Default feature set for building local binaries used by tests.
 NODE_FEATURES="test-feature,debug-page"
 CONTRACT_FEATURES=""
 if echo "$MPC_ENABLE_HELIOS" | grep -q "1"; then
+    SCRIPT_START_TEXT="${SCRIPT_START_TEXT}: building with helios enabled"
     NODE_FEATURES="${NODE_FEATURES},helios"
 fi
+
+echo $SCRIPT_START_TEXT
 
 # Add additional features if we're benchmarking.
 if echo "$CARGO_CMD_ARGS" | grep -q "bench"; then

--- a/setup.sh
+++ b/setup.sh
@@ -36,7 +36,7 @@ if echo "$MPC_ENABLE_HELIOS" | grep -q "1"; then
     NODE_FEATURES="${NODE_FEATURES},helios"
 fi
 
-echo $SCRIPT_START_TEXT
+echo "$SCRIPT_START_TEXT"
 
 # Add additional features if we're benchmarking.
 if echo "$CARGO_CMD_ARGS" | grep -q "bench"; then

--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,8 @@
 export ROOT_DIR=$(dirname -- "$0")
 # Use CARGO_TARGET_DIR if it is set, or the default ./target location otherwise
 export TARGET_DIR=${CARGO_TARGET_DIR:-$ROOT_DIR/target}
+# If we enable helios, then we have to build the helios feature gate.
+export MPC_ENABLE_HELIOS=${MPC_ENABLE_HELIOS:-0}
 
 # Only run the prebuild for integration tests unless explicitly forced.
 # Set MPC_SETUP_SKIP=1 to skip running setup.sh
@@ -29,6 +31,9 @@ echo "${CARGO_BUILD_INDENT} running MPC build script"
 # Default feature set for building local binaries used by tests.
 NODE_FEATURES="test-feature,debug-page"
 CONTRACT_FEATURES=""
+if echo "$MPC_ENABLE_HELIOS" | grep -q "1"; then
+    NODE_FEATURES="${NODE_FEATURES},helios"
+fi
 
 # Add additional features if we're benchmarking.
 if echo "$CARGO_CMD_ARGS" | grep -q "bench"; then


### PR DESCRIPTION
this feature gates and disables helios by default. Our binaries still ship helios when we go to deploy them, it's just that for faster local iterability, helios has been feature gated and disabled. Why build something when we barely ever touch it

building the `mpc-node` binary went from 1505 dependencies and 3m 26s build time to 1324 dependences and 2m 39s build time.
