### PR TITLE
feat: more granular SignStatus & requeue publishing to RPC

### DIFF
--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -76,7 +76,9 @@ impl PendingRequests {
     }
 
     fn pending_execution(&self, id: &SignId) -> Option<&BacklogEntry> {
-        self.requests.get(id).filter(|entry| entry.status().is_pending_execution())
+        self.requests
+            .get(id)
+            .filter(|entry| entry.status().is_pending_execution())
     }
 
     fn pending_executions(&self) -> Vec<(SignId, BacklogEntry)> {
@@ -378,6 +380,14 @@ impl Backlog {
             .unwrap_or_default()
     }
 
+    pub async fn pending_execution(&self, chain: Chain, id: &SignId) -> Option<BacklogEntry> {
+        self.requests
+            .read()
+            .await
+            .get(&chain)
+            .and_then(|requests| requests.pending_execution(id).cloned())
+    }
+
     pub async fn len_by_chain(&self, chain: Chain) -> usize {
         self.requests
             .read()
@@ -462,7 +472,7 @@ impl Backlog {
 
     /// Get the set of bidirectional transactions currently awaiting execution on the
     /// specified destination chain.
-    pub async fn pending_execution(
+    pub async fn execution_watchers(
         &self,
         chain: Chain,
     ) -> HashMap<BidirectionalTxId, (SignId, BidirectionalTx)> {
@@ -1169,6 +1179,7 @@ mod tests {
         let backlog = Backlog::new();
 
         // Add transactions with different statuses to Ethereum
+        let tx0 = create_test_tx(0);
         let tx1 = create_test_tx(1);
         let tx2 = create_test_tx(2);
         let tx3 = create_test_tx(3);
@@ -1211,12 +1222,9 @@ mod tests {
 
         // Filter Ethereum by Pending
         let eth_pending = backlog
-            .get_by_status(
-                Chain::Ethereum,
-                pending_execution_status(&create_test_tx(3)),
-            )
+            .pending_execution(Chain::Ethereum, &SignId::new(tx3.request_id))
             .await;
-        assert_eq!(eth_pending.len(), 1);
+        assert!(eth_pending.is_some());
 
         let eth_awaiting = backlog
             .get_by_status(Chain::Ethereum, SignStatus::PendingGeneration)
@@ -1231,15 +1239,15 @@ mod tests {
 
         // Filter Solana by Pending
         let sol_pending = backlog
-            .get_by_status(Chain::Solana, pending_execution_status(&create_test_tx(4)))
+            .pending_execution(Chain::Solana, &SignId::new(tx4.request_id))
             .await;
-        assert_eq!(sol_pending.len(), 1);
+        assert!(sol_pending.is_some());
 
         // Filter non-existent chain returns empty
         let near_pending = backlog
-            .get_by_status(Chain::NEAR, pending_execution_status(&create_test_tx(0)))
+            .pending_execution(Chain::NEAR, &SignId::new(tx0.request_id))
             .await;
-        assert_eq!(near_pending.len(), 0);
+        assert!(near_pending.is_none());
     }
 
     #[tokio::test]
@@ -1518,7 +1526,7 @@ mod tests {
             .await
             .expect("failed to recover");
 
-        let watchers = recovered.pending_execution(Chain::Ethereum).await;
+        let watchers = recovered.execution_watchers(Chain::Ethereum).await;
         assert_eq!(watchers.len(), 1);
         assert!(watchers.contains_key(&tx.id));
     }

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -8,7 +8,7 @@ use crate::sign_bidirectional::{BidirectionalTx, BidirectionalTxId, SignStatus};
 use crate::storage::checkpoint_storage::CheckpointStorage;
 
 use anyhow::Context;
-use mpc_primitives::{PendingTx, SignId};
+use mpc_primitives::{PendingTx, SignId, Signature};
 use sha3::{Digest, Sha3_256};
 use std::collections::{hash_map, HashMap};
 use std::hash::{Hash, Hasher};
@@ -325,6 +325,34 @@ impl Backlog {
         });
 
         requeueable
+    }
+
+    pub async fn publishable_requests(&self, chain: Chain) -> Vec<(IndexedSignRequest, Signature)> {
+        let requests = self.requests.read().await;
+        let Some(pending) = requests.get(&chain) else {
+            return Vec::new();
+        };
+
+        let mut publishable: Vec<_> = pending
+            .requests
+            .values()
+            .filter_map(|entry| match entry.status() {
+                SignStatus::PendingPublish { signature }
+                | SignStatus::PendingPublishBidirectional { signature } => {
+                    Some((entry.request.clone(), signature))
+                }
+                _ => None,
+            })
+            .collect();
+
+        publishable.sort_by(|left, right| {
+            left.0
+                .unix_timestamp_indexed
+                .cmp(&right.0.unix_timestamp_indexed)
+                .then_with(|| left.0.id.request_id.cmp(&right.0.id.request_id))
+        });
+
+        publishable
     }
 
     /// Returns all sign-respond transactions with a specific status
@@ -814,7 +842,10 @@ impl BacklogEntry {
         bidirectional_tx: BidirectionalTx,
     ) -> Result<(), BacklogError> {
         match (&self.request.kind, self.status.clone()) {
-            (SignKind::SignBidirectional(_), SignStatus::PendingPublish { .. }) => {
+            (
+                SignKind::SignBidirectional(_),
+                SignStatus::PendingGeneration | SignStatus::PendingPublish { .. },
+            ) => {
                 self.status = SignStatus::PendingExecution {
                     tx_hash: bidirectional_tx.id,
                     target_chain: bidirectional_tx.target_chain,
@@ -1054,6 +1085,9 @@ mod tests {
                     .set_request(chain, &sign_id, completion_request)
                     .await
                     .unwrap();
+                backlog
+                    .set_status(chain, &sign_id, SignStatus::PendingGenerationBidirectional)
+                    .await;
             }
             SignStatus::PendingPublish { .. } => {
                 backlog.set_status(chain, &sign_id, status).await;
@@ -1902,5 +1936,28 @@ mod tests {
             .expect_err("advance should fail for plain Sign requests");
 
         assert!(matches!(err, BacklogError::InvalidAdvanceTransition));
+    }
+
+    #[tokio::test]
+    async fn test_advance_accepts_pending_generation_bidirectional_entry() {
+        let backlog = Backlog::new();
+        let tx = create_test_tx(9);
+        let sign_id = SignId::new(tx.request_id);
+
+        backlog
+            .insert(create_bidirectional_request(sign_id, tx.source_chain, "ethereum", 0))
+            .await;
+
+        backlog
+            .advance(tx.source_chain, sign_id, tx.clone())
+            .await
+            .expect("advance should succeed once a real respond event is observed");
+
+        let entry = backlog
+            .get(tx.source_chain, &sign_id)
+            .await
+            .expect("entry should remain in backlog");
+        assert_eq!(entry.status(), pending_execution_status(&tx));
+        assert_eq!(entry.execution_tx().map(|execution| execution.id), Some(tx.id));
     }
 }

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -854,7 +854,7 @@ impl BacklogEntry {
         bidirectional_tx: BidirectionalTx,
     ) -> Result<(), BacklogError> {
         match (&self.request.kind, self.status.clone()) {
-            (SignKind::SignBidirectional(_), SignStatus::PendingPublish { .. }) => {
+            (SignKind::SignBidirectional(_), SignStatus::PendingGeneration | SignStatus::PendingPublish { .. }) => {
                 self.status = SignStatus::PendingExecution {
                     tx: bidirectional_tx,
                 };
@@ -1966,7 +1966,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_advance_rejects_pending_generation_bidirectional() {
+    async fn test_advance_accepts_pending_generation_bidirectional() {
         let backlog = Backlog::new();
         let tx = create_test_tx(9);
         let sign_id = SignId::new(tx.request_id);
@@ -1980,12 +1980,16 @@ mod tests {
             ))
             .await;
 
-        let err = backlog
-            .advance(tx.source_chain, sign_id, tx)
+        backlog
+            .advance(tx.source_chain, sign_id, tx.clone())
             .await
-            .expect_err("advance should require PendingPublish for bidirectional requests");
+            .expect("advance should accept catchup advancement from PendingGeneration");
 
-        assert!(matches!(err, BacklogError::InvalidAdvanceTransition));
+        let entry = backlog
+            .get(tx.source_chain, &sign_id)
+            .await
+            .expect("entry should remain in backlog");
+        assert_eq!(entry.status(), pending_execution_status(&tx));
     }
 
     #[tokio::test]

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -777,7 +777,6 @@ pub enum BacklogError {
 pub struct BacklogEntry {
     pub request: IndexedSignRequest,
     pub status: SignStatus,
-    pub execution: Option<BidirectionalTx>,
 }
 
 impl BacklogEntry {
@@ -785,31 +784,15 @@ impl BacklogEntry {
         Self {
             request,
             status: SignStatus::PendingGeneration,
-            execution: None,
         }
     }
 
-    pub fn with_status(
-        request: IndexedSignRequest,
-        status: SignStatus,
-        execution: Option<BidirectionalTx>,
-    ) -> Self {
-        Self {
-            request,
-            status,
-            execution,
-        }
+    pub fn with_status(request: IndexedSignRequest, status: SignStatus) -> Self {
+        Self { request, status }
     }
 
     pub fn pending_execution(request: IndexedSignRequest, tx: BidirectionalTx) -> Self {
-        Self::with_status(
-            request,
-            SignStatus::PendingExecution {
-                tx_hash: tx.id,
-                target_chain: tx.target_chain,
-            },
-            Some(tx),
-        )
+        Self::with_status(request, SignStatus::PendingExecution { tx })
     }
 
     pub fn sign_id(&self) -> SignId {
@@ -849,11 +832,7 @@ impl BacklogEntry {
                 SignKind::SignBidirectional(_),
                 SignStatus::PendingGeneration | SignStatus::PendingPublish { .. },
             ) => {
-                self.status = SignStatus::PendingExecution {
-                    tx_hash: bidirectional_tx.id,
-                    target_chain: bidirectional_tx.target_chain,
-                };
-                self.execution = Some(bidirectional_tx);
+                self.status = SignStatus::PendingExecution { tx: bidirectional_tx };
                 Ok(())
             }
             _ => Err(BacklogError::InvalidAdvanceTransition),
@@ -863,8 +842,8 @@ impl BacklogEntry {
     /// Get target chain if this is a bidirectional transaction
     // TODO: looks a bit weird having two different ways to get target_chain in the match
     pub fn target_chain(&self) -> Option<Chain> {
-        self.execution
-            .as_ref()
+        self.status
+            .execution_tx()
             .map(|tx| tx.target_chain)
             .or_else(|| match &self.request.kind {
                 SignKind::Sign => None,
@@ -879,25 +858,27 @@ impl BacklogEntry {
     }
 
     pub fn execution_tx(&self) -> Option<&BidirectionalTx> {
-        self.execution.as_ref()
+        self.status.execution_tx()
     }
 
     pub fn take_execution_tx(self) -> Option<BidirectionalTx> {
-        self.execution
+        self.status.into_execution_tx()
     }
 
     pub fn typename(&self) -> &'static str {
-        match (&self.request.kind, self.execution.is_some(), &self.status) {
-            (SignKind::Sign, _, _) => "Sign",
-            (SignKind::SignBidirectional(_), true, _) => "BidirectionalExecution",
-            (SignKind::SignBidirectional(_), false, SignStatus::PendingGeneration) => {
+        match (&self.request.kind, &self.status) {
+            (SignKind::Sign, _) => "Sign",
+            (SignKind::SignBidirectional(_), SignStatus::PendingExecution { .. }) => {
+                "BidirectionalExecution"
+            }
+            (SignKind::SignBidirectional(_), SignStatus::PendingGeneration) => {
                 "BidirectionalPending"
             }
-            (SignKind::SignBidirectional(_), false, _) => "BidirectionalPending",
-            (SignKind::RespondBidirectional(_), _, SignStatus::PendingGenerationBidirectional) => {
+            (SignKind::SignBidirectional(_), _) => "BidirectionalPending",
+            (SignKind::RespondBidirectional(_), SignStatus::PendingGenerationBidirectional) => {
                 "BidirectionalRespondPending"
             }
-            (SignKind::RespondBidirectional(_), _, _) => "RespondBidirectional",
+            (SignKind::RespondBidirectional(_), _) => "RespondBidirectional",
         }
     }
 }
@@ -962,10 +943,7 @@ mod tests {
     }
 
     fn pending_execution_status(tx: &BidirectionalTx) -> SignStatus {
-        SignStatus::PendingExecution {
-            tx_hash: tx.id,
-            target_chain: tx.target_chain,
-        }
+        SignStatus::PendingExecution { tx: tx.clone() }
     }
 
     fn create_test_tx(id: u8) -> BidirectionalTx {
@@ -1060,7 +1038,7 @@ mod tests {
             0,
             SignKind::SignBidirectional(create_test_event(dest)),
         );
-        BacklogEntry::with_status(request, status, Some(tx))
+        BacklogEntry::with_status(request, status)
     }
 
     async fn insert_bidirectional_with_status(

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -9,6 +9,7 @@ use crate::storage::checkpoint_storage::CheckpointStorage;
 
 use anyhow::Context;
 use mpc_primitives::{PendingTx, SignId};
+use sha3::{Digest, Sha3_256};
 use std::collections::{hash_map, HashMap};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -69,7 +70,7 @@ impl PendingRequests {
     pub fn get_by_status(&self, status: SignStatus) -> HashMap<SignId, BacklogEntry> {
         self.requests
             .iter()
-            .filter(|(_, entry)| entry.status() == status)
+            .filter(|(_, entry)| entry.status().same_kind(&status))
             .map(|(id, entry)| (*id, entry.clone()))
             .collect()
     }
@@ -77,7 +78,7 @@ impl PendingRequests {
     fn pending_execution(&self) -> Vec<(SignId, BacklogEntry)> {
         self.requests
             .iter()
-            .filter(|(_, entry)| entry.status() == SignStatus::PendingExecution)
+            .filter(|(_, entry)| entry.status().is_pending_execution())
             .map(|(&id, entry)| (id, entry.clone()))
             .collect()
     }
@@ -137,6 +138,32 @@ impl PendingRequests {
             processed_block_height: Some(checkpoint.block_height),
         })
     }
+}
+
+pub fn checkpoint_digest(checkpoint: &Checkpoint) -> anyhow::Result<[u8; 32]> {
+    let mut pending_entries = checkpoint
+        .pending_requests
+        .iter()
+        .map(|pending| {
+            let entry: BacklogEntry = ciborium::de::from_reader(pending.transaction.as_slice())
+                .with_context(|| {
+                    format!(
+                        "failed to deserialize pending backlog entry for sign_id {:?}",
+                        pending.sign_id
+                    )
+                })?;
+            Ok((pending.sign_id, entry.status()))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    pending_entries.sort_by_key(|(sign_id, _)| *sign_id);
+
+    let mut digest = Sha3_256::new();
+    for (sign_id, status) in pending_entries {
+        digest.update(sign_id.request_id);
+        digest.update(status.digest_bytes());
+    }
+
+    Ok(digest.finalize().into())
 }
 
 #[derive(Debug, Clone)]
@@ -287,12 +314,7 @@ impl Backlog {
         let mut requeueable: Vec<_> = pending
             .requests
             .values()
-            .filter(|entry| {
-                matches!(
-                    entry.status(),
-                    SignStatus::AwaitingResponse | SignStatus::AwaitingResponseBidirectional
-                ) && entry.execution_tx().is_none()
-            })
+            .filter(|entry| entry.status().is_pending_generation() && entry.execution_tx().is_none())
             .map(|entry| entry.request.clone())
             .collect();
 
@@ -342,7 +364,7 @@ impl Backlog {
     // TODO: the backlog is a bit bloated with transition functions, so we need to do a proper cleanup
     // where we can have proper typestate on a set of types. With these types, we can easily guide
     // ourselves into the right transitions. For now, this is used to set the request in
-    // `execution_confirmed` to transition from PendingExecution to AwaitingResponseBidirectional.
+    // `execution_confirmed` to transition from PendingExecution to PendingGenerationBidirectional.
     pub async fn set_request(
         &self,
         chain: Chain,
@@ -713,7 +735,7 @@ impl BacklogEntry {
     pub fn new(request: IndexedSignRequest) -> Self {
         Self {
             request,
-            status: SignStatus::AwaitingResponse,
+            status: SignStatus::PendingGeneration,
             execution: None,
         }
     }
@@ -731,7 +753,14 @@ impl BacklogEntry {
     }
 
     pub fn pending_execution(request: IndexedSignRequest, tx: BidirectionalTx) -> Self {
-        Self::with_status(request, SignStatus::PendingExecution, Some(tx))
+        Self::with_status(
+            request,
+            SignStatus::PendingExecution {
+                tx_hash: tx.id,
+                target_chain: tx.target_chain,
+            },
+            Some(tx),
+        )
     }
 
     pub fn sign_id(&self) -> SignId {
@@ -750,7 +779,7 @@ impl BacklogEntry {
 
     /// Get the status of this transaction
     pub fn status(&self) -> SignStatus {
-        self.status
+        self.status.clone()
     }
 
     /// Set the status of this transaction
@@ -766,9 +795,12 @@ impl BacklogEntry {
         &mut self,
         bidirectional_tx: BidirectionalTx,
     ) -> Result<(), BacklogError> {
-        match (&self.request.kind, self.status) {
-            (SignKind::SignBidirectional(_), SignStatus::AwaitingResponse) => {
-                self.status = SignStatus::PendingExecution;
+        match (&self.request.kind, self.status.clone()) {
+            (SignKind::SignBidirectional(_), SignStatus::PendingPublish { .. }) => {
+                self.status = SignStatus::PendingExecution {
+                    tx_hash: bidirectional_tx.id,
+                    target_chain: bidirectional_tx.target_chain,
+                };
                 self.execution = Some(bidirectional_tx);
                 Ok(())
             }
@@ -803,14 +835,18 @@ impl BacklogEntry {
     }
 
     pub fn typename(&self) -> &'static str {
-        match (&self.request.kind, self.execution.is_some(), self.status) {
+        match (&self.request.kind, self.execution.is_some(), &self.status) {
             (SignKind::Sign, _, _) => "Sign",
             (SignKind::SignBidirectional(_), true, _) => "BidirectionalExecution",
-            (SignKind::SignBidirectional(_), false, SignStatus::AwaitingResponse) => {
+            (SignKind::SignBidirectional(_), false, SignStatus::PendingGeneration) => {
                 "BidirectionalPending"
             }
             (SignKind::SignBidirectional(_), false, _) => "BidirectionalPending",
-            (SignKind::RespondBidirectional(_), _, SignStatus::AwaitingResponseBidirectional) => {
+            (
+                SignKind::RespondBidirectional(_),
+                _,
+                SignStatus::PendingGenerationBidirectional,
+            ) => {
                 "BidirectionalRespondPending"
             }
             (SignKind::RespondBidirectional(_), _, _) => "RespondBidirectional",
@@ -853,7 +889,27 @@ mod tests {
     };
     use alloy::primitives::{Address, B256};
     use anchor_lang::prelude::Pubkey;
+    use k256::{AffinePoint, Scalar};
+    use std::convert::TryInto;
     use mpc_primitives::{SignArgs, SignId};
+
+    fn digest_hex(hex_str: &str) -> [u8; 32] {
+        hex::decode(hex_str)
+            .unwrap()
+            .try_into()
+            .expect("digest hex must be 32 bytes")
+    }
+
+    fn test_signature() -> mpc_primitives::Signature {
+        mpc_primitives::Signature::new(AffinePoint::GENERATOR, Scalar::ONE, 0)
+    }
+
+    fn pending_execution_status(tx: &BidirectionalTx) -> SignStatus {
+        SignStatus::PendingExecution {
+            tx_hash: tx.id,
+            target_chain: tx.target_chain,
+        }
+    }
 
     fn create_test_tx(id: u8) -> BidirectionalTx {
         BidirectionalTx {
@@ -963,8 +1019,8 @@ mod tests {
             .await;
 
         match status {
-            SignStatus::AwaitingResponse => {}
-            SignStatus::AwaitingResponseBidirectional => {
+            SignStatus::PendingGeneration => {}
+            SignStatus::PendingGenerationBidirectional => {
                 let completion_request = IndexedSignRequest::respond_bidirectional(
                     sign_id,
                     create_test_args(sign_id.request_id[0]),
@@ -981,13 +1037,39 @@ mod tests {
                     .await
                     .unwrap();
             }
-            SignStatus::PendingExecution => {
+            SignStatus::PendingPublish { .. } => {
+                backlog.set_status(chain, &sign_id, status).await;
+            }
+            SignStatus::PendingExecution { .. } => {
+                backlog
+                    .set_status(
+                        chain,
+                        &sign_id,
+                        SignStatus::PendingPublish {
+                            signature: test_signature(),
+                        },
+                    )
+                    .await;
                 backlog.advance(chain, sign_id, tx).await.unwrap();
             }
-        }
-
-        if status == SignStatus::AwaitingResponseBidirectional {
-            backlog.set_status(chain, &sign_id, status).await;
+            SignStatus::PendingPublishBidirectional { .. } => {
+                let completion_request = IndexedSignRequest::respond_bidirectional(
+                    sign_id,
+                    create_test_args(sign_id.request_id[0]),
+                    chain,
+                    0,
+                    RespondBidirectionalTx {
+                        tx_id: tx.id,
+                        output: vec![],
+                        chain_ctx: None,
+                    },
+                );
+                backlog
+                    .set_request(chain, &sign_id, completion_request)
+                    .await
+                    .unwrap();
+                backlog.set_status(chain, &sign_id, status).await;
+            }
         }
     }
 
@@ -1066,8 +1148,8 @@ mod tests {
         insert_bidirectional_with_status(
             &backlog,
             Chain::Ethereum,
-            tx3,
-            SignStatus::PendingExecution,
+            tx3.clone(),
+            pending_execution_status(&tx3),
             "ethereum",
         )
         .await;
@@ -1077,15 +1159,15 @@ mod tests {
         insert_bidirectional_with_status(
             &backlog,
             Chain::Solana,
-            tx4,
-            SignStatus::PendingExecution,
+            tx4.clone(),
+            pending_execution_status(&tx4),
             "solana",
         )
         .await;
 
         // Filter Ethereum by Pending
         let eth_pending = backlog
-            .get_by_status(Chain::Ethereum, SignStatus::PendingExecution)
+            .get_by_status(Chain::Ethereum, pending_execution_status(&create_test_tx(3)))
             .await;
         assert_eq!(eth_pending.len(), 1);
 
@@ -1102,13 +1184,13 @@ mod tests {
 
         // Filter Solana by Pending
         let sol_pending = backlog
-            .get_by_status(Chain::Solana, SignStatus::PendingExecution)
+            .get_by_status(Chain::Solana, pending_execution_status(&create_test_tx(4)))
             .await;
         assert_eq!(sol_pending.len(), 1);
 
         // Filter non-existent chain returns empty
         let near_pending = backlog
-            .get_by_status(Chain::NEAR, SignStatus::PendingExecution)
+            .get_by_status(Chain::NEAR, pending_execution_status(&create_test_tx(0)))
             .await;
         assert_eq!(near_pending.len(), 0);
     }
@@ -1193,7 +1275,7 @@ mod tests {
             &backlog,
             Chain::Ethereum,
             tx1.clone(),
-            SignStatus::PendingExecution,
+            pending_execution_status(&tx1),
             "ethereum",
         )
         .await;
@@ -1210,6 +1292,10 @@ mod tests {
         assert_eq!(checkpoint.block_height, 100);
         assert_eq!(checkpoint.chain, Chain::Ethereum);
         assert_eq!(checkpoint.pending_requests.len(), 2);
+        assert_eq!(
+            checkpoint_digest(&checkpoint).unwrap(),
+            digest_hex("69f27e7699ec4cd50a16123f478679fdef45702d46f8908f1ab8c50ac0811024")
+        );
     }
 
     #[tokio::test]
@@ -1262,11 +1348,53 @@ mod tests {
         let checkpoint2 = pending2.checkpoint(Chain::Ethereum);
         // Same data should be equal
         assert_eq!(checkpoint1, checkpoint2);
+        assert_eq!(checkpoint_digest(&checkpoint1).unwrap(), checkpoint_digest(&checkpoint2).unwrap());
 
         // Different block height should not be equal
         let mut checkpoint3 = pending2.checkpoint(Chain::Ethereum);
         checkpoint3.block_height = 101;
         assert_ne!(checkpoint1, checkpoint3);
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_digest_changes_with_status() {
+        let tx = create_test_tx(7);
+
+        let mut pending1 = PendingRequests::new();
+        pending1.insert(
+            SignId::new(tx.request_id),
+            create_execution_entry(
+                tx.clone(),
+                Chain::Ethereum,
+                SignStatus::AwaitingResponse,
+                "ethereum",
+            ),
+        );
+        pending1.set_processed_block(100);
+
+        let mut pending2 = PendingRequests::new();
+        pending2.insert(
+            SignId::new(tx.request_id),
+            create_execution_entry(
+                tx.clone(),
+                Chain::Ethereum,
+                pending_execution_status(&tx),
+                "ethereum",
+            ),
+        );
+        pending2.set_processed_block(100);
+
+        let checkpoint1 = pending1.checkpoint(Chain::Ethereum);
+        let checkpoint2 = pending2.checkpoint(Chain::Ethereum);
+
+        assert_eq!(
+            checkpoint_digest(&checkpoint1).unwrap(),
+            digest_hex("009a777d41ac9c8dbae41c1b1a582142b68923e350975eb055e695ff2796d0df")
+        );
+        assert_eq!(
+            checkpoint_digest(&checkpoint2).unwrap(),
+            digest_hex("6fc5d31bd61077c86d7fc7ec3df209b9bd6ee18cb17c3bc34b1302c996bb58b0")
+        );
     }
 
     #[tokio::test]
@@ -1291,9 +1419,14 @@ mod tests {
         let deserialized: Checkpoint = serde_json::from_str(&json).unwrap();
 
         assert_eq!(checkpoint, deserialized);
+        assert_eq!(
+            checkpoint_digest(&checkpoint).unwrap(),
+            digest_hex("5a3f743ba792e69b970bef34c3dbb1c8649ee0f049fb7f3fb66f70b869106415")
+        );
+        assert_eq!(checkpoint_digest(&checkpoint).unwrap(), checkpoint_digest(&deserialized).unwrap());
 
         let (sign_id, restored_tx) = {
-            let pending = &checkpoint.pending_requests[0];
+            let pending = &deserialized.pending_requests[0];
             let backlog_entry: BacklogEntry =
                 ciborium::de::from_reader(pending.transaction.as_slice()).unwrap();
             let tx = backlog_entry
@@ -1317,7 +1450,7 @@ mod tests {
             &backlog,
             Chain::Solana,
             tx.clone(),
-            SignStatus::PendingExecution,
+            pending_execution_status(&tx),
             "ethereum",
         )
         .await;
@@ -1344,8 +1477,8 @@ mod tests {
         insert_bidirectional_with_status(
             &backlog,
             Chain::Solana,
-            tx,
-            SignStatus::PendingExecution,
+            tx.clone(),
+            pending_execution_status(&tx),
             "ethereum",
         )
         .await;
@@ -1438,7 +1571,7 @@ mod tests {
                 &backlog,
                 Chain::Solana,
                 tx.clone(),
-                status,
+                status.clone(),
                 "ethereum",
             )
             .await;
@@ -1585,7 +1718,7 @@ mod tests {
             &backlog,
             Chain::Ethereum,
             tx1.clone(),
-            SignStatus::PendingExecution,
+            pending_execution_status(&tx1),
             "ethereum",
         )
         .await;
@@ -1630,7 +1763,7 @@ mod tests {
             &backlog,
             Chain::Solana,
             tx1.clone(),
-            SignStatus::PendingExecution,
+            pending_execution_status(&tx1),
             "solana",
         )
         .await;

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -680,7 +680,7 @@ impl Backlog {
         // now repopulate our execution watchers
         for (sign_id, tx) in execution_to_watch {
             // Only restore execution watchers for bidirectional transactions
-            if let Some(tx) = tx.take_execution_tx() {
+            if let Some(tx) = tx.execution_tx().cloned() {
                 self.watch_execution(tx.target_chain, sign_id, tx).await;
             }
         }
@@ -832,7 +832,9 @@ impl BacklogEntry {
                 SignKind::SignBidirectional(_),
                 SignStatus::PendingGeneration | SignStatus::PendingPublish { .. },
             ) => {
-                self.status = SignStatus::PendingExecution { tx: bidirectional_tx };
+                self.status = SignStatus::PendingExecution {
+                    tx: bidirectional_tx,
+                };
                 Ok(())
             }
             _ => Err(BacklogError::InvalidAdvanceTransition),
@@ -859,10 +861,6 @@ impl BacklogEntry {
 
     pub fn execution_tx(&self) -> Option<&BidirectionalTx> {
         self.status.execution_tx()
-    }
-
-    pub fn take_execution_tx(self) -> Option<BidirectionalTx> {
-        self.status.into_execution_tx()
     }
 
     pub fn typename(&self) -> &'static str {
@@ -1038,7 +1036,11 @@ mod tests {
             0,
             SignKind::SignBidirectional(create_test_event(dest)),
         );
-        BacklogEntry::with_status(request, status)
+
+        match status {
+            SignStatus::PendingExecution { .. } => BacklogEntry::pending_execution(request, tx),
+            status => BacklogEntry::with_status(request, status),
+        }
     }
 
     async fn insert_bidirectional_with_status(
@@ -1451,7 +1453,7 @@ mod tests {
             create_execution_entry(
                 tx1.clone(),
                 Chain::Ethereum,
-                SignStatus::PendingGeneration,
+                pending_execution_status(&tx1),
                 "ethereum",
             ),
         );
@@ -1465,7 +1467,7 @@ mod tests {
         assert_eq!(checkpoint, deserialized);
         assert_eq!(
             checkpoint_digest(&checkpoint).unwrap(),
-            digest_hex("5a3f743ba792e69b970bef34c3dbb1c8649ee0f049fb7f3fb66f70b869106415")
+            digest_hex("ebe96b88e51f1c6a128563289f3cf83b6d282b40f2dafc81fef7f2f073f5436f")
         );
         assert_eq!(
             checkpoint_digest(&checkpoint).unwrap(),
@@ -1477,7 +1479,8 @@ mod tests {
             let backlog_entry: BacklogEntry =
                 ciborium::de::from_reader(pending.transaction.as_slice()).unwrap();
             let tx = backlog_entry
-                .take_execution_tx()
+                .execution_tx()
+                .cloned()
                 .expect("Expected pending execution entry");
             (pending.sign_id, tx)
         };

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -314,7 +314,9 @@ impl Backlog {
         let mut requeueable: Vec<_> = pending
             .requests
             .values()
-            .filter(|entry| entry.status().is_pending_generation() && entry.execution_tx().is_none())
+            .filter(|entry| {
+                entry.status().is_pending_generation() && entry.execution_tx().is_none()
+            })
             .map(|entry| entry.request.clone())
             .collect();
 
@@ -397,10 +399,8 @@ impl Backlog {
 
         match (&entry.request.kind, &entry.status) {
             (SignKind::SignBidirectional(_), SignStatus::PendingPublish { .. })
-            | (
-                SignKind::RespondBidirectional(_),
-                SignStatus::PendingPublishBidirectional { .. },
-            ) => {
+            | (SignKind::RespondBidirectional(_), SignStatus::PendingPublishBidirectional { .. }) =>
+            {
                 tracing::info!(?chain, ?id, success, status = ?entry.status, "publish attempt recorded");
                 Ok(())
             }
@@ -894,11 +894,7 @@ impl BacklogEntry {
                 "BidirectionalPending"
             }
             (SignKind::SignBidirectional(_), false, _) => "BidirectionalPending",
-            (
-                SignKind::RespondBidirectional(_),
-                _,
-                SignStatus::PendingGenerationBidirectional,
-            ) => {
+            (SignKind::RespondBidirectional(_), _, SignStatus::PendingGenerationBidirectional) => {
                 "BidirectionalRespondPending"
             }
             (SignKind::RespondBidirectional(_), _, _) => "RespondBidirectional",
@@ -943,8 +939,8 @@ mod tests {
     use anchor_lang::prelude::Pubkey;
     use cait_sith::protocol::Participant;
     use k256::{AffinePoint, Scalar};
-    use std::convert::TryInto;
     use mpc_primitives::{SignArgs, SignId};
+    use std::convert::TryInto;
 
     fn digest_hex(hex_str: &str) -> [u8; 32] {
         hex::decode(hex_str)
@@ -1231,7 +1227,10 @@ mod tests {
 
         // Filter Ethereum by Pending
         let eth_pending = backlog
-            .get_by_status(Chain::Ethereum, pending_execution_status(&create_test_tx(3)))
+            .get_by_status(
+                Chain::Ethereum,
+                pending_execution_status(&create_test_tx(3)),
+            )
             .await;
         assert_eq!(eth_pending.len(), 1);
 
@@ -1412,7 +1411,10 @@ mod tests {
         let checkpoint2 = pending2.checkpoint(Chain::Ethereum);
         // Same data should be equal
         assert_eq!(checkpoint1, checkpoint2);
-        assert_eq!(checkpoint_digest(&checkpoint1).unwrap(), checkpoint_digest(&checkpoint2).unwrap());
+        assert_eq!(
+            checkpoint_digest(&checkpoint1).unwrap(),
+            checkpoint_digest(&checkpoint2).unwrap()
+        );
 
         // Different block height should not be equal
         let mut checkpoint3 = pending2.checkpoint(Chain::Ethereum);
@@ -1487,7 +1489,10 @@ mod tests {
             checkpoint_digest(&checkpoint).unwrap(),
             digest_hex("5a3f743ba792e69b970bef34c3dbb1c8649ee0f049fb7f3fb66f70b869106415")
         );
-        assert_eq!(checkpoint_digest(&checkpoint).unwrap(), checkpoint_digest(&deserialized).unwrap());
+        assert_eq!(
+            checkpoint_digest(&checkpoint).unwrap(),
+            checkpoint_digest(&deserialized).unwrap()
+        );
 
         let (sign_id, restored_tx) = {
             let pending = &deserialized.pending_requests[0];
@@ -1727,7 +1732,12 @@ mod tests {
         let sign_id = SignId::new(tx.request_id);
 
         backlog
-            .insert(create_bidirectional_request(sign_id, Chain::Solana, "ethereum", 0))
+            .insert(create_bidirectional_request(
+                sign_id,
+                Chain::Solana,
+                "ethereum",
+                0,
+            ))
             .await;
         backlog
             .set_status(
@@ -1782,7 +1792,12 @@ mod tests {
         let sign_id = SignId::new(tx.request_id);
 
         backlog
-            .insert(create_bidirectional_request(sign_id, Chain::Solana, "ethereum", 0))
+            .insert(create_bidirectional_request(
+                sign_id,
+                Chain::Solana,
+                "ethereum",
+                0,
+            ))
             .await;
 
         let err = backlog
@@ -1957,7 +1972,12 @@ mod tests {
         let sign_id = SignId::new(tx.request_id);
 
         backlog
-            .insert(create_bidirectional_request(sign_id, tx.source_chain, "ethereum", 0))
+            .insert(create_bidirectional_request(
+                sign_id,
+                tx.source_chain,
+                "ethereum",
+                0,
+            ))
             .await;
 
         backlog
@@ -1970,6 +1990,9 @@ mod tests {
             .await
             .expect("entry should remain in backlog");
         assert_eq!(entry.status(), pending_execution_status(&tx));
-        assert_eq!(entry.execution_tx().map(|execution| execution.id), Some(tx.id));
+        assert_eq!(
+            entry.execution_tx().map(|execution| execution.id),
+            Some(tx.id)
+        );
     }
 }

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -353,12 +353,28 @@ impl Backlog {
     /// Mark a request as published (success or failure)
     pub async fn mark_published(
         &self,
-        _chain: Chain,
-        _id: &SignId,
-        _success: bool,
+        chain: Chain,
+        id: &SignId,
+        success: bool,
     ) -> Result<(), BacklogError> {
-        // TODO: implement
-        Ok(())
+        let requests = self.requests.read().await;
+        let pending = requests.get(&chain).ok_or(BacklogError::ChainNotFound)?;
+        let entry = pending
+            .requests
+            .get(id)
+            .ok_or(BacklogError::NotFound { chain, id: *id })?;
+
+        match (&entry.request.kind, &entry.status) {
+            (SignKind::SignBidirectional(_), SignStatus::PendingPublish { .. })
+            | (
+                SignKind::RespondBidirectional(_),
+                SignStatus::PendingPublishBidirectional { .. },
+            ) => {
+                tracing::info!(?chain, ?id, success, status = ?entry.status, "publish attempt recorded");
+                Ok(())
+            }
+            _ => Err(BacklogError::InvalidPublishTransition),
+        }
     }
 
     // TODO: the backlog is a bit bloated with transition functions, so we need to do a proper cleanup
@@ -722,6 +738,8 @@ pub enum BacklogError {
     TransactionNotFound,
     #[error("cannot advance non-bidirectional or already-advanced backlog entry")]
     InvalidAdvanceTransition,
+    #[error("cannot mark publish for current backlog state")]
+    InvalidPublishTransition,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -1090,7 +1108,7 @@ mod tests {
             &backlog,
             Chain::Ethereum,
             tx_eth.clone(),
-            SignStatus::AwaitingResponse,
+            SignStatus::PendingGeneration,
             "ethereum",
         )
         .await;
@@ -1098,7 +1116,7 @@ mod tests {
             &backlog,
             Chain::Solana,
             tx_sol.clone(),
-            SignStatus::AwaitingResponse,
+            SignStatus::PendingGeneration,
             "solana",
         )
         .await;
@@ -1106,7 +1124,7 @@ mod tests {
             &backlog,
             Chain::NEAR,
             tx_near.clone(),
-            SignStatus::AwaitingResponse,
+            SignStatus::PendingGeneration,
             "near",
         )
         .await;
@@ -1133,7 +1151,7 @@ mod tests {
             &backlog,
             Chain::Ethereum,
             tx1,
-            SignStatus::AwaitingResponse,
+            SignStatus::PendingGeneration,
             "ethereum",
         )
         .await;
@@ -1141,7 +1159,7 @@ mod tests {
             &backlog,
             Chain::Ethereum,
             tx2,
-            SignStatus::AwaitingResponseBidirectional,
+            SignStatus::PendingGenerationBidirectional,
             "ethereum",
         )
         .await;
@@ -1172,13 +1190,13 @@ mod tests {
         assert_eq!(eth_pending.len(), 1);
 
         let eth_awaiting = backlog
-            .get_by_status(Chain::Ethereum, SignStatus::AwaitingResponse)
+            .get_by_status(Chain::Ethereum, SignStatus::PendingGeneration)
             .await;
         assert_eq!(eth_awaiting.len(), 1);
 
         // Filter Ethereum by bidirectional completion awaiting final respond
         let eth_completion = backlog
-            .get_by_status(Chain::Ethereum, SignStatus::AwaitingResponseBidirectional)
+            .get_by_status(Chain::Ethereum, SignStatus::PendingGenerationBidirectional)
             .await;
         assert_eq!(eth_completion.len(), 1);
 
@@ -1209,7 +1227,7 @@ mod tests {
                     &backlog,
                     Chain::Ethereum,
                     tx,
-                    SignStatus::AwaitingResponse,
+                    SignStatus::PendingGeneration,
                     "ethereum",
                 )
                 .await;
@@ -1225,7 +1243,7 @@ mod tests {
                     &backlog,
                     Chain::Solana,
                     tx,
-                    SignStatus::AwaitingResponse,
+                    SignStatus::PendingGeneration,
                     "solana",
                 )
                 .await;
@@ -1283,7 +1301,7 @@ mod tests {
             &backlog,
             Chain::Ethereum,
             tx2.clone(),
-            SignStatus::AwaitingResponseBidirectional,
+            SignStatus::PendingGenerationBidirectional,
             "ethereum",
         )
         .await;
@@ -1308,7 +1326,7 @@ mod tests {
             create_execution_entry(
                 tx1.clone(),
                 Chain::Ethereum,
-                SignStatus::AwaitingResponse,
+                SignStatus::PendingGeneration,
                 "ethereum",
             ),
         );
@@ -1317,7 +1335,7 @@ mod tests {
             create_execution_entry(
                 tx2.clone(),
                 Chain::Ethereum,
-                SignStatus::AwaitingResponse,
+                SignStatus::PendingGeneration,
                 "ethereum",
             ),
         );
@@ -1329,7 +1347,7 @@ mod tests {
             create_execution_entry(
                 tx1.clone(),
                 Chain::Ethereum,
-                SignStatus::AwaitingResponse,
+                SignStatus::PendingGeneration,
                 "ethereum",
             ),
         );
@@ -1338,7 +1356,7 @@ mod tests {
             create_execution_entry(
                 tx2.clone(),
                 Chain::Ethereum,
-                SignStatus::AwaitingResponse,
+                SignStatus::PendingGeneration,
                 "ethereum",
             ),
         );
@@ -1366,7 +1384,7 @@ mod tests {
             create_execution_entry(
                 tx.clone(),
                 Chain::Ethereum,
-                SignStatus::AwaitingResponse,
+                SignStatus::PendingGeneration,
                 "ethereum",
             ),
         );
@@ -1407,7 +1425,7 @@ mod tests {
             create_execution_entry(
                 tx1.clone(),
                 Chain::Ethereum,
-                SignStatus::AwaitingResponse,
+                SignStatus::PendingGeneration,
                 "ethereum",
             ),
         );
@@ -1561,7 +1579,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_recovered_completed_bidirectional_requests_are_requeued_for_final_respond() {
-        let status = SignStatus::AwaitingResponseBidirectional;
+        let status = SignStatus::PendingGenerationBidirectional;
         for offset in 0..2 {
             let backlog = Backlog::new();
             let tx = create_test_tx(8 + offset as u8);
@@ -1604,7 +1622,7 @@ mod tests {
                 .set_status(
                     Chain::Solana,
                     &sign_id,
-                    SignStatus::AwaitingResponseBidirectional,
+                    SignStatus::PendingGenerationBidirectional,
                 )
                 .await;
 
@@ -1644,7 +1662,7 @@ mod tests {
             .set_status(
                 Chain::Solana,
                 &sign_id,
-                SignStatus::AwaitingResponseBidirectional,
+                SignStatus::PendingGenerationBidirectional,
             )
             .await;
 
@@ -1654,6 +1672,78 @@ mod tests {
             requeued[0].kind,
             SignKind::RespondBidirectional(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn test_mark_published_accepts_publish_states() {
+        let backlog = Backlog::new();
+        let tx = create_test_tx(43);
+        let sign_id = SignId::new(tx.request_id);
+
+        backlog
+            .insert(create_bidirectional_request(sign_id, Chain::Solana, "ethereum", 0))
+            .await;
+        backlog
+            .set_status(
+                Chain::Solana,
+                &sign_id,
+                SignStatus::PendingPublish {
+                    signature: test_signature(),
+                },
+            )
+            .await;
+
+        backlog
+            .mark_published(Chain::Solana, &sign_id, true)
+            .await
+            .expect("pending publish should be accepted");
+
+        let completion_request = IndexedSignRequest::respond_bidirectional(
+            sign_id,
+            create_test_args(sign_id.request_id[0]),
+            Chain::Solana,
+            0,
+            RespondBidirectionalTx {
+                tx_id: tx.id,
+                output: vec![],
+                chain_ctx: None,
+            },
+        );
+        backlog
+            .set_request(Chain::Solana, &sign_id, completion_request)
+            .await
+            .unwrap();
+        backlog
+            .set_status(
+                Chain::Solana,
+                &sign_id,
+                SignStatus::PendingPublishBidirectional {
+                    signature: test_signature(),
+                },
+            )
+            .await;
+
+        backlog
+            .mark_published(Chain::Solana, &sign_id, false)
+            .await
+            .expect("pending publish bidirectional should be accepted");
+    }
+
+    #[tokio::test]
+    async fn test_mark_published_rejects_non_publish_state() {
+        let backlog = Backlog::new();
+        let tx = create_test_tx(44);
+        let sign_id = SignId::new(tx.request_id);
+
+        backlog
+            .insert(create_bidirectional_request(sign_id, Chain::Solana, "ethereum", 0))
+            .await;
+
+        let err = backlog
+            .mark_published(Chain::Solana, &sign_id, true)
+            .await
+            .expect_err("pending generation should not be accepted as published");
+        assert!(matches!(err, BacklogError::InvalidPublishTransition));
     }
 
     #[tokio::test]
@@ -1699,11 +1789,11 @@ mod tests {
             .set_status(
                 tx.source_chain,
                 &sign_id,
-                SignStatus::AwaitingResponseBidirectional,
+                SignStatus::PendingGenerationBidirectional,
             )
             .await;
         let successes = backlog
-            .get_by_status(tx.source_chain, SignStatus::AwaitingResponseBidirectional)
+            .get_by_status(tx.source_chain, SignStatus::PendingGenerationBidirectional)
             .await;
         assert!(successes.contains_key(&sign_id));
     }

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -409,6 +409,23 @@ impl Backlog {
             .unwrap_or(0)
     }
 
+    pub async fn mark_publishing(
+        &self,
+        chain: Chain,
+        id: &SignId,
+        publish: PublishState,
+    ) -> Result<(), BacklogError> {
+        let mut requests = self.requests.write().await;
+        let Some(pending) = requests.get_mut(&chain) else {
+            return Err(BacklogError::ChainNotFound);
+        };
+        let Some(entry) = pending.requests.get_mut(id) else {
+            return Err(BacklogError::NotFound { chain, id: *id });
+        };
+
+        entry.mark_publishing(publish)
+    }
+
     // TODO: the backlog is a bit bloated with transition functions, so we need to do a proper cleanup
     // where we can have proper typestate on a set of types. With these types, we can easily guide
     // ourselves into the right transitions. For now, this is used to set the request in
@@ -768,6 +785,8 @@ pub enum BacklogError {
     ChainNotFound,
     #[error("transaction not found")]
     TransactionNotFound,
+    #[error("cannot mark publishing for current backlog state")]
+    InvalidPublishingTransition,
     #[error("cannot advance non-bidirectional or already-advanced backlog entry")]
     InvalidAdvanceTransition,
 }
@@ -820,6 +839,20 @@ impl BacklogEntry {
 
     pub fn set_request(&mut self, request: IndexedSignRequest) {
         self.request = request;
+    }
+
+    pub fn mark_publishing(&mut self, publish: PublishState) -> Result<(), BacklogError> {
+        match (&self.request.kind, self.status.clone()) {
+            (SignKind::Sign | SignKind::SignBidirectional(_), SignStatus::PendingGeneration) => {
+                self.status = SignStatus::PendingPublish { publish };
+                Ok(())
+            }
+            (SignKind::RespondBidirectional(_), SignStatus::PendingGenerationBidirectional) => {
+                self.status = SignStatus::PendingPublishBidirectional { publish };
+                Ok(())
+            }
+            _ => Err(BacklogError::InvalidPublishingTransition),
+        }
     }
 
     pub fn advance_to_execution(
@@ -1698,6 +1731,75 @@ mod tests {
         assert!(matches!(
             requeued[0].kind,
             SignKind::RespondBidirectional(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_mark_publishing_accepts_bidirectional_pending_generation() {
+        let backlog = Backlog::new();
+        let tx = create_test_tx(43);
+        let sign_id = SignId::new(tx.request_id);
+
+        backlog
+            .insert(create_bidirectional_request(
+                sign_id,
+                Chain::Solana,
+                "ethereum",
+                0,
+            ))
+            .await;
+
+        backlog
+            .mark_publishing(Chain::Solana, &sign_id, test_publish_state(true))
+            .await
+            .expect("pending generation should transition to pending publish");
+
+        let entry = backlog
+            .get(Chain::Solana, &sign_id)
+            .await
+            .expect("entry should remain in backlog");
+        assert!(matches!(entry.status(), SignStatus::PendingPublish { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_mark_publishing_accepts_final_respond_generation() {
+        let backlog = Backlog::new();
+        let tx = create_test_tx(44);
+        let sign_id = SignId::new(tx.request_id);
+
+        let completion_request = IndexedSignRequest::respond_bidirectional(
+            sign_id,
+            create_test_args(sign_id.request_id[0]),
+            Chain::Solana,
+            0,
+            RespondBidirectionalTx {
+                tx_id: tx.id,
+                output: vec![],
+                chain_ctx: None,
+            },
+        );
+
+        backlog.insert(completion_request).await;
+        backlog
+            .set_status(
+                Chain::Solana,
+                &sign_id,
+                SignStatus::PendingGenerationBidirectional,
+            )
+            .await;
+
+        backlog
+            .mark_publishing(Chain::Solana, &sign_id, test_publish_state(true))
+            .await
+            .expect("pending generation bidirectional should transition to pending publish bidirectional");
+
+        let entry = backlog
+            .get(Chain::Solana, &sign_id)
+            .await
+            .expect("entry should remain in backlog");
+        assert!(matches!(
+            entry.status(),
+            SignStatus::PendingPublishBidirectional { .. }
         ));
     }
 

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -320,9 +320,7 @@ impl Backlog {
         let mut requeueable: Vec<_> = pending
             .requests
             .values()
-            .filter(|entry| {
-                entry.status().is_pending_generation() && entry.execution_tx().is_none()
-            })
+            .filter(|entry| entry.status().is_pending_generation())
             .map(|entry| entry.request.clone())
             .collect();
 

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -409,31 +409,6 @@ impl Backlog {
             .unwrap_or(0)
     }
 
-    /// Mark a request as published (success or failure)
-    pub async fn mark_published(
-        &self,
-        chain: Chain,
-        id: &SignId,
-        success: bool,
-    ) -> Result<(), BacklogError> {
-        let requests = self.requests.read().await;
-        let pending = requests.get(&chain).ok_or(BacklogError::ChainNotFound)?;
-        let entry = pending
-            .requests
-            .get(id)
-            .ok_or(BacklogError::NotFound { chain, id: *id })?;
-
-        match (&entry.request.kind, &entry.status) {
-            (SignKind::SignBidirectional(_), SignStatus::PendingPublish { .. })
-            | (SignKind::RespondBidirectional(_), SignStatus::PendingPublishBidirectional { .. }) =>
-            {
-                tracing::info!(?chain, ?id, success, status = ?entry.status, "publish attempt recorded");
-                Ok(())
-            }
-            _ => Err(BacklogError::InvalidPublishTransition),
-        }
-    }
-
     // TODO: the backlog is a bit bloated with transition functions, so we need to do a proper cleanup
     // where we can have proper typestate on a set of types. With these types, we can easily guide
     // ourselves into the right transitions. For now, this is used to set the request in
@@ -795,8 +770,6 @@ pub enum BacklogError {
     TransactionNotFound,
     #[error("cannot advance non-bidirectional or already-advanced backlog entry")]
     InvalidAdvanceTransition,
-    #[error("cannot mark publish for current backlog state")]
-    InvalidPublishTransition,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -854,7 +827,10 @@ impl BacklogEntry {
         bidirectional_tx: BidirectionalTx,
     ) -> Result<(), BacklogError> {
         match (&self.request.kind, self.status.clone()) {
-            (SignKind::SignBidirectional(_), SignStatus::PendingGeneration | SignStatus::PendingPublish { .. }) => {
+            (
+                SignKind::SignBidirectional(_),
+                SignStatus::PendingGeneration | SignStatus::PendingPublish { .. },
+            ) => {
                 self.status = SignStatus::PendingExecution {
                     tx: bidirectional_tx,
                 };
@@ -1723,88 +1699,6 @@ mod tests {
             requeued[0].kind,
             SignKind::RespondBidirectional(_)
         ));
-    }
-
-    #[tokio::test]
-    async fn test_mark_published_accepts_publish_states() {
-        let backlog = Backlog::new();
-        let tx = create_test_tx(43);
-        let sign_id = SignId::new(tx.request_id);
-
-        backlog
-            .insert(create_bidirectional_request(
-                sign_id,
-                Chain::Solana,
-                "ethereum",
-                0,
-            ))
-            .await;
-        backlog
-            .set_status(
-                Chain::Solana,
-                &sign_id,
-                SignStatus::PendingPublish {
-                    publish: test_publish_state(true),
-                },
-            )
-            .await;
-
-        backlog
-            .mark_published(Chain::Solana, &sign_id, true)
-            .await
-            .expect("pending publish should be accepted");
-
-        let completion_request = IndexedSignRequest::respond_bidirectional(
-            sign_id,
-            create_test_args(sign_id.request_id[0]),
-            Chain::Solana,
-            0,
-            RespondBidirectionalTx {
-                tx_id: tx.id,
-                output: vec![],
-                chain_ctx: None,
-            },
-        );
-        backlog
-            .set_request(Chain::Solana, &sign_id, completion_request)
-            .await
-            .unwrap();
-        backlog
-            .set_status(
-                Chain::Solana,
-                &sign_id,
-                SignStatus::PendingPublishBidirectional {
-                    publish: test_publish_state(true),
-                },
-            )
-            .await;
-
-        backlog
-            .mark_published(Chain::Solana, &sign_id, false)
-            .await
-            .expect("pending publish bidirectional should be accepted");
-    }
-
-    #[tokio::test]
-    async fn test_mark_published_rejects_non_publish_state() {
-        let backlog = Backlog::new();
-        let tx = create_test_tx(44);
-        let sign_id = SignId::new(tx.request_id);
-
-        backlog
-            .insert(create_bidirectional_request(
-                sign_id,
-                Chain::Solana,
-                "ethereum",
-                0,
-            ))
-            .await;
-
-        let err = backlog
-            .mark_published(Chain::Solana, &sign_id, true)
-            .await
-            .expect_err("pending generation should not be accepted as published");
-        assert!(matches!(err, BacklogError::InvalidPublishTransition));
     }
 
     #[tokio::test]

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -4,11 +4,11 @@ use self::selection::select_checkpoints;
 use crate::mesh::MeshState;
 use crate::node_client::NodeClient;
 use crate::protocol::{Chain, IndexedSignRequest, SignKind};
-use crate::sign_bidirectional::{BidirectionalTx, BidirectionalTxId, SignStatus};
+use crate::sign_bidirectional::{BidirectionalTx, BidirectionalTxId, PublishState, SignStatus};
 use crate::storage::checkpoint_storage::CheckpointStorage;
 
 use anyhow::Context;
-use mpc_primitives::{PendingTx, SignId, Signature};
+use mpc_primitives::{PendingTx, SignId};
 use sha3::{Digest, Sha3_256};
 use std::collections::{hash_map, HashMap};
 use std::hash::{Hash, Hasher};
@@ -327,7 +327,10 @@ impl Backlog {
         requeueable
     }
 
-    pub async fn publishable_requests(&self, chain: Chain) -> Vec<(IndexedSignRequest, Signature)> {
+    pub async fn publishable_requests(
+        &self,
+        chain: Chain,
+    ) -> Vec<(IndexedSignRequest, PublishState)> {
         let requests = self.requests.read().await;
         let Some(pending) = requests.get(&chain) else {
             return Vec::new();
@@ -337,9 +340,9 @@ impl Backlog {
             .requests
             .values()
             .filter_map(|entry| match entry.status() {
-                SignStatus::PendingPublish { signature }
-                | SignStatus::PendingPublishBidirectional { signature } => {
-                    Some((entry.request.clone(), signature))
+                SignStatus::PendingPublish { publish }
+                | SignStatus::PendingPublishBidirectional { publish } => {
+                    Some((entry.request.clone(), publish))
                 }
                 _ => None,
             })
@@ -933,11 +936,12 @@ mod tests {
     use crate::{
         protocol::SignKind,
         respond_bidirectional::RespondBidirectionalTx,
-        sign_bidirectional::{BidirectionalTx, BidirectionalTxId, SignStatus},
+        sign_bidirectional::{BidirectionalTx, BidirectionalTxId, PublishState, SignStatus},
         stream::ops::SignBidirectionalEvent,
     };
     use alloy::primitives::{Address, B256};
     use anchor_lang::prelude::Pubkey;
+    use cait_sith::protocol::Participant;
     use k256::{AffinePoint, Scalar};
     use std::convert::TryInto;
     use mpc_primitives::{SignArgs, SignId};
@@ -951,6 +955,14 @@ mod tests {
 
     fn test_signature() -> mpc_primitives::Signature {
         mpc_primitives::Signature::new(AffinePoint::GENERATOR, Scalar::ONE, 0)
+    }
+
+    fn test_publish_state(is_proposer: bool) -> PublishState {
+        PublishState {
+            signature: test_signature(),
+            participants: vec![Participant::from(0u32), Participant::from(1u32)],
+            is_proposer,
+        }
     }
 
     fn pending_execution_status(tx: &BidirectionalTx) -> SignStatus {
@@ -1098,7 +1110,7 @@ mod tests {
                         chain,
                         &sign_id,
                         SignStatus::PendingPublish {
-                            signature: test_signature(),
+                            publish: test_publish_state(true),
                         },
                     )
                     .await;
@@ -1346,7 +1358,7 @@ mod tests {
         assert_eq!(checkpoint.pending_requests.len(), 2);
         assert_eq!(
             checkpoint_digest(&checkpoint).unwrap(),
-            digest_hex("69f27e7699ec4cd50a16123f478679fdef45702d46f8908f1ab8c50ac0811024")
+            digest_hex("287237dc78e67eb9695b1472da0353a64a97a2b76d643cf50b4ce0ccdb28073b")
         );
     }
 
@@ -1722,7 +1734,7 @@ mod tests {
                 Chain::Solana,
                 &sign_id,
                 SignStatus::PendingPublish {
-                    signature: test_signature(),
+                    publish: test_publish_state(true),
                 },
             )
             .await;
@@ -1752,7 +1764,7 @@ mod tests {
                 Chain::Solana,
                 &sign_id,
                 SignStatus::PendingPublishBidirectional {
-                    signature: test_signature(),
+                    publish: test_publish_state(true),
                 },
             )
             .await;

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -70,12 +70,16 @@ impl PendingRequests {
     pub fn get_by_status(&self, status: SignStatus) -> HashMap<SignId, BacklogEntry> {
         self.requests
             .iter()
-            .filter(|(_, entry)| entry.status().same_kind(&status))
+            .filter(|(_, entry)| entry.status().is_same_kind(&status))
             .map(|(id, entry)| (*id, entry.clone()))
             .collect()
     }
 
-    fn pending_execution(&self) -> Vec<(SignId, BacklogEntry)> {
+    fn pending_execution(&self, id: &SignId) -> Option<&BacklogEntry> {
+        self.requests.get(id).filter(|entry| entry.status().is_pending_execution())
+    }
+
+    fn pending_executions(&self) -> Vec<(SignId, BacklogEntry)> {
         self.requests
             .iter()
             .filter(|(_, entry)| entry.status().is_pending_execution())
@@ -639,7 +643,7 @@ impl Backlog {
         let execution_to_watch = if checkpoint_height > previous_height {
             let cleared = pending.len();
             *pending = PendingRequests::from_checkpoint(checkpoint)?;
-            let execution_to_watch = pending.pending_execution();
+            let execution_to_watch = pending.pending_executions();
 
             tracing::info!(
                 ?chain,

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -66,11 +66,18 @@ impl PendingRequests {
         self.requests.len()
     }
 
-    /// Returns all sign-respond transactions with a specific status
-    pub fn get_by_status(&self, status: SignStatus) -> HashMap<SignId, BacklogEntry> {
+    fn pending_generations(&self) -> HashMap<SignId, BacklogEntry> {
         self.requests
             .iter()
-            .filter(|(_, entry)| entry.status().is_same_kind(&status))
+            .filter(|(_, entry)| entry.status() == SignStatus::PendingGeneration)
+            .map(|(id, entry)| (*id, entry.clone()))
+            .collect()
+    }
+
+    fn pending_generation_bidirectionals(&self) -> HashMap<SignId, BacklogEntry> {
+        self.requests
+            .iter()
+            .filter(|(_, entry)| entry.status() == SignStatus::PendingGenerationBidirectional)
             .map(|(id, entry)| (*id, entry.clone()))
             .collect()
     }
@@ -364,17 +371,24 @@ impl Backlog {
         publishable
     }
 
-    /// Returns all sign-respond transactions with a specific status
-    pub async fn get_by_status(
+    pub async fn pending_generations(&self, chain: Chain) -> HashMap<SignId, BacklogEntry> {
+        self.requests
+            .read()
+            .await
+            .get(&chain)
+            .map(PendingRequests::pending_generations)
+            .unwrap_or_default()
+    }
+
+    pub async fn pending_generation_bidirectionals(
         &self,
         chain: Chain,
-        status: SignStatus,
     ) -> HashMap<SignId, BacklogEntry> {
         self.requests
             .read()
             .await
             .get(&chain)
-            .map(|requests| requests.get_by_status(status))
+            .map(PendingRequests::pending_generation_bidirectionals)
             .unwrap_or_default()
     }
 
@@ -840,10 +854,7 @@ impl BacklogEntry {
         bidirectional_tx: BidirectionalTx,
     ) -> Result<(), BacklogError> {
         match (&self.request.kind, self.status.clone()) {
-            (
-                SignKind::SignBidirectional(_),
-                SignStatus::PendingGeneration | SignStatus::PendingPublish { .. },
-            ) => {
+            (SignKind::SignBidirectional(_), SignStatus::PendingPublish { .. }) => {
                 self.status = SignStatus::PendingExecution {
                     tx: bidirectional_tx,
                 };
@@ -856,14 +867,14 @@ impl BacklogEntry {
     /// Get target chain if this is a bidirectional transaction
     // TODO: looks a bit weird having two different ways to get target_chain in the match
     pub fn target_chain(&self) -> Option<Chain> {
-        self.status
-            .execution_tx()
-            .map(|tx| tx.target_chain)
-            .or_else(|| match &self.request.kind {
-                SignKind::Sign => None,
-                SignKind::SignBidirectional(event) => event.target_chain().ok(),
-                SignKind::RespondBidirectional(_) => None,
-            })
+        match &self.request.kind {
+            SignKind::Sign => None,
+            SignKind::SignBidirectional(event) => self
+                .execution_tx()
+                .map(|tx| tx.target_chain)
+                .or_else(|| event.target_chain().ok()),
+            SignKind::RespondBidirectional(_) => None,
+        }
     }
 
     /// Check if this is a bidirectional transaction
@@ -1224,14 +1235,12 @@ mod tests {
             .await;
         assert!(eth_pending.is_some());
 
-        let eth_awaiting = backlog
-            .get_by_status(Chain::Ethereum, SignStatus::PendingGeneration)
-            .await;
+        let eth_awaiting = backlog.pending_generations(Chain::Ethereum).await;
         assert_eq!(eth_awaiting.len(), 1);
 
         // Filter Ethereum by bidirectional completion awaiting final respond
         let eth_completion = backlog
-            .get_by_status(Chain::Ethereum, SignStatus::PendingGenerationBidirectional)
+            .pending_generation_bidirectionals(Chain::Ethereum)
             .await;
         assert_eq!(eth_completion.len(), 1);
 
@@ -1845,7 +1854,7 @@ mod tests {
             )
             .await;
         let successes = backlog
-            .get_by_status(tx.source_chain, SignStatus::PendingGenerationBidirectional)
+            .pending_generation_bidirectionals(tx.source_chain)
             .await;
         assert!(successes.contains_key(&sign_id));
     }
@@ -1957,7 +1966,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_advance_accepts_pending_generation_bidirectional_entry() {
+    async fn test_advance_rejects_pending_generation_bidirectional() {
         let backlog = Backlog::new();
         let tx = create_test_tx(9);
         let sign_id = SignId::new(tx.request_id);
@@ -1971,10 +1980,42 @@ mod tests {
             ))
             .await;
 
+        let err = backlog
+            .advance(tx.source_chain, sign_id, tx)
+            .await
+            .expect_err("advance should require PendingPublish for bidirectional requests");
+
+        assert!(matches!(err, BacklogError::InvalidAdvanceTransition));
+    }
+
+    #[tokio::test]
+    async fn test_advance_accepts_pending_publish_bidirectional() {
+        let backlog = Backlog::new();
+        let tx = create_test_tx(10);
+        let sign_id = SignId::new(tx.request_id);
+
+        backlog
+            .insert(create_bidirectional_request(
+                sign_id,
+                tx.source_chain,
+                "ethereum",
+                0,
+            ))
+            .await;
+        backlog
+            .set_status(
+                tx.source_chain,
+                &sign_id,
+                SignStatus::PendingPublish {
+                    publish: test_publish_state(true),
+                },
+            )
+            .await;
+
         backlog
             .advance(tx.source_chain, sign_id, tx.clone())
             .await
-            .expect("advance should succeed once a real respond event is observed");
+            .expect("advance should succeed once respond() is confirmed from PendingPublish");
 
         let entry = backlog
             .get(tx.source_chain, &sign_id)

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -305,15 +305,8 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let near_client =
                 NearClient::new(&near_rpc, &my_address, &network, &mpc_contract_id, signer);
 
-            let (rpc_channel, rpc) = RpcExecutor::new(
-                &near_client,
-                &eth,
-                &sol,
-                &hydration,
-                &canton,
-                backlog.clone(),
-            )
-            .await;
+            let (rpc_channel, rpc) =
+                RpcExecutor::new(&near_client, &eth, &sol, &hydration, &canton).await;
 
             let (sync_channel, sync) = SyncTask::new(
                 &client,

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -416,6 +416,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                     tokio::spawn(run_stream(
                         eth_stream,
                         sign_tx.clone(),
+                        rpc_channel.clone(),
                         backlog.clone(),
                         contract_watcher.clone(),
                         mesh_state.clone(),
@@ -431,6 +432,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 tokio::spawn(run_stream(
                     sol_stream,
                     sign_tx.clone(),
+                    rpc_channel.clone(),
                     backlog.clone(),
                     contract_watcher.clone(),
                     mesh_state.clone(),
@@ -450,6 +452,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 tokio::spawn(run_stream(
                     canton_stream,
                     sign_tx.clone(),
+                    rpc_channel.clone(),
                     backlog.clone(),
                     contract_watcher.clone(),
                     mesh_state.clone(),

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -1177,7 +1177,7 @@ impl EthereumIndexer {
         let mut events = Vec::new();
         let mut resolved_tx_ids = HashSet::new();
 
-        let watchers = self.backlog.pending_execution(Chain::Ethereum).await;
+        let watchers = self.backlog.execution_watchers(Chain::Ethereum).await;
         tracing::info!(
             watchers_count = watchers.len(),
             block_number,
@@ -1221,7 +1221,7 @@ impl EthereumIndexer {
         }
 
         // Staleness checks (nonce too low)
-        let remaining_pending = self.backlog.pending_execution(Chain::Ethereum).await;
+        let remaining_pending = self.backlog.execution_watchers(Chain::Ethereum).await;
 
         for (tx_id, (sign_id, tx)) in remaining_pending {
             if resolved_tx_ids.contains(&tx_id) || observed_tx_ids.contains(&tx_id) {

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -14,6 +14,7 @@ use crate::protocol::presignature::PresignatureId;
 use crate::protocol::SignKind;
 use crate::protocol::{Chain, ProtocolState};
 use crate::rpc::{ContractStateWatcher, GovernanceInfo, RpcChannel};
+use crate::sign_bidirectional::SignStatus;
 use crate::storage::presignature_storage::{
     PresignatureReservation, PresignatureTaken, PresignatureTakenDropper,
 };
@@ -1256,6 +1257,20 @@ impl SignGenerator {
 
                     if self.proposer == me {
                         crate::metrics::protocols::SIGNATURE_GENERATOR_MINE_SUCCESS.inc();
+                        if let Some(status) = publish_status(
+                            ctx.governance.public_key,
+                            &self.indexed,
+                            &output,
+                        ) {
+                            if ctx
+                                .backlog
+                                .set_status(self.indexed.chain, &sign_id, status)
+                                .await
+                                .is_none()
+                            {
+                                tracing::warn!(?sign_id, "failed to persist publish status in backlog");
+                            }
+                        }
                         ctx.rpc.publish(
                             ctx.governance.public_key,
                             self.indexed.clone(),
@@ -1289,6 +1304,26 @@ impl SignGenerator {
         };
         self.debug_view.send(markup);
     }
+}
+
+fn publish_status(
+    public_key: mpc_crypto::PublicKey,
+    indexed: &IndexedSignRequest,
+    output: &cait_sith::FullSignature<Secp256k1>,
+) -> Option<SignStatus> {
+    let expected_public_key = derive_key(public_key, indexed.args.epsilon);
+    let signature = crate::kdf::into_signature(
+        &expected_public_key,
+        &output.big_r,
+        &output.s,
+        indexed.args.payload,
+    )
+    .ok()?;
+
+    Some(match indexed.kind {
+        SignKind::RespondBidirectional(_) => SignStatus::PendingPublishBidirectional { signature },
+        _ => SignStatus::PendingPublish { signature },
+    })
 }
 
 impl Drop for SignGenerator {

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -14,7 +14,7 @@ use crate::protocol::presignature::PresignatureId;
 use crate::protocol::SignKind;
 use crate::protocol::{Chain, ProtocolState};
 use crate::rpc::{ContractStateWatcher, GovernanceInfo, RpcChannel};
-use crate::sign_bidirectional::SignStatus;
+use crate::sign_bidirectional::{PublishState, SignStatus};
 use crate::storage::presignature_storage::{
     PresignatureReservation, PresignatureTaken, PresignatureTakenDropper,
 };
@@ -1255,22 +1255,26 @@ impl SignGenerator {
                         .observe(self.created.elapsed().as_secs_f64());
                     crate::metrics::protocols::SIGNATURE_GENERATOR_SUCCESS.inc();
 
-                    if self.proposer == me {
-                        crate::metrics::protocols::SIGNATURE_GENERATOR_MINE_SUCCESS.inc();
-                        if let Some(status) = publish_status(
-                            ctx.governance.public_key,
-                            &self.indexed,
-                            &output,
-                        ) {
-                            if ctx
-                                .backlog
-                                .set_status(self.indexed.chain, &sign_id, status)
-                                .await
-                                .is_none()
-                            {
-                                tracing::warn!(?sign_id, "failed to persist publish status in backlog");
-                            }
+                    let is_proposer = self.proposer == me;
+                    if let Some(status) = publish_status(
+                        ctx.governance.public_key,
+                        &self.indexed,
+                        &output,
+                        self.participants.clone(),
+                        is_proposer,
+                    ) {
+                        if ctx
+                            .backlog
+                            .set_status(self.indexed.chain, &sign_id, status)
+                            .await
+                            .is_none()
+                        {
+                            tracing::warn!(?sign_id, "failed to persist publish status in backlog");
                         }
+                    }
+
+                    if is_proposer {
+                        crate::metrics::protocols::SIGNATURE_GENERATOR_MINE_SUCCESS.inc();
                         ctx.rpc.publish(
                             ctx.governance.public_key,
                             self.indexed.clone(),
@@ -1310,6 +1314,8 @@ fn publish_status(
     public_key: mpc_crypto::PublicKey,
     indexed: &IndexedSignRequest,
     output: &cait_sith::FullSignature<Secp256k1>,
+    participants: Vec<Participant>,
+    is_proposer: bool,
 ) -> Option<SignStatus> {
     let expected_public_key = derive_key(public_key, indexed.args.epsilon);
     let signature = crate::kdf::into_signature(
@@ -1319,10 +1325,15 @@ fn publish_status(
         indexed.args.payload,
     )
     .ok()?;
+    let publish = PublishState {
+        signature,
+        participants,
+        is_proposer,
+    };
 
     Some(match indexed.kind {
-        SignKind::RespondBidirectional(_) => SignStatus::PendingPublishBidirectional { signature },
-        _ => SignStatus::PendingPublish { signature },
+        SignKind::RespondBidirectional(_) => SignStatus::PendingPublishBidirectional { publish },
+        _ => SignStatus::PendingPublish { publish },
     })
 }
 

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -14,7 +14,7 @@ use crate::protocol::presignature::PresignatureId;
 use crate::protocol::SignKind;
 use crate::protocol::{Chain, ProtocolState};
 use crate::rpc::{ContractStateWatcher, GovernanceInfo, RpcChannel};
-use crate::sign_bidirectional::{PublishState, SignStatus};
+use crate::sign_bidirectional::PublishState;
 use crate::storage::presignature_storage::{
     PresignatureReservation, PresignatureTaken, PresignatureTakenDropper,
 };
@@ -1256,20 +1256,23 @@ impl SignGenerator {
                     crate::metrics::protocols::SIGNATURE_GENERATOR_SUCCESS.inc();
 
                     let is_proposer = self.proposer == me;
-                    if let Some(status) = publish_status(
+                    if let Some(publish) = publish_status(
                         ctx.governance.public_key,
                         &self.indexed,
                         &output,
                         self.participants.clone(),
                         is_proposer,
                     ) {
-                        if ctx
+                        if let Err(err) = ctx
                             .backlog
-                            .set_status(self.indexed.chain, &sign_id, status)
+                            .mark_publishing(self.indexed.chain, &sign_id, publish)
                             .await
-                            .is_none()
                         {
-                            tracing::warn!(?sign_id, "failed to persist publish status in backlog");
+                            tracing::warn!(
+                                ?sign_id,
+                                ?err,
+                                "failed to mark publishing for sign request"
+                            );
                         }
                     }
 
@@ -1316,7 +1319,7 @@ fn publish_status(
     output: &cait_sith::FullSignature<Secp256k1>,
     participants: Vec<Participant>,
     is_proposer: bool,
-) -> Option<SignStatus> {
+) -> Option<PublishState> {
     let expected_public_key = derive_key(public_key, indexed.args.epsilon);
     let signature = crate::kdf::into_signature(
         &expected_public_key,
@@ -1331,10 +1334,7 @@ fn publish_status(
         is_proposer,
     };
 
-    Some(match indexed.kind {
-        SignKind::RespondBidirectional(_) => SignStatus::PendingPublishBidirectional { publish },
-        _ => SignStatus::PendingPublish { publish },
-    })
+    Some(publish)
 }
 
 impl Drop for SignGenerator {

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -1256,7 +1256,10 @@ async fn execute_publish(client: ChainClient, action: PublishAction, backlog: Ba
         );
     }
 
-    if matches!(action.indexed.kind, SignKind::SignBidirectional(_)) {
+    if matches!(
+        action.indexed.kind,
+        SignKind::SignBidirectional(_) | SignKind::RespondBidirectional(_)
+    ) {
         if let Err(err) = backlog.mark_published(chain, &sign_id, publish_ok).await {
             tracing::warn!(?sign_id, ?err, "failed to mark publish status in backlog");
         }

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -170,6 +170,31 @@ impl RpcChannel {
             }
         });
     }
+
+    pub fn publish_signature(
+        &self,
+        public_key: mpc_crypto::PublicKey,
+        indexed: IndexedSignRequest,
+        signature: Signature,
+        participants: Vec<Participant>,
+    ) {
+        let rpc = self.clone();
+        tokio::spawn(async move {
+            if let Err(err) = rpc
+                .tx
+                .send(RpcAction::Publish(PublishAction {
+                    public_key,
+                    indexed,
+                    signature,
+                    participants,
+                    timestamp: Instant::now(),
+                }))
+                .await
+            {
+                tracing::error!(%err, "failed to send publish action");
+            }
+        });
+    }
 }
 
 #[derive(Clone)]

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -1,4 +1,3 @@
-use crate::backlog::Backlog;
 use crate::config::{Config, ContractConfig, NetworkConfig};
 use crate::indexer_eth::EthConfig;
 use crate::indexer_sol::SolConfig;
@@ -409,7 +408,6 @@ pub struct RpcExecutor {
     hydration: Option<HydrationClient>,
     canton: Option<CantonClient>,
     action_rx: mpsc::Receiver<RpcAction>,
-    backlog: Backlog,
 }
 
 impl RpcExecutor {
@@ -419,7 +417,6 @@ impl RpcExecutor {
         solana: &Option<SolConfig>,
         hydration: &Option<HydrationConfig>,
         canton: &Option<CantonConfig>,
-        backlog: Backlog,
     ) -> (RpcChannel, Self) {
         let eth = eth.as_ref().map(EthClient::new);
         let solana = solana.as_ref().map(SolanaClient::new);
@@ -453,7 +450,6 @@ impl RpcExecutor {
                 hydration,
                 canton,
                 action_rx: rx,
-                backlog,
             },
         )
     }
@@ -496,12 +492,11 @@ impl RpcExecutor {
             let chain = action.indexed.chain;
             let client = self.client(&chain);
             let eth_rpc_tx = eth_rpc_tx.clone(); // clone for task use
-            let backlog = self.backlog.clone();
 
             tokio::spawn(async move {
                 match chain {
                     Chain::NEAR | Chain::Solana | Chain::Hydration | Chain::Canton => {
-                        execute_publish(client, action, backlog).await;
+                        execute_publish(client, action).await;
                     }
                     Chain::Ethereum => {
                         if let Err(err) = eth_rpc_tx.send(action).await {
@@ -1178,7 +1173,7 @@ async fn update_config(near: NearClient, config: watch::Sender<Config>) {
 }
 
 /// Publish the signature and retry if it fails
-async fn execute_publish(client: ChainClient, action: PublishAction, backlog: Backlog) {
+async fn execute_publish(client: ChainClient, action: PublishAction) {
     let chain = action.indexed.chain;
     let sign_id = action.indexed.id;
 

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -1280,15 +1280,6 @@ async fn execute_publish(client: ChainClient, action: PublishAction, backlog: Ba
             "exceeded max retries, trashing publish request"
         );
     }
-
-    if matches!(
-        action.indexed.kind,
-        SignKind::SignBidirectional(_) | SignKind::RespondBidirectional(_)
-    ) {
-        if let Err(err) = backlog.mark_published(chain, &sign_id, publish_ok).await {
-            tracing::warn!(?sign_id, ?err, "failed to mark publish status in backlog");
-        }
-    }
 }
 
 async fn run_batch_respond(

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -44,12 +44,6 @@ pub enum SignStatus {
 }
 
 impl SignStatus {
-    #[allow(non_upper_case_globals)]
-    pub const AwaitingResponse: Self = Self::PendingGeneration;
-
-    #[allow(non_upper_case_globals)]
-    pub const AwaitingResponseBidirectional: Self = Self::PendingGenerationBidirectional;
-
     pub fn is_pending_generation(&self) -> bool {
         matches!(
             self,

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -2,6 +2,7 @@ use crate::protocol::{Chain, IndexedSignRequest};
 use alloy::primitives::{keccak256, Address, Bytes, B256, I256, U256};
 use alloy_dyn_abi::{DynSolType, DynSolValue};
 use borsh::{to_vec as borsh_to_vec, BorshSerialize};
+use cait_sith::protocol::Participant;
 use k256::elliptic_curve::point::AffineCoordinates;
 use k256::{AffinePoint, Scalar};
 use mpc_crypto::derive_key;
@@ -32,15 +33,35 @@ struct AbiField {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PublishState {
+    pub signature: Signature,
+    pub participants: Vec<Participant>,
+    pub is_proposer: bool,
+}
+
+impl PublishState {
+    fn digest_bytes(&self, tag: u8) -> Vec<u8> {
+        let mut bytes = vec![tag];
+        bytes.extend(
+            borsh_to_vec(&self.signature).expect("signature serialization is infallible"),
+        );
+        ciborium::ser::into_writer(&self.participants, &mut bytes)
+            .expect("participant serialization is infallible");
+        bytes.push(u8::from(self.is_proposer));
+        bytes
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum SignStatus {
     PendingGeneration,
-    PendingPublish { signature: Signature },
+    PendingPublish { publish: PublishState },
     PendingExecution {
         tx_hash: BidirectionalTxId,
         target_chain: Chain,
     },
     PendingGenerationBidirectional,
-    PendingPublishBidirectional { signature: Signature },
+    PendingPublishBidirectional { publish: PublishState },
 }
 
 impl SignStatus {
@@ -86,11 +107,7 @@ impl SignStatus {
     pub fn digest_bytes(&self) -> Vec<u8> {
         match self {
             SignStatus::PendingGeneration => vec![0],
-            SignStatus::PendingPublish { signature } => {
-                let mut bytes = vec![1];
-                bytes.extend(borsh_to_vec(signature).expect("signature serialization is infallible"));
-                bytes
-            }
+            SignStatus::PendingPublish { publish } => publish.digest_bytes(1),
             SignStatus::PendingExecution {
                 tx_hash,
                 target_chain,
@@ -103,11 +120,7 @@ impl SignStatus {
                 bytes
             }
             SignStatus::PendingGenerationBidirectional => vec![3],
-            SignStatus::PendingPublishBidirectional { signature } => {
-                let mut bytes = vec![4];
-                bytes.extend(borsh_to_vec(signature).expect("signature serialization is infallible"));
-                bytes
-            }
+            SignStatus::PendingPublishBidirectional { publish } => publish.digest_bytes(4),
         }
     }
 }

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -43,8 +43,10 @@ impl PublishState {
     fn digest_bytes(&self, tag: u8) -> Vec<u8> {
         let mut bytes = vec![tag];
         bytes.extend_from_slice(&self.signature.to_bytes());
-        ciborium::ser::into_writer(&self.participants, &mut bytes)
-            .expect("participant serialization is infallible");
+        bytes.extend_from_slice(&(self.participants.len() as u32).to_le_bytes());
+        for participant in &self.participants {
+            bytes.extend_from_slice(&participant.bytes());
+        }
         bytes.push(u8::from(self.is_proposer));
         bytes
     }

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -1,7 +1,7 @@
 use crate::protocol::{Chain, IndexedSignRequest};
 use alloy::primitives::{keccak256, Address, Bytes, B256, I256, U256};
 use alloy_dyn_abi::{DynSolType, DynSolValue};
-use borsh::{to_vec as borsh_to_vec, BorshSerialize};
+use borsh::BorshSerialize;
 use cait_sith::protocol::Participant;
 use k256::elliptic_curve::point::AffineCoordinates;
 use k256::{AffinePoint, Scalar};
@@ -42,7 +42,7 @@ pub struct PublishState {
 impl PublishState {
     fn digest_bytes(&self, tag: u8) -> Vec<u8> {
         let mut bytes = vec![tag];
-        bytes.extend(borsh_to_vec(&self.signature).expect("signature serialization is infallible"));
+        bytes.extend_from_slice(&self.signature.to_bytes());
         ciborium::ser::into_writer(&self.participants, &mut bytes)
             .expect("participant serialization is infallible");
         bytes.push(u8::from(self.is_proposer));

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -42,9 +42,7 @@ pub struct PublishState {
 impl PublishState {
     fn digest_bytes(&self, tag: u8) -> Vec<u8> {
         let mut bytes = vec![tag];
-        bytes.extend(
-            borsh_to_vec(&self.signature).expect("signature serialization is infallible"),
-        );
+        bytes.extend(borsh_to_vec(&self.signature).expect("signature serialization is infallible"));
         ciborium::ser::into_writer(&self.participants, &mut bytes)
             .expect("participant serialization is infallible");
         bytes.push(u8::from(self.is_proposer));
@@ -55,13 +53,17 @@ impl PublishState {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum SignStatus {
     PendingGeneration,
-    PendingPublish { publish: PublishState },
+    PendingPublish {
+        publish: PublishState,
+    },
     PendingExecution {
         tx_hash: BidirectionalTxId,
         target_chain: Chain,
     },
     PendingGenerationBidirectional,
-    PendingPublishBidirectional { publish: PublishState },
+    PendingPublishBidirectional {
+        publish: PublishState,
+    },
 }
 
 impl SignStatus {
@@ -80,7 +82,10 @@ impl SignStatus {
         matches!(
             (self, other),
             (SignStatus::PendingGeneration, SignStatus::PendingGeneration)
-                | (SignStatus::PendingPublish { .. }, SignStatus::PendingPublish { .. })
+                | (
+                    SignStatus::PendingPublish { .. },
+                    SignStatus::PendingPublish { .. }
+                )
                 | (
                     SignStatus::PendingGenerationBidirectional,
                     SignStatus::PendingGenerationBidirectional,
@@ -114,9 +119,8 @@ impl SignStatus {
             } => {
                 let mut bytes = vec![2];
                 bytes.extend_from_slice(tx_hash.0.as_slice());
-                bytes.extend(
-                    borsh_to_vec(target_chain).expect("chain serialization is infallible"),
-                );
+                bytes
+                    .extend(borsh_to_vec(target_chain).expect("chain serialization is infallible"));
                 bytes
             }
             SignStatus::PendingGenerationBidirectional => vec![3],

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -53,16 +53,10 @@ impl PublishState {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum SignStatus {
     PendingGeneration,
-    PendingPublish {
-        publish: PublishState,
-    },
-    PendingExecution {
-        tx: BidirectionalTx,
-    },
+    PendingPublish { publish: PublishState },
+    PendingExecution { tx: BidirectionalTx },
     PendingGenerationBidirectional,
-    PendingPublishBidirectional {
-        publish: PublishState,
-    },
+    PendingPublishBidirectional { publish: PublishState },
 }
 
 impl SignStatus {
@@ -109,8 +103,7 @@ impl SignStatus {
             SignStatus::PendingExecution { tx } => {
                 let mut bytes = vec![2];
                 bytes.extend_from_slice(tx.id.0.as_slice());
-                bytes
-                    .extend(borsh_to_vec(&tx.target_chain).expect("chain serialization is infallible"));
+                bytes.extend_from_slice(&tx.target_chain.to_bytes());
                 bytes
             }
             SignStatus::PendingGenerationBidirectional => vec![3],
@@ -119,13 +112,6 @@ impl SignStatus {
     }
 
     pub fn execution_tx(&self) -> Option<&BidirectionalTx> {
-        match self {
-            SignStatus::PendingExecution { tx } => Some(tx),
-            _ => None,
-        }
-    }
-
-    pub fn into_execution_tx(self) -> Option<BidirectionalTx> {
         match self {
             SignStatus::PendingExecution { tx } => Some(tx),
             _ => None,

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -71,7 +71,7 @@ impl SignStatus {
         matches!(self, SignStatus::PendingExecution { .. })
     }
 
-    pub fn same_kind(&self, other: &Self) -> bool {
+    pub fn is_same_kind(&self, other: &Self) -> bool {
         matches!(
             (self, other),
             (SignStatus::PendingGeneration, SignStatus::PendingGeneration)

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -1,7 +1,7 @@
 use crate::protocol::{Chain, IndexedSignRequest};
 use alloy::primitives::{keccak256, Address, Bytes, B256, I256, U256};
 use alloy_dyn_abi::{DynSolType, DynSolValue};
-use borsh::BorshSerialize;
+use borsh::{to_vec as borsh_to_vec, BorshSerialize};
 use k256::elliptic_curve::point::AffineCoordinates;
 use k256::{AffinePoint, Scalar};
 use mpc_crypto::derive_key;
@@ -31,16 +31,83 @@ struct AbiField {
     typ: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum SignStatus {
-    /// Request has been received on the source chain and is waiting for a `respond`
-    /// transaction to be observed.
-    AwaitingResponse,
-    /// Request has been responded to and the derived transaction is now waiting to
-    /// execute on the destination chain.
-    PendingExecution,
-    /// Execution was confirmed and final respond request is waiting to be signed.
-    AwaitingResponseBidirectional,
+    PendingGeneration,
+    PendingPublish { signature: Signature },
+    PendingExecution {
+        tx_hash: BidirectionalTxId,
+        target_chain: Chain,
+    },
+    PendingGenerationBidirectional,
+    PendingPublishBidirectional { signature: Signature },
+}
+
+impl SignStatus {
+    #[allow(non_upper_case_globals)]
+    pub const AwaitingResponse: Self = Self::PendingGeneration;
+
+    #[allow(non_upper_case_globals)]
+    pub const AwaitingResponseBidirectional: Self = Self::PendingGenerationBidirectional;
+
+    pub fn is_pending_generation(&self) -> bool {
+        matches!(
+            self,
+            SignStatus::PendingGeneration | SignStatus::PendingGenerationBidirectional
+        )
+    }
+
+    pub fn is_pending_execution(&self) -> bool {
+        matches!(self, SignStatus::PendingExecution { .. })
+    }
+
+    pub fn same_kind(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (SignStatus::PendingGeneration, SignStatus::PendingGeneration)
+                | (SignStatus::PendingPublish { .. }, SignStatus::PendingPublish { .. })
+                | (
+                    SignStatus::PendingExecution { .. },
+                    SignStatus::PendingExecution { .. }
+                )
+                | (
+                    SignStatus::PendingGenerationBidirectional,
+                    SignStatus::PendingGenerationBidirectional,
+                )
+                | (
+                    SignStatus::PendingPublishBidirectional { .. },
+                    SignStatus::PendingPublishBidirectional { .. },
+                )
+        )
+    }
+
+    pub fn digest_bytes(&self) -> Vec<u8> {
+        match self {
+            SignStatus::PendingGeneration => vec![0],
+            SignStatus::PendingPublish { signature } => {
+                let mut bytes = vec![1];
+                bytes.extend(borsh_to_vec(signature).expect("signature serialization is infallible"));
+                bytes
+            }
+            SignStatus::PendingExecution {
+                tx_hash,
+                target_chain,
+            } => {
+                let mut bytes = vec![2];
+                bytes.extend_from_slice(tx_hash.0.as_slice());
+                bytes.extend(
+                    borsh_to_vec(target_chain).expect("chain serialization is infallible"),
+                );
+                bytes
+            }
+            SignStatus::PendingGenerationBidirectional => vec![3],
+            SignStatus::PendingPublishBidirectional { signature } => {
+                let mut bytes = vec![4];
+                bytes.extend(borsh_to_vec(signature).expect("signature serialization is infallible"));
+                bytes
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Hash, serde::Serialize, serde::Deserialize)]

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -57,8 +57,7 @@ pub enum SignStatus {
         publish: PublishState,
     },
     PendingExecution {
-        tx_hash: BidirectionalTxId,
-        target_chain: Chain,
+        tx: BidirectionalTx,
     },
     PendingGenerationBidirectional,
     PendingPublishBidirectional {
@@ -97,15 +96,9 @@ impl SignStatus {
         ) || matches!(
             (self, other),
             (
-                SignStatus::PendingExecution {
-                    tx_hash: left_tx_hash,
-                    target_chain: left_target_chain,
-                },
-                SignStatus::PendingExecution {
-                    tx_hash: right_tx_hash,
-                    target_chain: right_target_chain,
-                }
-            ) if left_tx_hash == right_tx_hash && left_target_chain == right_target_chain
+                SignStatus::PendingExecution { tx: left_tx },
+                SignStatus::PendingExecution { tx: right_tx }
+            ) if left_tx.id == right_tx.id && left_tx.target_chain == right_tx.target_chain
         )
     }
 
@@ -113,23 +106,34 @@ impl SignStatus {
         match self {
             SignStatus::PendingGeneration => vec![0],
             SignStatus::PendingPublish { publish } => publish.digest_bytes(1),
-            SignStatus::PendingExecution {
-                tx_hash,
-                target_chain,
-            } => {
+            SignStatus::PendingExecution { tx } => {
                 let mut bytes = vec![2];
-                bytes.extend_from_slice(tx_hash.0.as_slice());
+                bytes.extend_from_slice(tx.id.0.as_slice());
                 bytes
-                    .extend(borsh_to_vec(target_chain).expect("chain serialization is infallible"));
+                    .extend(borsh_to_vec(&tx.target_chain).expect("chain serialization is infallible"));
                 bytes
             }
             SignStatus::PendingGenerationBidirectional => vec![3],
             SignStatus::PendingPublishBidirectional { publish } => publish.digest_bytes(4),
         }
     }
+
+    pub fn execution_tx(&self) -> Option<&BidirectionalTx> {
+        match self {
+            SignStatus::PendingExecution { tx } => Some(tx),
+            _ => None,
+        }
+    }
+
+    pub fn into_execution_tx(self) -> Option<BidirectionalTx> {
+        match self {
+            SignStatus::PendingExecution { tx } => Some(tx),
+            _ => None,
+        }
+    }
 }
 
-#[derive(Debug, Clone, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct BidirectionalTx {
     pub id: BidirectionalTxId,
     pub sender: [u8; 32],

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -71,31 +71,6 @@ impl SignStatus {
         matches!(self, SignStatus::PendingExecution { .. })
     }
 
-    pub fn is_same_kind(&self, other: &Self) -> bool {
-        matches!(
-            (self, other),
-            (SignStatus::PendingGeneration, SignStatus::PendingGeneration)
-                | (
-                    SignStatus::PendingPublish { .. },
-                    SignStatus::PendingPublish { .. }
-                )
-                | (
-                    SignStatus::PendingGenerationBidirectional,
-                    SignStatus::PendingGenerationBidirectional,
-                )
-                | (
-                    SignStatus::PendingPublishBidirectional { .. },
-                    SignStatus::PendingPublishBidirectional { .. },
-                )
-        ) || matches!(
-            (self, other),
-            (
-                SignStatus::PendingExecution { tx: left_tx },
-                SignStatus::PendingExecution { tx: right_tx }
-            ) if left_tx.id == right_tx.id && left_tx.target_chain == right_tx.target_chain
-        )
-    }
-
     pub fn digest_bytes(&self) -> Vec<u8> {
         match self {
             SignStatus::PendingGeneration => vec![0],

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -61,10 +61,6 @@ impl SignStatus {
             (SignStatus::PendingGeneration, SignStatus::PendingGeneration)
                 | (SignStatus::PendingPublish { .. }, SignStatus::PendingPublish { .. })
                 | (
-                    SignStatus::PendingExecution { .. },
-                    SignStatus::PendingExecution { .. }
-                )
-                | (
                     SignStatus::PendingGenerationBidirectional,
                     SignStatus::PendingGenerationBidirectional,
                 )
@@ -72,6 +68,18 @@ impl SignStatus {
                     SignStatus::PendingPublishBidirectional { .. },
                     SignStatus::PendingPublishBidirectional { .. },
                 )
+        ) || matches!(
+            (self, other),
+            (
+                SignStatus::PendingExecution {
+                    tx_hash: left_tx_hash,
+                    target_chain: left_target_chain,
+                },
+                SignStatus::PendingExecution {
+                    tx_hash: right_tx_hash,
+                    target_chain: right_target_chain,
+                }
+            ) if left_tx_hash == right_tx_hash && left_target_chain == right_target_chain
         )
     }
 

--- a/chain-signatures/node/src/storage/checkpoint_storage.rs
+++ b/chain-signatures/node/src/storage/checkpoint_storage.rs
@@ -10,7 +10,7 @@ use tokio::sync::RwLock;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-const CHECKPOINT_VERSION: &str = "v6";
+const CHECKPOINT_VERSION: &str = "v7";
 
 #[derive(Clone, Debug)]
 pub enum CheckpointStorage {

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -8,8 +8,7 @@ use crate::sign_bidirectional::BidirectionalTxId;
 use crate::stream::ops::{
     process_execution_confirmed, process_respond_bidirectional_event, process_respond_event,
     process_sign_request, recover_backlog, requeue_pending_sign_requests,
-    resume_pending_publish_requests,
-    RespondBidirectionalEvent, SignatureRespondedEvent,
+    resume_pending_publish_requests, RespondBidirectionalEvent, SignatureRespondedEvent,
 };
 
 pub mod ops;
@@ -779,7 +778,7 @@ mod tests {
             run_stream(
                 client,
                 sign_tx,
-            rpc,
+                rpc,
                 backlog_for_run,
                 contract_watcher,
                 mesh_state_rx,

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -851,6 +851,20 @@ mod tests {
             _ => panic!("expected sign request"),
         }
 
+        backlog
+            .set_status(
+                Chain::Solana,
+                &sign_id,
+                SignStatus::PendingPublish {
+                    publish: crate::sign_bidirectional::PublishState {
+                        signature: Signature::new(AffinePoint::GENERATOR, Scalar::ONE, 0),
+                        participants: vec![cait_sith::protocol::Participant::from(0u32)],
+                        is_proposer: true,
+                    },
+                },
+            )
+            .await;
+
         // Prepare a SignatureRespondedEvent that will advance to bidirectional and register watcher
         // Construct a valid signature (use generator point for big_r and small s)
         use k256::elliptic_curve::sec1::ToEncodedPoint;

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -1213,7 +1213,13 @@ mod tests {
             .set_status(
                 Chain::Solana,
                 &sign_id,
-                SignStatus::PendingPublish { signature },
+                SignStatus::PendingPublish {
+                    publish: crate::sign_bidirectional::PublishState {
+                        signature,
+                        participants: vec![cait_sith::protocol::Participant::from(0u32)],
+                        is_proposer: true,
+                    },
+                },
             )
             .await;
 
@@ -1258,6 +1264,73 @@ mod tests {
                 assert_eq!(action.signature, signature);
             }
         }
+
+        run_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_stream_does_not_resume_non_proposer_pending_publish_after_catchup() {
+        use crate::sign_bidirectional::SignStatus;
+
+        let backlog = Backlog::new();
+        let sign_id = SignId::new([78u8; 32]);
+        let signature = Signature::new(AffinePoint::GENERATOR, Scalar::ONE, 0);
+
+        backlog
+            .insert(IndexedSignRequest::sign(
+                sign_id,
+                SignArgs {
+                    entropy: [10u8; 32],
+                    epsilon: Scalar::from(1u64),
+                    payload: Scalar::from(2u64),
+                    path: "test".to_string(),
+                    key_version: 1,
+                },
+                Chain::Solana,
+                current_unix_timestamp(),
+            ))
+            .await;
+        backlog
+            .set_status(
+                Chain::Solana,
+                &sign_id,
+                SignStatus::PendingPublish {
+                    publish: crate::sign_bidirectional::PublishState {
+                        signature,
+                        participants: vec![cait_sith::protocol::Participant::from(0u32)],
+                        is_proposer: false,
+                    },
+                },
+            )
+            .await;
+
+        let client = SolanaTestStream::new(vec![Some(ChainEvent::CatchupCompleted), None]);
+        let (sign_tx, _sign_rx) = mpsc::channel(4);
+        let (rpc, mut rpc_rx) = test_rpc_channel(4);
+        let (contract_watcher, _tx) = ContractStateWatcher::with_running(
+            &"test.near".parse::<AccountId>().unwrap(),
+            k256::ProjectivePoint::GENERATOR.to_affine(),
+            0,
+            Default::default(),
+        );
+        let (_mesh_state_tx, mesh_state_rx) = tokio::sync::watch::channel(MeshState::default());
+        let node_client = NodeClient::new(&Default::default());
+
+        let run_handle = tokio::spawn(async move {
+            run_stream(
+                client,
+                sign_tx,
+                rpc,
+                backlog,
+                contract_watcher,
+                mesh_state_rx,
+                node_client,
+            )
+            .await;
+        });
+
+        let no_publish = timeout(Duration::from_millis(100), rpc_rx.recv()).await;
+        assert!(matches!(no_publish, Err(_) | Ok(None)));
 
         run_handle.abort();
     }

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -886,7 +886,7 @@ mod tests {
         let target_chain = Chain::Ethereum;
         timeout(Duration::from_secs(1), async {
             loop {
-                let watchers = backlog.pending_execution(target_chain).await;
+                let watchers = backlog.execution_watchers(target_chain).await;
                 if watchers.values().any(|(s, _)| *s == sign_id) {
                     break;
                 }
@@ -898,7 +898,7 @@ mod tests {
 
         // mark status as PendingExecution so it will be included in checkpoints
         let execution = backlog
-            .pending_execution(target_chain)
+            .execution_watchers(target_chain)
             .await
             .into_iter()
             .find_map(|(_, (watched_sign_id, watched_tx))| {
@@ -931,8 +931,8 @@ mod tests {
             .await
             .expect("recovery failed");
 
-        let old_watchers = backlog.pending_execution(target_chain).await;
-        let new_watchers = recovered.pending_execution(target_chain).await;
+        let old_watchers = backlog.execution_watchers(target_chain).await;
+        let new_watchers = recovered.execution_watchers(target_chain).await;
         assert_eq!(old_watchers.len(), new_watchers.len());
         for (tx_id, (s, _)) in old_watchers {
             assert!(new_watchers.contains_key(&tx_id));

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -909,10 +909,7 @@ mod tests {
             .set_status(
                 Chain::Solana,
                 &sign_id,
-                SignStatus::PendingExecution {
-                    tx_hash: execution.id,
-                    target_chain: execution.target_chain,
-                },
+                SignStatus::PendingExecution { tx: execution },
             )
             .await;
 

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -3,11 +3,12 @@ use crate::mesh::MeshState;
 use crate::node_client::NodeClient;
 use crate::protocol::IndexedSignRequest;
 use crate::protocol::{Chain, Sign};
-use crate::rpc::ContractStateWatcher;
+use crate::rpc::{ContractStateWatcher, RpcChannel};
 use crate::sign_bidirectional::BidirectionalTxId;
 use crate::stream::ops::{
     process_execution_confirmed, process_respond_bidirectional_event, process_respond_event,
     process_sign_request, recover_backlog, requeue_pending_sign_requests,
+    resume_pending_publish_requests,
     RespondBidirectionalEvent, SignatureRespondedEvent,
 };
 
@@ -213,6 +214,7 @@ pub async fn catchup_then_livestream<I: ChainIndexer>(mut indexer: I) {
 pub async fn run_stream<S: ChainStream>(
     mut stream: S,
     sign_tx: mpsc::Sender<Sign>,
+    rpc: RpcChannel,
     backlog: Backlog,
     mut contract_watcher: ContractStateWatcher,
     mut mesh_state: watch::Receiver<MeshState>,
@@ -249,6 +251,7 @@ pub async fn run_stream<S: ChainStream>(
                 caught_up = true;
 
                 requeue_pending_sign_requests(&backlog, chain, sign_tx.clone()).await;
+                resume_pending_publish_requests(&backlog, chain, &contract_watcher, &rpc).await;
             }
             ChainEvent::SignRequest(req) => {
                 if let Err(err) =
@@ -325,12 +328,12 @@ mod tests {
     use crate::protocol::ParticipantInfo;
     use crate::protocol::Sign;
     use crate::protocol::{Chain, IndexedSignRequest};
-    use crate::rpc::ContractStateWatcher;
+    use crate::rpc::{ContractStateWatcher, RpcAction, RpcChannel};
     use crate::storage::checkpoint_storage::CheckpointStorage;
     use crate::stream::ops::{EthereumSignatureRespondedEvent, SignatureRespondedEvent};
     use crate::util::current_unix_timestamp;
     use alloy::primitives::Address;
-    use k256::Scalar;
+    use k256::{AffinePoint, Scalar};
     use mockito::Server;
     use mpc_primitives::SignArgs;
     use mpc_primitives::SignId;
@@ -341,6 +344,11 @@ mod tests {
     use std::time::Duration;
     use tokio::sync::mpsc;
     use tokio::time::timeout;
+
+    fn test_rpc_channel(buffer: usize) -> (RpcChannel, mpsc::Receiver<RpcAction>) {
+        let (tx, rx) = mpsc::channel(buffer);
+        (RpcChannel { tx }, rx)
+    }
 
     struct VecEventStreamState {
         started: bool,
@@ -654,11 +662,13 @@ mod tests {
         );
         let (_mesh_state_tx, mesh_state_rx) = tokio::sync::watch::channel(MeshState::default());
         let node_client = NodeClient::new(&Default::default());
+        let (rpc, _rpc_rx) = test_rpc_channel(4);
 
         // Run the indexer
         run_stream(
             client,
             sign_tx.clone(),
+            rpc,
             backlog.clone(),
             contract_watcher,
             mesh_state_rx,
@@ -761,6 +771,7 @@ mod tests {
         );
         let (_mesh_state_tx, mesh_state_rx) = tokio::sync::watch::channel(MeshState::default());
         let node_client = NodeClient::new(&Default::default());
+        let (rpc, _rpc_rx) = test_rpc_channel(8);
 
         // Start indexer in background (clone backlog so the test retains ownership)
         let backlog_for_run = backlog.clone();
@@ -768,6 +779,7 @@ mod tests {
             run_stream(
                 client,
                 sign_tx,
+            rpc,
                 backlog_for_run,
                 contract_watcher,
                 mesh_state_rx,
@@ -1047,10 +1059,12 @@ mod tests {
         }
         let (_mesh_state_tx, mesh_state_rx) = tokio::sync::watch::channel(mesh_state);
         let node_client = NodeClient::new(&Default::default());
+        let (rpc, _rpc_rx) = test_rpc_channel(8);
 
         run_stream(
             client,
             sign_tx,
+            rpc,
             backlog.clone(),
             contract_watcher,
             mesh_state_rx,
@@ -1141,10 +1155,12 @@ mod tests {
         }
         let (_mesh_state_tx, mesh_state_rx) = tokio::sync::watch::channel(mesh_state);
         let node_client = NodeClient::new(&Default::default());
+        let (rpc, _rpc_rx) = test_rpc_channel(8);
 
         run_stream(
             client,
             sign_tx,
+            rpc,
             backlog.clone(),
             contract_watcher,
             mesh_state_rx,
@@ -1169,5 +1185,80 @@ mod tests {
             .await
             .expect("replayed entry should remain in backlog");
         assert_eq!(entry.request.unix_timestamp_indexed, replayed_timestamp);
+    }
+
+    #[tokio::test]
+    async fn test_stream_resumes_pending_publish_after_catchup() {
+        use crate::sign_bidirectional::SignStatus;
+
+        let backlog = Backlog::new();
+        let sign_id = SignId::new([77u8; 32]);
+        let signature = Signature::new(AffinePoint::GENERATOR, Scalar::ONE, 0);
+
+        backlog
+            .insert(IndexedSignRequest::sign(
+                sign_id,
+                SignArgs {
+                    entropy: [9u8; 32],
+                    epsilon: Scalar::from(1u64),
+                    payload: Scalar::from(2u64),
+                    path: "test".to_string(),
+                    key_version: 1,
+                },
+                Chain::Solana,
+                current_unix_timestamp(),
+            ))
+            .await;
+        backlog
+            .set_status(
+                Chain::Solana,
+                &sign_id,
+                SignStatus::PendingPublish { signature },
+            )
+            .await;
+
+        let client = SolanaTestStream::new(vec![Some(ChainEvent::CatchupCompleted), None]);
+        let (sign_tx, mut sign_rx) = mpsc::channel(4);
+        let (rpc, mut rpc_rx) = test_rpc_channel(4);
+        let (contract_watcher, _tx) = ContractStateWatcher::with_running(
+            &"test.near".parse::<AccountId>().unwrap(),
+            k256::ProjectivePoint::GENERATOR.to_affine(),
+            0,
+            Default::default(),
+        );
+        let (_mesh_state_tx, mesh_state_rx) = tokio::sync::watch::channel(MeshState::default());
+        let node_client = NodeClient::new(&Default::default());
+
+        let run_handle = tokio::spawn(async move {
+            run_stream(
+                client,
+                sign_tx,
+                rpc,
+                backlog,
+                contract_watcher,
+                mesh_state_rx,
+                node_client,
+            )
+            .await;
+        });
+
+        match timeout(Duration::from_millis(100), sign_rx.recv()).await {
+            Err(_) | Ok(None) => {}
+            Ok(Some(msg)) => panic!("unexpected sign message during publish resume: {msg:?}"),
+        }
+
+        let action = timeout(Duration::from_secs(1), rpc_rx.recv())
+            .await
+            .expect("publish resume should not timeout")
+            .expect("publish resume should enqueue an RPC action");
+        match action {
+            RpcAction::Publish(action) => {
+                assert_eq!(action.indexed.id, sign_id);
+                assert_eq!(action.indexed.chain, Chain::Solana);
+                assert_eq!(action.signature, signature);
+            }
+        }
+
+        run_handle.abort();
     }
 }

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -886,8 +886,23 @@ mod tests {
         .unwrap();
 
         // mark status as PendingExecution so it will be included in checkpoints
+        let execution = backlog
+            .pending_execution(target_chain)
+            .await
+            .into_iter()
+            .find_map(|(_, (watched_sign_id, watched_tx))| {
+                (watched_sign_id == sign_id).then_some(watched_tx)
+            })
+            .expect("expected execution watcher to exist");
         backlog
-            .set_status(Chain::Solana, &sign_id, SignStatus::PendingExecution)
+            .set_status(
+                Chain::Solana,
+                &sign_id,
+                SignStatus::PendingExecution {
+                    tx_hash: execution.id,
+                    target_chain: execution.target_chain,
+                },
+            )
             .await;
 
         // send a block event for this chain and ensure checkpoint is persisted

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -12,7 +12,7 @@ use crate::metrics::requests::record_indexing_step_reached;
 use crate::node_client::NodeClient;
 use crate::protocol::{Chain, IndexedSignRequest, Sign, SignKind};
 use crate::respond_bidirectional::CompletedTx;
-use crate::rpc::ContractStateWatcher;
+use crate::rpc::{ContractStateWatcher, RpcChannel};
 use crate::sign_bidirectional::{BidirectionalTx, BidirectionalTxId, SignStatus};
 use crate::stream::ExecutionOutcome;
 
@@ -372,6 +372,34 @@ pub(crate) async fn requeue_pending_sign_requests(
                 "failed to requeue sign request after catchup"
             );
         }
+    }
+}
+
+pub(crate) async fn resume_pending_publish_requests(
+    backlog: &Backlog,
+    source_chain: Chain,
+    contract_watcher: &ContractStateWatcher,
+    rpc: &RpcChannel,
+) {
+    let publishable = backlog.publishable_requests(source_chain).await;
+    if publishable.is_empty() {
+        return;
+    }
+
+    let Some(public_key) = contract_watcher.public_key().await else {
+        tracing::warn!(%source_chain, count = publishable.len(), "cannot resume pending publish requests without a public key");
+        return;
+    };
+    let Some(participants) = contract_watcher.participants() else {
+        tracing::warn!(%source_chain, count = publishable.len(), "cannot resume pending publish requests without participants");
+        return;
+    };
+    let participants = participants.keys_vec();
+
+    for (sign_request, signature) in publishable {
+        let sign_id = sign_request.id;
+        rpc.publish_signature(public_key, sign_request, signature, participants.clone());
+        tracing::info!(?sign_id, %source_chain, "resumed pending publish request after catchup");
     }
 }
 

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -602,7 +602,7 @@ pub async fn process_execution_confirmed(
         .set_status(
             pending_tx.source_chain,
             &unwatched_sign_id,
-            SignStatus::AwaitingResponseBidirectional,
+            SignStatus::PendingGenerationBidirectional,
         )
         .await;
     let updated_tx = match set_res {
@@ -887,8 +887,8 @@ mod tests {
         let tx_after = maybe_tx.unwrap();
         assert_eq!(
             tx_after.status(),
-            SignStatus::AwaitingResponseBidirectional,
-            "expected AwaitingResponseBidirectional but found status: {:?}",
+            SignStatus::PendingGenerationBidirectional,
+            "expected PendingGenerationBidirectional but found status: {:?}",
             tx_after.status()
         );
         assert!(matches!(
@@ -1026,7 +1026,7 @@ mod tests {
         .unwrap();
 
         let tx_after = backlog.get(tx.source_chain, &sign_id).await.unwrap();
-        assert_eq!(tx_after.status(), SignStatus::AwaitingResponseBidirectional);
+        assert_eq!(tx_after.status(), SignStatus::PendingGenerationBidirectional);
         assert!(matches!(
             tx_after.request.kind,
             SignKind::RespondBidirectional(_)

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -1440,7 +1440,10 @@ mod tests {
             .get(Chain::Ethereum, &sign_id)
             .await
             .expect("entry should remain in backlog");
-        assert!(matches!(entry.status(), SignStatus::PendingExecution { .. }));
+        assert!(matches!(
+            entry.status(),
+            SignStatus::PendingExecution { .. }
+        ));
 
         let watchers = backlog.execution_watchers(Chain::Solana).await;
         assert_eq!(watchers.len(), 1);

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -890,7 +890,7 @@ mod tests {
         // Call the handler with a Success and empty output
         let tx_id = tx.id;
         // ensure watcher exists before processing
-        let before_watchers = backlog.pending_execution(tx.target_chain).await;
+        let before_watchers = backlog.execution_watchers(tx.target_chain).await;
         assert!(before_watchers.contains_key(&tx.id));
         process_execution_confirmed(
             tx_id,
@@ -907,7 +907,7 @@ mod tests {
         .unwrap();
 
         // Watcher should be removed
-        let watchers = backlog.pending_execution(tx.target_chain).await;
+        let watchers = backlog.execution_watchers(tx.target_chain).await;
         tracing::info!(?watchers, "watchers after execution confirmed");
         assert!(watchers.is_empty());
 
@@ -1011,7 +1011,7 @@ mod tests {
         let no_second = timeout(Duration::from_millis(100), sign_rx.recv()).await;
         assert!(matches!(no_second, Err(_) | Ok(None)));
 
-        assert!(backlog.pending_execution(tx.target_chain).await.is_empty());
+        assert!(backlog.execution_watchers(tx.target_chain).await.is_empty());
     }
 
     #[tokio::test]
@@ -1065,7 +1065,7 @@ mod tests {
             tx_after.request.kind,
             SignKind::RespondBidirectional(_)
         ));
-        assert!(backlog.pending_execution(tx.target_chain).await.is_empty());
+        assert!(backlog.execution_watchers(tx.target_chain).await.is_empty());
 
         let msg = timeout(Duration::from_secs(1), sign_rx.recv())
             .await
@@ -1456,7 +1456,7 @@ mod tests {
         .unwrap();
 
         // Watcher removed
-        let watchers = backlog.pending_execution(tx.target_chain).await;
+        let watchers = backlog.execution_watchers(tx.target_chain).await;
         assert!(watchers.is_empty());
 
         // Source chain should now wait for final bidirectional response.
@@ -1611,7 +1611,7 @@ mod tests {
             assert_eq!(decoded.sign_event_contract_id, sign_event_contract_id);
         };
 
-        assert!(backlog.pending_execution(tx.target_chain).await.is_empty());
+        assert!(backlog.execution_watchers(tx.target_chain).await.is_empty());
         let tx_after = backlog.get(tx.source_chain, &sign_id).await.unwrap();
         assert_eq!(
             tx_after.status(),

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -1461,7 +1461,7 @@ mod tests {
 
         // Source chain should now wait for final bidirectional response.
         let waiting = backlog
-            .get_by_status(tx.source_chain, SignStatus::PendingGenerationBidirectional)
+            .pending_generation_bidirectionals(tx.source_chain)
             .await;
         assert!(waiting.contains_key(&sign_id));
 

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -1057,7 +1057,10 @@ mod tests {
         .unwrap();
 
         let tx_after = backlog.get(tx.source_chain, &sign_id).await.unwrap();
-        assert_eq!(tx_after.status(), SignStatus::PendingGenerationBidirectional);
+        assert_eq!(
+            tx_after.status(),
+            SignStatus::PendingGenerationBidirectional
+        );
         assert!(matches!(
             tx_after.request.kind,
             SignKind::RespondBidirectional(_)
@@ -1610,7 +1613,10 @@ mod tests {
 
         assert!(backlog.pending_execution(tx.target_chain).await.is_empty());
         let tx_after = backlog.get(tx.source_chain, &sign_id).await.unwrap();
-        assert_eq!(tx_after.status(), SignStatus::PendingGenerationBidirectional);
+        assert_eq!(
+            tx_after.status(),
+            SignStatus::PendingGenerationBidirectional
+        );
         match &tx_after.request.kind {
             SignKind::RespondBidirectional(res) => {
                 assert_eq!(res.tx_id, tx.id);

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -1391,6 +1391,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn process_respond_event_advances_bidirectional_from_pending_generation() {
+        let backlog = Backlog::new();
+        let tx = test_bidirectional_tx(14, Chain::Ethereum, Chain::Solana);
+        let sign_id = SignId::new(tx.request_id);
+
+        backlog
+            .insert(IndexedSignRequest::sign_bidirectional(
+                sign_id,
+                test_sign_args(14),
+                Chain::Ethereum,
+                current_unix_timestamp(),
+                SignBidirectionalEvent::Solana(signet_program::SignBidirectionalEvent {
+                    sender: Default::default(),
+                    serialized_transaction: tx.serialized_transaction.clone(),
+                    dest: tx.dest.clone(),
+                    caip2_id: tx.caip2_id.clone(),
+                    key_version: tx.key_version,
+                    deposit: tx.deposit,
+                    path: tx.path.clone(),
+                    algo: tx.algo.clone(),
+                    params: tx.params.clone(),
+                    program_id: Pubkey::new_unique(),
+                    output_deserialization_schema: tx.output_deserialization_schema.clone(),
+                    respond_serialization_schema: tx.respond_serialization_schema.clone(),
+                }),
+            ))
+            .await;
+
+        let event = SignatureRespondedEvent::Ethereum(EthereumSignatureRespondedEvent {
+            request_id: sign_id.request_id,
+            responder: alloy::primitives::Address::from_slice(&[0u8; 20]),
+            signature: Signature::new(ProjectivePoint::GENERATOR.to_affine(), Scalar::ONE, 0),
+        });
+
+        let account_id: AccountId = "test.near".parse().unwrap();
+        let public_key = ProjectivePoint::GENERATOR.to_affine();
+        let (mut contract_watcher, _tx) =
+            ContractStateWatcher::with_running(&account_id, public_key, 1, Default::default());
+
+        let (sign_tx, _sign_rx) = mpsc::channel(4);
+
+        process_respond_event(event, sign_tx, &mut contract_watcher, &backlog, false)
+            .await
+            .expect("respond event should advance pending generation bidirectional entries");
+
+        let entry = backlog
+            .get(Chain::Ethereum, &sign_id)
+            .await
+            .expect("entry should remain in backlog");
+        assert!(matches!(entry.status(), SignStatus::PendingExecution { .. }));
+
+        let watchers = backlog.execution_watchers(Chain::Solana).await;
+        assert_eq!(watchers.len(), 1);
+        assert!(watchers.contains_key(&tx.id));
+    }
+
+    #[tokio::test]
     async fn process_execution_confirmed_failed_creates_error_respond_request() {
         let backlog = Backlog::new();
 

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -390,15 +390,18 @@ pub(crate) async fn resume_pending_publish_requests(
         tracing::warn!(%source_chain, count = publishable.len(), "cannot resume pending publish requests without a public key");
         return;
     };
-    let Some(participants) = contract_watcher.participants() else {
-        tracing::warn!(%source_chain, count = publishable.len(), "cannot resume pending publish requests without participants");
-        return;
-    };
-    let participants = participants.keys_vec();
+    for (sign_request, publish) in publishable {
+        if !publish.is_proposer {
+            continue;
+        }
 
-    for (sign_request, signature) in publishable {
         let sign_id = sign_request.id;
-        rpc.publish_signature(public_key, sign_request, signature, participants.clone());
+        rpc.publish_signature(
+            public_key,
+            sign_request,
+            publish.signature,
+            publish.participants,
+        );
         tracing::info!(?sign_id, %source_chain, "resumed pending publish request after catchup");
     }
 }

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -1391,10 +1391,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn process_respond_event_advances_bidirectional_from_pending_generation() {
+    async fn process_respond_event_advances_bidirectional_from_pending_publish() {
         let backlog = Backlog::new();
         let tx = test_bidirectional_tx(14, Chain::Ethereum, Chain::Solana);
         let sign_id = SignId::new(tx.request_id);
+
+        let mut rlp_s = rlp::RlpStream::new_list(9);
+        rlp_s.append(&0u64);
+        rlp_s.append(&0u64);
+        rlp_s.append(&0u64);
+        rlp_s.append(&Vec::<u8>::new());
+        rlp_s.append(&0u64);
+        rlp_s.append(&Vec::<u8>::new());
+        rlp_s.append(&1u64);
+        rlp_s.append(&0u64);
+        rlp_s.append(&0u64);
+        let unsigned_rlp = rlp_s.out().to_vec();
 
         backlog
             .insert(IndexedSignRequest::sign_bidirectional(
@@ -1404,7 +1416,7 @@ mod tests {
                 current_unix_timestamp(),
                 SignBidirectionalEvent::Solana(signet_program::SignBidirectionalEvent {
                     sender: Default::default(),
-                    serialized_transaction: tx.serialized_transaction.clone(),
+                    serialized_transaction: unsigned_rlp,
                     dest: tx.dest.clone(),
                     caip2_id: tx.caip2_id.clone(),
                     key_version: tx.key_version,
@@ -1417,6 +1429,24 @@ mod tests {
                     respond_serialization_schema: tx.respond_serialization_schema.clone(),
                 }),
             ))
+            .await;
+
+        backlog
+            .set_status(
+                Chain::Ethereum,
+                &sign_id,
+                crate::sign_bidirectional::SignStatus::PendingPublish {
+                    publish: crate::sign_bidirectional::PublishState {
+                        signature: Signature::new(
+                            ProjectivePoint::GENERATOR.to_affine(),
+                            Scalar::ONE,
+                            0,
+                        ),
+                        participants: vec![],
+                        is_proposer: true,
+                    },
+                },
+            )
             .await;
 
         let event = SignatureRespondedEvent::Ethereum(EthereumSignatureRespondedEvent {
@@ -1434,7 +1464,7 @@ mod tests {
 
         process_respond_event(event, sign_tx, &mut contract_watcher, &backlog, false)
             .await
-            .expect("respond event should advance pending generation bidirectional entries");
+            .expect("respond event should advance pending publish bidirectional entries");
 
         let entry = backlog
             .get(Chain::Ethereum, &sign_id)
@@ -1444,10 +1474,14 @@ mod tests {
             entry.status(),
             SignStatus::PendingExecution { .. }
         ));
+        let execution_tx_id = entry
+            .execution_tx()
+            .expect("pending execution entries should store the execution transaction")
+            .id;
 
         let watchers = backlog.execution_watchers(Chain::Solana).await;
         assert_eq!(watchers.len(), 1);
-        assert!(watchers.contains_key(&tx.id));
+        assert!(watchers.contains_key(&execution_tx_id));
     }
 
     #[tokio::test]

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -1427,7 +1427,7 @@ mod tests {
 
         // Source chain should now wait for final bidirectional response.
         let waiting = backlog
-            .get_by_status(tx.source_chain, SignStatus::AwaitingResponseBidirectional)
+            .get_by_status(tx.source_chain, SignStatus::PendingGenerationBidirectional)
             .await;
         assert!(waiting.contains_key(&sign_id));
 
@@ -1579,7 +1579,7 @@ mod tests {
 
         assert!(backlog.pending_execution(tx.target_chain).await.is_empty());
         let tx_after = backlog.get(tx.source_chain, &sign_id).await.unwrap();
-        assert_eq!(tx_after.status(), SignStatus::AwaitingResponseBidirectional);
+        assert_eq!(tx_after.status(), SignStatus::PendingGenerationBidirectional);
         match &tx_after.request.kind {
             SignKind::RespondBidirectional(res) => {
                 assert_eq!(res.tx_id, tx.id);

--- a/chain-signatures/primitives/src/lib.rs
+++ b/chain-signatures/primitives/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod bytes;
 
-use k256::elliptic_curve::{bigint::ArrayEncoding, CurveArithmetic, PrimeField};
+use k256::elliptic_curve::{
+    bigint::ArrayEncoding, sec1::ToEncodedPoint, CurveArithmetic, PrimeField,
+};
 use k256::{AffinePoint, Scalar, Secp256k1, U256};
 use near_account_id::AccountId;
 use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
@@ -142,6 +144,15 @@ impl Signature {
             s,
             recovery_id,
         }
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let encoded_point = self.big_r.to_encoded_point(false);
+        let mut bytes = Vec::with_capacity(encoded_point.len() + 32 + 1);
+        bytes.extend_from_slice(encoded_point.as_bytes());
+        bytes.extend_from_slice(self.s.to_bytes().as_slice());
+        bytes.push(self.recovery_id);
+        bytes
     }
 }
 
@@ -388,6 +399,18 @@ impl Checkpoint {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn signature_to_bytes_is_stable() {
+        let signature = Signature::new(AffinePoint::GENERATOR, Scalar::ONE, 7);
+
+        let bytes = signature.to_bytes();
+
+        assert_eq!(bytes.len(), 98);
+        assert_eq!(bytes[0], 0x04);
+        assert_eq!(&bytes[65..97], Scalar::ONE.to_bytes().as_slice());
+        assert_eq!(bytes[97], 7);
+    }
 
     #[test]
     fn scalar_fails_as_expected() {

--- a/chain-signatures/primitives/src/lib.rs
+++ b/chain-signatures/primitives/src/lib.rs
@@ -185,6 +185,21 @@ pub enum ChainFromError {
 }
 
 impl Chain {
+    pub const fn to_byte(self) -> u8 {
+        match self {
+            Chain::NEAR => 0,
+            Chain::Ethereum => 1,
+            Chain::Solana => 2,
+            Chain::Bitcoin => 3,
+            Chain::Hydration => 4,
+            Chain::Canton => 5,
+        }
+    }
+
+    pub const fn to_bytes(self) -> [u8; 1] {
+        [self.to_byte()]
+    }
+
     pub const fn as_str(&self) -> &'static str {
         match self {
             Chain::NEAR => "NEAR",

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -8,12 +8,14 @@ use integration_tests::cluster::spawner::ClusterSpawner;
 use integration_tests::containers::EthereumSandbox;
 use integration_tests::eth::{self, ChainSignatures, SignRequest};
 use k256::elliptic_curve::sec1::ToEncodedPoint as _;
+use k256::{AffinePoint, Scalar};
 use mpc_node::backlog::Backlog;
 use mpc_node::indexer_eth::{EthConfig, EthereumStream};
 use mpc_node::mesh::{connection::NodeStatus, MeshState};
 use mpc_node::node_client::NodeClient;
 use mpc_node::protocol::{Chain, IndexedSignRequest, ParticipantInfo, Sign, SignKind};
 use mpc_node::rpc::{ContractStateWatcher, RpcChannel};
+use mpc_node::sign_bidirectional::{PublishState, SignStatus};
 use mpc_node::storage::checkpoint_storage::CheckpointStorage;
 use mpc_node::stream::ops::SignBidirectionalEvent as NodeSignBidirectionalEvent;
 use mpc_node::stream::ops::SignatureRespondedEvent;
@@ -545,6 +547,23 @@ async fn test_ethereum_stream_linear_catchup_from_checkpoint() -> Result<()> {
         nonce: checkpoint_nonce,
     };
     backlog
+        .set_status(
+            execution_tx.source_chain,
+            &execution_sign_id,
+            SignStatus::PendingPublish {
+                publish: PublishState {
+                    signature: mpc_primitives::Signature::new(
+                        AffinePoint::GENERATOR,
+                        Scalar::ONE,
+                        0,
+                    ),
+                    participants: vec![Participant::from(0u32), Participant::from(1u32)],
+                    is_proposer: true,
+                },
+            },
+        )
+        .await;
+    backlog
         .advance(Chain::Solana, execution_sign_id, execution_tx)
         .await
         .context("failed to seed execution watcher")?;
@@ -827,6 +846,23 @@ async fn test_ethereum_stream_backfills_late_execution_watcher_after_catchup() -
             current_unix_timestamp(),
             test_bidirectional_event(),
         ))
+        .await;
+    backlog
+        .set_status(
+            tx.source_chain,
+            &sign_id,
+            SignStatus::PendingPublish {
+                publish: PublishState {
+                    signature: mpc_primitives::Signature::new(
+                        AffinePoint::GENERATOR,
+                        Scalar::ONE,
+                        0,
+                    ),
+                    participants: vec![Participant::from(0u32), Participant::from(1u32)],
+                    is_proposer: true,
+                },
+            },
+        )
         .await;
     backlog
         .advance(Chain::Solana, sign_id, tx)

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -852,7 +852,7 @@ async fn test_ethereum_stream_backfills_late_execution_watcher_after_catchup() -
         other => panic!("expected Sign::Request from late watcher backfill, got {other:?}"),
     }
 
-    let watchers = backlog.pending_execution(Chain::Ethereum).await;
+    let watchers = backlog.execution_watchers(Chain::Ethereum).await;
     assert!(
         watchers.is_empty(),
         "late watcher should be cleared after backfill"

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -13,7 +13,7 @@ use mpc_node::indexer_eth::{EthConfig, EthereumStream};
 use mpc_node::mesh::{connection::NodeStatus, MeshState};
 use mpc_node::node_client::NodeClient;
 use mpc_node::protocol::{Chain, IndexedSignRequest, ParticipantInfo, Sign, SignKind};
-use mpc_node::rpc::ContractStateWatcher;
+use mpc_node::rpc::{ContractStateWatcher, RpcChannel};
 use mpc_node::storage::checkpoint_storage::CheckpointStorage;
 use mpc_node::stream::ops::SignBidirectionalEvent as NodeSignBidirectionalEvent;
 use mpc_node::stream::ops::SignatureRespondedEvent;
@@ -27,6 +27,11 @@ use tokio::time::timeout;
 
 fn signature_deposit() -> U256 {
     U256::from(1u64)
+}
+
+fn test_rpc_channel(buffer: usize) -> (RpcChannel, mpsc::Receiver<mpc_node::rpc::RpcAction>) {
+    let (tx, rx) = mpsc::channel(buffer);
+    (RpcChannel { tx }, rx)
 }
 
 // Integration tests for EthereumStream
@@ -418,10 +423,12 @@ async fn test_ethereum_stream_resume_starts_after_checkpoint_height() -> Result<
     info.url = "http://127.0.0.1:1".to_string();
     mesh_state.update(Participant::from(0u32), NodeStatus::Active, info);
     let (_mesh_tx, mesh_rx) = watch::channel(mesh_state);
+    let (rpc, _rpc_rx) = test_rpc_channel(16);
 
     let run_handle = tokio::spawn(run_stream(
         stream,
         sign_tx,
+        rpc,
         backlog,
         contract_watcher,
         mesh_rx,
@@ -563,10 +570,12 @@ async fn test_ethereum_stream_linear_catchup_from_checkpoint() -> Result<()> {
     info.url = "http://127.0.0.1:1".to_string();
     mesh_state.update(Participant::from(0u32), NodeStatus::Active, info);
     let (_mesh_tx, mesh_rx) = watch::channel(mesh_state);
+    let (rpc, _rpc_rx) = test_rpc_channel(16);
 
     let run_handle = tokio::spawn(run_stream(
         stream,
         sign_tx,
+        rpc,
         backlog.clone(),
         contract_watcher,
         mesh_rx,
@@ -746,10 +755,12 @@ async fn test_ethereum_stream_backfills_late_execution_watcher_after_catchup() -
     info.url = "http://127.0.0.1:1".to_string();
     mesh_state.update(Participant::from(0u32), NodeStatus::Active, info);
     let (_mesh_tx, mesh_rx) = watch::channel(mesh_state);
+    let (rpc, _rpc_rx) = test_rpc_channel(16);
 
     let run_handle = tokio::spawn(run_stream(
         stream,
         sign_tx,
+        rpc,
         backlog.clone(),
         contract_watcher,
         mesh_rx,

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -1,15 +1,24 @@
 use anyhow::{Context, Result};
+use cait_sith::protocol::Participant;
 use integration_tests::containers::Solana;
-use k256::Scalar;
+use k256::{AffinePoint, Scalar};
 use mpc_crypto::ScalarExt;
 use mpc_node::backlog::Backlog;
 use mpc_node::indexer_sol::{SolConfig, SolanaStream};
+use mpc_node::mesh::connection::NodeStatus;
 use mpc_node::mesh::MeshState;
 use mpc_node::node_client::NodeClient;
-use mpc_node::protocol::{Chain, IndexedSignRequest};
-use mpc_node::stream::{catchup_then_livestream, ChainEvent, ChainStream};
+use mpc_node::protocol::contract::primitives::{ParticipantInfo, Participants};
+use mpc_node::protocol::{Chain, IndexedSignRequest, Sign};
+use mpc_node::rpc::{ContractStateWatcher, RpcAction, RpcChannel};
+use mpc_node::sign_bidirectional::{PublishState, SignStatus};
+use mpc_node::storage::checkpoint_storage::CheckpointStorage;
+use mpc_node::stream::{catchup_then_livestream, run_stream, ChainEvent, ChainStream};
 use mpc_primitives::LATEST_MPC_KEY_VERSION;
+use mpc_primitives::{SignArgs, SignId, Signature};
+use near_primitives::types::AccountId;
 use solana_sdk::signer::Signer;
+use tokio::sync::mpsc;
 use tokio::sync::watch;
 use tokio::time::timeout;
 use tokio::time::Instant;
@@ -380,5 +389,124 @@ async fn test_solana_stream_checkpoint_persistence() -> Result<()> {
     .context("timeout waiting for event")?
     .context("client returned None")?;
 
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_solana_stream_republishes_pending_publish_after_checkpoint_recovery() -> Result<()> {
+    let solana = solana_sandbox().await?;
+    let program_address = solana.program_keypair.pubkey().to_string();
+    let config = solana.get_config(program_address);
+
+    let storage = CheckpointStorage::in_memory();
+    let seeded_backlog = Backlog::persisted(storage.clone());
+    let sign_id = SignId::new([77u8; 32]);
+    let signature = Signature::new(AffinePoint::GENERATOR, Scalar::ONE, 0);
+    let checkpoint_slot = solana.rpc_client.get_slot().await?;
+
+    seeded_backlog
+        .insert(IndexedSignRequest::sign(
+            sign_id,
+            SignArgs {
+                entropy: [9u8; 32],
+                epsilon: Scalar::from(1u64),
+                payload: Scalar::from(2u64),
+                path: "test".to_string(),
+                key_version: LATEST_MPC_KEY_VERSION,
+            },
+            Chain::Solana,
+            0,
+        ))
+        .await;
+    seeded_backlog
+        .set_status(
+            Chain::Solana,
+            &sign_id,
+            SignStatus::PendingPublish {
+                publish: PublishState {
+                    signature,
+                    participants: vec![Participant::from(0u32)],
+                    is_proposer: true,
+                },
+            },
+        )
+        .await;
+    seeded_backlog
+        .set_processed_block(Chain::Solana, checkpoint_slot)
+        .await;
+    seeded_backlog.checkpoint(Chain::Solana).await;
+
+    let recovered_backlog = Backlog::persisted(storage);
+    let stream = SolanaStream::new(Some(config), recovered_backlog.clone())
+        .context("failed to create SolanaStream")?;
+
+    let (sign_tx, mut sign_rx) = mpsc::channel::<Sign>(4);
+    let (rpc_tx, mut rpc_rx) = mpsc::channel::<RpcAction>(4);
+    let rpc = RpcChannel { tx: rpc_tx };
+
+    let account_id: AccountId = "test.near".parse().unwrap();
+    let (contract_watcher, _contract_tx) = ContractStateWatcher::with_running(
+        &account_id,
+        AffinePoint::GENERATOR,
+        1,
+        Participants::default(),
+    );
+
+    let mut mesh_state = MeshState::default();
+    mesh_state.update(
+        Participant::from(0u32),
+        NodeStatus::Active,
+        ParticipantInfo::new(0),
+    );
+    let (_mesh_tx, mesh_rx) = watch::channel(mesh_state);
+    let node_client = NodeClient::new(&Default::default());
+
+    let run_handle = tokio::spawn(async move {
+        run_stream(
+            stream,
+            sign_tx,
+            rpc,
+            recovered_backlog,
+            contract_watcher,
+            mesh_rx,
+            node_client,
+        )
+        .await;
+    });
+
+    solana
+        .sign(
+            [3u8; 32],
+            "recovery-anchor",
+            LATEST_MPC_KEY_VERSION,
+            "secp256k1",
+            "",
+            "",
+        )
+        .await?;
+
+    let action = timeout(Duration::from_secs(15), rpc_rx.recv())
+        .await
+        .context("timeout waiting for recovered publish action")?
+        .context("rpc channel closed before publish action")?;
+
+    while let Ok(Some(message)) = timeout(Duration::from_millis(50), sign_rx.recv()).await {
+        if let Sign::Request(req) = &message {
+            if req.id == sign_id {
+                anyhow::bail!("recovered publish request was incorrectly requeued for signing");
+            }
+        }
+    }
+
+    match action {
+        RpcAction::Publish(action) => {
+            assert_eq!(action.indexed.id, sign_id);
+            assert_eq!(action.indexed.chain, Chain::Solana);
+            assert_eq!(action.signature, signature);
+            assert_eq!(action.participants, vec![Participant::from(0u32)]);
+        }
+    }
+
+    run_handle.abort();
     Ok(())
 }


### PR DESCRIPTION
This makes our SignStatus more granular:
```
enum SignStatus {
    PendingGeneration,
    PendingPublish { publish: PublishState },
    PendingExecution { tx: BidirectionalTx },
    PendingGenerationBidirectional,
    PendingPublishBidirectional { publish: PublishState },
}
```

Where we will now explicitly handle the publishing part where if a node were to restart in the middle of a publishing, they would restart from there instead of going back to signature generation phase. This however does not solve the issue of watchdogging over rpc publishing where if the proposer fails to republish, the other participants could publish themselves