### PR TITLE
fix: sync staleness

### DIFF
--- a/chain-signatures/node/src/storage/protocol_storage.rs
+++ b/chain-signatures/node/src/storage/protocol_storage.rs
@@ -776,17 +776,23 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
                 -- Skip if not owned by me (defense against malicious/buggy peer responses)
                 if redis.call('SISMEMBER', owner_key, id) == 0 then
                     -- noop: not our artifact
-                elseif redis.call('EXISTS', artifact_key .. ':holders:' .. id) == 1 then
+                else
                     local holders_key = artifact_key .. ':holders:' .. id
-                    redis.call('SREM', holders_key, peer)
-                    local count = redis.call('SCARD', holders_key)
-                    if count < threshold then
+                    if redis.call('EXISTS', holders_key) == 0 then
                         redis.call('HDEL', artifact_key, id)
-                        redis.call('DEL', holders_key)
                         redis.call('SREM', owner_key, id)
                         table.insert(removed, id)
                     else
-                        table.insert(updated, id)
+                        redis.call('SREM', holders_key, peer)
+                        local count = redis.call('SCARD', holders_key)
+                        if count < threshold then
+                            redis.call('HDEL', artifact_key, id)
+                            redis.call('DEL', holders_key)
+                            redis.call('SREM', owner_key, id)
+                            table.insert(removed, id)
+                        else
+                            table.insert(updated, id)
+                        end
                     end
                 end
             end

--- a/chain-signatures/node/src/storage/protocol_storage.rs
+++ b/chain-signatures/node/src/storage/protocol_storage.rs
@@ -380,11 +380,16 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
                 end
             end
 
+            local our_shares_check = {}
+            for _, id in ipairs(our_shares) do
+                our_shares_check[id] = 1
+            end
+
             -- find shares that were shared with us but not found in our storage
             local not_found = {}
             for _, id in ipairs(ARGV) do
                 local holders_key = artifact_key .. ':holders:' .. id
-                local owner_has = redis.call("SISMEMBER", owner_key, id) == 1
+                local owner_has = our_shares_check[id] == 1
                 local artifact_exists = redis.call("HEXISTS", artifact_key, id) == 1
                 local holders_exist = redis.call("EXISTS", holders_key) == 1
                 if not owner_has or not artifact_exists or not holders_exist then

--- a/chain-signatures/node/src/storage/protocol_storage.rs
+++ b/chain-signatures/node/src/storage/protocol_storage.rs
@@ -383,7 +383,15 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
             -- find shares that were shared with us but not found in our storage
             local not_found = {}
             for _, id in ipairs(ARGV) do
-                if redis.call("HEXISTS", artifact_key, id) == 0 then
+                local holders_key = artifact_key .. ':holders:' .. id
+                local artifact_exists = redis.call("HEXISTS", artifact_key, id) == 1
+                local holders_exist = redis.call("EXISTS", holders_key) == 1
+                if not artifact_exists or not holders_exist then
+                    if artifact_exists then
+                        redis.call("HDEL", artifact_key, id)
+                    end
+                    redis.call("SREM", owner_key, id)
+                    redis.call("DEL", holders_key)
                     table.insert(not_found, id)
                 end
             end

--- a/chain-signatures/node/src/storage/protocol_storage.rs
+++ b/chain-signatures/node/src/storage/protocol_storage.rs
@@ -384,9 +384,10 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
             local not_found = {}
             for _, id in ipairs(ARGV) do
                 local holders_key = artifact_key .. ':holders:' .. id
+                local owner_has = redis.call("SISMEMBER", owner_key, id) == 1
                 local artifact_exists = redis.call("HEXISTS", artifact_key, id) == 1
                 local holders_exist = redis.call("EXISTS", holders_key) == 1
-                if not artifact_exists or not holders_exist then
+                if not owner_has or not artifact_exists or not holders_exist then
                     if artifact_exists then
                         redis.call("HDEL", artifact_key, id)
                     end
@@ -754,6 +755,10 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
 
     pub fn artifact_key(&self) -> &str {
         &self.artifact_key
+    }
+
+    pub fn owner_keys(&self) -> &str {
+        &self.owner_keys
     }
 
     /// Batch remove a peer from holders for a set of artifact IDs, and prune

--- a/integration-tests/tests/cases/state_sync.rs
+++ b/integration-tests/tests/cases/state_sync.rs
@@ -242,7 +242,13 @@ async fn test_sync_reports_missing_when_holders_metadata_is_missing_on_responder
     let node1 = &fixture.nodes[1];
     let all_participants = fixture.sorted_participants();
 
-    insert_triples_for_owner(&node1.triple_storage, node0.me, &all_participants, 303..=303).await;
+    insert_triples_for_owner(
+        &node1.triple_storage,
+        node0.me,
+        &all_participants,
+        303..=303,
+    )
+    .await;
     insert_presignatures_for_owner(
         &node1.presignature_storage,
         node0.me,
@@ -276,6 +282,60 @@ async fn test_sync_reports_missing_when_holders_metadata_is_missing_on_responder
 
     assert_triples_owned_state(&node1.triple_storage, node0.me, &[], &[303]).await;
     assert_presig_owned_state(&node1.presignature_storage, node0.me, &[], &[303]).await;
+}
+
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_sync_reports_missing_when_owner_mapping_is_missing_on_responder() {
+    let fixture = MpcFixtureBuilder::default()
+        .only_generate_signatures()
+        .build()
+        .await;
+
+    let node0 = &fixture.nodes[0];
+    let node1 = &fixture.nodes[1];
+    let all_participants = fixture.sorted_participants();
+
+    insert_triples_for_owner(
+        &node1.triple_storage,
+        node0.me,
+        &all_participants,
+        404..=404,
+    )
+    .await;
+    insert_presignatures_for_owner(
+        &node1.presignature_storage,
+        node0.me,
+        &all_participants,
+        404..=404,
+    )
+    .await;
+
+    let pool = fixture.redis_container.pool();
+    let mut conn = pool.get().await.unwrap();
+    let triple_owner_key = format!(
+        "{}:p{}",
+        node1.triple_storage.owner_keys(),
+        u32::from(node0.me)
+    );
+    let presig_owner_key = format!(
+        "{}:p{}",
+        node1.presignature_storage.owner_keys(),
+        u32::from(node0.me)
+    );
+    let _: usize = conn.srem(&triple_owner_key, 404).await.unwrap();
+    let _: usize = conn.srem(&presig_owner_key, 404).await.unwrap();
+
+    let response = node1.sync(node0.me, vec![404], vec![404]).await;
+    assert_eq!(
+        response.triples,
+        vec![404],
+        "responder should report triple as missing when owner mapping is gone"
+    );
+    assert_eq!(
+        response.presignatures,
+        vec![404],
+        "responder should report presignature as missing when owner mapping is gone"
+    );
 }
 
 /// Orphaned artifact: owner doesn't have id=77 but other nodes do.

--- a/integration-tests/tests/cases/state_sync.rs
+++ b/integration-tests/tests/cases/state_sync.rs
@@ -336,6 +336,8 @@ async fn test_sync_reports_missing_when_owner_mapping_is_missing_on_responder() 
         vec![404],
         "responder should report presignature as missing when owner mapping is gone"
     );
+    assert_triples_owned_state(&node1.triple_storage, node0.me, &[], &[404]).await;
+    assert_presig_owned_state(&node1.presignature_storage, node0.me, &[], &[404]).await;
 }
 
 /// Orphaned artifact: owner doesn't have id=77 but other nodes do.

--- a/integration-tests/tests/cases/state_sync.rs
+++ b/integration-tests/tests/cases/state_sync.rs
@@ -1,3 +1,4 @@
+use deadpool_redis::redis::AsyncCommands;
 use integration_tests::mpc_fixture::MpcFixtureBuilder;
 use test_log::test;
 
@@ -182,6 +183,52 @@ async fn test_sync_prune_below_threshold() {
             "fixture presig {id} should still have all holders"
         );
     }
+}
+
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_sync_prunes_artifacts_with_missing_holders_metadata() {
+    let fixture = MpcFixtureBuilder::default()
+        .only_generate_signatures()
+        .build()
+        .await;
+
+    let node0 = &fixture.nodes[0];
+    let node1 = &fixture.nodes[1];
+    let node2 = &fixture.nodes[2];
+    let all_participants = fixture.sorted_participants();
+
+    insert_triples_for_owner(&node0.triple_storage, node0.me, &all_participants, 99..=99).await;
+    insert_presignatures_for_owner(
+        &node0.presignature_storage,
+        node0.me,
+        &all_participants,
+        99..=99,
+    )
+    .await;
+
+    let pool = fixture.redis_container.pool();
+    let mut conn = pool.get().await.unwrap();
+    let triple_holders_key = format!("{}:holders:{}", node0.triple_storage.artifact_key(), 99);
+    let presig_holders_key = format!(
+        "{}:holders:{}",
+        node0.presignature_storage.artifact_key(),
+        99
+    );
+    let _: usize = conn.del(&triple_holders_key).await.unwrap();
+    let _: usize = conn.del(&presig_holders_key).await.unwrap();
+
+    let response1 = node1.sync(node0.me, vec![99], vec![99]).await;
+    let response2 = node2.sync(node0.me, vec![99], vec![99]).await;
+    assert_eq!(response1.triples, vec![99]);
+    assert_eq!(response1.presignatures, vec![99]);
+    assert_eq!(response2.triples, vec![99]);
+    assert_eq!(response2.presignatures, vec![99]);
+
+    node0.process_sync_response(node1.me, 2, &response1).await;
+    node0.process_sync_response(node2.me, 2, &response2).await;
+
+    assert_triples_owned_state(&node0.triple_storage, node0.me, &[], &[99]).await;
+    assert_presig_owned_state(&node0.presignature_storage, node0.me, &[], &[99]).await;
 }
 
 /// Orphaned artifact: owner doesn't have id=77 but other nodes do.

--- a/integration-tests/tests/cases/state_sync.rs
+++ b/integration-tests/tests/cases/state_sync.rs
@@ -231,6 +231,53 @@ async fn test_sync_prunes_artifacts_with_missing_holders_metadata() {
     assert_presig_owned_state(&node0.presignature_storage, node0.me, &[], &[99]).await;
 }
 
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_sync_reports_missing_when_holders_metadata_is_missing_on_responder() {
+    let fixture = MpcFixtureBuilder::default()
+        .only_generate_signatures()
+        .build()
+        .await;
+
+    let node0 = &fixture.nodes[0];
+    let node1 = &fixture.nodes[1];
+    let all_participants = fixture.sorted_participants();
+
+    insert_triples_for_owner(&node1.triple_storage, node0.me, &all_participants, 303..=303).await;
+    insert_presignatures_for_owner(
+        &node1.presignature_storage,
+        node0.me,
+        &all_participants,
+        303..=303,
+    )
+    .await;
+
+    let pool = fixture.redis_container.pool();
+    let mut conn = pool.get().await.unwrap();
+    let triple_holders_key = format!("{}:holders:{}", node1.triple_storage.artifact_key(), 303);
+    let presig_holders_key = format!(
+        "{}:holders:{}",
+        node1.presignature_storage.artifact_key(),
+        303
+    );
+    let _: usize = conn.del(&triple_holders_key).await.unwrap();
+    let _: usize = conn.del(&presig_holders_key).await.unwrap();
+
+    let response = node1.sync(node0.me, vec![303], vec![303]).await;
+    assert_eq!(
+        response.triples,
+        vec![303],
+        "responder should report triple as missing when holders metadata is gone"
+    );
+    assert_eq!(
+        response.presignatures,
+        vec![303],
+        "responder should report presignature as missing when holders metadata is gone"
+    );
+
+    assert_triples_owned_state(&node1.triple_storage, node0.me, &[], &[303]).await;
+    assert_presig_owned_state(&node1.presignature_storage, node0.me, &[], &[303]).await;
+}
+
 /// Orphaned artifact: owner doesn't have id=77 but other nodes do.
 /// When owner broadcasts its sync update (without id=77), responders remove it
 /// via remove_outdated.


### PR DESCRIPTION
was debugging through testnet redis storage, and these are some bugs I've noticed if we're missing metadata:
- if owner mapping, artifact mapping, or holders metadata is missing in remove_outdated, then the entry should be marked as not_found
- in remove_holder_and_prune, if holders metadata does not exist we should remove the artifact itself.

These are all for artifacts that do not have these metadata. This is likely due to us adding these metadata as we went on without deleting prior old state or not bumping the versions