### PR TITLE
Remove reject

### DIFF
--- a/chain-signatures/node/src/protocol/message/types.rs
+++ b/chain-signatures/node/src/protocol/message/types.rs
@@ -46,8 +46,6 @@ impl PositMessage {
                 participants.len() * std::mem::size_of::<Participant>()
             }
             PositAction::Accept => 0,
-            #[allow(deprecated)]
-            PositAction::Reject => 0,
             PositAction::RejectWithReason(_reason) => std::mem::size_of::<PositRejectReason>(),
         }
     }

--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -52,9 +52,6 @@ pub enum PositAction {
     Propose,
     Start(Vec<Participant>),
     Accept,
-    /// Kept for wire compatibility with older nodes
-    #[deprecated = "use `RejectWithReason` instead"]
-    Reject,
     RejectWithReason(PositRejectReason),
 }
 

--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -253,8 +253,7 @@ impl<Id: Copy + Hash + Eq + fmt::Debug, S> Posits<Id, S> {
                     Positor::Deliberator(from),
                 )
             }
-            #[allow(deprecated)]
-            PositAction::Accept | PositAction::Reject | PositAction::RejectWithReason(_) => {
+            PositAction::Accept | PositAction::RejectWithReason(_) => {
                 let mut entry = match self.posits.entry(id) {
                     Entry::Occupied(entry) => entry,
                     Entry::Vacant(_) => {
@@ -480,10 +479,6 @@ impl SinglePositCounter {
         match action {
             PositAction::Accept => {
                 self.accepts.insert(from);
-            }
-            #[allow(deprecated)]
-            PositAction::Reject => {
-                self.rejects.insert(from, PositRejectReason::Unknown);
             }
             PositAction::RejectWithReason(reason) => {
                 self.rejects.insert(from, *reason);


### PR DESCRIPTION
I [agree](https://github.com/sig-net/mpc/pull/832#discussion_r3327123682) with Phuong that keeping Reject does not make much sense since serialization issues exist anyway.

I considered bumping the PROTOCOL_VERSION, but realized that it isn't the best option.
Why:
- Let's say we have 7 nodes, T=5
- 1, then 2, upgrade, all fine
- node 3 upgrades - system stops functioning
- node 4 upgrades - still down
- node 5 upgrades - system is functioning again

The time between 3 and 5 updates can be long. We can not afford that.