### PR TITLE
chore: disable integration-test parallelism

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,5 @@
-# Always limit cluster tests to 4 threads
 [test-groups]
-cluster = { max-threads = 4 }
+cluster = { max-threads = 1 }
 fixture = { max-threads = "num-cpus" }
 
 [[profile.default.overrides]]


### PR DESCRIPTION
I don't have time to get integration test parallelism to be running properly, so let's just disable it for now and not have it be a pain point for other PRs. 

If someone wants to pick this up, feel free too. Otherwise, some stuff in https://github.com/sig-net/mpc/pull/801 would be needed to confirm that we're no longer failing non-deterministically.