### PR TITLE
component test: missed respond event lead to nodes stop signature generation

### DIFF
--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -2,7 +2,7 @@ mod filter;
 mod sub;
 mod types;
 
-pub use sub::Subscriber;
+pub use sub::{Subscriber, POSIT_INBOX_CHANNEL_SIZE};
 
 use super::contract::primitives::{ParticipantMap, Participants};
 use super::presignature::PresignatureId;

--- a/chain-signatures/node/src/protocol/message/sub.rs
+++ b/chain-signatures/node/src/protocol/message/sub.rs
@@ -18,6 +18,15 @@ use crate::util::channel_len;
 /// This should be enough to hold a few messages in the inbox.
 pub const MAX_MESSAGE_SUB_CHANNEL_SIZE: usize = 4 * 1024;
 
+/// Channel size for posit inboxes in SignatureSpawner::handle_posit.
+/// Kept small under test-feature so dead-letter inboxes (created for completed
+/// sign_ids) fill quickly and expose the clogging cascade in component tests.
+pub const POSIT_INBOX_CHANNEL_SIZE: usize = if cfg!(feature = "test-feature") {
+    4
+} else {
+    MAX_MESSAGE_SUB_CHANNEL_SIZE
+};
+
 pub enum SubscribeId {
     Generating,
     Resharing,

--- a/chain-signatures/node/src/protocol/message/sub.rs
+++ b/chain-signatures/node/src/protocol/message/sub.rs
@@ -18,9 +18,7 @@ use crate::util::channel_len;
 /// This should be enough to hold a few messages in the inbox.
 pub const MAX_MESSAGE_SUB_CHANNEL_SIZE: usize = 4 * 1024;
 
-/// Channel size for posit inboxes in SignatureSpawner::handle_posit.
-/// Kept small under test-feature so dead-letter inboxes (created for completed
-/// sign_ids) fill quickly and expose the clogging cascade in component tests.
+/// Small under test-feature so dead-letter inboxes fill quickly in clog tests.
 pub const POSIT_INBOX_CHANNEL_SIZE: usize = if cfg!(feature = "test-feature") {
     4
 } else {

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -1708,10 +1708,12 @@ impl SignatureSpawner {
         if from == me {
             return;
         }
-        let inbox = self
-            .inboxes
-            .entry(sign_id)
-            .or_insert_with(|| Subscriber::unsubscribed(SIGN_POSIT_INBOX_LABEL));
+        let inbox = self.inboxes.entry(sign_id).or_insert_with(|| {
+            Subscriber::unsubscribed_with_capacity(
+                SIGN_POSIT_INBOX_LABEL,
+                crate::protocol::message::POSIT_INBOX_CHANNEL_SIZE,
+            )
+        });
         let _ = inbox
             .send(SignTaskMessage::PositMessage {
                 presignature_id,

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -6,6 +6,7 @@ use crate::mpc_fixture::fixture_interface::SharedOutput;
 use crate::mpc_fixture::fixture_tasks::MessageFilter;
 use crate::mpc_fixture::input::FixtureInput;
 use crate::mpc_fixture::message_collector::CollectMessages;
+use crate::mpc_fixture::mock_chain::{ChainEventFilter, MockChain};
 use crate::mpc_fixture::mock_governance::MockGovernance;
 use crate::mpc_fixture::mock_stream::MockStream;
 use crate::mpc_fixture::{fixture_tasks, MpcFixture, MpcFixtureNode};
@@ -50,6 +51,7 @@ pub struct MpcFixtureBuilder {
     candidates: Candidates,
     fixture_config: FixtureConfig,
     output: SharedOutput,
+    chain_event_filters: HashMap<usize, ChainEventFilter>,
 }
 
 struct MpcFixtureNodeBuilder {
@@ -173,6 +175,7 @@ impl MpcFixtureBuilder {
             candidates,
             fixture_config: FixtureConfig::new(num_nodes, threshold),
             output: SharedOutput::default(),
+            chain_event_filters: HashMap::new(),
         }
     }
 
@@ -229,6 +232,27 @@ impl MpcFixtureBuilder {
         let output = self.output;
         let mut nodes = vec![];
 
+        // Build MockChain from all nodes' streams if any mock streams are configured.
+        // Each node already has deep-cloned streams from with_mock_stream().
+        let has_mock_streams = self
+            .prepared_nodes
+            .iter()
+            .any(|n| !n.mock_streams.is_empty());
+        let mock_chain = if has_mock_streams {
+            let all_streams: Vec<MockStream> = self
+                .prepared_nodes
+                .iter()
+                .flat_map(|n| n.mock_streams.values().cloned())
+                .collect();
+            let chain = MockChain::new(all_streams);
+            for (node_idx, filter) in self.chain_event_filters.drain() {
+                chain.set_filter(node_idx, filter).await;
+            }
+            Some(chain)
+        } else {
+            None
+        };
+
         let account_ids: Vec<_> = self
             .prepared_nodes
             .iter()
@@ -254,6 +278,7 @@ impl MpcFixtureBuilder {
                     shared_contract_state_tx.clone(),
                     &mut fixture_input,
                     &output,
+                    mock_chain.clone(),
                 )
                 .await;
 
@@ -265,6 +290,7 @@ impl MpcFixtureBuilder {
             nodes,
             output,
             shared_contract_state: shared_contract_state_tx,
+            mock_chain,
         }
     }
 
@@ -389,6 +415,13 @@ impl MpcFixtureBuilder {
         self
     }
 
+    /// Specify a filter for chain events delivered to the given node.
+    /// Events returning [`EventDelivery::Drop`] are not delivered to the node's stream.
+    pub fn with_chain_event_filter(mut self, node_idx: usize, filter: ChainEventFilter) -> Self {
+        self.chain_event_filters.insert(node_idx, filter);
+        self
+    }
+
     /// Specify a method that acts as message filter for all sent messages the given node.
     pub fn with_message_collector(
         mut self,
@@ -497,6 +530,7 @@ impl MpcFixtureNodeBuilder {
         protocol_state_tx: watch::Sender<Option<ProtocolState>>,
         fixture_input: &mut Option<FixtureInput>,
         shared_output: &SharedOutput,
+        mock_chain: Option<MockChain>,
     ) -> MpcFixtureNode {
         // overwrite the default protocol config with the built config
         self.config.protocol = context.protocol_config.clone();
@@ -575,7 +609,7 @@ impl MpcFixtureNodeBuilder {
             mesh_tx.clone(),
             config_tx.clone(),
             self.messaging.filter,
-            flat_mock_streams.clone(),
+            mock_chain,
         );
 
         // --- SyncChannel and SyncTask setup ---

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -232,8 +232,6 @@ impl MpcFixtureBuilder {
         let output = self.output;
         let mut nodes = vec![];
 
-        // Build MockChain from all nodes' streams if any mock streams are configured.
-        // Each node already has deep-cloned streams from with_mock_stream().
         let has_mock_streams = self
             .prepared_nodes
             .iter()
@@ -415,8 +413,7 @@ impl MpcFixtureBuilder {
         self
     }
 
-    /// Specify a filter for chain events delivered to the given node.
-    /// Events returning [`EventDelivery::Drop`] are not delivered to the node's stream.
+    /// Filter chain events for a specific node. Dropped events are not delivered.
     pub fn with_chain_event_filter(mut self, node_idx: usize, filter: ChainEventFilter) -> Self {
         self.chain_event_filters.insert(node_idx, filter);
         self

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -3,6 +3,7 @@
 
 use crate::containers::Redis;
 use crate::mpc_fixture::message_collector::{CollectMessages, MessagePrinter};
+use crate::mpc_fixture::mock_chain::MockChain;
 use crate::mpc_fixture::mock_stream::MockStream;
 use cait_sith::protocol::Participant;
 use mpc_node::backlog::Backlog;
@@ -26,6 +27,7 @@ pub struct MpcFixture {
     pub redis_container: Redis,
     pub shared_contract_state: watch::Sender<Option<ProtocolState>>,
     pub output: SharedOutput,
+    pub mock_chain: Option<MockChain>,
 }
 
 pub struct MpcFixtureNode {
@@ -190,13 +192,17 @@ impl MpcFixture {
     /// Add a block that contains signature requesting events, visible to all
     /// nodes, then progress the chain to execute it immediately.
     pub async fn process_sign_requests(&self, chain: Chain, requests: &[IndexedSignRequest]) {
-        for node in &self.nodes {
-            let stream = node
-                .mock_streams
-                .get(&chain)
-                .expect("must have mock stream configured");
-            stream.prepare_block_of_sign_requests(requests).await;
-            stream.progress_block_height(1).await;
+        if let Some(mock_chain) = &self.mock_chain {
+            mock_chain.add_sign_requests(requests).await;
+        } else {
+            for node in &self.nodes {
+                let stream = node
+                    .mock_streams
+                    .get(&chain)
+                    .expect("must have mock stream configured");
+                stream.prepare_block_of_sign_requests(requests).await;
+                stream.progress_block_height(1).await;
+            }
         }
     }
 }

--- a/integration-tests/src/mpc_fixture/fixture_tasks.rs
+++ b/integration-tests/src/mpc_fixture/fixture_tasks.rs
@@ -2,6 +2,7 @@
 //! passing between nodes and updates to the governance smart contract.
 
 use crate::mpc_fixture::fixture_interface::SharedOutput;
+use crate::mpc_fixture::mock_chain::MockChain;
 use crate::mpc_fixture::mock_stream::MockStream;
 use cait_sith::protocol::Participant;
 use mpc_keys::hpke::Ciphered;
@@ -30,7 +31,7 @@ pub(super) fn test_mock_network(
     mesh: watch::Sender<MeshState>,
     config: watch::Sender<Config>,
     mut filter: MessageFilter,
-    mock_streams: Vec<MockStream>,
+    mock_chain: Option<MockChain>,
 ) -> JoinHandle<()> {
     let msg_log = Arc::clone(&shared_output.msg_log);
     let rpc_actions = Arc::clone(&shared_output.rpc_actions);
@@ -85,9 +86,10 @@ pub(super) fn test_mock_network(
                     tracing::info!(target: "mock_network", ?action_str, "Received RPC action");
                     let mut actions_log = rpc_actions.lock().await;
                     actions_log.insert(action_str);
-                    let block = [rpc];
-                    for stream in &mock_streams {
-                        stream.prepare_block_of_rpc_actions(&block).await;
+                    drop(actions_log);
+
+                    if let Some(chain) = &mock_chain {
+                        chain.on_rpc_publish(&rpc).await;
                     }
                 }
 

--- a/integration-tests/src/mpc_fixture/mock_chain.rs
+++ b/integration-tests/src/mpc_fixture/mock_chain.rs
@@ -1,0 +1,132 @@
+//! A simulated chain that distributes events to all nodes' streams.
+//!
+//! In production, all nodes independently observe the same on-chain events via
+//! their indexers. `MockChain` replicates this: sign requests and respond events
+//! are pushed to every node's [`MockStream`], with optional per-node filters for
+//! simulating event misses or delays.
+
+use crate::mpc_fixture::mock_stream::MockStream;
+use mpc_node::protocol::IndexedSignRequest;
+use mpc_node::rpc::RpcAction;
+use mpc_node::stream::ChainEvent;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Controls whether a [`ChainEvent`] is delivered to a particular node.
+pub enum EventDelivery {
+    /// Deliver the event immediately.
+    Deliver,
+    /// Drop the event — the node never sees it.
+    Drop,
+}
+
+/// Per-node filter applied before delivering a chain event.
+pub type ChainEventFilter = Box<dyn FnMut(&ChainEvent) -> EventDelivery + Send>;
+
+struct MockChainInner {
+    node_streams: Vec<MockStream>,
+    filters: Vec<Option<ChainEventFilter>>,
+}
+
+/// Simulates a shared chain that all nodes observe independently.
+///
+/// When events are added (sign requests, respond events from RPC publish
+/// actions), they are distributed to each node's [`MockStream`] after passing
+/// through an optional per-node filter.
+#[derive(Clone)]
+pub struct MockChain {
+    inner: Arc<Mutex<MockChainInner>>,
+}
+
+impl MockChain {
+    pub fn new(node_streams: Vec<MockStream>) -> Self {
+        let num_nodes = node_streams.len();
+        Self {
+            inner: Arc::new(Mutex::new(MockChainInner {
+                node_streams,
+                filters: (0..num_nodes).map(|_| None).collect(),
+            })),
+        }
+    }
+
+    /// Set a per-node event filter. Events that return [`EventDelivery::Drop`]
+    /// are not delivered to this node's stream.
+    pub async fn set_filter(&self, node_idx: usize, filter: ChainEventFilter) {
+        self.inner.lock().await.filters[node_idx] = Some(filter);
+    }
+
+    /// Push sign requests to all nodes' streams, applying per-node filters.
+    pub async fn add_sign_requests(&self, requests: &[IndexedSignRequest]) {
+        let mut inner = self.inner.lock().await;
+        let events: Vec<ChainEvent> = requests
+            .iter()
+            .map(|r| ChainEvent::SignRequest(r.clone()))
+            .collect();
+        inner.distribute_events(&events).await;
+    }
+
+    /// Handle an RPC publish action: convert it to respond event(s) and
+    /// distribute to all nodes. Called by `test_mock_network` when a node
+    /// publishes a signature.
+    pub async fn on_rpc_publish(&self, action: &RpcAction) {
+        let events = Self::rpc_action_to_events(action);
+        if events.is_empty() {
+            return;
+        }
+        self.inner.lock().await.distribute_events(&events).await;
+    }
+
+    /// Convert an RPC action to chain events (same logic as
+    /// `MockStream::prepare_block_of_rpc_actions`).
+    fn rpc_action_to_events(action: &RpcAction) -> Vec<ChainEvent> {
+        use elliptic_curve::sec1::ToEncodedPoint;
+        use mpc_node::protocol::SignKind;
+        use mpc_primitives::Chain;
+        use solana_sdk::pubkey::Pubkey;
+
+        let RpcAction::Publish(publish_action) = action;
+
+        if publish_action.indexed.chain != Chain::Solana {
+            return vec![];
+        }
+        if !matches!(publish_action.indexed.kind, SignKind::Sign) {
+            tracing::warn!(
+                kind=?publish_action.indexed.kind,
+                "MockChain: kind not yet supported",
+            );
+            return vec![];
+        }
+
+        let big_r = publish_action.signature.big_r.to_encoded_point(false);
+        let sol_event = signet_program::SignatureRespondedEvent {
+            request_id: publish_action.indexed.id.request_id,
+            responder: Pubkey::new_unique(),
+            signature: mpc_node::util::mpc_to_sol_signature(&publish_action.signature, big_r),
+        };
+        let respond_event = mpc_node::stream::ops::SignatureRespondedEvent::Solana(sol_event);
+        vec![ChainEvent::Respond(respond_event)]
+    }
+}
+
+impl MockChainInner {
+    async fn distribute_events(&mut self, events: &[ChainEvent]) {
+        for (i, stream) in self.node_streams.iter().enumerate() {
+            let filtered: Vec<ChainEvent> = events
+                .iter()
+                .filter(|event| {
+                    if let Some(filter) = self.filters[i].as_mut() {
+                        matches!(filter(event), EventDelivery::Deliver)
+                    } else {
+                        true
+                    }
+                })
+                .cloned()
+                .collect();
+
+            if !filtered.is_empty() {
+                stream.prepare_block_of_events(&filtered).await;
+                stream.progress_block_height(1).await;
+            }
+        }
+    }
+}

--- a/integration-tests/src/mpc_fixture/mock_chain.rs
+++ b/integration-tests/src/mpc_fixture/mock_chain.rs
@@ -1,9 +1,5 @@
-//! A simulated chain that distributes events to all nodes' streams.
-//!
-//! In production, all nodes independently observe the same on-chain events via
-//! their indexers. `MockChain` replicates this: sign requests and respond events
-//! are pushed to every node's [`MockStream`], with optional per-node filters for
-//! simulating event misses or delays.
+//! Simulated chain that distributes events to all nodes' streams with
+//! optional per-node filters for simulating event misses.
 
 use crate::mpc_fixture::mock_stream::MockStream;
 use mpc_node::protocol::IndexedSignRequest;
@@ -12,15 +8,11 @@ use mpc_node::stream::ChainEvent;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-/// Controls whether a [`ChainEvent`] is delivered to a particular node.
 pub enum EventDelivery {
-    /// Deliver the event immediately.
     Deliver,
-    /// Drop the event — the node never sees it.
     Drop,
 }
 
-/// Per-node filter applied before delivering a chain event.
 pub type ChainEventFilter = Box<dyn FnMut(&ChainEvent) -> EventDelivery + Send>;
 
 struct MockChainInner {
@@ -28,11 +20,6 @@ struct MockChainInner {
     filters: Vec<Option<ChainEventFilter>>,
 }
 
-/// Simulates a shared chain that all nodes observe independently.
-///
-/// When events are added (sign requests, respond events from RPC publish
-/// actions), they are distributed to each node's [`MockStream`] after passing
-/// through an optional per-node filter.
 #[derive(Clone)]
 pub struct MockChain {
     inner: Arc<Mutex<MockChainInner>>,
@@ -49,13 +36,10 @@ impl MockChain {
         }
     }
 
-    /// Set a per-node event filter. Events that return [`EventDelivery::Drop`]
-    /// are not delivered to this node's stream.
     pub async fn set_filter(&self, node_idx: usize, filter: ChainEventFilter) {
         self.inner.lock().await.filters[node_idx] = Some(filter);
     }
 
-    /// Push sign requests to all nodes' streams, applying per-node filters.
     pub async fn add_sign_requests(&self, requests: &[IndexedSignRequest]) {
         let mut inner = self.inner.lock().await;
         let events: Vec<ChainEvent> = requests
@@ -65,9 +49,7 @@ impl MockChain {
         inner.distribute_events(&events).await;
     }
 
-    /// Handle an RPC publish action: convert it to respond event(s) and
-    /// distribute to all nodes. Called by `test_mock_network` when a node
-    /// publishes a signature.
+    /// Convert an RPC publish into respond event(s) and distribute to all nodes.
     pub async fn on_rpc_publish(&self, action: &RpcAction) {
         let events = Self::rpc_action_to_events(action);
         if events.is_empty() {
@@ -76,8 +58,6 @@ impl MockChain {
         self.inner.lock().await.distribute_events(&events).await;
     }
 
-    /// Convert an RPC action to chain events (same logic as
-    /// `MockStream::prepare_block_of_rpc_actions`).
     fn rpc_action_to_events(action: &RpcAction) -> Vec<ChainEvent> {
         use elliptic_curve::sec1::ToEncodedPoint;
         use mpc_node::protocol::SignKind;
@@ -123,10 +103,8 @@ impl MockChainInner {
                 .cloned()
                 .collect();
 
-            if !filtered.is_empty() {
-                stream.prepare_block_of_events(&filtered).await;
-                stream.progress_block_height(1).await;
-            }
+            stream.prepare_block_of_events(&filtered).await;
+            stream.progress_block_height(1).await;
         }
     }
 }

--- a/integration-tests/src/mpc_fixture/mock_stream.rs
+++ b/integration-tests/src/mpc_fixture/mock_stream.rs
@@ -103,6 +103,12 @@ impl MockStream {
         guard.prepare_block_of_sign_requests(requests)
     }
 
+    /// Add a future block containing arbitrary chain events.
+    pub async fn prepare_block_of_events(&self, events: &[ChainEvent]) {
+        let mut guard = self.inner.lock().await;
+        guard.future_blocks.push(events.to_vec());
+    }
+
     /// Add a future block that contains events corresponding to the provided rpc actions.
     pub async fn prepare_block_of_rpc_actions(&self, actions: &[RpcAction]) {
         let mut guard = self.inner.lock().await;

--- a/integration-tests/src/mpc_fixture/mod.rs
+++ b/integration-tests/src/mpc_fixture/mod.rs
@@ -7,6 +7,7 @@ pub mod fixture_interface;
 pub mod fixture_tasks;
 pub mod input;
 pub mod message_collector;
+pub mod mock_chain;
 pub mod mock_governance;
 pub mod mock_stream;
 

--- a/integration-tests/tests/cases/mpc_with_stream.rs
+++ b/integration-tests/tests/cases/mpc_with_stream.rs
@@ -153,34 +153,19 @@ async fn test_channel_contention_1M_requests() {
     check_channel_contention(1000, 1000, 75, None).await;
 }
 
-/// When node 2 misses the respond event for a failed generation, its stale
-/// task keeps proposing and eventually clogs other nodes' message inboxes.
-///
-/// Scenario:
-/// - Requests 0..2 succeed normally. Respond events clean up all tasks.
-/// - Request 3: node 2 is excluded from generation (Accept dropped) AND
-///   misses the respond event → stale task keeps proposing.
-/// - Requests 4+: node 2's stale posit messages fill dead-letter inboxes on
-///   nodes 0+1 (POSIT_INBOX_CHANNEL_SIZE=4 under test-feature). Once full,
-///   handle_posit blocks → SignatureSpawner freezes → no more signatures.
+/// A missed respond event leaves a stale task that clogs other nodes' inboxes.
 #[test(tokio::test(flavor = "multi_thread"))]
 async fn test_missed_respond_event_clogs_inbox() {
     run_stale_task_test(true).await;
 }
 
-/// Control test: same setup as [`test_missed_respond_event_clogs_inbox`] but
-/// node 2 DOES receive the respond event. The respond event aborts node 2's
-/// stale task, so the dead-letter inbox never fills and all requests complete.
+/// Control: same setup but with respond event delivered — no clog.
 #[test(tokio::test(flavor = "multi_thread"))]
 async fn test_respond_event_prevents_clog() {
     run_stale_task_test(false).await;
 }
 
 /// Shared implementation for the clog / no-clog test pair.
-///
-/// When `drop_respond_event` is true, node 2 misses the respond event for the
-/// bad request and the system clogs. When false, the respond event cleans up
-/// the stale task and all requests complete.
 async fn run_stale_task_test(drop_respond_event: bool) {
     use cait_sith::protocol::Participant;
     use integration_tests::mpc_fixture::message_collector::CollectMessages;
@@ -246,10 +231,7 @@ async fn run_stale_task_test(drop_respond_event: bool) {
         .with_signature_timeout_ms(signature_timeout_ms)
         .with_mock_stream(Chain::Solana, MockStream::default())
         .await
-        // Drop node 2's Accept for the bad request so it is excluded from
-        // generation. Dropping Accept guarantees node 2 is never selected
-        // as a participant (the fast mock completes cait-sith in milliseconds,
-        // so dropping Signature messages wouldn't prevent completion).
+        // Exclude node 2 from generation for the bad request by dropping its Accept.
         .with_outgoing_message_filter(
             2,
             Box::new(move |msg: &SendMessage| {
@@ -289,8 +271,7 @@ async fn run_stale_task_test(drop_respond_event: bool) {
 
     let per_request_timeout = Duration::from_secs(60);
 
-    // Send requests one at a time with delays between them so the stale task
-    // (if any) has time to send proposals.
+    // Send requests with delays so the stale task has time to send proposals.
     let mut completed = 0u32;
     for seed in 0..20 {
         network
@@ -313,14 +294,11 @@ async fn run_stale_task_test(drop_respond_event: bool) {
             }
         }
 
-        // Give the stale task time to send proposals between requests.
         tokio::time::sleep(Duration::from_secs(5)).await;
     }
 
     if drop_respond_event {
-        // With missed respond event: clog should have occurred.
-        // At minimum, the bad request itself must have been sent and completed
-        // by nodes 0+1 (even though node 2 was excluded).
+        // Clog: bad request must have been processed, but not all 20.
         assert!(
             completed > bad_request_seed,
             "expected more than {bad_request_seed} successful requests (including the bad one), got {completed}"
@@ -330,7 +308,7 @@ async fn run_stale_task_test(drop_respond_event: bool) {
             "expected clog to prevent some requests, but all 20 completed"
         );
 
-        // Verify the bad request: nodes 0+1 generated, node 2 did not.
+        // Bad request: nodes 0+1 generated, node 2 was excluded.
         let n0_bad = tracker_counts
             .lock()
             .unwrap()
@@ -361,8 +339,7 @@ async fn run_stale_task_test(drop_respond_event: bool) {
             n2_bad.signature
         );
 
-        // Verify clog: send a fresh request (not the timed-out one), wait for
-        // node 2 to be active on both sign_ids, then check nodes 0+1 are silent.
+        // Send a fresh request and verify nodes 0+1 are durably silent.
         let fresh_seed = completed + 100;
         let new_sign_id = sign_request(fresh_seed).id;
         let n2_bad_before = tracker_counts
@@ -396,31 +373,58 @@ async fn run_stale_task_test(drop_respond_event: bool) {
         .await
         .expect("node 2 should be sending posit messages for both bad and new requests");
 
-        let n0_new = tracker_counts
+        // Two snapshots with a quiet period prove durable silence.
+        let n0_snap1 = tracker_counts
             .lock()
             .unwrap()
             .get(&(node_0, new_sign_id))
             .cloned()
             .unwrap_or_default();
-        let n1_new = tracker_counts
+        let n1_snap1 = tracker_counts
             .lock()
             .unwrap()
             .get(&(node_1, new_sign_id))
             .cloned()
             .unwrap_or_default();
+
+        let quiet_period = 2 * mpc_node::protocol::signature::organize_posit_timeout();
+        tokio::time::sleep(quiet_period).await;
+
+        let n0_snap2 = tracker_counts
+            .lock()
+            .unwrap()
+            .get(&(node_0, new_sign_id))
+            .cloned()
+            .unwrap_or_default();
+        let n1_snap2 = tracker_counts
+            .lock()
+            .unwrap()
+            .get(&(node_1, new_sign_id))
+            .cloned()
+            .unwrap_or_default();
+
         assert_eq!(
-            n0_new.posit + n0_new.signature,
+            n0_snap1.posit + n0_snap1.signature,
             0,
             "node 0 sent messages for new request — expected 0 (spawner clogged)"
         );
         assert_eq!(
-            n1_new.posit + n1_new.signature,
+            n1_snap1.posit + n1_snap1.signature,
             0,
             "node 1 sent messages for new request — expected 0 (spawner clogged)"
         );
+        assert_eq!(
+            n0_snap2.posit + n0_snap2.signature,
+            0,
+            "node 0 sent messages during quiet period — clog is not durable"
+        );
+        assert_eq!(
+            n1_snap2.posit + n1_snap2.signature,
+            0,
+            "node 1 sent messages during quiet period — clog is not durable"
+        );
     } else {
-        // Without missed respond event: respond event cleans up the stale task,
-        // so all requests should complete without clogging.
+        // Respond event cleans up the stale task — all requests complete.
         assert_eq!(
             completed, 20,
             "expected all 20 requests to complete (respond event prevents clog), got {completed}"

--- a/integration-tests/tests/cases/mpc_with_stream.rs
+++ b/integration-tests/tests/cases/mpc_with_stream.rs
@@ -153,53 +153,77 @@ async fn test_channel_contention_1M_requests() {
     check_channel_contention(1000, 1000, 75, None).await;
 }
 
-/// Demonstrates that when a node participates in generation but its generation
-/// times out (while other nodes complete), and it never receives the respond
-/// event, the stale task keeps sending Posit messages that eventually clog the
-/// other nodes' message inboxes.
+/// When node 2 misses the respond event for a failed generation, its stale
+/// task keeps proposing and eventually clogs other nodes' message inboxes.
 ///
-/// The clogging cascade:
-/// 1. Nodes 0+1 complete generation, their tasks exit, inboxes removed
-/// 2. Node 2's generation times out → falls back to Organizing → keeps proposing
-/// 3. handle_posit on nodes 0+1 creates dead-letter inboxes for the completed sign_id
-/// 4. Dead-letter inbox fills (POSIT_INBOX_CHANNEL_SIZE=4 under test-feature)
-/// 5. handle_posit blocks → SignatureSpawner blocks → MessageInbox blocks
-/// 6. Nodes 0+1 can no longer process any new signatures
+/// Scenario:
+/// - Requests 0..2 succeed normally. Respond events clean up all tasks.
+/// - Request 3: node 2 is excluded from generation (Accept dropped) AND
+///   misses the respond event → stale task keeps proposing.
+/// - Requests 4+: node 2's stale posit messages fill dead-letter inboxes on
+///   nodes 0+1 (POSIT_INBOX_CHANNEL_SIZE=4 under test-feature). Once full,
+///   handle_posit blocks → SignatureSpawner freezes → no more signatures.
 #[test(tokio::test(flavor = "multi_thread"))]
-async fn test_missed_respond_clogs_inbox() {
+async fn test_missed_respond_event_clogs_inbox() {
+    run_stale_task_test(true).await;
+}
+
+/// Control test: same setup as [`test_missed_respond_event_clogs_inbox`] but
+/// node 2 DOES receive the respond event. The respond event aborts node 2's
+/// stale task, so the dead-letter inbox never fills and all requests complete.
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_respond_event_prevents_clog() {
+    run_stale_task_test(false).await;
+}
+
+/// Shared implementation for the clog / no-clog test pair.
+///
+/// When `drop_respond_event` is true, node 2 misses the respond event for the
+/// bad request and the system clogs. When false, the respond event cleans up
+/// the stale task and all requests complete.
+async fn run_stale_task_test(drop_respond_event: bool) {
     use cait_sith::protocol::Participant;
     use integration_tests::mpc_fixture::message_collector::CollectMessages;
+    use integration_tests::mpc_fixture::mock_chain::EventDelivery;
     use mpc_node::protocol::message::{PositProtocolId, SendMessage};
     use mpc_node::protocol::Message;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use mpc_node::stream::ChainEvent;
+    use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::Mutex;
 
-    struct PostClogTracker {
-        tracking_active: Arc<AtomicBool>,
-        node_01_propose_count: Arc<AtomicUsize>,
-        node_01_signature_count: Arc<AtomicUsize>,
-        node_2_propose_count: Arc<AtomicUsize>,
+    #[derive(Default, Clone, Debug)]
+    struct MessageCounts {
+        posit: usize,
+        signature: usize,
     }
-    impl CollectMessages for PostClogTracker {
+
+    #[derive(Default)]
+    struct SignatureTracker {
+        counts: Arc<std::sync::Mutex<HashMap<(Participant, SignId), MessageCounts>>>,
+    }
+
+    impl CollectMessages for SignatureTracker {
         fn observe_message(&mut self, msg: &SendMessage, _passed_filter: bool) {
-            if !self.tracking_active.load(Ordering::Relaxed) {
-                return;
-            }
             let (message, (from, _to, _ts)) = msg;
-            let from_node_01 = *from == Participant::from(0) || *from == Participant::from(1);
             match message {
                 Message::Posit(posit_msg) => {
-                    if let PositProtocolId::Signature(..) = posit_msg.id {
-                        if from_node_01 {
-                            self.node_01_propose_count.fetch_add(1, Ordering::Relaxed);
-                        } else {
-                            self.node_2_propose_count.fetch_add(1, Ordering::Relaxed);
-                        }
+                    if let PositProtocolId::Signature(sign_id, ..) = posit_msg.id {
+                        self.counts
+                            .lock()
+                            .unwrap()
+                            .entry((*from, sign_id))
+                            .or_default()
+                            .posit += 1;
                     }
                 }
-                Message::Signature(_) if from_node_01 => {
-                    self.node_01_signature_count.fetch_add(1, Ordering::Relaxed);
+                Message::Signature(sig_msg) => {
+                    self.counts
+                        .lock()
+                        .unwrap()
+                        .entry((*from, sig_msg.id))
+                        .or_default()
+                        .signature += 1;
                 }
                 _ => {}
             }
@@ -207,103 +231,199 @@ async fn test_missed_respond_clogs_inbox() {
         fn print_summary(&self) {}
     }
 
-    use std::sync::atomic::AtomicBool;
-    let tracking_active = Arc::new(AtomicBool::new(false));
-    let node_01_propose_count = Arc::new(AtomicUsize::new(0));
-    let node_01_signature_count = Arc::new(AtomicUsize::new(0));
-    let node_2_propose_count = Arc::new(AtomicUsize::new(0));
-
-    let tracker = PostClogTracker {
-        tracking_active: Arc::clone(&tracking_active),
-        node_01_propose_count: Arc::clone(&node_01_propose_count),
-        node_01_signature_count: Arc::clone(&node_01_signature_count),
-        node_2_propose_count: Arc::clone(&node_2_propose_count),
-    };
-
+    let node_0 = Participant::from(0);
+    let node_1 = Participant::from(1);
     let node_2 = Participant::from(2);
+    let bad_request_seed = 3u32;
+    let bad_sign_id = sign_request(bad_request_seed).id;
     let signature_timeout_ms = 5_000;
 
-    let network = MpcFixtureBuilder::new(3, 2)
+    let tracker = SignatureTracker::default();
+    let tracker_counts = Arc::clone(&tracker.counts);
+
+    let mut builder = MpcFixtureBuilder::new(3, 2)
         .only_generate_signatures()
         .with_signature_timeout_ms(signature_timeout_ms)
         .with_mock_stream(Chain::Solana, MockStream::default())
         .await
-        // Drop Signature protocol messages from node 0 → node 2.
-        // Nodes 0+1 can still complete with threshold=2 messages between them.
-        // Node 2's generation will time out because it never receives protocol messages.
+        // Drop node 2's Accept for the bad request so it is excluded from
+        // generation. Dropping Accept guarantees node 2 is never selected
+        // as a participant (the fast mock completes cait-sith in milliseconds,
+        // so dropping Signature messages wouldn't prevent completion).
         .with_outgoing_message_filter(
+            2,
+            Box::new(move |msg: &SendMessage| {
+                let (message, (_from, _to, _ts)) = msg;
+                if let Message::Posit(posit_msg) = message {
+                    if let PositProtocolId::Signature(sign_id, ..) = posit_msg.id {
+                        if sign_id == bad_sign_id
+                            && matches!(
+                                posit_msg.action,
+                                mpc_node::protocol::posit::PositAction::Accept
+                            )
+                        {
+                            return false;
+                        }
+                    }
+                }
+                true
+            }),
+        )
+        .with_message_collector(Arc::new(Mutex::new(tracker)));
+
+    if drop_respond_event {
+        builder = builder.with_chain_event_filter(
+            2,
+            Box::new(move |event: &ChainEvent| {
+                if let ChainEvent::Respond(respond) = event {
+                    if respond.request_id() == bad_sign_id.request_id {
+                        return EventDelivery::Drop;
+                    }
+                }
+                EventDelivery::Deliver
+            }),
+        );
+    }
+
+    let network = builder.build().await;
+
+    let per_request_timeout = Duration::from_secs(60);
+
+    // Send requests one at a time with delays between them so the stale task
+    // (if any) has time to send proposals.
+    let mut completed = 0u32;
+    for seed in 0..20 {
+        network
+            .process_sign_requests(Chain::Solana, &[sign_request(seed)])
+            .await;
+
+        match tokio::time::timeout(
+            per_request_timeout,
+            network.wait_for_actions(completed as usize + 1),
+        )
+        .await
+        {
+            Ok(_) => {
+                completed += 1;
+                tracing::info!(seed, completed, "request completed successfully");
+            }
+            Err(_) => {
+                tracing::info!(seed, completed, "request timed out — clog detected");
+                break;
+            }
+        }
+
+        // Give the stale task time to send proposals between requests.
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+
+    if drop_respond_event {
+        // With missed respond event: clog should have occurred.
+        // At minimum, the bad request itself must have been sent and completed
+        // by nodes 0+1 (even though node 2 was excluded).
+        assert!(
+            completed > bad_request_seed,
+            "expected more than {bad_request_seed} successful requests (including the bad one), got {completed}"
+        );
+        assert!(
+            completed < 20,
+            "expected clog to prevent some requests, but all 20 completed"
+        );
+
+        // Verify the bad request: nodes 0+1 generated, node 2 did not.
+        let n0_bad = tracker_counts
+            .lock()
+            .unwrap()
+            .get(&(node_0, bad_sign_id))
+            .cloned()
+            .unwrap_or_default();
+        let n1_bad = tracker_counts
+            .lock()
+            .unwrap()
+            .get(&(node_1, bad_sign_id))
+            .cloned()
+            .unwrap_or_default();
+        let n2_bad = tracker_counts
+            .lock()
+            .unwrap()
+            .get(&(node_2, bad_sign_id))
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            n0_bad.signature > 0 && n1_bad.signature > 0,
+            "bad request: nodes 0+1 should have exchanged signature messages (n0={}, n1={})",
+            n0_bad.signature,
+            n1_bad.signature
+        );
+        assert_eq!(
+            n2_bad.signature, 0,
+            "bad request: node 2 should have 0 signature messages, got {}",
+            n2_bad.signature
+        );
+
+        // Verify clog: send a fresh request (not the timed-out one), wait for
+        // node 2 to be active on both sign_ids, then check nodes 0+1 are silent.
+        let fresh_seed = completed + 100;
+        let new_sign_id = sign_request(fresh_seed).id;
+        let n2_bad_before = tracker_counts
+            .lock()
+            .unwrap()
+            .get(&(node_2, bad_sign_id))
+            .cloned()
+            .unwrap_or_default()
+            .posit;
+
+        network
+            .process_sign_requests(Chain::Solana, &[sign_request(fresh_seed)])
+            .await;
+
+        tokio::time::timeout(Duration::from_secs(120), async {
+            loop {
+                let ready = {
+                    let counts = tracker_counts.lock().unwrap();
+                    let bad_posits = counts
+                        .get(&(node_2, bad_sign_id))
+                        .map_or(0, |c| c.posit.saturating_sub(n2_bad_before));
+                    let new_posits = counts.get(&(node_2, new_sign_id)).map_or(0, |c| c.posit);
+                    bad_posits >= 2 && new_posits >= 2
+                };
+                if ready {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        })
+        .await
+        .expect("node 2 should be sending posit messages for both bad and new requests");
+
+        let n0_new = tracker_counts
+            .lock()
+            .unwrap()
+            .get(&(node_0, new_sign_id))
+            .cloned()
+            .unwrap_or_default();
+        let n1_new = tracker_counts
+            .lock()
+            .unwrap()
+            .get(&(node_1, new_sign_id))
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(
+            n0_new.posit + n0_new.signature,
             0,
-            Box::new(move |msg: &SendMessage| {
-                let (message, (_from, to, _ts)) = msg;
-                !(matches!(message, Message::Signature(_)) && *to == node_2)
-            }),
-        )
-        .with_outgoing_message_filter(
-            1,
-            Box::new(move |msg: &SendMessage| {
-                let (message, (_from, to, _ts)) = msg;
-                !(matches!(message, Message::Signature(_)) && *to == node_2)
-            }),
-        )
-        .with_message_collector(Arc::new(Mutex::new(tracker)))
-        .build()
-        .await;
-
-    // Send first sign request — nodes 0+1 will complete, node 2's generation will time out
-    network
-        .process_sign_requests(Chain::Solana, &[sign_request(0)])
-        .await;
-
-    let actions = network.assert_actions(1, Duration::from_secs(30)).await;
-    assert_eq!(actions.len(), 1);
-
-    // Start tracking messages after the first signature is published.
-    // From this point, nodes 0+1 should have no generators in flight.
-    tracking_active.store(true, Ordering::Relaxed);
-
-    // Wait for node 2's generation to time out and start proposing again,
-    // then for enough proposals to fill the dead-letter inbox on nodes 0+1.
-    //
-    // After generation_timeout (5s), node 2 re-enters Organizing and cycles
-    // through rounds. It is proposer ~1/3 of rounds (round-robin with 3 active
-    // nodes in the mesh). Each round takes ORGANIZE_POSIT_TIMEOUT (5s).
-    // With POSIT_INBOX_CHANNEL_SIZE=4, we need 5 Propose messages to block
-    // (4 to fill the channel + 1 that blocks on send).
-    // Time: generation_timeout + 5 proposals × 3 rounds/proposal × ORGANIZE_POSIT_TIMEOUT
-    //     = 5s + 5 × 3 × 5s = 80s
-    let organize_timeout = mpc_node::protocol::signature::organize_posit_timeout();
-    let clog_wait = Duration::from_millis(signature_timeout_ms) + 18 * organize_timeout;
-    tokio::time::sleep(clog_wait).await;
-
-    // Verify nodes 0+1 have no signature generators in flight: they should not
-    // have sent any Posit or Signature protocol messages since tracking started.
-    let n01_posits = node_01_propose_count.load(Ordering::Relaxed);
-    let n01_sigs = node_01_signature_count.load(Ordering::Relaxed);
-    let n2_posits = node_2_propose_count.load(Ordering::Relaxed);
-    assert_eq!(
-        n01_posits, 0,
-        "nodes 0+1 sent {n01_posits} posit messages after completing — expected 0 (no generators in flight)"
-    );
-    assert_eq!(
-        n01_sigs, 0,
-        "nodes 0+1 sent {n01_sigs} signature messages after completing — expected 0 (no generators in flight)"
-    );
-    assert!(
-        n2_posits > 0,
-        "node 2 should have sent posit messages (stale task proposing), but count was 0"
-    );
-
-    // Send another sign request — should NOT be processable because nodes 0+1 are clogged.
-    // Their SignatureSpawner is blocked on a dead-letter inbox send, so it cannot
-    // process new Sign::Request or Posit messages.
-    network
-        .process_sign_requests(Chain::Solana, &[sign_request(1)])
-        .await;
-
-    let result = tokio::time::timeout(Duration::from_secs(30), network.wait_for_actions(2)).await;
-
-    assert!(
-        result.is_err(),
-        "expected second signature to NOT be produced (inbox clogged), but it was"
-    );
+            "node 0 sent messages for new request — expected 0 (spawner clogged)"
+        );
+        assert_eq!(
+            n1_new.posit + n1_new.signature,
+            0,
+            "node 1 sent messages for new request — expected 0 (spawner clogged)"
+        );
+    } else {
+        // Without missed respond event: respond event cleans up the stale task,
+        // so all requests should complete without clogging.
+        assert_eq!(
+            completed, 20,
+            "expected all 20 requests to complete (respond event prevents clog), got {completed}"
+        );
+    }
 }

--- a/integration-tests/tests/cases/mpc_with_stream.rs
+++ b/integration-tests/tests/cases/mpc_with_stream.rs
@@ -152,3 +152,158 @@ async fn test_channel_contention_1M_requests() {
     // sending 1000 x 1000 requests at once
     check_channel_contention(1000, 1000, 75, None).await;
 }
+
+/// Demonstrates that when a node participates in generation but its generation
+/// times out (while other nodes complete), and it never receives the respond
+/// event, the stale task keeps sending Posit messages that eventually clog the
+/// other nodes' message inboxes.
+///
+/// The clogging cascade:
+/// 1. Nodes 0+1 complete generation, their tasks exit, inboxes removed
+/// 2. Node 2's generation times out → falls back to Organizing → keeps proposing
+/// 3. handle_posit on nodes 0+1 creates dead-letter inboxes for the completed sign_id
+/// 4. Dead-letter inbox fills (POSIT_INBOX_CHANNEL_SIZE=4 under test-feature)
+/// 5. handle_posit blocks → SignatureSpawner blocks → MessageInbox blocks
+/// 6. Nodes 0+1 can no longer process any new signatures
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_missed_respond_clogs_inbox() {
+    use cait_sith::protocol::Participant;
+    use integration_tests::mpc_fixture::message_collector::CollectMessages;
+    use mpc_node::protocol::message::{PositProtocolId, SendMessage};
+    use mpc_node::protocol::Message;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    struct PostClogTracker {
+        tracking_active: Arc<AtomicBool>,
+        node_01_propose_count: Arc<AtomicUsize>,
+        node_01_signature_count: Arc<AtomicUsize>,
+        node_2_propose_count: Arc<AtomicUsize>,
+    }
+    impl CollectMessages for PostClogTracker {
+        fn observe_message(&mut self, msg: &SendMessage, _passed_filter: bool) {
+            if !self.tracking_active.load(Ordering::Relaxed) {
+                return;
+            }
+            let (message, (from, _to, _ts)) = msg;
+            let from_node_01 = *from == Participant::from(0) || *from == Participant::from(1);
+            match message {
+                Message::Posit(posit_msg) => {
+                    if let PositProtocolId::Signature(..) = posit_msg.id {
+                        if from_node_01 {
+                            self.node_01_propose_count.fetch_add(1, Ordering::Relaxed);
+                        } else {
+                            self.node_2_propose_count.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                }
+                Message::Signature(_) if from_node_01 => {
+                    self.node_01_signature_count.fetch_add(1, Ordering::Relaxed);
+                }
+                _ => {}
+            }
+        }
+        fn print_summary(&self) {}
+    }
+
+    use std::sync::atomic::AtomicBool;
+    let tracking_active = Arc::new(AtomicBool::new(false));
+    let node_01_propose_count = Arc::new(AtomicUsize::new(0));
+    let node_01_signature_count = Arc::new(AtomicUsize::new(0));
+    let node_2_propose_count = Arc::new(AtomicUsize::new(0));
+
+    let tracker = PostClogTracker {
+        tracking_active: Arc::clone(&tracking_active),
+        node_01_propose_count: Arc::clone(&node_01_propose_count),
+        node_01_signature_count: Arc::clone(&node_01_signature_count),
+        node_2_propose_count: Arc::clone(&node_2_propose_count),
+    };
+
+    let node_2 = Participant::from(2);
+    let signature_timeout_ms = 5_000;
+
+    let network = MpcFixtureBuilder::new(3, 2)
+        .only_generate_signatures()
+        .with_signature_timeout_ms(signature_timeout_ms)
+        .with_mock_stream(Chain::Solana, MockStream::default())
+        .await
+        // Drop Signature protocol messages from node 0 → node 2.
+        // Nodes 0+1 can still complete with threshold=2 messages between them.
+        // Node 2's generation will time out because it never receives protocol messages.
+        .with_outgoing_message_filter(
+            0,
+            Box::new(move |msg: &SendMessage| {
+                let (message, (_from, to, _ts)) = msg;
+                !(matches!(message, Message::Signature(_)) && *to == node_2)
+            }),
+        )
+        .with_outgoing_message_filter(
+            1,
+            Box::new(move |msg: &SendMessage| {
+                let (message, (_from, to, _ts)) = msg;
+                !(matches!(message, Message::Signature(_)) && *to == node_2)
+            }),
+        )
+        .with_message_collector(Arc::new(Mutex::new(tracker)))
+        .build()
+        .await;
+
+    // Send first sign request — nodes 0+1 will complete, node 2's generation will time out
+    network
+        .process_sign_requests(Chain::Solana, &[sign_request(0)])
+        .await;
+
+    let actions = network.assert_actions(1, Duration::from_secs(30)).await;
+    assert_eq!(actions.len(), 1);
+
+    // Start tracking messages after the first signature is published.
+    // From this point, nodes 0+1 should have no generators in flight.
+    tracking_active.store(true, Ordering::Relaxed);
+
+    // Wait for node 2's generation to time out and start proposing again,
+    // then for enough proposals to fill the dead-letter inbox on nodes 0+1.
+    //
+    // After generation_timeout (5s), node 2 re-enters Organizing and cycles
+    // through rounds. It is proposer ~1/3 of rounds (round-robin with 3 active
+    // nodes in the mesh). Each round takes ORGANIZE_POSIT_TIMEOUT (5s).
+    // With POSIT_INBOX_CHANNEL_SIZE=4, we need 5 Propose messages to block
+    // (4 to fill the channel + 1 that blocks on send).
+    // Time: generation_timeout + 5 proposals × 3 rounds/proposal × ORGANIZE_POSIT_TIMEOUT
+    //     = 5s + 5 × 3 × 5s = 80s
+    let organize_timeout = mpc_node::protocol::signature::organize_posit_timeout();
+    let clog_wait = Duration::from_millis(signature_timeout_ms) + 18 * organize_timeout;
+    tokio::time::sleep(clog_wait).await;
+
+    // Verify nodes 0+1 have no signature generators in flight: they should not
+    // have sent any Posit or Signature protocol messages since tracking started.
+    let n01_posits = node_01_propose_count.load(Ordering::Relaxed);
+    let n01_sigs = node_01_signature_count.load(Ordering::Relaxed);
+    let n2_posits = node_2_propose_count.load(Ordering::Relaxed);
+    assert_eq!(
+        n01_posits, 0,
+        "nodes 0+1 sent {n01_posits} posit messages after completing — expected 0 (no generators in flight)"
+    );
+    assert_eq!(
+        n01_sigs, 0,
+        "nodes 0+1 sent {n01_sigs} signature messages after completing — expected 0 (no generators in flight)"
+    );
+    assert!(
+        n2_posits > 0,
+        "node 2 should have sent posit messages (stale task proposing), but count was 0"
+    );
+
+    // Send another sign request — should NOT be processable because nodes 0+1 are clogged.
+    // Their SignatureSpawner is blocked on a dead-letter inbox send, so it cannot
+    // process new Sign::Request or Posit messages.
+    network
+        .process_sign_requests(Chain::Solana, &[sign_request(1)])
+        .await;
+
+    let result = tokio::time::timeout(Duration::from_secs(30), network.wait_for_actions(2)).await;
+
+    assert!(
+        result.is_err(),
+        "expected second signature to NOT be produced (inbox clogged), but it was"
+    );
+}


### PR DESCRIPTION
- Adds a MockChain test infrastructure that simulates a shared chain: sign requests and respond events are distributed to all nodes' streams, with per-node filters for simulating event misses
- Adds two component tests that demonstrate a production issue where a single missed respond event can clog the signature spawner inbox, both are expected to pass:
-- test_missed_respond_event_clogs_inbox: node 2 is excluded from generation for a single request(bad_request) and misses the respond event. Its stale task keeps sending posit messages that fill inboxes of this sign_id on the nodes 0 and 1, eventually blocking their SignatureSpawner and preventing all future signature generation.
-- test_respond_event_prevents_clog: Same setup but the respond event IS delivered. It cleans up the stale task and all 20 requests complete — proving the respond event is the key factor.
- Reduces POSIT_INBOX_CHANNEL_SIZE to 4 under test-feature so the lingering signId's inbox fills quickly in tests (production keeps 4096, which will typically fill in ~8 hrs if stale task persists)