### PR TITLE
feat: avoid presignature waste on posit rounds

### DIFF
--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -12,8 +12,9 @@ use crate::protocol::presignature::PresignatureId;
 use crate::protocol::SignKind;
 use crate::protocol::{Chain, ProtocolState};
 use crate::rpc::{ContractStateWatcher, GovernanceInfo, RpcChannel};
-use crate::storage::presignature_storage::{PresignatureTaken, PresignatureTakenDropper};
-use crate::storage::protocol_storage::ProtocolArtifact;
+use crate::storage::presignature_storage::{
+    PresignatureReservation, PresignatureTaken, PresignatureTakenDropper,
+};
 use crate::storage::PresignatureStorage;
 use crate::stream::ops::SignBidirectionalEvent;
 use crate::types::SignatureProtocol;
@@ -332,13 +333,13 @@ struct SignPositor {
     proposer: Participant,
     active: BTreeSet<Participant>,
     presignature_id: PresignatureId,
-    presignature: Option<PresignatureTaken>,
+    presignature: Option<PresignatureReservation>,
 }
 
 struct SignGenerating {
     proposer: Participant,
     presignature_id: PresignatureId,
-    presignature: Option<PresignatureTaken>,
+    presignature: Option<PresignatureReservation>,
     accepted_participants: Vec<Participant>,
 }
 
@@ -504,35 +505,33 @@ impl SignOrganizer {
             let active = active.iter().copied().collect::<Vec<_>>();
             let remaining = state.budget.remaining();
             let fetch = tokio::time::timeout(remaining, async {
+                // IDs that were found unsuitable this round (kept in redis, skipped next peek)
+                let mut local_skip: Vec<PresignatureId> = Vec::new();
                 loop {
-                    if let Some(taken) = ctx.presignatures.take_mine().await {
-                        let Some(holders) = taken.artifact.holders() else {
-                            tracing::error!(
-                                id = taken.artifact.id,
-                                "holders not set on taken presignature"
-                            );
-                            continue;
-                        };
+                    if let Some(reservation) = ctx.presignatures.peek_mine(&local_skip).await {
+                        let holders = reservation.holders();
                         let participants = intersect_vec(&[holders, &active]);
                         if participants.len() < ctx.governance.threshold {
                             tracing::warn!(
                                 ?sign_id,
-                                id = taken.artifact.id,
+                                id = reservation.id,
                                 ?holders,
                                 ?active,
-                                "discarding presignature due to inactive participants"
+                                "skipping presignature due to inactive participants, returning to pool"
                             );
+                            local_skip.push(reservation.id);
+                            // drop: in-memory reservation released, presignature stays in redis
                             continue;
                         }
 
-                        break (taken, participants);
+                        break (reservation, participants);
                     }
                     tokio::time::sleep(Duration::from_millis(500)).await;
                 }
             })
             .await;
 
-            let (taken, participants) = match fetch {
+            let (reservation, participants) = match fetch {
                 Ok(value) => value,
                 Err(_) => {
                     tracing::warn!(
@@ -545,7 +544,7 @@ impl SignOrganizer {
                 }
             };
 
-            let presignature_id = taken.artifact.id;
+            let presignature_id = reservation.id;
 
             tracing::info!(?sign_id, ?presignature_id, "proposer got presignature");
 
@@ -569,7 +568,7 @@ impl SignOrganizer {
 
             // Update active to only include participants that are in both the presignature and active set
             let active = participants.into_iter().collect::<BTreeSet<_>>();
-            (presignature_id, Some(taken), active)
+            (presignature_id, Some(reservation), active)
         } else {
             (PresignatureId::default(), None, active)
         };
@@ -859,8 +858,8 @@ impl SignPositor {
 
                         if counter.enough_rejects(ctx.governance.threshold) {
                             tracing::warn!(?sign_id, ?round, ?from, "received enough REJECTs, reorganizing");
-                            if let Some(_taken) = presignature {
-                                tracing::warn!(?sign_id, "discarding presignature due to REJECTs");
+                            if let Some(_reservation) = presignature {
+                                tracing::warn!(?sign_id, "returning presignature to pool due to REJECTs");
                             }
                             state.bump_round();
                             return SignPhase::Organizing(SignOrganizer);
@@ -897,8 +896,8 @@ impl SignPositor {
                             ?round,
                             "proposer posit deadline reached, expiring round"
                         );
-                        if let Some(_taken) = presignature {
-                            tracing::warn!(?sign_id, "discarding presignature due to proposer timeout");
+                        if let Some(_reservation) = presignature {
+                            tracing::warn!(?sign_id, "returning presignature to pool due to proposer timeout");
                         }
                     } else {
                         tracing::warn!(?sign_id, me=?ctx.governance.me, ?proposer, "deliberator posit timeout waiting for Start, reorganizing");
@@ -974,8 +973,20 @@ impl SignGenerating {
             "posit complete, starting generation"
         );
 
-        let presignature_pending = if let Some(taken) = self.presignature.take() {
-            PendingPresignature::Available(Box::new(taken))
+        let presignature_pending = if let Some(reservation) = self.presignature.take() {
+            // Commit: actually remove from Redis now that posit succeeded and generation starts
+            match reservation.commit().await {
+                Some(taken) => PendingPresignature::Available(Box::new(taken)),
+                None => {
+                    tracing::warn!(
+                        ?sign_id,
+                        ?round,
+                        "failed to commit presignature reservation, reorganizing"
+                    );
+                    state.bump_round();
+                    return SignPhase::Organizing(SignOrganizer);
+                }
+            }
         } else {
             PendingPresignature::InStorage(
                 self.presignature_id,

--- a/chain-signatures/node/src/storage/presignature_storage.rs
+++ b/chain-signatures/node/src/storage/presignature_storage.rs
@@ -4,7 +4,9 @@ use redis::{FromRedisValue, RedisError, RedisWrite, ToRedisArgs};
 
 use cait_sith::protocol::Participant;
 
-use super::protocol_storage::{ArtifactSlot, ArtifactTaken, ArtifactTakenDropper, ProtocolStorage};
+use super::protocol_storage::{
+    ArtifactReservation, ArtifactSlot, ArtifactTaken, ArtifactTakenDropper, ProtocolStorage,
+};
 use crate::protocol::presignature::{Presignature, PresignatureId};
 use crate::storage::protocol_storage::ProtocolArtifact;
 
@@ -12,6 +14,7 @@ pub type PresignatureStorage = ProtocolStorage<Presignature>;
 pub type PresignatureSlot = ArtifactSlot<Presignature>;
 pub type PresignatureTaken = ArtifactTaken<Presignature>;
 pub type PresignatureTakenDropper = ArtifactTakenDropper<Presignature>;
+pub type PresignatureReservation = ArtifactReservation<Presignature>;
 
 impl Presignature {
     pub fn storage(pool: &Pool, account_id: &AccountId) -> PresignatureStorage {

--- a/chain-signatures/node/src/storage/protocol_storage.rs
+++ b/chain-signatures/node/src/storage/protocol_storage.rs
@@ -123,9 +123,50 @@ impl<A: ProtocolArtifact> ArtifactTaken<A> {
     }
 }
 
+/// A peeked artifact ID that is reserved in memory but still physically present in Redis.
+pub struct ArtifactReservation<A: ProtocolArtifact> {
+    pub id: A::Id,
+    holders: Vec<Participant>,
+    /// `None` after `commit()` has consumed the storage handle to suppress Drop cleanup.
+    storage: Option<ProtocolStorage<A>>,
+}
+
+impl<A: ProtocolArtifact> ArtifactReservation<A> {
+    pub fn holders(&self) -> &[Participant] {
+        &self.holders
+    }
+
+    /// Transitions from `pending` to `using` and remove the artifact from Redis.
+    /// Returns `None` on a Redis failure.
+    pub async fn commit(mut self) -> Option<ArtifactTaken<A>> {
+        let storage = self.storage.take()?;
+        let id = self.id;
+        // Because storage is `None`, dropping does nothing.
+        drop(self);
+
+        let me = storage.me().ok()?;
+        let mut guard = storage.reserved.write().await;
+        guard.pending.remove(&id);
+        guard.using.insert(id, true);
+        storage.take_reserved_inner(id, me).await
+    }
+}
+
+impl<A: ProtocolArtifact> Drop for ArtifactReservation<A> {
+    fn drop(&mut self) {
+        if let Some(storage) = self.storage.take() {
+            storage.remove_reserved(self.id, ReservedKind::Pending);
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 enum ReservedKind {
+    /// Artifact is being generated
     Generating,
+    /// Artifact is about to be used but not removed from Redis, yet
+    Pending,
+    /// Artifact is in use, no longer stored in Redis
     Using,
 }
 
@@ -138,6 +179,10 @@ struct ReservedState<Id> {
     /// IDs taken from Redis and actively consumed by a protocol.
     /// Value is `true` if this node is the owner of the artifact.
     using: HashMap<Id, bool>,
+    /// IDs peeked by this node for the posit round. The artifact is still in
+    /// Redis but reserved in memory to prevent conflicts due ti concurrent
+    /// tasks. This node is always the owner for pending IDs.
+    pending: HashSet<Id>,
 }
 
 impl<Id: Eq + std::hash::Hash> ReservedState<Id> {
@@ -145,6 +190,7 @@ impl<Id: Eq + std::hash::Hash> ReservedState<Id> {
         Self {
             generating: HashMap::new(),
             using: HashMap::new(),
+            pending: HashSet::new(),
         }
     }
 
@@ -154,6 +200,10 @@ impl<Id: Eq + std::hash::Hash> ReservedState<Id> {
 
     fn contains_reserved(&self, id: &Id) -> bool {
         self.generating.contains_key(id) || self.using.contains_key(id)
+    }
+
+    fn contains_pending_or_using(&self, id: &Id) -> bool {
+        self.pending.contains(id) || self.using.contains_key(id)
     }
 }
 
@@ -222,6 +272,10 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
             match kind {
                 ReservedKind::Generating => state.generating.remove(&id),
                 ReservedKind::Using => state.using.remove(&id),
+                ReservedKind::Pending => {
+                    state.pending.remove(&id);
+                    None
+                }
             };
             return;
         }
@@ -231,6 +285,10 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
                 match kind {
                     ReservedKind::Generating => state.generating.remove(&id),
                     ReservedKind::Using => state.using.remove(&id),
+                    ReservedKind::Pending => {
+                        state.pending.remove(&id);
+                        None
+                    }
                 };
             });
         } else {
@@ -753,6 +811,153 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
             Ok(None) => None,
             Err(err) => {
                 tracing::warn!(?err, ?elapsed, "failed to take mine artifact from storage");
+                None
+            }
+        }
+    }
+
+    /// Peek at an available mine artifact without removing it from Redis.
+    /// Marks the chosen ID as `pending` in memory so concurrent proposer tasks on this
+    /// node cannot select the same artifact. Call `ArtifactReservation::commit()` to
+    /// actually consume it when generation starts, or just drop it to release the
+    /// reservation without touching Redis.
+    ///
+    /// `local_excluded` lets the caller skip IDs that were already tried (and found
+    /// unsuitable) within the current organizing round.
+    ///
+    /// For Redis, this is a read-only operation.
+    pub async fn peek_mine(&self, local_excluded: &[A::Id]) -> Option<ArtifactReservation<A>> {
+        const SCRIPT: &str = r#"
+            local artifact_key = KEYS[1]
+            local mine_key = KEYS[2]
+
+            if redis.call("SCARD", mine_key) < 1 then
+                return nil
+            end
+
+            -- Build exclusion lookup from caller-supplied IDs
+            local excluded = {}
+            for i = 1, #ARGV do
+                excluded[ARGV[i]] = true
+            end
+
+            -- Find the first available member not excluded and having non-empty holders
+            local members = redis.call("SMEMBERS", mine_key)
+            for _, id in ipairs(members) do
+                if not excluded[id] then
+                    local holders_key = artifact_key .. ':holders:' .. id
+                    if redis.call("SCARD", holders_key) > 0 then
+                        return {id, redis.call("SMEMBERS", holders_key)}
+                    end
+                end
+            end
+            return nil
+        "#;
+
+        let me = self.me().ok()?;
+
+        // Build exclusion list: in-memory pending + using + caller-supplied local_excluded
+        let excluded: Vec<A::Id> = {
+            let state = self.reserved.read().await;
+            state
+                .pending
+                .iter()
+                .chain(state.using.keys())
+                .copied()
+                .chain(local_excluded.iter().copied())
+                .collect()
+        };
+
+        let mut conn = self.connect().await?;
+        let result: Result<Option<(A::Id, Vec<u32>)>, _> = redis::Script::new(SCRIPT)
+            .key(&self.artifact_key)
+            .key(owner_key(&self.owner_keys, me))
+            .arg(excluded.as_slice())
+            .invoke_async(&mut conn)
+            .await;
+
+        let (id, holders_raw) = match result {
+            Ok(Some(val)) => val,
+            Ok(None) => return None,
+            Err(err) => {
+                tracing::warn!(?err, "failed to peek mine artifact from storage");
+                return None;
+            }
+        };
+        let holders: Vec<Participant> = holders_raw.into_iter().map(Participant::from).collect();
+
+        // Atomically mark as pending in memory.
+        // Retry once if another task raced us to this ID.
+        // Give up on further retries and treat it the same way as "artifact unavailable".
+        for _ in 0..2 {
+            let mut state = self.reserved.write().await;
+            if !state.contains_pending_or_using(&id) {
+                state.pending.insert(id);
+                return Some(ArtifactReservation {
+                    id,
+                    holders,
+                    storage: Some(self.clone()),
+                });
+            }
+        }
+
+        tracing::debug!(id, "peek_mine: lost reservation race, caller should retry");
+        None
+    }
+
+    /// Take a specifically reserved artifact from Redis. The in-memory
+    /// transition from `pending` to `using` must have happened before.
+    async fn take_reserved_inner(&self, id: A::Id, owner: Participant) -> Option<ArtifactTaken<A>> {
+        const SCRIPT: &str = r#"
+            local artifact_key = KEYS[1]
+            local owner_key = KEYS[2]
+            local artifact_id = ARGV[1]
+
+            if redis.call("SREM", owner_key, artifact_id) == 0 then
+                return {err = "WARN artifact " .. artifact_id .. " is not owned by this owner"}
+            end
+
+            local artifact = redis.call("HGET", artifact_key, artifact_id)
+            if not artifact then
+                return {err = "WARN artifact " .. artifact_id .. " not found"}
+            end
+            redis.call("HDEL", artifact_key, artifact_id)
+
+            local holders_key = artifact_key .. ':holders:' .. artifact_id
+            local holders = redis.call("SMEMBERS", holders_key)
+            redis.call("DEL", holders_key)
+
+            return {artifact, holders}
+        "#;
+
+        let start = Instant::now();
+        let Some(mut conn) = self.connect().await else {
+            tracing::warn!(id, "failed to commit reservation: connection failed");
+            self.reserved.write().await.using.remove(&id);
+            return None;
+        };
+        let result: Result<(A, Vec<u32>), _> = redis::Script::new(SCRIPT)
+            .key(&self.artifact_key)
+            .key(owner_key(&self.owner_keys, owner))
+            .arg(id)
+            .invoke_async(&mut conn)
+            .await;
+
+        let elapsed = start.elapsed();
+        crate::metrics::storage::REDIS_LATENCY
+            .with_label_values(&[A::METRIC_LABEL, "take_reserved"])
+            .observe(elapsed.as_millis() as f64);
+
+        match result {
+            Ok((mut artifact, holders)) => {
+                let holders = holders.into_iter().map(Participant::from).collect();
+                artifact.set_holders(holders);
+                tracing::info!(id, ?elapsed, "committed reservation, took artifact");
+                Some(ArtifactTaken::new(artifact, self.clone()))
+            }
+            Err(err) => {
+                self.reserved.write().await.using.remove(&id);
+                tracing::warn!(id, ?err, ?elapsed, "failed to commit reservation");
                 None
             }
         }


### PR DESCRIPTION
As described in #793, for every extra posit round for signatures is needed, we waste a presignature.

When not all nodes are included as participants, this is particularly bad, as the remaining nodes will keep trying to run more posit rounds until they see the finalized resulting signature on chain.

This PR avoid the presignature waste. For the posit round, we only mark it as "pending" and don't remove it from Redis. Only when we actually start using the presignature is it removed from Redis.

This preserves the invariants that:

- no signing algorithm starts before we remove the presignature from Redis
- once removed from redis, we never put a presignature back