### PR TITLE
chore: remove direct usage of secp256k1 and subxt-signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3179,21 +3179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto_secretbox"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
-dependencies = [
- "aead",
- "cipher",
- "generic-array",
- "poly1305",
- "salsa20",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6108,7 +6093,6 @@ dependencies = [
  "rand 0.8.5",
  "reqwest 0.11.27",
  "rlp",
- "secp256k1 0.28.2",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -7497,7 +7481,6 @@ dependencies = [
  "redis",
  "reqwest 0.11.27",
  "rlp",
- "secp256k1 0.28.2",
  "semver 1.0.26",
  "serde",
  "serde-aux",
@@ -7513,7 +7496,6 @@ dependencies = [
  "sp-state-machine",
  "sp-trie",
  "subxt",
- "subxt-signer",
  "sysinfo",
  "test-log",
  "thiserror 1.0.69",
@@ -7736,7 +7718,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smart-default 0.6.0",
+ "smart-default",
  "time",
  "tracing",
 ]
@@ -7760,7 +7742,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smart-default 0.6.0",
+ "smart-default",
  "time",
  "tracing",
 ]
@@ -7786,18 +7768,6 @@ dependencies = [
  "anyhow",
  "json_comments",
  "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "near-config-utils"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b992cca8d3b00f34b37f638c9632a97b734656151294e7a29b60b93b8a92948"
-dependencies = [
- "anyhow",
- "json_comments",
- "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -7842,7 +7812,7 @@ dependencies = [
  "hex",
  "near-account-id",
  "near-config-utils 0.27.0",
- "near-schema-checker-lib 0.27.0",
+ "near-schema-checker-lib",
  "near-stdx 0.27.0",
  "primitive-types 0.10.1",
  "rand 0.8.5",
@@ -7851,31 +7821,6 @@ dependencies = [
  "serde_json",
  "subtle",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "near-crypto"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938773caf4ce15aa435d422fd5823e5302a260c93dbd070281eecae74f1a2559"
-dependencies = [
- "blake2",
- "borsh 1.5.7",
- "bs58 0.4.0",
- "curve25519-dalek 4.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "derive_more 1.0.0",
- "ed25519-dalek 2.1.1",
- "hex",
- "near-account-id",
- "near-config-utils 0.29.2",
- "near-schema-checker-lib 0.29.2",
- "near-stdx 0.29.2",
- "primitive-types 0.10.1",
- "secp256k1 0.27.0",
- "serde",
- "serde_json",
- "subtle",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7915,15 +7860,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1eff0731995774d1498f017c968a3ebbfdadad84f556afea4b83679f6706ac9"
 dependencies = [
  "near-primitives-core 0.27.0",
-]
-
-[[package]]
-name = "near-fmt"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0599477a38b5596c283212d4db8eb11c6cc33fb43d02002db9cd3f141ba735f1"
-dependencies = [
- "near-primitives-core 0.29.2",
 ]
 
 [[package]]
@@ -8002,7 +7938,7 @@ dependencies = [
  "near-chain-configs 0.27.0",
  "near-crypto 0.27.0",
  "near-primitives 0.27.0",
- "near-schema-checker-lib 0.27.0",
+ "near-schema-checker-lib",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -8037,32 +7973,13 @@ dependencies = [
  "enum-map",
  "near-account-id",
  "near-primitives-core 0.27.0",
- "near-schema-checker-lib 0.27.0",
+ "near-schema-checker-lib",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
  "serde_yaml",
  "strum 0.24.1",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "near-parameters"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfe696b28e2406001d4d5be14414a32c91f9c7202ae631367a6b22288ccad8d"
-dependencies = [
- "borsh 1.5.7",
- "enum-map",
- "near-account-id",
- "near-primitives-core 0.29.2",
- "near-schema-checker-lib 0.29.2",
- "num-rational 0.3.2",
- "serde",
- "serde_repr",
- "serde_yaml",
- "strum 0.24.1",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8101,7 +8018,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha3",
- "smart-default 0.6.0",
+ "smart-default",
  "strum 0.24.1",
  "thiserror 1.0.69",
  "tracing",
@@ -8131,7 +8048,7 @@ dependencies = [
  "near-fmt 0.27.0",
  "near-parameters 0.27.0",
  "near-primitives-core 0.27.0",
- "near-schema-checker-lib 0.27.0",
+ "near-schema-checker-lib",
  "near-stdx 0.27.0",
  "near-time 0.27.0",
  "num-rational 0.3.2",
@@ -8143,49 +8060,9 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha3",
- "smart-default 0.6.0",
+ "smart-default",
  "strum 0.24.1",
  "thiserror 1.0.69",
- "tracing",
- "zstd 0.13.3",
-]
-
-[[package]]
-name = "near-primitives"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5009712faf116cdadda4c1636daf04f0f53a5537555f38ded2736f2d9e0cac"
-dependencies = [
- "arbitrary",
- "base64 0.21.7",
- "bitvec",
- "borsh 1.5.7",
- "bytes",
- "bytesize",
- "cfg-if 1.0.0",
- "chrono",
- "derive_more 1.0.0",
- "easy-ext",
- "enum-map",
- "hex",
- "itertools 0.12.1",
- "near-crypto 0.29.2",
- "near-fmt 0.29.2",
- "near-parameters 0.29.2",
- "near-primitives-core 0.29.2",
- "near-schema-checker-lib 0.29.2",
- "near-stdx 0.29.2",
- "near-time 0.29.2",
- "num-rational 0.3.2",
- "ordered-float 4.6.0",
- "primitive-types 0.10.1",
- "serde",
- "serde_json",
- "serde_with",
- "sha3",
- "smart-default 0.7.1",
- "strum 0.24.1",
- "thiserror 2.0.12",
  "tracing",
  "zstd 0.13.3",
 ]
@@ -8224,33 +8101,12 @@ dependencies = [
  "derive_more 0.99.20",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 0.27.0",
+ "near-schema-checker-lib",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
  "sha2 0.10.9",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "near-primitives-core"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc441b97a25a22b2344944962dba34bea9bfc732c6ce3a23728593e82166ae6"
-dependencies = [
- "arbitrary",
- "base64 0.21.7",
- "borsh 1.5.7",
- "bs58 0.4.0",
- "derive_more 1.0.0",
- "enum-map",
- "near-account-id",
- "near-schema-checker-lib 0.29.2",
- "num-rational 0.3.2",
- "serde",
- "serde_repr",
- "sha2 0.10.9",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8295,29 +8151,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03541d1dadd0b5dd0a2e1ae1fbe5735fdab79332ed556af36cdcbe50d4b8cf04"
 
 [[package]]
-name = "near-schema-checker-core"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d54cd2888814fc2398316ec6d870754d7dd08704233bda770a75360afc8a7b"
-
-[[package]]
 name = "near-schema-checker-lib"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa9050b0822d2c0dbd90d8c523fd74634f77c5be4ed3337e7010c0d986121982"
 dependencies = [
- "near-schema-checker-core 0.27.0",
- "near-schema-checker-macro 0.27.0",
-]
-
-[[package]]
-name = "near-schema-checker-lib"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311745157f685c26e05ca8532efbfcc09f63ab9fc7d94b824b2c75946ef37197"
-dependencies = [
- "near-schema-checker-core 0.29.2",
- "near-schema-checker-macro 0.29.2",
+ "near-schema-checker-core",
+ "near-schema-checker-macro",
 ]
 
 [[package]]
@@ -8325,12 +8165,6 @@ name = "near-schema-checker-macro"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1bca8c93ff0ad17138c147323a07f036d11c9e1602e3bc2ac9d29c3cf78b89d"
-
-[[package]]
-name = "near-schema-checker-macro"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "515c63689e1e7940ac34629ad9d16ba8fd6bea58ad8ddbd4acf705d6149f3c77"
 
 [[package]]
 name = "near-sdk"
@@ -8342,15 +8176,10 @@ dependencies = [
  "borsh 1.5.7",
  "bs58 0.5.1",
  "near-account-id",
- "near-crypto 0.29.2",
  "near-gas",
- "near-parameters 0.29.2",
- "near-primitives 0.29.2",
- "near-primitives-core 0.29.2",
  "near-sdk-macros",
  "near-sys",
  "near-token",
- "near-vm-runner",
  "once_cell",
  "serde",
  "serde_json",
@@ -8385,12 +8214,6 @@ name = "near-stdx"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427b4e4af5e32f682064772da8b1a7558b3f090e6151c8804cff24ee6c5c4966"
-
-[[package]]
-name = "near-stdx"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf9306662fe8ced267a85aa1d3fc9205f1968d88b9ddbb9a03c657da8457533"
 
 [[package]]
 name = "near-structs-checker-core"
@@ -8443,16 +8266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-time"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a8ffbee0028f08220c46d864d81ac780f2805ab3156b044ee04a927005a84f"
-dependencies = [
- "serde",
- "time",
-]
-
-[[package]]
 name = "near-token"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8460,38 +8273,6 @@ checksum = "cd3e60aa26a74dc514b1b6408fdd06cefe2eb0ff029020956c1c6517594048fd"
 dependencies = [
  "borsh 1.5.7",
  "serde",
-]
-
-[[package]]
-name = "near-vm-runner"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca3f18ed6a87b334b93b53e4c2c98cf185fd1fde5a4b538980508fb7e51b147"
-dependencies = [
- "blst",
- "borsh 1.5.7",
- "bytesize",
- "ed25519-dalek 2.1.1",
- "enum-map",
- "lru 0.12.5",
- "near-crypto 0.29.2",
- "near-parameters 0.29.2",
- "near-primitives-core 0.29.2",
- "near-schema-checker-lib 0.29.2",
- "near-stdx 0.29.2",
- "num-rational 0.3.2",
- "rayon",
- "ripemd",
- "rustix 0.38.44",
- "serde",
- "serde_repr",
- "sha2 0.10.9",
- "sha3",
- "strum 0.24.1",
- "tempfile",
- "thiserror 2.0.12",
- "tracing",
- "zeropool-bn",
 ]
 
 [[package]]
@@ -11344,15 +11125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11575,18 +11347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "password-hash 0.5.0",
- "pbkdf2 0.12.2",
- "salsa20",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11706,15 +11466,6 @@ name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "secrecy"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
 ]
@@ -12200,17 +11951,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "smart-default"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -14659,7 +14399,7 @@ dependencies = [
  "scale-info",
  "schnorrkel",
  "secp256k1 0.28.2",
- "secrecy 0.8.0",
+ "secrecy",
  "serde",
  "sha2 0.10.9",
  "sp-crypto-hashing",
@@ -15651,34 +15391,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url 2.5.4",
-]
-
-[[package]]
-name = "subxt-signer"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb6463f7f46817043de9f20ba11f485ee474378fcdbe4150aa849274523bd1c"
-dependencies = [
- "base64 0.22.1",
- "bip39",
- "cfg-if 1.0.0",
- "crypto_secretbox",
- "hex",
- "hmac 0.12.1",
- "parity-scale-codec",
- "pbkdf2 0.12.2",
- "regex",
- "schnorrkel",
- "scrypt",
- "secp256k1 0.30.0",
- "secrecy 0.10.3",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "sp-crypto-hashing",
- "subxt-core",
- "thiserror 2.0.12",
- "zeroize",
 ]
 
 [[package]]
@@ -17923,19 +17635,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "zeropool-bn"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e61de68ede9ffdd69c01664f65a178c5188b73f78faa21f0936016a888ff7c"
-dependencies = [
- "byteorder",
- "crunchy",
- "lazy_static",
- "rand 0.8.5",
- "rustc-hex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7718,7 +7718,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smart-default",
+ "smart-default 0.6.0",
  "time",
  "tracing",
 ]
@@ -7742,7 +7742,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smart-default",
+ "smart-default 0.6.0",
  "time",
  "tracing",
 ]
@@ -7768,6 +7768,18 @@ dependencies = [
  "anyhow",
  "json_comments",
  "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "near-config-utils"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b992cca8d3b00f34b37f638c9632a97b734656151294e7a29b60b93b8a92948"
+dependencies = [
+ "anyhow",
+ "json_comments",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -7812,7 +7824,7 @@ dependencies = [
  "hex",
  "near-account-id",
  "near-config-utils 0.27.0",
- "near-schema-checker-lib",
+ "near-schema-checker-lib 0.27.0",
  "near-stdx 0.27.0",
  "primitive-types 0.10.1",
  "rand 0.8.5",
@@ -7821,6 +7833,31 @@ dependencies = [
  "serde_json",
  "subtle",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "near-crypto"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938773caf4ce15aa435d422fd5823e5302a260c93dbd070281eecae74f1a2559"
+dependencies = [
+ "blake2",
+ "borsh 1.5.7",
+ "bs58 0.4.0",
+ "curve25519-dalek 4.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 1.0.0",
+ "ed25519-dalek 2.1.1",
+ "hex",
+ "near-account-id",
+ "near-config-utils 0.29.2",
+ "near-schema-checker-lib 0.29.2",
+ "near-stdx 0.29.2",
+ "primitive-types 0.10.1",
+ "secp256k1 0.27.0",
+ "serde",
+ "serde_json",
+ "subtle",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7860,6 +7897,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1eff0731995774d1498f017c968a3ebbfdadad84f556afea4b83679f6706ac9"
 dependencies = [
  "near-primitives-core 0.27.0",
+]
+
+[[package]]
+name = "near-fmt"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0599477a38b5596c283212d4db8eb11c6cc33fb43d02002db9cd3f141ba735f1"
+dependencies = [
+ "near-primitives-core 0.29.2",
 ]
 
 [[package]]
@@ -7938,7 +7984,7 @@ dependencies = [
  "near-chain-configs 0.27.0",
  "near-crypto 0.27.0",
  "near-primitives 0.27.0",
- "near-schema-checker-lib",
+ "near-schema-checker-lib 0.27.0",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -7973,13 +8019,32 @@ dependencies = [
  "enum-map",
  "near-account-id",
  "near-primitives-core 0.27.0",
- "near-schema-checker-lib",
+ "near-schema-checker-lib 0.27.0",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
  "serde_yaml",
  "strum 0.24.1",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "near-parameters"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfe696b28e2406001d4d5be14414a32c91f9c7202ae631367a6b22288ccad8d"
+dependencies = [
+ "borsh 1.5.7",
+ "enum-map",
+ "near-account-id",
+ "near-primitives-core 0.29.2",
+ "near-schema-checker-lib 0.29.2",
+ "num-rational 0.3.2",
+ "serde",
+ "serde_repr",
+ "serde_yaml",
+ "strum 0.24.1",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8018,7 +8083,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha3",
- "smart-default",
+ "smart-default 0.6.0",
  "strum 0.24.1",
  "thiserror 1.0.69",
  "tracing",
@@ -8048,7 +8113,7 @@ dependencies = [
  "near-fmt 0.27.0",
  "near-parameters 0.27.0",
  "near-primitives-core 0.27.0",
- "near-schema-checker-lib",
+ "near-schema-checker-lib 0.27.0",
  "near-stdx 0.27.0",
  "near-time 0.27.0",
  "num-rational 0.3.2",
@@ -8060,9 +8125,49 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha3",
- "smart-default",
+ "smart-default 0.6.0",
  "strum 0.24.1",
  "thiserror 1.0.69",
+ "tracing",
+ "zstd 0.13.3",
+]
+
+[[package]]
+name = "near-primitives"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5009712faf116cdadda4c1636daf04f0f53a5537555f38ded2736f2d9e0cac"
+dependencies = [
+ "arbitrary",
+ "base64 0.21.7",
+ "bitvec",
+ "borsh 1.5.7",
+ "bytes",
+ "bytesize",
+ "cfg-if 1.0.0",
+ "chrono",
+ "derive_more 1.0.0",
+ "easy-ext",
+ "enum-map",
+ "hex",
+ "itertools 0.12.1",
+ "near-crypto 0.29.2",
+ "near-fmt 0.29.2",
+ "near-parameters 0.29.2",
+ "near-primitives-core 0.29.2",
+ "near-schema-checker-lib 0.29.2",
+ "near-stdx 0.29.2",
+ "near-time 0.29.2",
+ "num-rational 0.3.2",
+ "ordered-float 4.6.0",
+ "primitive-types 0.10.1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha3",
+ "smart-default 0.7.1",
+ "strum 0.24.1",
+ "thiserror 2.0.12",
  "tracing",
  "zstd 0.13.3",
 ]
@@ -8101,12 +8206,33 @@ dependencies = [
  "derive_more 0.99.20",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib",
+ "near-schema-checker-lib 0.27.0",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
  "sha2 0.10.9",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "near-primitives-core"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc441b97a25a22b2344944962dba34bea9bfc732c6ce3a23728593e82166ae6"
+dependencies = [
+ "arbitrary",
+ "base64 0.21.7",
+ "borsh 1.5.7",
+ "bs58 0.4.0",
+ "derive_more 1.0.0",
+ "enum-map",
+ "near-account-id",
+ "near-schema-checker-lib 0.29.2",
+ "num-rational 0.3.2",
+ "serde",
+ "serde_repr",
+ "sha2 0.10.9",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8151,13 +8277,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03541d1dadd0b5dd0a2e1ae1fbe5735fdab79332ed556af36cdcbe50d4b8cf04"
 
 [[package]]
+name = "near-schema-checker-core"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00d54cd2888814fc2398316ec6d870754d7dd08704233bda770a75360afc8a7b"
+
+[[package]]
 name = "near-schema-checker-lib"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa9050b0822d2c0dbd90d8c523fd74634f77c5be4ed3337e7010c0d986121982"
 dependencies = [
- "near-schema-checker-core",
- "near-schema-checker-macro",
+ "near-schema-checker-core 0.27.0",
+ "near-schema-checker-macro 0.27.0",
+]
+
+[[package]]
+name = "near-schema-checker-lib"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311745157f685c26e05ca8532efbfcc09f63ab9fc7d94b824b2c75946ef37197"
+dependencies = [
+ "near-schema-checker-core 0.29.2",
+ "near-schema-checker-macro 0.29.2",
 ]
 
 [[package]]
@@ -8165,6 +8307,12 @@ name = "near-schema-checker-macro"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1bca8c93ff0ad17138c147323a07f036d11c9e1602e3bc2ac9d29c3cf78b89d"
+
+[[package]]
+name = "near-schema-checker-macro"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "515c63689e1e7940ac34629ad9d16ba8fd6bea58ad8ddbd4acf705d6149f3c77"
 
 [[package]]
 name = "near-sdk"
@@ -8176,10 +8324,15 @@ dependencies = [
  "borsh 1.5.7",
  "bs58 0.5.1",
  "near-account-id",
+ "near-crypto 0.29.2",
  "near-gas",
+ "near-parameters 0.29.2",
+ "near-primitives 0.29.2",
+ "near-primitives-core 0.29.2",
  "near-sdk-macros",
  "near-sys",
  "near-token",
+ "near-vm-runner",
  "once_cell",
  "serde",
  "serde_json",
@@ -8214,6 +8367,12 @@ name = "near-stdx"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427b4e4af5e32f682064772da8b1a7558b3f090e6151c8804cff24ee6c5c4966"
+
+[[package]]
+name = "near-stdx"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf9306662fe8ced267a85aa1d3fc9205f1968d88b9ddbb9a03c657da8457533"
 
 [[package]]
 name = "near-structs-checker-core"
@@ -8266,6 +8425,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-time"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a8ffbee0028f08220c46d864d81ac780f2805ab3156b044ee04a927005a84f"
+dependencies = [
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "near-token"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8273,6 +8442,38 @@ checksum = "cd3e60aa26a74dc514b1b6408fdd06cefe2eb0ff029020956c1c6517594048fd"
 dependencies = [
  "borsh 1.5.7",
  "serde",
+]
+
+[[package]]
+name = "near-vm-runner"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca3f18ed6a87b334b93b53e4c2c98cf185fd1fde5a4b538980508fb7e51b147"
+dependencies = [
+ "blst",
+ "borsh 1.5.7",
+ "bytesize",
+ "ed25519-dalek 2.1.1",
+ "enum-map",
+ "lru 0.12.5",
+ "near-crypto 0.29.2",
+ "near-parameters 0.29.2",
+ "near-primitives-core 0.29.2",
+ "near-schema-checker-lib 0.29.2",
+ "near-stdx 0.29.2",
+ "num-rational 0.3.2",
+ "rayon",
+ "ripemd",
+ "rustix 0.38.44",
+ "serde",
+ "serde_repr",
+ "sha2 0.10.9",
+ "sha3",
+ "strum 0.24.1",
+ "tempfile",
+ "thiserror 2.0.12",
+ "tracing",
+ "zeropool-bn",
 ]
 
 [[package]]
@@ -11951,6 +12152,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -17635,6 +17847,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "zeropool-bn"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e61de68ede9ffdd69c01664f65a178c5188b73f78faa21f0936016a888ff7c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand 0.8.5",
+ "rustc-hex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ parity-scale-codec = { version = "3", features = ["derive"] }
 
 near-account-id = "1.0.0"
 near-primitives = "0.26.0"
-near-sdk = { version = "5.6.0", features = ["unit-testing", "unstable"] }
+near-sdk = { version = "5.6.0", features = ["unstable"] }
 
 mpc-contract = { path = "./chain-signatures/contract" }
 mpc-crypto = { path = "./chain-signatures/crypto" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ parity-scale-codec = { version = "3", features = ["derive"] }
 
 near-account-id = "1.0.0"
 near-primitives = "0.26.0"
-near-sdk = { version = "5.6.0", features = ["unstable"] }
+near-sdk = { version = "5.6.0", features = ["unstable", "unit-testing"] }
 
 mpc-contract = { path = "./chain-signatures/contract" }
 mpc-crypto = { path = "./chain-signatures/crypto" }

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -45,8 +45,6 @@ sp-core = { version = "38.1", default-features = false, features = ["std"] }
 sp-runtime = { version = "44.0.0", default-features = false, features = ["std"] }
 sp-trie = { version = "41.1.0", default-features = false, features = ["std"] }
 sp-state-machine = { version = "0.48", default-features = false, features = ["std"] }
-subxt-signer = "0.44"
-
 # workspace dependencies
 alloy.workspace = true
 anyhow.workspace = true
@@ -98,7 +96,6 @@ signet-program.workspace = true
 alloy-dyn-abi.workspace = true
 alloy-json-abi.workspace = true
 alloy-primitives.workspace = true
-secp256k1.workspace = true
 rlp.workspace = true
 
 maud = { version = "0.27.0", optional = true }

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -291,15 +291,15 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                     .to_string()
             });
             let hydration_signer_address = hydration.signer_uri.as_ref().and_then(|uri| {
-                use sp_core::Pair as _;
                 use sp_core::sr25519;
+                use sp_core::Pair as _;
                 use sp_runtime::traits::{IdentifyAccount, Verify};
                 use sp_runtime::MultiSignature as SpMultiSignature;
                 use subxt::config::substrate::AccountId32;
 
                 let pair = sr25519::Pair::from_string(uri, None).ok()?;
-                let account_id = <SpMultiSignature as Verify>::Signer::from(pair.public())
-                    .into_account();
+                let account_id =
+                    <SpMultiSignature as Verify>::Signer::from(pair.public()).into_account();
                 Some(AccountId32(account_id.into()).to_string())
             });
             let eth = eth.into_config();

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -291,11 +291,16 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                     .to_string()
             });
             let hydration_signer_address = hydration.signer_uri.as_ref().and_then(|uri| {
-                use std::str::FromStr;
-                use subxt_signer::{sr25519, SecretUri};
-                let uri = SecretUri::from_str(uri).ok()?;
-                let kp = sr25519::Keypair::from_uri(&uri).ok()?;
-                Some(kp.public_key().to_account_id().to_string())
+                use sp_core::Pair as _;
+                use sp_core::sr25519;
+                use sp_runtime::traits::{IdentifyAccount, Verify};
+                use sp_runtime::MultiSignature as SpMultiSignature;
+                use subxt::config::substrate::AccountId32;
+
+                let pair = sr25519::Pair::from_string(uri, None).ok()?;
+                let account_id = <SpMultiSignature as Verify>::Signer::from(pair.public())
+                    .into_account();
+                Some(AccountId32(account_id.into()).to_string())
             });
             let eth = eth.into_config();
             let sol = sol.into_config();

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -36,12 +36,12 @@ use k256::elliptic_curve::sec1::ToEncodedPoint;
 use near_account_id::AccountId;
 use near_crypto::InMemorySigner;
 use near_fetch::result::ExecutionFinalResult;
-use sp_core::{Pair as _, sr25519};
-use sp_runtime::{
-    MultiSignature as SpMultiSignature,
-    traits::{IdentifyAccount, Verify},
-};
 use serde_json::json;
+use sp_core::{sr25519, Pair as _};
+use sp_runtime::{
+    traits::{IdentifyAccount, Verify},
+    MultiSignature as SpMultiSignature,
+};
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -772,8 +772,7 @@ struct HydrationSigner {
 impl HydrationSigner {
     fn from_uri(uri: &str) -> anyhow::Result<Self> {
         let signer = sr25519::Pair::from_string(uri, None)?;
-        let account_id = <SpMultiSignature as Verify>::Signer::from(signer.public())
-            .into_account();
+        let account_id = <SpMultiSignature as Verify>::Signer::from(signer.public()).into_account();
 
         Ok(Self {
             account_id: AccountId32(account_id.into()),

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -36,6 +36,11 @@ use k256::elliptic_curve::sec1::ToEncodedPoint;
 use near_account_id::AccountId;
 use near_crypto::InMemorySigner;
 use near_fetch::result::ExecutionFinalResult;
+use sp_core::{Pair as _, sr25519};
+use sp_runtime::{
+    MultiSignature as SpMultiSignature,
+    traits::{IdentifyAccount, Verify},
+};
 use serde_json::json;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -53,12 +58,12 @@ use crate::indexer_canton::{generate_jwt_with_key, CantonConfig};
 use crate::indexer_hydration::HydrationConfig;
 use parity_scale_codec::{Decode, Encode};
 use subxt::config::substrate::{
-    BlakeTwo256, SubstrateConfig, SubstrateExtrinsicParams, SubstrateHeader,
+    AccountId32, BlakeTwo256, MultiSignature, SubstrateConfig, SubstrateExtrinsicParams,
+    SubstrateHeader,
 };
 use subxt::tx::Payload;
 use subxt::Config as SubxtConfig;
 use subxt::OnlineClient;
-use subxt_signer::{sr25519, SecretUri};
 
 /// The maximum amount of times to retry publishing a signature.
 const MAX_PUBLISH_RETRY: usize = 6;
@@ -759,9 +764,38 @@ impl SubxtConfig for HydradxConfig {
 }
 
 #[derive(Clone)]
+struct HydrationSigner {
+    account_id: AccountId32,
+    signer: sr25519::Pair,
+}
+
+impl HydrationSigner {
+    fn from_uri(uri: &str) -> anyhow::Result<Self> {
+        let signer = sr25519::Pair::from_string(uri, None)?;
+        let account_id = <SpMultiSignature as Verify>::Signer::from(signer.public())
+            .into_account();
+
+        Ok(Self {
+            account_id: AccountId32(account_id.into()),
+            signer,
+        })
+    }
+}
+
+impl subxt::tx::Signer<HydradxConfig> for HydrationSigner {
+    fn account_id(&self) -> <HydradxConfig as SubxtConfig>::AccountId {
+        self.account_id.clone()
+    }
+
+    fn sign(&self, signer_payload: &[u8]) -> <HydradxConfig as SubxtConfig>::Signature {
+        MultiSignature::Sr25519(self.signer.sign(signer_payload).0)
+    }
+}
+
+#[derive(Clone)]
 pub struct HydrationClient {
     api: OnlineClient<HydradxConfig>,
-    signer: sr25519::Keypair,
+    signer: HydrationSigner,
 }
 
 const PALLET_SIGNET: &str = "Signet";
@@ -872,8 +906,7 @@ impl Payload for HydrationRespondBidirectionalTx {
 impl HydrationClient {
     pub async fn new(config: &HydrationConfig) -> anyhow::Result<Self> {
         let api = OnlineClient::<HydradxConfig>::from_url(&config.rpc_ws_url).await?;
-        let uri = SecretUri::from_str(&config.signer_uri)?;
-        let signer = sr25519::Keypair::from_uri(&uri)?;
+        let signer = HydrationSigner::from_uri(&config.signer_uri)?;
         Ok(Self { api, signer })
     }
 

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -451,9 +451,10 @@ mod derive_tests {
         let mpc_pk = hex::decode(mpc_key).unwrap();
         let mpc_pk = EncodedPoint::from_bytes(mpc_pk).unwrap();
         let mpc_pk = AffinePoint::from_encoded_point(&mpc_pk).unwrap();
-        let derivation_epsilon =
-            derive_epsilon_near(LEGACY_MPC_KEY_VERSION_0, &account_id, "test");
-        let expected: Address = "0x083c8776b5e447e91bae43b7883a92a9bdb66d1d".parse().unwrap();
+        let derivation_epsilon = derive_epsilon_near(LEGACY_MPC_KEY_VERSION_0, &account_id, "test");
+        let expected: Address = "0x083c8776b5e447e91bae43b7883a92a9bdb66d1d"
+            .parse()
+            .unwrap();
 
         assert_eq!(derive_user_address(mpc_pk, derivation_epsilon), expected);
     }

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -3,6 +3,7 @@ use alloy::primitives::{keccak256, Address, Bytes, B256, I256, U256};
 use alloy_dyn_abi::{DynSolType, DynSolValue};
 use borsh::BorshSerialize;
 use k256::elliptic_curve::point::AffineCoordinates;
+use k256::elliptic_curve::sec1::ToEncodedPoint as _;
 use k256::{AffinePoint, Scalar};
 use mpc_crypto::derive_key;
 use mpc_primitives::{SerDeserFormat, Signature};
@@ -391,14 +392,7 @@ impl EthereumTxRlp {
     }
 }
 
-/// Get the x coordinate of a point, as a scalar
-fn x_coordinate<C: cait_sith::CSCurve>(point: &C::AffinePoint) -> C::Scalar {
-    <C::Scalar as k256::elliptic_curve::ops::Reduce<<C as k256::elliptic_curve::Curve>::Uint>>::reduce_bytes(&point.x())
-}
-
-fn public_key_to_address(public_key: &secp256k1::PublicKey) -> Address {
-    let public_key = public_key.serialize_uncompressed();
-
+pub fn public_key_to_address(public_key: &[u8]) -> Address {
     debug_assert_eq!(public_key[0], 0x04);
     let hash: [u8; 32] = *alloy::primitives::keccak256(&public_key[1..]);
 
@@ -407,17 +401,8 @@ fn public_key_to_address(public_key: &secp256k1::PublicKey) -> Address {
 
 pub fn derive_user_address(mpc_pk: mpc_crypto::PublicKey, derivation_epsilon: Scalar) -> Address {
     let user_pk: AffinePoint = derive_key(mpc_pk, derivation_epsilon);
-    let parity = match user_pk.y_is_odd().unwrap_u8() {
-        0 => secp256k1::Parity::Even,
-        1 => secp256k1::Parity::Odd,
-        _ => unreachable!(),
-    };
 
-    let x_coord = x_coordinate::<k256::Secp256k1>(&user_pk);
-    let x_only = secp256k1::XOnlyPublicKey::from_slice(&x_coord.to_bytes()).unwrap();
-    let secp_pk = secp256k1::PublicKey::from_x_only_public_key(x_only, parity);
-
-    public_key_to_address(&secp_pk)
+    public_key_to_address(user_pk.to_encoded_point(false).as_bytes())
 }
 
 /// Synthesize per-field default values for an `Output` whose source tx was
@@ -446,6 +431,32 @@ fn default_output_for_non_contract_call(schema: &[AbiField]) -> anyhow::Result<O
         fields: data,
         from_contract_call: false,
     })
+}
+
+#[cfg(test)]
+mod derive_tests {
+    use super::derive_user_address;
+    use alloy::primitives::Address;
+    use k256::elliptic_curve::sec1::FromEncodedPoint;
+    use k256::{AffinePoint, EncodedPoint};
+    use mpc_crypto::derive_epsilon_near;
+    use mpc_primitives::LEGACY_MPC_KEY_VERSION_0;
+
+    #[test]
+    fn derive_user_address_matches_golden() {
+        let mpc_key = "045b4fa179e005361fd858f8a6f896d7afc23a53d3f95d6566a88cde954e7b2f1cb77c554705c35d4ffced67aeafbcda46d9d89d6f200c3a3d109f92872863b3dc";
+        let account_id = "dev-20250212213501-93636560094065.test.near"
+            .parse()
+            .unwrap();
+        let mpc_pk = hex::decode(mpc_key).unwrap();
+        let mpc_pk = EncodedPoint::from_bytes(mpc_pk).unwrap();
+        let mpc_pk = AffinePoint::from_encoded_point(&mpc_pk).unwrap();
+        let derivation_epsilon =
+            derive_epsilon_near(LEGACY_MPC_KEY_VERSION_0, &account_id, "test");
+        let expected: Address = "0x083c8776b5e447e91bae43b7883a92a9bdb66d1d".parse().unwrap();
+
+        assert_eq!(derive_user_address(mpc_pk, derivation_epsilon), expected);
+    }
 }
 
 fn encode_abi_values(schema: &[AbiField], values: &[DynSolValue]) -> anyhow::Result<Vec<u8>> {

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -52,7 +52,6 @@ ecdsa = "0.16.9"
 cait-sith = { git = "https://github.com/sig-net/cait-sith", rev = "9f34e8c", features = ["k256"] }
 elliptic-curve = { version = "0.13.5", default-features = false }
 k256 = { version = "0.13.1", features = ["sha256", "ecdsa", "serde"] }
-secp256k1.workspace = true
 
 # near dependencies
 near-account-id.workspace = true

--- a/integration-tests/src/actions/mod.rs
+++ b/integration-tests/src/actions/mod.rs
@@ -15,6 +15,7 @@ use mpc_contract::errors::SignError;
 use mpc_contract::primitives::SignRequest;
 use mpc_crypto::ScalarExt;
 use mpc_crypto::{derive_epsilon_near, derive_key};
+use mpc_node::sign_bidirectional::public_key_to_address;
 use mpc_primitives::LATEST_MPC_KEY_VERSION;
 use near_crypto::InMemorySigner;
 use near_fetch::ops::AsyncTransactionStatus;
@@ -151,15 +152,6 @@ pub fn x_coordinate<C: cait_sith::CSCurve>(point: &C::AffinePoint) -> C::Scalar 
     <C::Scalar as k256::elliptic_curve::ops::Reduce<<C as k256::elliptic_curve::Curve>::Uint>>::reduce_bytes(&point.x())
 }
 
-pub fn public_key_to_address(public_key: &secp256k1::PublicKey) -> Address {
-    let public_key = public_key.serialize_uncompressed();
-
-    debug_assert_eq!(public_key[0], 0x04);
-    let hash: [u8; 32] = *alloy::primitives::keccak256(&public_key[1..]);
-
-    Address::from_slice(&hash[12..])
-}
-
 pub fn recover_eth_address(
     msg_hash: &[u8; 32],
     signature_bytes: &[u8; 64],
@@ -173,16 +165,13 @@ pub fn recover_eth_address(
     let verifying_key = VerifyingKey::recover_from_prehash(msg_hash, &signature, recid)
         .expect("failed to recover pubkey");
 
-    let encoded = verifying_key.to_encoded_point(false);
-    let public_key =
-        secp256k1::PublicKey::from_slice(encoded.as_bytes()).expect("valid secp256k1 pubkey");
-
-    public_key_to_address(&public_key)
+    public_key_to_address(verifying_key.to_encoded_point(false).as_bytes())
 }
 
 #[cfg(test)]
 mod tests {
     use elliptic_curve::sec1::FromEncodedPoint as _;
+    use elliptic_curve::sec1::ToEncodedPoint as _;
     use k256::ecdsa::VerifyingKey;
     use k256::elliptic_curve::ops::{Invert, Reduce};
     use k256::elliptic_curve::point::AffineCoordinates;
@@ -218,16 +207,7 @@ mod tests {
         let derivation_epsilon: k256::Scalar =
             derive_epsilon_near(LEGACY_MPC_KEY_VERSION_0, &account_id, "test");
         let user_pk: AffinePoint = derive_key(mpc_pk, derivation_epsilon);
-        let user_pk_y_parity = match user_pk.y_is_odd().unwrap_u8() {
-            0 => secp256k1::Parity::Even,
-            1 => secp256k1::Parity::Odd,
-            _ => unreachable!(),
-        };
-        let user_pk_x = x_coordinate::<k256::Secp256k1>(&user_pk);
-        let user_pk_x = secp256k1::XOnlyPublicKey::from_slice(&user_pk_x.to_bytes()).unwrap();
-        let user_secp_pk: secp256k1::PublicKey =
-            secp256k1::PublicKey::from_x_only_public_key(user_pk_x, user_pk_y_parity);
-        let user_address_from_pk = public_key_to_address(&user_secp_pk);
+        let user_address_from_pk = public_key_to_address(user_pk.to_encoded_point(false).as_bytes());
 
         // Prepare R ans s signature values
         let big_r = hex::decode(big_r).unwrap();

--- a/integration-tests/src/actions/mod.rs
+++ b/integration-tests/src/actions/mod.rs
@@ -207,7 +207,8 @@ mod tests {
         let derivation_epsilon: k256::Scalar =
             derive_epsilon_near(LEGACY_MPC_KEY_VERSION_0, &account_id, "test");
         let user_pk: AffinePoint = derive_key(mpc_pk, derivation_epsilon);
-        let user_address_from_pk = public_key_to_address(user_pk.to_encoded_point(false).as_bytes());
+        let user_address_from_pk =
+            public_key_to_address(user_pk.to_encoded_point(false).as_bytes());
 
         // Prepare R ans s signature values
         let big_r = hex::decode(big_r).unwrap();

--- a/integration-tests/tests/cases/chains.rs
+++ b/integration-tests/tests/cases/chains.rs
@@ -13,8 +13,6 @@ use mpc_primitives::Chain;
 use mpc_primitives::LATEST_MPC_KEY_VERSION;
 use reqwest::Client;
 use rlp::RlpStream;
-use secp256k1::PublicKey as SecpPublicKey;
-use secp256k1::{Secp256k1 as LibSecp256k1, SecretKey as SecpSecretKey};
 use serde_json::json;
 use sha3::{Digest, Keccak256};
 use solana_sdk::signer::Signer as _;
@@ -61,9 +59,7 @@ async fn test_solana_eth_bidirectional_flow() -> anyhow::Result<()> {
     let epsilon = derive_epsilon_sol(key_version, &signer_account, path);
     let user_pk = derive_key(root_pk, epsilon);
     let user_pk_bytes = user_pk.to_encoded_point(false);
-    let user_secp_pk = SecpPublicKey::from_slice(user_pk_bytes.as_bytes())
-        .context("failed to convert user public key")?;
-    let user_address = actions::public_key_to_address(&user_secp_pk);
+    let user_address = actions::public_key_to_address(user_pk_bytes.as_bytes());
     let user_alloy_address = AlloyAddress::from_slice(user_address.as_slice());
 
     let client = Client::new();
@@ -275,12 +271,9 @@ async fn ensure_eth_signer_funded(
         .as_slice()
         .try_into()
         .map_err(|_| anyhow::anyhow!("expected 32-byte ethereum secret key"))?;
-    let payer_sk = SecpSecretKey::from_slice(&payer_sk_array)?;
-    let secp = LibSecp256k1::signing_only();
-    let payer_pk = SecpPublicKey::from_secret_key(&secp, &payer_sk);
-    let payer_address = actions::public_key_to_address(&payer_pk);
-    let payer_alloy = AlloyAddress::from_slice(payer_address.as_slice());
     let signing_key = SigningKey::from_bytes(&payer_sk_array.into())?;
+    let payer_address = actions::public_key_to_address(signing_key.verifying_key().to_encoded_point(false).as_bytes());
+    let payer_alloy = AlloyAddress::from_slice(payer_address.as_slice());
 
     let mut gas_price = fetch_gas_price(client, rpc_url).await?;
     if gas_price < default_gas_price {

--- a/integration-tests/tests/cases/chains.rs
+++ b/integration-tests/tests/cases/chains.rs
@@ -9,6 +9,7 @@ use k256::elliptic_curve::sec1::ToEncodedPoint as _;
 use k256::Secp256k1;
 use mpc_crypto::kdf::check_ec_signature;
 use mpc_crypto::{derive_epsilon_sol, derive_key, near_public_key_to_affine_point};
+use mpc_node::sign_bidirectional::public_key_to_address;
 use mpc_primitives::Chain;
 use mpc_primitives::LATEST_MPC_KEY_VERSION;
 use reqwest::Client;
@@ -59,7 +60,7 @@ async fn test_solana_eth_bidirectional_flow() -> anyhow::Result<()> {
     let epsilon = derive_epsilon_sol(key_version, &signer_account, path);
     let user_pk = derive_key(root_pk, epsilon);
     let user_pk_bytes = user_pk.to_encoded_point(false);
-    let user_address = actions::public_key_to_address(user_pk_bytes.as_bytes());
+    let user_address = public_key_to_address(user_pk_bytes.as_bytes());
     let user_alloy_address = AlloyAddress::from_slice(user_address.as_slice());
 
     let client = Client::new();
@@ -272,7 +273,12 @@ async fn ensure_eth_signer_funded(
         .try_into()
         .map_err(|_| anyhow::anyhow!("expected 32-byte ethereum secret key"))?;
     let signing_key = SigningKey::from_bytes(&payer_sk_array.into())?;
-    let payer_address = actions::public_key_to_address(signing_key.verifying_key().to_encoded_point(false).as_bytes());
+    let payer_address = public_key_to_address(
+        signing_key
+            .verifying_key()
+            .to_encoded_point(false)
+            .as_bytes(),
+    );
     let payer_alloy = AlloyAddress::from_slice(payer_address.as_slice());
 
     let mut gas_price = fetch_gas_price(client, rpc_url).await?;

--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -12,6 +12,7 @@ use k256::elliptic_curve::sec1::FromEncodedPoint;
 use k256::{AffinePoint, EncodedPoint, FieldBytes, PublicKey as K256PublicKey};
 use mpc_crypto::derive_key;
 use mpc_crypto::kdf::derive_epsilon_eth;
+use mpc_node::sign_bidirectional::public_key_to_address;
 use mpc_primitives::{Chain, Checkpoint, LATEST_MPC_KEY_VERSION};
 use test_log::test;
 use tokio::time::Duration;
@@ -147,7 +148,7 @@ async fn test_signature_ethereum() -> Result<()> {
         .map_err(|_| anyhow!("invalid derived public key"))?;
     let verifying_key = VerifyingKey::from(&user_public_key);
     let verifying_key = verifying_key.to_encoded_point(false);
-    let expected_address = actions::public_key_to_address(verifying_key.as_bytes());
+    let expected_address = public_key_to_address(verifying_key.as_bytes());
 
     anyhow::ensure!(
         recovered_address == expected_address,

--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -147,9 +147,7 @@ async fn test_signature_ethereum() -> Result<()> {
         .map_err(|_| anyhow!("invalid derived public key"))?;
     let verifying_key = VerifyingKey::from(&user_public_key);
     let verifying_key = verifying_key.to_encoded_point(false);
-    let secp_public_key =
-        secp256k1::PublicKey::from_slice(verifying_key.as_bytes()).context("invalid secp key")?;
-    let expected_address = actions::public_key_to_address(&secp_public_key);
+    let expected_address = actions::public_key_to_address(verifying_key.as_bytes());
 
     anyhow::ensure!(
         recovered_address == expected_address,

--- a/integration-tests/tests/cases/mod.rs
+++ b/integration-tests/tests/cases/mod.rs
@@ -134,16 +134,7 @@ async fn test_key_derivation() -> anyhow::Result<()> {
         .unwrap();
 
         // start recovering the address and compare them:
-        let user_pk_x = x_coordinate(&user_pk);
-        let user_pk_y_parity = match user_pk.y_is_odd().unwrap_u8() {
-            1 => secp256k1::Parity::Odd,
-            0 => secp256k1::Parity::Even,
-            _ => unreachable!(),
-        };
-        let user_pk_x = secp256k1::XOnlyPublicKey::from_slice(&user_pk_x.to_bytes()).unwrap();
-        let user_secp_pk =
-            secp256k1::PublicKey::from_x_only_public_key(user_pk_x, user_pk_y_parity);
-        let user_addr = actions::public_key_to_address(&user_secp_pk);
+        let user_addr = actions::public_key_to_address(user_pk.to_encoded_point(false).as_bytes());
         let r = x_coordinate(&multichain_sig.big_r);
         let s = multichain_sig.s;
         let signature_for_recovery: [u8; 64] = {

--- a/integration-tests/tests/cases/mod.rs
+++ b/integration-tests/tests/cases/mod.rs
@@ -2,13 +2,14 @@ use integration_tests::actions;
 use integration_tests::cluster;
 use integration_tests::utils;
 
-use k256::elliptic_curve::point::AffineCoordinates;
+use k256::elliptic_curve::sec1::ToEncodedPoint as _;
 use mpc_contract::config::Config;
 use mpc_contract::update::ProposeUpdateArgs;
 use mpc_crypto::{self, derive_epsilon_near, derive_key, x_coordinate, ScalarExt};
 use mpc_node::kdf::into_signature;
 use mpc_node::protocol::cryptography::set_resharing_running_timeout;
 use mpc_node::protocol::state::ResharingStatus;
+use mpc_node::sign_bidirectional::public_key_to_address;
 use mpc_node::util::NearPublicKeyExt as _;
 use mpc_node::web::StateView;
 use mpc_primitives::LATEST_MPC_KEY_VERSION;
@@ -134,7 +135,7 @@ async fn test_key_derivation() -> anyhow::Result<()> {
         .unwrap();
 
         // start recovering the address and compare them:
-        let user_addr = actions::public_key_to_address(user_pk.to_encoded_point(false).as_bytes());
+        let user_addr = public_key_to_address(user_pk.to_encoded_point(false).as_bytes());
         let r = x_coordinate(&multichain_sig.big_r);
         let s = multichain_sig.s;
         let signature_for_recovery: [u8; 64] = {


### PR DESCRIPTION
this cleans up our derive_user_address a bit and removes direct usage of the secp256k1 crate in favor of k256. Adds `derive_user_address_matches_golden` to make sure our user addresses aren't changing