### PR TITLE
metrcis: trim multichain_task_queue_capacity buckets and add 0.0 bucket 

### DIFF
--- a/chain-signatures/node/src/metrics/messaging.rs
+++ b/chain-signatures/node/src/metrics/messaging.rs
@@ -109,7 +109,7 @@ pub(crate) static TASK_QUEUE_CAPACITY: LazyLock<HistogramVec> = LazyLock::new(||
         "Distribution of queue capacities across message channels",
         &["channel"],
         Some(vec![
-            1.0, 10.0, 50.0, 100.0, 200.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0, 16000.0, 32000.0,
+            0.0, 1.0, 10.0, 50.0, 100.0, 200.0, 500.0, 1000.0, 2000.0, 4096.0,
         ]),
     )
     .unwrap()


### PR DESCRIPTION
because the max size possible is only 4096, previous bigger buckets are not necessary. Changed biggest value to 4096, and added bucket 0 so that we can observe whether any channel has a full inbox on grafana