### PR TITLE
more buckets for TASK_QUEUE_CAPACITY and add inbox count metric

### DIFF
--- a/chain-signatures/node/src/metrics/messaging.rs
+++ b/chain-signatures/node/src/metrics/messaging.rs
@@ -109,7 +109,7 @@ pub(crate) static TASK_QUEUE_CAPACITY: LazyLock<HistogramVec> = LazyLock::new(||
         "Distribution of queue capacities across message channels",
         &["channel"],
         Some(vec![
-            0.0, 1.0, 10.0, 50.0, 100.0, 200.0, 500.0, 1000.0, 2000.0, 2500.0, 3000.0, 3500.0,
+            0.0, 1.0, 10.0, 50.0, 100.0, 500.0, 1000.0, 1500.0, 2000.0, 2500.0, 3000.0, 3500.0,
             4000.0, 4096.0,
         ]),
     )
@@ -120,4 +120,19 @@ pub(crate) fn observe_queue_capacity(channel: &str, len: usize) {
     TASK_QUEUE_CAPACITY
         .with_label_values(&[channel])
         .observe(len as f64);
+}
+
+pub(crate) static TASK_QUEUE_INBOX_COUNT: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    super::try_create_int_gauge_vec_with_node_account_id(
+        "multichain_task_queue_inbox_count",
+        "Number of active inboxes per channel",
+        &["channel"],
+    )
+    .unwrap()
+});
+
+pub(crate) fn set_inbox_count(channel: &str, count: usize) {
+    TASK_QUEUE_INBOX_COUNT
+        .with_label_values(&[channel])
+        .set(count as i64);
 }

--- a/chain-signatures/node/src/metrics/messaging.rs
+++ b/chain-signatures/node/src/metrics/messaging.rs
@@ -109,7 +109,8 @@ pub(crate) static TASK_QUEUE_CAPACITY: LazyLock<HistogramVec> = LazyLock::new(||
         "Distribution of queue capacities across message channels",
         &["channel"],
         Some(vec![
-            0.0, 1.0, 10.0, 50.0, 100.0, 200.0, 500.0, 1000.0, 2000.0, 4096.0,
+            0.0, 1.0, 10.0, 50.0, 100.0, 200.0, 500.0, 1000.0, 2000.0, 2500.0, 3000.0, 3500.0,
+            4000.0, 4096.0,
         ]),
     )
     .unwrap()

--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -8,7 +8,7 @@ use super::contract::primitives::{ParticipantMap, Participants};
 use super::presignature::PresignatureId;
 use super::triple::TripleId;
 use crate::metrics;
-use crate::metrics::messaging::set_channel_capacity_tx;
+use crate::metrics::messaging::{set_channel_capacity_tx, set_inbox_count};
 use crate::node_client::NodeClient;
 use crate::protocol::message::filter::{MessageFilter, MAX_FILTER_SIZE};
 use crate::protocol::message::sub::{
@@ -156,6 +156,7 @@ impl MessageInbox {
                     .or_insert_with(|| Subscriber::unsubscribed("triple_task"));
                 let _ = sub.send(message).await;
                 sub.report_capacity();
+                set_inbox_count("triple_task", self.triple.len());
             }
             Message::Presignature(message) => {
                 let sub = self
@@ -164,6 +165,7 @@ impl MessageInbox {
                     .or_insert_with(|| Subscriber::unsubscribed("presign_task"));
                 let _ = sub.send(message).await;
                 sub.report_capacity();
+                set_inbox_count("presign_task", self.presignature.len());
             }
             Message::Signature(message) => {
                 let sub = self
@@ -172,6 +174,7 @@ impl MessageInbox {
                     .or_insert_with(|| Subscriber::unsubscribed("sign_task"));
                 let _ = sub.send(message).await;
                 sub.report_capacity();
+                set_inbox_count("sign_task", self.signature.len());
             }
             Message::Unknown(entries) => {
                 tracing::warn!(
@@ -283,6 +286,7 @@ impl MessageInbox {
                     } else {
                         tracing::warn!(id, "trying to unsub from an unknown triple subscription");
                     }
+                    set_inbox_count("triple_task", self.triple.len());
                 }
             },
             SubscribeId::Presignature(id) => match sub.action {
@@ -303,6 +307,7 @@ impl MessageInbox {
                             "trying to unsub from an unknown presignature subscription"
                         );
                     }
+                    set_inbox_count("presign_task", self.presignature.len());
                 }
             },
             SubscribeId::Signature(sign_id, presignature_id) => match sub.action {
@@ -324,6 +329,7 @@ impl MessageInbox {
                             "trying to unsub from an unknown signature subscription"
                         );
                     }
+                    set_inbox_count("sign_task", self.signature.len());
                 }
             },
             SubscribeId::Ready => match sub.action {

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -2,6 +2,7 @@ use crate::backlog::Backlog;
 use crate::config::Config;
 use crate::kdf::derive_delta;
 use crate::mesh::MeshState;
+use crate::metrics::messaging::set_inbox_count;
 use crate::metrics::requests::{
     record_request_latency, record_request_latency_since, SignRequestStep, SIGN_REQUEST_LOOPS,
 };
@@ -1674,6 +1675,7 @@ impl SignatureSpawner {
             .or_insert_with(|| Subscriber::unsubscribed(SIGN_POSIT_INBOX_LABEL));
         let rx = inbox.subscribe();
         inbox.report_capacity();
+        set_inbox_count(SIGN_POSIT_INBOX_LABEL, self.inboxes.len());
 
         let task = SignTask {
             governance: governance.clone(),
@@ -1727,6 +1729,7 @@ impl SignatureSpawner {
         if let Some(inbox) = self.inboxes.remove(&sign_id) {
             inbox.clear_capacity_global();
         }
+        set_inbox_count(SIGN_POSIT_INBOX_LABEL, self.inboxes.len());
         self.abort_delayed_watcher(sign_id, "completion");
         if self.tasks.abort(sign_id) {
             tracing::info!(?sign_id, "aborting signature task due to completion event");
@@ -1744,6 +1747,7 @@ impl SignatureSpawner {
                 if let Some(inbox) = self.inboxes.remove(&sign_id) {
                     inbox.clear_capacity_global();
                 }
+                set_inbox_count(SIGN_POSIT_INBOX_LABEL, self.inboxes.len());
                 self.abort_delayed_watcher(sign_id, "interruption");
                 return;
             }
@@ -1751,6 +1755,7 @@ impl SignatureSpawner {
         if let Some(inbox) = self.inboxes.remove(&sign_id) {
             inbox.clear_capacity_global();
         }
+        set_inbox_count(SIGN_POSIT_INBOX_LABEL, self.inboxes.len());
         self.abort_delayed_watcher(sign_id, "task completion");
         match result {
             Ok(()) => {


### PR DESCRIPTION
- Currently we do not know if the inbox capacities are decreasing until they are under 2000. Added more buckets between 2000 and 4096
- add inbox count per channel so we know if number of inboxes are increasing, which may lead to ram decreasing