### PR TITLE
fix(ci): target ARC runner scale set

### DIFF
--- a/.github/workflows/k6-ci-loadtest.yml
+++ b/.github/workflows/k6-ci-loadtest.yml
@@ -54,7 +54,7 @@ on:
 jobs:
   load-test:
     if: ${{ github.event_name == 'push' || github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
-    runs-on: ${{ github.event_name == 'schedule' && 'arc-runners-arc-runner-set' || 'ubuntu-latest' }}
+    runs-on: ${{ github.event_name == 'schedule' && 'arc-runner-set' || 'ubuntu-latest' }}
     steps:
       - name: Wait for 1 hour due to new version deployment
         if: ${{ github.event.pull_request.merged == true }}


### PR DESCRIPTION
## Summary
- update the scheduled k6 load test to target the current ARC runner scale set label (`arc-runner-set`)
- replace the stale `arc-runners-arc-runner-set` label left over from earlier ARC wiring

## Verification
- `git diff --check origin/develop..HEAD`
- confirmed live ARC listener config in `gke_`<gcp_project_dev>`_europe-west1_dev` reports `runner_scale_set_name: arc-runner-set` and `runner_scale_set_id: 3`
