### PR TITLE
feat: add eth_subscribe for RpcEthererumClient

### DIFF
--- a/chain-signatures/node/src/indexer_eth/indexer_eth_direct_rpc.rs
+++ b/chain-signatures/node/src/indexer_eth/indexer_eth_direct_rpc.rs
@@ -1,10 +1,16 @@
-use crate::indexer_eth::MaybeBlock;
+use crate::indexer_eth::{BlockNumber, EthereumConnection, MaybeBlock};
+
 use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::hex::{self, ToHexExt};
 use alloy::primitives::{Address, Bytes, B256};
 use alloy::rpc::types::{Block, BlockId, Transaction, TransactionReceipt};
+use futures_util::{SinkExt, StreamExt};
 use serde::de::DeserializeOwned;
 use serde_json::json;
+use tokio::time::{timeout, Duration};
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use url::Url;
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -23,12 +29,39 @@ pub struct RpcEthereumClient {
 }
 
 impl RpcEthereumClient {
+    const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+    const MESSAGE_TIMEOUT: Duration = Duration::from_secs(60);
+    const DISCONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
     pub fn new(endpoint: &str) -> Self {
         Self {
             http: reqwest::Client::new(),
             url: endpoint.to_owned(),
             id: Arc::new(AtomicU64::new(1)),
         }
+    }
+
+    pub async fn subscribe(&self) -> EthereumConnection {
+        let Some(ws_url) = websocket_url(&self.url) else {
+            tracing::info!(rpc_url = %self.url, "ethereum RPC URL has no websocket scheme");
+            return EthereumConnection::Disconnected;
+        };
+
+        let mut connection = match EthereumConnection::connect(ws_url.as_str()).await {
+            Ok(connection) => connection,
+            Err(err) => {
+                tracing::info!(%err, ws_url = %ws_url, "failed to connect ethereum websocket");
+                return EthereumConnection::Disconnected;
+            }
+        };
+
+        if let Err(err) = connection.subscribe_new_heads(self.next_id()).await {
+            tracing::info!(%err, ws_url = %ws_url, "failed to subscribe to ethereum newHeads");
+            let _ = connection.close().await;
+            return EthereumConnection::Disconnected;
+        }
+
+        connection
     }
 
     pub async fn get_block(&self, block_id: BlockId) -> anyhow::Result<Option<Block>> {
@@ -351,6 +384,152 @@ fn trace_output_to_bytes(
     Ok(Bytes::from(hex::decode(stripped)?))
 }
 
+impl EthereumConnection {
+    async fn connect(ws_url: &str) -> anyhow::Result<Self> {
+        let (ws_stream, _) = timeout(RpcEthereumClient::CONNECT_TIMEOUT, connect_async(ws_url))
+            .await
+            .map_err(|_| anyhow::anyhow!("ethereum websocket connect timeout"))??;
+        let (ws_write, ws_read) = ws_stream.split();
+        Ok(Self::Connected(ws_read, ws_write))
+    }
+
+    async fn subscribe_new_heads(&mut self, request_id: u64) -> anyhow::Result<()> {
+        let Self::Connected(_, ws_write) = self else {
+            anyhow::bail!("ethereum websocket not connected")
+        };
+
+        let subscribe_request = json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "eth_subscribe",
+            "params": ["newHeads"],
+        });
+
+        timeout(
+            RpcEthereumClient::CONNECT_TIMEOUT,
+            ws_write.send(Message::Text(subscribe_request.to_string().into())),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("ethereum websocket subscription send timeout"))??;
+
+        loop {
+            let Some(msg) = self.next_message().await else {
+                anyhow::bail!("ethereum websocket closed before subscription ack")
+            };
+
+            let Message::Text(text) = msg else {
+                continue;
+            };
+
+            let value: serde_json::Value = serde_json::from_str(&text)?;
+            if let Some(error) = value.get("error") {
+                anyhow::bail!("ethereum eth_subscribe failed: {error}");
+            }
+
+            let Some(id) = value.get("id").and_then(serde_json::Value::as_u64) else {
+                continue;
+            };
+            if id != request_id {
+                continue;
+            }
+
+            let Some(subscription_id) = value.get("result").and_then(serde_json::Value::as_str)
+            else {
+                anyhow::bail!("ethereum eth_subscribe ack missing subscription id")
+            };
+
+            tracing::info!(%subscription_id, "ethereum websocket subscribed to newHeads");
+            return Ok(());
+        }
+    }
+
+    pub async fn next_block_number(&mut self) -> Option<BlockNumber> {
+        loop {
+            let msg = self.next_message().await?;
+
+            let Message::Text(text) = msg else {
+                continue;
+            };
+
+            let value: serde_json::Value = match serde_json::from_str(&text) {
+                Ok(value) => value,
+                Err(err) => {
+                    tracing::warn!(%err, "failed to parse ethereum websocket message");
+                    continue;
+                }
+            };
+
+            if let Some(error) = value.get("error") {
+                tracing::warn!(?error, "ethereum websocket returned rpc error");
+                continue;
+            }
+
+            let Some(params) = value.get("params") else {
+                continue;
+            };
+            let Some(result) = params.get("result") else {
+                continue;
+            };
+            let Some(number_hex) = result.get("number").and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+
+            match hex_to_u64(number_hex) {
+                Ok(block_number) => return Some(block_number),
+                Err(err) => {
+                    tracing::warn!(%err, %number_hex, "failed to parse ethereum head number");
+                }
+            }
+        }
+    }
+
+    async fn next_message(&mut self) -> Option<Message> {
+        let Self::Connected(ws_read, _) = self else {
+            return None;
+        };
+
+        let Ok(maybe_msg) = timeout(RpcEthereumClient::MESSAGE_TIMEOUT, ws_read.next()).await
+        else {
+            tracing::warn!("ethereum websocket stalled: no message for 60s");
+            *self = Self::Disconnected;
+            return None;
+        };
+
+        let Some(msg) = maybe_msg else {
+            *self = Self::Disconnected;
+            return None;
+        };
+
+        match msg {
+            Ok(Message::Close(_)) => {
+                tracing::info!("ethereum websocket received close frame");
+                if let Err(err) = self.close().await {
+                    tracing::debug!(%err, "failed to flush ethereum websocket close reply");
+                }
+                None
+            }
+            Ok(msg) => Some(msg),
+            Err(err) => {
+                tracing::warn!(%err, "ethereum websocket error");
+                *self = Self::Disconnected;
+                None
+            }
+        }
+    }
+
+    async fn close(&mut self) -> anyhow::Result<()> {
+        let Self::Connected(_, ws_write) = self else {
+            return Ok(());
+        };
+
+        timeout(RpcEthereumClient::DISCONNECT_TIMEOUT, ws_write.close())
+            .await
+            .map_err(|_| anyhow::anyhow!("ethereum websocket close timeout"))??;
+        *self = Self::Disconnected;
+        Ok(())
+    }
+}
+
 fn format_address(address: Address) -> String {
     format!("0x{}", address.encode_hex())
 }
@@ -385,6 +564,23 @@ fn to_hex_block_id(block_id: BlockId) -> String {
         BlockId::Number(BlockNumberOrTag::Earliest) => "earliest".to_string(),
         BlockId::Number(BlockNumberOrTag::Pending) => "pending".to_string(),
         BlockId::Hash(hash) => format!("{:#x}", hash.block_hash),
+    }
+}
+
+fn websocket_url(rpc_url: &str) -> Option<Url> {
+    let mut url = Url::parse(rpc_url).ok()?;
+
+    match url.scheme() {
+        "ws" | "wss" => Some(url),
+        "http" => {
+            url.set_scheme("ws").ok()?;
+            Some(url)
+        }
+        "https" => {
+            url.set_scheme("wss").ok()?;
+            Some(url)
+        }
+        _ => None,
     }
 }
 
@@ -493,5 +689,13 @@ mod tests {
         let frame = json!({ "type": "CALL" });
         let err = trace_output_to_bytes(B256::ZERO, &frame).expect_err("should bail");
         assert!(format!("{err}").contains("missing `output`"));
+    }
+
+    #[test]
+    fn websocket_url_promotes_http_to_ws() {
+        let ws_url = super::websocket_url("https://rpc.example.com/path")
+            .expect("https URL should convert to websocket URL");
+
+        assert_eq!(ws_url.as_str(), "wss://rpc.example.com/path");
     }
 }

--- a/chain-signatures/node/src/indexer_eth/indexer_eth_direct_rpc.rs
+++ b/chain-signatures/node/src/indexer_eth/indexer_eth_direct_rpc.rs
@@ -29,10 +29,6 @@ pub struct RpcEthereumClient {
 }
 
 impl RpcEthereumClient {
-    const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
-    const MESSAGE_TIMEOUT: Duration = Duration::from_secs(60);
-    const DISCONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-
     pub fn new(endpoint: &str) -> Self {
         Self {
             http: reqwest::Client::new(),
@@ -43,20 +39,20 @@ impl RpcEthereumClient {
 
     pub async fn subscribe(&self) -> EthereumConnection {
         let Some(ws_url) = websocket_url(&self.url) else {
-            tracing::info!(rpc_url = %self.url, "ethereum RPC URL has no websocket scheme");
+            tracing::info!("ethereum RPC URL has no websocket scheme");
             return EthereumConnection::Disconnected;
         };
 
         let mut connection = match EthereumConnection::connect(ws_url.as_str()).await {
             Ok(connection) => connection,
             Err(err) => {
-                tracing::info!(%err, ws_url = %ws_url, "failed to connect ethereum websocket");
+                tracing::info!(%err, "failed to connect ethereum websocket");
                 return EthereumConnection::Disconnected;
             }
         };
 
         if let Err(err) = connection.subscribe_new_heads(self.next_id()).await {
-            tracing::info!(%err, ws_url = %ws_url, "failed to subscribe to ethereum newHeads");
+            tracing::info!(%err, "failed to subscribe to ethereum newHeads");
             let _ = connection.close().await;
             return EthereumConnection::Disconnected;
         }
@@ -385,8 +381,12 @@ fn trace_output_to_bytes(
 }
 
 impl EthereumConnection {
+    const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+    const MESSAGE_TIMEOUT: Duration = Duration::from_secs(60);
+    const DISCONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
     async fn connect(ws_url: &str) -> anyhow::Result<Self> {
-        let (ws_stream, _) = timeout(RpcEthereumClient::CONNECT_TIMEOUT, connect_async(ws_url))
+        let (ws_stream, _) = timeout(Self::CONNECT_TIMEOUT, connect_async(ws_url))
             .await
             .map_err(|_| anyhow::anyhow!("ethereum websocket connect timeout"))??;
         let (ws_write, ws_read) = ws_stream.split();
@@ -406,7 +406,7 @@ impl EthereumConnection {
         });
 
         timeout(
-            RpcEthereumClient::CONNECT_TIMEOUT,
+            Self::CONNECT_TIMEOUT,
             ws_write.send(Message::Text(subscribe_request.to_string().into())),
         )
         .await
@@ -488,9 +488,8 @@ impl EthereumConnection {
             return None;
         };
 
-        let Ok(maybe_msg) = timeout(RpcEthereumClient::MESSAGE_TIMEOUT, ws_read.next()).await
-        else {
-            tracing::warn!("ethereum websocket stalled: no message for 60s");
+        let Ok(maybe_msg) = timeout(Self::MESSAGE_TIMEOUT, ws_read.next()).await else {
+            tracing::warn!(timeout = ?Self::MESSAGE_TIMEOUT, "ethereum websocket stalled");
             *self = Self::Disconnected;
             return None;
         };
@@ -522,7 +521,7 @@ impl EthereumConnection {
             return Ok(());
         };
 
-        timeout(RpcEthereumClient::DISCONNECT_TIMEOUT, ws_write.close())
+        timeout(Self::DISCONNECT_TIMEOUT, ws_write.close())
             .await
             .map_err(|_| anyhow::anyhow!("ethereum websocket close timeout"))??;
         *self = Self::Disconnected;

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -19,6 +19,7 @@ use alloy::rpc::types::{Block, BlockId, Log};
 use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use async_trait::async_trait;
+use futures_util::stream::{SplitSink, SplitStream};
 use k256::elliptic_curve::sec1::FromEncodedPoint;
 use k256::{AffinePoint as K256AffinePoint, EncodedPoint, FieldBytes, Scalar};
 use mpc_crypto::{kdf::derive_epsilon_eth, ScalarExt as _};
@@ -31,7 +32,10 @@ use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Notify};
+use tokio::task::JoinHandle;
 use tokio::time::Duration;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 const MAX_LIVE_BLOCK_BUFFER: usize = 16384;
 const CATCHUP_BLOCK_BATCH_SIZE: u64 = 32;
@@ -41,6 +45,67 @@ fn live_blocks_channel() -> (mpsc::Sender<MaybeBlock>, mpsc::Receiver<MaybeBlock
 }
 
 type BlockNumber = u64;
+type EthereumWs = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+type EthereumWsRead = SplitStream<EthereumWs>;
+type EthereumWsWrite = SplitSink<EthereumWs, Message>;
+
+pub enum EthereumConnection {
+    Connected(EthereumWsRead, EthereumWsWrite),
+    Disconnected,
+}
+
+enum EthereumBlockSource {
+    Polling(tokio::time::Interval),
+    Subscription(EthereumConnection),
+}
+
+impl EthereumBlockSource {
+    fn polling(retry_delay: Duration) -> Self {
+        let mut interval = tokio::time::interval(retry_delay);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        Self::Polling(interval)
+    }
+
+    async fn next(&mut self, client: &EthereumClient, current: BlockNumber) -> Option<BlockNumber> {
+        match self {
+            Self::Polling(interval) => {
+                interval.tick().await;
+                client.get_latest_block_number().await
+            }
+            Self::Subscription(connection) => {
+                loop {
+                    if let Some(block_number) = connection.next_block_number().await {
+                        return Some(block_number);
+                    }
+
+                    // TODO: same with solana in https://github.com/sig-net/mpc/issues/811,
+                    // we need to handle reconnection logic properly where we should catchup again
+                    tracing::info!(current, "eth websocket failed; attempting reconnect");
+                    Self::reconnect(connection, client).await;
+                }
+            }
+        }
+    }
+
+    async fn reconnect(connection: &mut EthereumConnection, client: &EthereumClient) {
+        let mut backoff = Duration::from_secs(1);
+
+        loop {
+            match client.subscribe().await {
+                new_connection @ EthereumConnection::Connected(_, _) => {
+                    *connection = new_connection;
+                    tracing::info!("eth websocket reconnected");
+                    return;
+                }
+                EthereumConnection::Disconnected => {
+                    tracing::warn!(?backoff, "eth websocket reconnect failed; retrying");
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(30));
+                }
+            }
+        }
+    }
+}
 
 pub struct CatchupIter {
     client: Arc<EthereumClient>,
@@ -614,6 +679,14 @@ impl EthereumClient {
         }
     }
 
+    async fn subscribe(&self) -> EthereumConnection {
+        match self {
+            #[cfg(feature = "helios")]
+            EthereumClient::Helios(_) => EthereumConnection::Disconnected,
+            EthereumClient::DirectRpc(client) => client.subscribe().await,
+        }
+    }
+
     async fn get_block(&self, block_id: BlockId) -> Option<Block> {
         // Configure retry behaviour and delegate to shared retry_async helper.
         let retry_config = retry::RetryConfig::default();
@@ -848,6 +921,15 @@ pub struct EthereumIndexer {
     contract_address: Address,
     catchup_complete: Arc<Notify>,
     live_blocks_rx: Option<mpsc::Receiver<MaybeBlock>>,
+    task: Option<JoinHandle<()>>,
+}
+
+impl Drop for EthereumIndexer {
+    fn drop(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
 }
 
 /// Result of a `backfill_execution_confirmation`. `Observed` carries an
@@ -880,6 +962,7 @@ impl EthereumIndexer {
             contract_address,
             catchup_complete: Arc::new(Notify::new()),
             live_blocks_rx: None,
+            task: None,
         })
     }
 
@@ -888,21 +971,19 @@ impl EthereumIndexer {
         catchup_complete: Arc<Notify>,
         start_block_number: u64,
         live_blocks: mpsc::Sender<MaybeBlock>,
+        mut source: EthereumBlockSource,
     ) {
-        tracing::info!("indexing ethereum live blocks");
+        tracing::info!(start_block_number, "indexing ethereum live blocks");
 
         // Wait for catchup to complete before starting to index live blocks
         catchup_complete.notified().await;
 
         let mut current_block_number = start_block_number;
 
-        // Missing ticks is what we want due to retrying on transient errors
-        let mut interval = tokio::time::interval(Self::RETRY_DELAY);
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-
         loop {
-            interval.tick().await;
-            let Some(latest_block_number) = client.get_latest_block_number().await else {
+            let Some(latest_block_number) =
+                source.next(client.as_ref(), current_block_number).await
+            else {
                 continue;
             };
 
@@ -915,7 +996,7 @@ impl EthereumIndexer {
                 else {
                     tracing::warn!(
                         current_block_number,
-                        "ethereum live block not yet available"
+                        "ethereum subscribed block not yet available"
                     );
                     break;
                 };
@@ -924,7 +1005,7 @@ impl EthereumIndexer {
                     tracing::warn!(
                         ?err,
                         current_block_number,
-                        "failed to add ethereum live block"
+                        "failed to add ethereum subscribed block"
                     );
                     return;
                 }
@@ -1387,7 +1468,7 @@ impl ChainIndexer for EthereumIndexer {
     type Iter = CatchupIter;
 
     async fn livestream(&mut self) -> anyhow::Result<Option<u64>> {
-        let start_block_number = loop {
+        let start_block = loop {
             if let Some(block_number) = self.client.get_latest_block_number().await {
                 break block_number.saturating_add(1);
             };
@@ -1395,15 +1476,28 @@ impl ChainIndexer for EthereumIndexer {
         };
 
         let (live_blocks_tx, live_blocks_rx) = live_blocks_channel();
-        tokio::spawn(Self::index_live_blocks(
+        let source = match self.client.subscribe().await {
+            connection @ EthereumConnection::Connected(_, _) => {
+                tracing::info!(start_block, "eth subscription enabled");
+                EthereumBlockSource::Subscription(connection)
+            }
+            EthereumConnection::Disconnected => {
+                tracing::info!(start_block, "eth subscription disabled; polling instead");
+                EthereumBlockSource::polling(Self::RETRY_DELAY)
+            }
+        };
+
+        let task = tokio::spawn(Self::index_live_blocks(
             self.client.clone(),
             self.catchup_complete.clone(),
-            start_block_number,
+            start_block,
             live_blocks_tx,
+            source,
         ));
+        self.task = Some(task);
 
         self.live_blocks_rx = Some(live_blocks_rx);
-        Ok(Some(start_block_number))
+        Ok(Some(start_block))
     }
 
     async fn next(&mut self) -> Option<Self::Block> {
@@ -1530,7 +1624,9 @@ impl ChainStream for EthereumStream {
 }
 #[cfg(test)]
 mod tests {
-    use super::{CatchupIter, EthConfig, EthereumClient, EthereumIndexer, MaybeBlock};
+    use super::{
+        CatchupIter, EthConfig, EthereumClient, EthereumConnection, EthereumIndexer, MaybeBlock,
+    };
     use crate::backlog::Backlog;
     #[cfg(feature = "helios")]
     use crate::indexer_eth::indexer_eth_helios;
@@ -1647,6 +1743,7 @@ mod tests {
             contract_address: Address::ZERO,
             catchup_complete: Arc::new(Notify::new()),
             live_blocks_rx: None,
+            task: None,
         };
 
         indexer
@@ -1686,6 +1783,7 @@ mod tests {
             contract_address: Address::ZERO,
             catchup_complete: Arc::new(Notify::new()),
             live_blocks_rx: None,
+            task: None,
         };
 
         let err = indexer
@@ -1789,6 +1887,19 @@ mod tests {
             MaybeBlock::Missing(BlockId::Number(BlockNumberOrTag::Number(21)))
         ));
         assert!(matches!(&blocks[2], MaybeBlock::Block(block) if block.header.number == 22));
+    }
+
+    #[tokio::test]
+    async fn ethereum_client_subscribe_returns_disconnected_when_ws_unavailable() {
+        let server = Server::new_async().await;
+        let client = EthereumClient::DirectRpc(
+            super::indexer_eth_direct_rpc::RpcEthereumClient::new(&server.url()),
+        );
+
+        assert!(matches!(
+            client.subscribe().await,
+            EthereumConnection::Disconnected
+        ));
     }
 
     #[tokio::test]
@@ -2037,6 +2148,7 @@ mod tests {
             contract_address: Address::ZERO,
             catchup_complete: Arc::new(Notify::new()),
             live_blocks_rx: None,
+            task: None,
         };
 
         let events = indexer

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -994,19 +994,12 @@ impl EthereumIndexer {
                     )))
                     .await
                 else {
-                    tracing::warn!(
-                        current_block_number,
-                        "ethereum subscribed block not yet available"
-                    );
+                    tracing::warn!(current_block_number, "ethereum block not yet available");
                     break;
                 };
 
                 if let Err(err) = live_blocks.send(MaybeBlock::Block(block)).await {
-                    tracing::warn!(
-                        ?err,
-                        current_block_number,
-                        "failed to add ethereum subscribed block"
-                    );
+                    tracing::warn!(?err, current_block_number, "failed to fetch ethereum block");
                     return;
                 }
 


### PR DESCRIPTION
this makes it so that the `RpcEthereumClient` use `eth_subscribe` to connect to a websocket stream. This would remove the need to poll for latest block from ethereum. We could also switch from `newHeads` to `logs` which makes it even more efficient by only getting blocks that are only related to our contract but requires more refactoring