### PR TITLE
chore: cleanup transient types that are the same across chains

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake .

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -1003,7 +1003,7 @@ mod tests {
         let prefix_len = dest.len().min(program_id.len());
         program_id[..prefix_len].copy_from_slice(&dest.as_bytes()[..prefix_len]);
 
-        SignBidirectionalEvent::Solana(signet_program::SignBidirectionalEvent {
+        SignBidirectionalEvent {
             sender: Default::default(),
             serialized_transaction: vec![],
             dest: dest.to_string(),
@@ -1013,10 +1013,11 @@ mod tests {
             path: "".to_string(),
             algo: "".to_string(),
             params: "".to_string(),
-            program_id: Pubkey::new_from_array(program_id),
+            chain: Chain::Solana,
+            chain_ctx: Some(program_id.to_vec()),
             output_deserialization_schema: vec![],
             respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
-        })
+        }
     }
 
     fn create_test_args(id: u8) -> SignArgs {
@@ -1590,22 +1591,21 @@ mod tests {
         };
 
         let program_id = Pubkey::new_unique();
-        let sign_kind = SignKind::SignBidirectional(SignBidirectionalEvent::Solana(
-            signet_program::SignBidirectionalEvent {
-                sender: Default::default(),
-                serialized_transaction: vec![1, 2, 3],
-                dest: "ethereum".to_string(),
-                caip2_id: Chain::Ethereum.caip2_chain_id().to_string(),
-                key_version: 1,
-                deposit: 10,
-                path: "m/0".to_string(),
-                algo: "ECDSA".to_string(),
-                params: "{}".to_string(),
-                program_id,
-                output_deserialization_schema: vec![9],
-                respond_serialization_schema: vec![8],
-            },
-        ));
+        let sign_kind = SignKind::SignBidirectional(SignBidirectionalEvent {
+            sender: Default::default(),
+            serialized_transaction: vec![1, 2, 3],
+            dest: "ethereum".to_string(),
+            caip2_id: Chain::Ethereum.caip2_chain_id().to_string(),
+            key_version: 1,
+            deposit: 10,
+            path: "m/0".to_string(),
+            algo: "ECDSA".to_string(),
+            params: "{}".to_string(),
+            chain: Chain::Solana,
+            chain_ctx: Some(program_id.to_bytes().to_vec()),
+            output_deserialization_schema: vec![9],
+            respond_serialization_schema: vec![8],
+        });
 
         backlog
             .insert(create_indexed_request(

--- a/chain-signatures/node/src/indexer_canton/mod.rs
+++ b/chain-signatures/node/src/indexer_canton/mod.rs
@@ -86,15 +86,6 @@ impl CantonSignBidirectionalRequestedEvent {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct CantonRespondBidirectionalEvent {
-    pub request_id: [u8; 32],
-    pub responder: String,
-    pub serialized_output: Vec<u8>,
-    pub signature: Signature,
-}
-// NOTE: No Hash derive — Signature contains k256 types that don't impl Hash
-
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct CantonSignatureRespondedEvent {
     pub request_id: [u8; 32],

--- a/chain-signatures/node/src/indexer_canton/mod.rs
+++ b/chain-signatures/node/src/indexer_canton/mod.rs
@@ -12,7 +12,7 @@ pub use stream::{parse_canton_signature, CantonStream};
 
 use crate::protocol::Chain;
 use crate::sign_bidirectional::hash_rlp_data;
-use crate::stream::ops::{SignBidirectionalEvent, SignatureEvent};
+use crate::stream::ops::SignBidirectionalEvent;
 use alloy::consensus::{SignableTransaction, TxEip1559};
 use borsh::{BorshDeserialize, BorshSerialize};
 use k256::Scalar;
@@ -86,12 +86,12 @@ impl CantonSignBidirectionalRequestedEvent {
     }
 }
 
-impl SignatureEvent for CantonSignBidirectionalRequestedEvent {
-    fn generate_request_id(&self) -> [u8; 32] {
+impl CantonSignBidirectionalRequestedEvent {
+    pub fn generate_request_id(&self) -> [u8; 32] {
         self.request_id
     }
 
-    fn generate_sign_request(
+    pub fn generate_sign_request(
         &self,
         entropy: [u8; 32],
     ) -> anyhow::Result<crate::protocol::IndexedSignRequest> {
@@ -154,11 +154,11 @@ impl SignatureEvent for CantonSignBidirectionalRequestedEvent {
         ))
     }
 
-    fn source_chain(&self) -> Chain {
+    pub fn source_chain(&self) -> Chain {
         Chain::Canton
     }
 
-    fn sender_string(&self) -> String {
+    pub fn sender_string(&self) -> String {
         hex::encode(self.sender)
     }
 }

--- a/chain-signatures/node/src/indexer_canton/mod.rs
+++ b/chain-signatures/node/src/indexer_canton/mod.rs
@@ -16,7 +16,7 @@ use crate::stream::ops::{SignBidirectionalEvent, SignatureEvent};
 use alloy::consensus::{SignableTransaction, TxEip1559};
 use borsh::{BorshDeserialize, BorshSerialize};
 use k256::Scalar;
-use mpc_primitives::{ScalarExt, SignArgs, SignId, Signature, LATEST_MPC_KEY_VERSION};
+use mpc_primitives::{ScalarExt, SignArgs, SignId, LATEST_MPC_KEY_VERSION};
 use std::fmt;
 
 use contracts::TxParams as CantonTxParams;
@@ -85,14 +85,6 @@ impl CantonSignBidirectionalRequestedEvent {
         })
     }
 }
-
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub struct CantonSignatureRespondedEvent {
-    pub request_id: [u8; 32],
-    pub responder: String,
-    pub signature: Signature,
-}
-// NOTE: No Hash, PartialEq, Eq derives — matches HydrationSignatureRespondedEvent
 
 impl SignatureEvent for CantonSignBidirectionalRequestedEvent {
     fn generate_request_id(&self) -> [u8; 32] {

--- a/chain-signatures/node/src/indexer_canton/mod.rs
+++ b/chain-signatures/node/src/indexer_canton/mod.rs
@@ -136,6 +136,12 @@ impl SignatureEvent for CantonSignBidirectionalRequestedEvent {
         let sign_id = SignId::new(request_id);
         tracing::info!(?sign_id, "canton signature requested");
 
+        let ctx = CantonChainCtx {
+            sign_event_contract_id: self.sign_event_contract_id.clone(),
+        };
+        let chain_ctx =
+            Some(borsh::to_vec(&ctx).expect("CantonChainCtx Borsh serialization is infallible"));
+
         Ok(crate::protocol::IndexedSignRequest::sign_bidirectional(
             sign_id,
             SignArgs {
@@ -147,7 +153,21 @@ impl SignatureEvent for CantonSignBidirectionalRequestedEvent {
             },
             Chain::Canton,
             crate::util::current_unix_timestamp(),
-            SignBidirectionalEvent::Canton(self.clone()),
+            SignBidirectionalEvent {
+                sender: self.sender,
+                serialized_transaction: self.serialized_transaction.clone(),
+                caip2_id: self.caip2_id.clone(),
+                key_version: self.key_version,
+                deposit: 0,
+                path: self.path.clone(),
+                algo: self.algo.clone(),
+                dest: self.dest.clone(),
+                params: self.params.clone(),
+                output_deserialization_schema: self.output_deserialization_schema.clone(),
+                respond_serialization_schema: self.respond_serialization_schema.clone(),
+                chain: Chain::Canton,
+                chain_ctx,
+            },
         ))
     }
 

--- a/chain-signatures/node/src/indexer_canton/mod.rs
+++ b/chain-signatures/node/src/indexer_canton/mod.rs
@@ -110,7 +110,7 @@ impl CantonSignBidirectionalRequestedEvent {
             &self.path,
         );
 
-        let unsigned_tx_hash = hash_rlp_data(self.serialized_transaction.clone());
+        let unsigned_tx_hash = hash_rlp_data(&self.serialized_transaction);
 
         let Some(payload) = Scalar::from_bytes(unsigned_tx_hash) else {
             anyhow::bail!("failed to convert unsigned_tx_hash to scalar: {unsigned_tx_hash:?}");

--- a/chain-signatures/node/src/indexer_canton/stream.rs
+++ b/chain-signatures/node/src/indexer_canton/stream.rs
@@ -20,8 +20,8 @@ use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use super::{
-    contracts, ledger_api, CantonConfig, CantonRespondBidirectionalEvent,
-    CantonSignBidirectionalRequestedEvent, CantonSignatureRespondedEvent,
+    contracts, ledger_api, CantonConfig, CantonSignBidirectionalRequestedEvent,
+    CantonSignatureRespondedEvent,
 };
 
 type CantonWs = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
@@ -422,7 +422,11 @@ async fn process_canton_event(
     ) {
         match parse_signature_responded_event(created) {
             Ok(responded) => {
-                let event = SignatureRespondedEvent::Canton(responded);
+                let event = SignatureRespondedEvent {
+                    request_id: responded.request_id,
+                    signature: responded.signature,
+                    chain: Chain::Canton,
+                };
                 if events_tx.send(ChainEvent::Respond(event)).await.is_err() {
                     tracing::error!("canton event channel closed");
                 }
@@ -435,15 +439,25 @@ async fn process_canton_event(
         template_id,
         ledger_api::templates::RESPOND_BIDIRECTIONAL_EVENT,
     ) {
-        match parse_respond_bidirectional_event(created) {
-            Ok(respond) => {
-                let event = RespondBidirectionalEvent::Canton(respond);
-                if events_tx
-                    .send(ChainEvent::RespondBidirectional(event))
-                    .await
-                    .is_err()
-                {
-                    tracing::error!("canton event channel closed");
+        match serde_json::from_value::<contracts::RespondBidirectionalEventPayload>(
+            created.payload.clone(),
+        ) {
+            Ok(payload) => {
+                let mut request_id = [0u8; 32];
+                if let Err(e) = hex::decode_to_slice(&payload.request_id, &mut request_id) {
+                    tracing::warn!("invalid request_id hex: {e}");
+                } else {
+                    let event = RespondBidirectionalEvent {
+                        request_id,
+                        chain: crate::protocol::Chain::Canton,
+                    };
+                    if events_tx
+                        .send(ChainEvent::RespondBidirectional(event))
+                        .await
+                        .is_err()
+                    {
+                        tracing::error!("canton event channel closed");
+                    }
                 }
             }
             Err(e) => {
@@ -520,26 +534,6 @@ fn parse_signature_responded_event(
     Ok(CantonSignatureRespondedEvent {
         request_id,
         responder: payload.responder,
-        signature: parse_canton_signature(&payload.signature)?,
-    })
-}
-
-fn parse_respond_bidirectional_event(
-    created: &ledger_api::CreatedEvent,
-) -> anyhow::Result<CantonRespondBidirectionalEvent> {
-    let payload: contracts::RespondBidirectionalEventPayload =
-        serde_json::from_value(created.payload.clone())?;
-    let mut request_id = [0u8; 32];
-    hex::decode_to_slice(&payload.request_id, &mut request_id)
-        .map_err(|e| anyhow::anyhow!("invalid request_id hex: {e}"))?;
-
-    let serialized_output = hex::decode(&payload.serialized_output)
-        .map_err(|e| anyhow::anyhow!("invalid serializedOutput hex: {e}"))?;
-
-    Ok(CantonRespondBidirectionalEvent {
-        request_id,
-        responder: payload.responder,
-        serialized_output,
         signature: parse_canton_signature(&payload.signature)?,
     })
 }
@@ -755,11 +749,16 @@ mod tests {
             package_name: None,
         };
 
-        let event = parse_respond_bidirectional_event(&created).expect("payload should parse");
-        assert_eq!(event.request_id, [5u8; 32]);
-        assert_eq!(event.responder, "alice");
-        assert_eq!(event.serialized_output, vec![8u8, 9u8]);
-        assert_eq!(event.signature.recovery_id, 0);
+        let payload: contracts::RespondBidirectionalEventPayload =
+            serde_json::from_value(created.payload.clone()).expect("payload should parse");
+        let mut request_id = [0u8; 32];
+        hex::decode_to_slice(&payload.request_id, &mut request_id).unwrap();
+        assert_eq!(request_id, [5u8; 32]);
+        assert_eq!(payload.responder, "alice");
+        assert_eq!(
+            hex::decode(&payload.serialized_output).unwrap(),
+            vec![8u8, 9u8]
+        );
     }
 
     #[tokio::test]
@@ -789,7 +788,8 @@ mod tests {
         .await;
 
         match events_rx.recv().await {
-            Some(ChainEvent::Respond(SignatureRespondedEvent::Canton(event))) => {
+            Some(ChainEvent::Respond(event)) => {
+                assert_eq!(event.chain, Chain::Canton);
                 assert_eq!(event.request_id, [6u8; 32]);
             }
             other => panic!("expected Canton respond event, got {other:?}"),

--- a/chain-signatures/node/src/indexer_canton/stream.rs
+++ b/chain-signatures/node/src/indexer_canton/stream.rs
@@ -1,7 +1,7 @@
 use crate::backlog::Backlog;
 use crate::protocol::Chain;
 use crate::rpc::CantonClient;
-use crate::stream::ops::{RespondBidirectionalEvent, SignatureEvent, SignatureRespondedEvent};
+use crate::stream::ops::{RespondBidirectionalEvent, SignatureRespondedEvent};
 use crate::stream::{ChainEvent, ChainIndexer, ChainStream};
 
 use alloy::primitives::keccak256;

--- a/chain-signatures/node/src/indexer_canton/stream.rs
+++ b/chain-signatures/node/src/indexer_canton/stream.rs
@@ -19,10 +19,7 @@ use tokio_tungstenite::tungstenite::http::header;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
-use super::{
-    contracts, ledger_api, CantonConfig, CantonSignBidirectionalRequestedEvent,
-    CantonSignatureRespondedEvent,
-};
+use super::{contracts, ledger_api, CantonConfig, CantonSignBidirectionalRequestedEvent};
 
 type CantonWs = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
 type CantonWsRead = SplitStream<CantonWs>;
@@ -421,12 +418,7 @@ async fn process_canton_event(
         ledger_api::templates::SIGNATURE_RESPONDED_EVENT,
     ) {
         match parse_signature_responded_event(created) {
-            Ok(responded) => {
-                let event = SignatureRespondedEvent {
-                    request_id: responded.request_id,
-                    signature: responded.signature,
-                    chain: Chain::Canton,
-                };
+            Ok(event) => {
                 if events_tx.send(ChainEvent::Respond(event)).await.is_err() {
                     tracing::error!("canton event channel closed");
                 }
@@ -524,17 +516,17 @@ fn verify_sign_event(
 
 fn parse_signature_responded_event(
     created: &ledger_api::CreatedEvent,
-) -> anyhow::Result<CantonSignatureRespondedEvent> {
+) -> anyhow::Result<SignatureRespondedEvent> {
     let payload: contracts::SignatureRespondedEventPayload =
         serde_json::from_value(created.payload.clone())?;
     let mut request_id = [0u8; 32];
     hex::decode_to_slice(&payload.request_id, &mut request_id)
         .map_err(|e| anyhow::anyhow!("invalid request_id hex: {e}"))?;
 
-    Ok(CantonSignatureRespondedEvent {
+    Ok(SignatureRespondedEvent {
         request_id,
-        responder: payload.responder,
         signature: parse_canton_signature(&payload.signature)?,
+        chain: Chain::Canton,
     })
 }
 

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -8,7 +8,7 @@ use crate::indexer_eth::abi::{ChainSignatures, SignatureRequestedEncoding};
 use crate::metrics::requests::{record_request_latency_since, SignRequestStep};
 use crate::protocol::{Chain, IndexedSignRequest};
 use crate::respond_bidirectional::CompletedTx;
-use crate::stream::ops::{EthereumSignatureRespondedEvent, SignatureRespondedEvent};
+use crate::stream::ops::SignatureRespondedEvent;
 use crate::stream::{AsyncCatchupIter, ChainEvent, ChainIndexer, ChainStream, ExecutionOutcome};
 use crate::util::retry;
 
@@ -489,8 +489,6 @@ async fn emit_respond_events(logs: &[Log], events_tx: mpsc::Sender<ChainEvent>) 
             continue;
         }
 
-        // responder: offset 0..32 (address right-padded)
-        let responder_addr = Address::from_slice(&data[12..32]);
         // signature struct encoding layout:
         // bigR.x at 32..64, bigR.y at 64..96, s at 96..128, recoveryId at 159
         let big_r_x = &data[32..64];
@@ -513,13 +511,11 @@ async fn emit_respond_events(logs: &[Log], events_tx: mpsc::Sender<ChainEvent>) 
 
         let signature = MpcSignature::new(big_r, s, recovery_id);
 
-        let eth_event = EthereumSignatureRespondedEvent {
+        let respond_event = SignatureRespondedEvent {
             request_id: sign_id.request_id,
-            responder: responder_addr,
             signature,
+            chain: Chain::Ethereum,
         };
-
-        let respond_event = SignatureRespondedEvent::Ethereum(eth_event);
         tracing::info!(?sign_id, "emitting SignatureResponded event");
         if let Err(err) = events_tx.send(ChainEvent::Respond(respond_event)).await {
             tracing::error!(?err, "failed to emit Respond event");

--- a/chain-signatures/node/src/indexer_hydration.rs
+++ b/chain-signatures/node/src/indexer_hydration.rs
@@ -316,14 +316,6 @@ impl SignatureEvent for HydrationSignBidirectionalRequestedEvent {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct HydrationRespondBidirectionalEvent {
-    pub request_id: [u8; 32],
-    pub responder: [u8; 32],
-    pub serialized_output: Vec<u8>,
-    pub signature: Signature,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HydrationSignatureRespondedEvent {
     pub request_id: [u8; 32],
     pub responder: [u8; 32],
@@ -542,8 +534,13 @@ pub async fn run(
                     "Hydration::Signet::SignatureResponded in block #{number} ({hash:?}): {:?}",
                     event
                 );
+                let respond_event = crate::stream::ops::SignatureRespondedEvent {
+                    request_id: event.request_id,
+                    signature: event.signature,
+                    chain: Chain::Hydration,
+                };
                 if let Err(e) = crate::stream::ops::process_respond_event(
-                    crate::stream::ops::SignatureRespondedEvent::Hydration(event),
+                    respond_event,
                     sign_tx.clone(),
                     &mut contract_watcher,
                     &backlog,
@@ -589,19 +586,28 @@ pub async fn run(
             // Bidirectional response
             if ev.pallet_name() == PALLET_SIGNET && ev.variant_name() == EVENT_RESPOND_BIDIRECTIONAL
             {
-                let event = match decode_respond_bidirectional(&ev) {
-                    Ok(event) => event,
+                let fields = match ev.field_values() {
+                    Ok(f) => f,
                     Err(e) => {
-                        tracing::error!("failed to decode respond bidirectional event: {e}");
+                        tracing::error!("failed to get fields for respond bidirectional: {e}");
+                        continue;
+                    }
+                };
+                let request_id = match get_named_bytes32(&fields, "request_id") {
+                    Ok(id) => id,
+                    Err(e) => {
+                        tracing::error!("failed to get request_id: {e}");
                         continue;
                     }
                 };
                 tracing::info!(
-                    "Hydration::Signet::RespondBidirectionalEvent in block #{number} ({hash:?}): {:?}",
-                    event
+                    "Hydration::Signet::RespondBidirectionalEvent in block #{number} ({hash:?})"
                 );
                 if let Err(e) = crate::stream::ops::process_respond_bidirectional_event(
-                    crate::stream::ops::RespondBidirectionalEvent::Hydration(event),
+                    crate::stream::ops::RespondBidirectionalEvent {
+                        request_id,
+                        chain: crate::protocol::Chain::Hydration,
+                    },
                     sign_tx.clone(),
                     &backlog,
                     true,
@@ -718,26 +724,6 @@ fn decode_sign_bidirectional_requested(
         params,
         output_deserialization_schema,
         respond_serialization_schema,
-    })
-}
-
-fn decode_respond_bidirectional(
-    ev: &EventDetails<SubstrateConfig>,
-) -> anyhow::Result<HydrationRespondBidirectionalEvent> {
-    let fields = ev.field_values()?;
-
-    let request_id = get_named_bytes32(&fields, "request_id")?;
-    let responder = get_named_bytes32(&fields, "responder")?;
-    let serialized_output = get_named_vec_u8(&fields, "serialized_output")?;
-
-    let sig_val = get_named(&fields, "signature")?;
-    let mpc_sig = parse_signature(sig_val)?;
-
-    Ok(HydrationRespondBidirectionalEvent {
-        request_id,
-        responder,
-        serialized_output,
-        signature: mpc_sig,
     })
 }
 

--- a/chain-signatures/node/src/indexer_hydration.rs
+++ b/chain-signatures/node/src/indexer_hydration.rs
@@ -105,9 +105,8 @@ pub struct HydrationSignatureRequestedEvent {
 
 impl HydrationSignatureRequestedEvent {
     fn generate_request_id(&self) -> [u8; 32] {
-        let sender = self.sender_string();
         ethabi_request_id(
-            &sender,
+            &self.sender_string(),
             self.payload,
             &self.path,
             self.key_version,
@@ -118,29 +117,29 @@ impl HydrationSignatureRequestedEvent {
         )
     }
 
-    fn generate_sign_request(&self, entropy: [u8; 32]) -> anyhow::Result<IndexedSignRequest> {
+    fn generate_sign_request(&self, entropy: [u8; 32]) -> Option<IndexedSignRequest> {
         tracing::info!("found hydration event: {:?}", self);
         if self.deposit == 0 {
             tracing::warn!("deposit is 0, skipping sign request");
-            anyhow::bail!("deposit is 0");
+            return None;
         }
 
         if self.key_version > LATEST_MPC_KEY_VERSION {
             tracing::warn!("unsupported key version: {}", self.key_version);
-            anyhow::bail!("unsupported key version");
+            return None;
         }
 
-        let Some(payload) = Scalar::from_bytes(self.payload) else {
+        let payload = Scalar::from_bytes(self.payload).or_else(|| {
             tracing::warn!(
                 "hydration `sign` did not produce payload hash correctly: {:?}",
                 self.payload,
             );
-            anyhow::bail!("failed to convert event payload hash to scalar");
-        };
+            None
+        })?;
 
         if payload > *MAX_SECP256K1_SCALAR {
             tracing::warn!("payload exceeds secp256k1 curve order: {payload:?}");
-            anyhow::bail!("payload exceeds secp256k1 curve order");
+            return None;
         }
 
         let epsilon = mpc_crypto::kdf::derive_epsilon_hydration(
@@ -152,7 +151,7 @@ impl HydrationSignatureRequestedEvent {
         let sign_id = SignId::new(self.generate_request_id());
         tracing::info!(?sign_id, "hydration signature requested");
 
-        Ok(IndexedSignRequest::sign(
+        Some(IndexedSignRequest::sign(
             sign_id,
             SignArgs {
                 entropy,
@@ -243,20 +242,19 @@ impl HydrationSignBidirectionalRequestedEvent {
         alloy::primitives::keccak256(encoded).into()
     }
 
-    pub fn generate_sign_request(&self, entropy: [u8; 32]) -> anyhow::Result<IndexedSignRequest> {
+    pub fn generate_sign_request(&self, entropy: [u8; 32]) -> Option<IndexedSignRequest> {
         tracing::info!("found hydration event: {:?}", self);
         if self.deposit == 0 {
             tracing::warn!("deposit is 0, skipping sign request");
-            anyhow::bail!("deposit is 0");
+            return None;
         }
 
         if self.key_version > LATEST_MPC_KEY_VERSION {
             tracing::warn!("unsupported key version: {}", self.key_version);
-            anyhow::bail!("unsupported key version");
+            return None;
         }
 
         let request_id = self.generate_request_id();
-        let rlp_encoded_tx = self.serialized_transaction.clone();
 
         // Call the existing derive_epsilon_sol function with the correct parameters
         // to match the TypeScript implementation
@@ -268,17 +266,18 @@ impl HydrationSignBidirectionalRequestedEvent {
 
         let sign_id = SignId::new(request_id);
         tracing::info!(?sign_id, "hydration signature requested");
-        let unsigned_tx_hash = hash_rlp_data(rlp_encoded_tx);
-        let Some(payload) = Scalar::from_bytes(unsigned_tx_hash) else {
-            anyhow::bail!("Failed to convert unsigned_tx_hash to scalar: {unsigned_tx_hash:?}");
-        };
+        let unsigned_tx_hash = hash_rlp_data(&self.serialized_transaction);
+        let payload = Scalar::from_bytes(unsigned_tx_hash).or_else(|| {
+            tracing::warn!("failed to convert unsigned_tx_hash to scalar: {unsigned_tx_hash:?}");
+            None
+        })?;
 
         if payload > *MAX_SECP256K1_SCALAR {
             tracing::warn!("payload exceeds secp256k1 curve order: {payload:?}");
-            anyhow::bail!("payload exceeds secp256k1 curve order");
+            return None;
         }
 
-        Ok(IndexedSignRequest::sign_bidirectional(
+        Some(IndexedSignRequest::sign_bidirectional(
             sign_id,
             SignArgs {
                 entropy,
@@ -506,12 +505,8 @@ pub async fn run(
 
                 let entropy = sp_core::hashing::blake2_256(ev.bytes());
 
-                let sign_request = match event.generate_sign_request(entropy) {
-                    Ok(req) => req,
-                    Err(e) => {
-                        tracing::error!("failed to generate sign request: {e}");
-                        continue;
-                    }
+                let Some(sign_request) = event.generate_sign_request(entropy) else {
+                    continue;
                 };
 
                 if let Err(e) = crate::stream::ops::process_sign_request(
@@ -568,12 +563,8 @@ pub async fn run(
 
                 let entropy = sp_core::hashing::blake2_256(ev.bytes());
 
-                let sign_request = match event.generate_sign_request(entropy) {
-                    Ok(req) => req,
-                    Err(e) => {
-                        tracing::error!("failed to generate sign request: {e}");
-                        continue;
-                    }
+                let Some(sign_request) = event.generate_sign_request(entropy) else {
+                    continue;
                 };
 
                 if let Err(e) = crate::stream::ops::process_sign_request(

--- a/chain-signatures/node/src/indexer_hydration.rs
+++ b/chain-signatures/node/src/indexer_hydration.rs
@@ -288,7 +288,21 @@ impl SignatureEvent for HydrationSignBidirectionalRequestedEvent {
             },
             Chain::Hydration,
             crate::util::current_unix_timestamp(),
-            crate::stream::ops::SignBidirectionalEvent::Hydration(self.clone()),
+            crate::stream::ops::SignBidirectionalEvent {
+                sender: self.sender,
+                serialized_transaction: self.serialized_transaction.clone(),
+                caip2_id: self.caip2_id.clone(),
+                key_version: self.key_version,
+                deposit: self.deposit,
+                path: self.path.clone(),
+                algo: self.algo.clone(),
+                dest: self.dest.clone(),
+                params: self.params.clone(),
+                output_deserialization_schema: self.output_deserialization_schema.clone(),
+                respond_serialization_schema: self.respond_serialization_schema.clone(),
+                chain: Chain::Hydration,
+                chain_ctx: None,
+            },
         ))
     }
 

--- a/chain-signatures/node/src/indexer_hydration.rs
+++ b/chain-signatures/node/src/indexer_hydration.rs
@@ -105,15 +105,16 @@ pub struct HydrationSignatureRequestedEvent {
 
 impl HydrationSignatureRequestedEvent {
     fn generate_request_id(&self) -> [u8; 32] {
+        let sender = self.sender_string();
         ethabi_request_id(
-            self.sender_string(),
+            &sender,
             self.payload,
-            self.path.clone(),
+            &self.path,
             self.key_version,
-            self.chain_id.clone(),
-            self.algo.clone(),
-            self.dest.clone(),
-            self.params.clone(),
+            &self.chain_id,
+            &self.algo,
+            &self.dest,
+            &self.params,
         )
     }
 

--- a/chain-signatures/node/src/indexer_hydration.rs
+++ b/chain-signatures/node/src/indexer_hydration.rs
@@ -4,7 +4,7 @@ use crate::node_client::NodeClient;
 use crate::protocol::{Chain, IndexedSignRequest, Sign};
 use crate::rpc::ContractStateWatcher;
 use crate::sign_bidirectional::hash_rlp_data;
-use crate::stream::ops::SignatureEvent;
+
 use crate::util::ethabi_request_id;
 use alloy_sol_types::SolValue;
 use anyhow::{anyhow, Result};
@@ -103,7 +103,7 @@ pub struct HydrationSignatureRequestedEvent {
     pub params: String,
 }
 
-impl SignatureEvent for HydrationSignatureRequestedEvent {
+impl HydrationSignatureRequestedEvent {
     fn generate_request_id(&self) -> [u8; 32] {
         ethabi_request_id(
             self.sender_string(),
@@ -165,11 +165,11 @@ impl SignatureEvent for HydrationSignatureRequestedEvent {
         ))
     }
 
-    fn source_chain(&self) -> Chain {
+    pub fn source_chain(&self) -> Chain {
         Chain::Hydration
     }
 
-    fn sender_string(&self) -> String {
+    pub fn sender_string(&self) -> String {
         ss58_address_from_account32(self.sender)
     }
 }
@@ -224,7 +224,7 @@ pub struct HydrationSignBidirectionalRequestedEvent {
     pub respond_serialization_schema: Vec<u8>,
 }
 
-impl SignatureEvent for HydrationSignBidirectionalRequestedEvent {
+impl HydrationSignBidirectionalRequestedEvent {
     fn generate_request_id(&self) -> [u8; 32] {
         // Match TypeScript implementation using ABI encoding
         let encoded = (
@@ -242,7 +242,7 @@ impl SignatureEvent for HydrationSignBidirectionalRequestedEvent {
         alloy::primitives::keccak256(encoded).into()
     }
 
-    fn generate_sign_request(&self, entropy: [u8; 32]) -> anyhow::Result<IndexedSignRequest> {
+    pub fn generate_sign_request(&self, entropy: [u8; 32]) -> anyhow::Result<IndexedSignRequest> {
         tracing::info!("found hydration event: {:?}", self);
         if self.deposit == 0 {
             tracing::warn!("deposit is 0, skipping sign request");
@@ -306,11 +306,11 @@ impl SignatureEvent for HydrationSignBidirectionalRequestedEvent {
         ))
     }
 
-    fn source_chain(&self) -> Chain {
+    pub fn source_chain(&self) -> Chain {
         Chain::Hydration
     }
 
-    fn sender_string(&self) -> String {
+    pub fn sender_string(&self) -> String {
         ss58_address_from_account32(self.sender)
     }
 }
@@ -505,9 +505,16 @@ pub async fn run(
 
                 let entropy = sp_core::hashing::blake2_256(ev.bytes());
 
-                if let Err(e) = crate::stream::ops::process_sign_event(
-                    Box::new(event),
-                    entropy,
+                let sign_request = match event.generate_sign_request(entropy) {
+                    Ok(req) => req,
+                    Err(e) => {
+                        tracing::error!("failed to generate sign request: {e}");
+                        continue;
+                    }
+                };
+
+                if let Err(e) = crate::stream::ops::process_sign_request(
+                    sign_request,
                     sign_tx.clone(),
                     backlog.clone(),
                     true,
@@ -560,9 +567,16 @@ pub async fn run(
 
                 let entropy = sp_core::hashing::blake2_256(ev.bytes());
 
-                if let Err(e) = crate::stream::ops::process_sign_event(
-                    Box::new(event),
-                    entropy,
+                let sign_request = match event.generate_sign_request(entropy) {
+                    Ok(req) => req,
+                    Err(e) => {
+                        tracing::error!("failed to generate sign request: {e}");
+                        continue;
+                    }
+                };
+
+                if let Err(e) = crate::stream::ops::process_sign_request(
+                    sign_request,
                     sign_tx.clone(),
                     backlog.clone(),
                     true,

--- a/chain-signatures/node/src/indexer_hydration.rs
+++ b/chain-signatures/node/src/indexer_hydration.rs
@@ -315,13 +315,6 @@ impl SignatureEvent for HydrationSignBidirectionalRequestedEvent {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct HydrationSignatureRespondedEvent {
-    pub request_id: [u8; 32],
-    pub responder: [u8; 32],
-    pub signature: Signature,
-}
-
 /// Storage key for `frame_system::Events`.
 fn system_events_key() -> Vec<u8> {
     let mut key = Vec::with_capacity(32);
@@ -531,16 +524,10 @@ pub async fn run(
                     }
                 };
                 tracing::info!(
-                    "Hydration::Signet::SignatureResponded in block #{number} ({hash:?}): {:?}",
-                    event
+                    "Hydration::Signet::SignatureResponded in block #{number} ({hash:?})"
                 );
-                let respond_event = crate::stream::ops::SignatureRespondedEvent {
-                    request_id: event.request_id,
-                    signature: event.signature,
-                    chain: Chain::Hydration,
-                };
                 if let Err(e) = crate::stream::ops::process_respond_event(
-                    respond_event,
+                    event,
                     sign_tx.clone(),
                     &mut contract_watcher,
                     &backlog,
@@ -672,20 +659,19 @@ fn decode_signature_requested(
 
 fn decode_signature_responded(
     ev: &EventDetails<SubstrateConfig>,
-) -> anyhow::Result<HydrationSignatureRespondedEvent> {
+) -> anyhow::Result<crate::stream::ops::SignatureRespondedEvent> {
     let fields = ev.field_values()?;
 
     let request_id = get_named_bytes32(&fields, "request_id")?;
-    let responder = get_named_bytes32(&fields, "responder")?; // Hydration 一般是 AccountId32
 
     // signature: pallet 的 Signature 结构（嵌套）
     let sig_value = get_named(&fields, "signature")?;
     let mpc_sig = parse_signature(sig_value)?;
 
-    Ok(HydrationSignatureRespondedEvent {
+    Ok(crate::stream::ops::SignatureRespondedEvent {
         request_id,
-        responder,
         signature: mpc_sig,
+        chain: Chain::Hydration,
     })
 }
 

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -37,7 +37,8 @@ use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey, signature:
 use solana_transaction_status::option_serializer::OptionSerializer;
 use solana_transaction_status::{
     EncodedConfirmedTransactionWithStatusMeta, EncodedTransaction,
-    EncodedTransactionWithStatusMeta, TransactionDetails, UiConfirmedBlock, UiTransactionEncoding,
+    EncodedTransactionWithStatusMeta, TransactionDetails, UiConfirmedBlock, UiInstruction,
+    UiParsedInstruction, UiTransactionEncoding,
 };
 use tokio::sync::{mpsc, oneshot};
 
@@ -143,10 +144,6 @@ pub struct SolSignRequest {
     pub path: String,
     pub key_version: u32,
 }
-
-// SolanaSignatureEvent trait removed
-
-type Result<T> = anyhow::Result<T>;
 
 const MAX_SIGNATURES_FOR_FAST_CATCHUP: usize = 1000;
 
@@ -488,18 +485,16 @@ pub enum SolanaSignEvent {
 impl SolanaSignEvent {
     pub fn generate_request_id(&self) -> [u8; 32] {
         match self {
-            SolanaSignEvent::SignatureRequested(ev) => {
-                ethabi_request_id(
-                    ev.sender.to_string(),
-                    ev.payload,
-                    ev.path.clone(),
-                    ev.key_version,
-                    ev.chain_id.clone(),
-                    ev.algo.clone(),
-                    ev.dest.clone(),
-                    ev.params.clone(),
-                )
-            }
+            SolanaSignEvent::SignatureRequested(ev) => ethabi_request_id(
+                &ev.sender.to_string(),
+                ev.payload,
+                &ev.path,
+                ev.key_version,
+                &ev.chain_id,
+                &ev.algo,
+                &ev.dest,
+                &ev.params,
+            ),
             SolanaSignEvent::SignBidirectional(ev) => {
                 let encoded = (
                     ev.sender.to_string(),
@@ -583,9 +578,7 @@ impl SolanaSignEvent {
                 let sign_id = SignId::new(request_id);
                 tracing::info!(?sign_id, "solana signature requested");
                 let unsigned_tx_hash = hash_rlp_data(rlp_encoded_tx);
-                let payload = Scalar::from_bytes(unsigned_tx_hash).or_else(|| {
-                    None
-                })?;
+                let payload = Scalar::from_bytes(unsigned_tx_hash).or_else(|| None)?;
 
                 if payload > *MAX_SECP256K1_SCALAR {
                     tracing::warn!("payload exceeds secp256k1 curve order: {payload:?}");
@@ -624,10 +617,7 @@ impl SolanaSignEvent {
     }
 }
 
-fn build_sign_request(
-    sign_event: SolanaSignEvent,
-    tx_sig: Vec<u8>,
-) -> Option<IndexedSignRequest> {
+fn build_sign_request(sign_event: SolanaSignEvent, tx_sig: Vec<u8>) -> Option<IndexedSignRequest> {
     let mut entropy = [0u8; 32];
     entropy.copy_from_slice(&tx_sig[..32]);
     sign_event.generate_sign_request(entropy)
@@ -668,9 +658,7 @@ async fn subscribe_and_buffer_live_events(
 fn parse_cpi_events(
     tx: &EncodedTransactionWithStatusMeta,
     target_program_id: &Pubkey,
-) -> Result<Vec<SolanaSignEvent>> {
-    use solana_transaction_status::{UiInstruction, UiParsedInstruction};
-
+) -> anyhow::Result<Vec<SolanaSignEvent>> {
     let Some(meta) = &tx.meta else {
         return Ok(Vec::new());
     };
@@ -679,7 +667,7 @@ fn parse_cpi_events(
     let mut out = Vec::<SolanaSignEvent>::new();
 
     // Small helper closure to try decoding both event types from raw data
-    let try_parse_events = |data: &str| -> Result<Vec<SolanaSignEvent>> {
+    let try_parse_events = |data: &str| -> anyhow::Result<Vec<SolanaSignEvent>> {
         let Ok(ix_data) = solana_sdk::bs58::decode(data).into_vec() else {
             tracing::warn!("Failed to decode instruction data for target program");
             return Ok(Vec::new());
@@ -764,7 +752,7 @@ async fn subscribe_to_program_events(
     ws_url: &str,
     events_tx: mpsc::Sender<ChainEvent>,
     anchor_tx: &mut Option<oneshot::Sender<u64>>,
-) -> Result<()> {
+) -> anyhow::Result<()> {
     let pubsub_client = PubsubClient::new(ws_url).await?;
 
     let filter = RpcTransactionLogsFilter::Mentions(vec![program_id.to_string()]);
@@ -885,7 +873,7 @@ fn has_log_starts_with(logs: &[String], start_with: &str) -> bool {
 fn parse_cpi_respond_events(
     tx: &EncodedTransactionWithStatusMeta,
     target_program_id: &Pubkey,
-) -> Result<(Vec<RespondBidirectionalEvent>, Vec<SignatureRespondedEvent>)> {
+) -> anyhow::Result<(Vec<RespondBidirectionalEvent>, Vec<SignatureRespondedEvent>)> {
     use solana_transaction_status::{UiInstruction, UiParsedInstruction};
 
     let Some(meta) = &tx.meta else {
@@ -897,46 +885,48 @@ fn parse_cpi_respond_events(
     let mut signature_responded_events = Vec::<SignatureRespondedEvent>::new();
 
     // Helper closure to try decoding RespondBidirectionalEvent and SignatureRespondedEvent from raw data
-    let try_parse_respond_event =
-        |data: &str| -> Result<(Vec<RespondBidirectionalEvent>, Vec<SignatureRespondedEvent>)> {
-            let Ok(ix_data) = solana_sdk::bs58::decode(data).into_vec() else {
-                tracing::warn!("Failed to decode instruction data for target program");
-                return Ok((Vec::new(), Vec::new()));
-            };
-
-            // Ensure this is an Anchor event instruction
-            if !ix_data.starts_with(anchor_lang::event::EVENT_IX_TAG_LE) {
-                return Ok((Vec::new(), Vec::new()));
-            }
-
-            let event_discriminator = &ix_data[8..16];
-            let event_data = &ix_data[16..];
-
-            let mut respond_bdx = Vec::new();
-            let mut sig_resp = Vec::new();
-
-            // Handle RespondBidirectionalEvent
-            if event_discriminator == RespondBidirectionalEvent::DISCRIMINATOR {
-                match RespondBidirectionalEvent::deserialize(&mut &event_data[..]) {
-                    Ok(ev) => respond_bdx.push(ev),
-                    Err(e) => {
-                        tracing::warn!("Failed to deserialize RespondBidirectionalEvent: {e}")
-                    }
-                }
-            }
-
-            // Handle SignatureRespondedEvent
-            if event_discriminator == SignatureRespondedEvent::DISCRIMINATOR {
-                match SignatureRespondedEvent::deserialize(&mut &event_data[..]) {
-                    Ok(ev) => sig_resp.push(ev),
-                    Err(e) => {
-                        tracing::warn!("Failed to deserialize SignatureRespondedEvent: {e}")
-                    }
-                }
-            }
-
-            Ok((respond_bdx, sig_resp))
+    let try_parse_respond_event = |data: &str| -> anyhow::Result<(
+        Vec<RespondBidirectionalEvent>,
+        Vec<SignatureRespondedEvent>,
+    )> {
+        let Ok(ix_data) = solana_sdk::bs58::decode(data).into_vec() else {
+            tracing::warn!("Failed to decode instruction data for target program");
+            return Ok((Vec::new(), Vec::new()));
         };
+
+        // Ensure this is an Anchor event instruction
+        if !ix_data.starts_with(anchor_lang::event::EVENT_IX_TAG_LE) {
+            return Ok((Vec::new(), Vec::new()));
+        }
+
+        let event_discriminator = &ix_data[8..16];
+        let event_data = &ix_data[16..];
+
+        let mut respond_bdx = Vec::new();
+        let mut sig_resp = Vec::new();
+
+        // Handle RespondBidirectionalEvent
+        if event_discriminator == RespondBidirectionalEvent::DISCRIMINATOR {
+            match RespondBidirectionalEvent::deserialize(&mut &event_data[..]) {
+                Ok(ev) => respond_bdx.push(ev),
+                Err(e) => {
+                    tracing::warn!("Failed to deserialize RespondBidirectionalEvent: {e}")
+                }
+            }
+        }
+
+        // Handle SignatureRespondedEvent
+        if event_discriminator == SignatureRespondedEvent::DISCRIMINATOR {
+            match SignatureRespondedEvent::deserialize(&mut &event_data[..]) {
+                Ok(ev) => sig_resp.push(ev),
+                Err(e) => {
+                    tracing::warn!("Failed to deserialize SignatureRespondedEvent: {e}")
+                }
+            }
+        }
+
+        Ok((respond_bdx, sig_resp))
+    };
 
     // Look into inner instructions for CPI calls
     let inner_ixs = match &meta.inner_instructions {
@@ -998,7 +988,7 @@ impl SolanaEvents {
         tx: &EncodedTransactionWithStatusMeta,
         target_program_id: &Pubkey,
         logs: &[String],
-    ) -> Result<Self> {
+    ) -> anyhow::Result<Self> {
         if looks_like_cpi_sign_event(logs) {
             Ok(SolanaEvents::Sign(parse_cpi_events(tx, target_program_id)?))
         } else if looks_like_respond_event(logs) {
@@ -1019,7 +1009,7 @@ async fn emit_events(
     signature: Signature,
     tx: &EncodedTransactionWithStatusMeta,
     logs: &[String],
-) -> Result<()> {
+) -> anyhow::Result<()> {
     match SolanaEvents::parse(tx, program_id, logs)? {
         SolanaEvents::Sign(events) => {
             for ev in events {

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -518,31 +518,31 @@ impl SolanaSignEvent {
         }
     }
 
-    pub fn generate_sign_request(&self, entropy: [u8; 32]) -> anyhow::Result<IndexedSignRequest> {
+    pub fn generate_sign_request(&self, entropy: [u8; 32]) -> Option<IndexedSignRequest> {
         match self {
             SolanaSignEvent::SignatureRequested(ev) => {
                 tracing::info!("found solana event: {:?}", ev);
                 if ev.deposit == 0 {
                     tracing::warn!("deposit is 0, skipping sign request");
-                    anyhow::bail!("deposit is 0");
+                    return None;
                 }
 
                 if ev.key_version > LATEST_MPC_KEY_VERSION {
                     tracing::warn!("unsupported key version: {}", ev.key_version);
-                    anyhow::bail!("unsupported key version");
+                    return None;
                 }
 
-                let Some(payload) = Scalar::from_bytes(ev.payload) else {
+                let payload = Scalar::from_bytes(ev.payload).or_else(|| {
                     tracing::warn!(
                         "solana `sign` did not produce payload hash correctly: {:?}",
                         ev.payload,
                     );
-                    anyhow::bail!("failed to convert event payload hash to scalar");
-                };
+                    None
+                })?;
 
                 if payload > *MAX_SECP256K1_SCALAR {
                     tracing::warn!("payload exceeds secp256k1 curve order: {payload:?}");
-                    anyhow::bail!("payload exceeds secp256k1 curve order");
+                    return None;
                 }
 
                 let epsilon = derive_epsilon_sol(ev.key_version, &ev.sender.to_string(), &ev.path);
@@ -550,7 +550,7 @@ impl SolanaSignEvent {
                 let sign_id = SignId::new(self.generate_request_id());
                 tracing::info!(?sign_id, "solana signature requested");
 
-                Ok(IndexedSignRequest::sign(
+                Some(IndexedSignRequest::sign(
                     sign_id,
                     SignArgs {
                         entropy,
@@ -567,12 +567,12 @@ impl SolanaSignEvent {
                 tracing::info!("found solana event: {:?}", ev);
                 if ev.deposit == 0 {
                     tracing::warn!("deposit is 0, skipping sign request");
-                    anyhow::bail!("deposit is 0");
+                    return None;
                 }
 
                 if ev.key_version > LATEST_MPC_KEY_VERSION {
                     tracing::warn!("unsupported key version: {}", ev.key_version);
-                    anyhow::bail!("unsupported key version");
+                    return None;
                 }
 
                 let request_id = self.generate_request_id();
@@ -583,16 +583,16 @@ impl SolanaSignEvent {
                 let sign_id = SignId::new(request_id);
                 tracing::info!(?sign_id, "solana signature requested");
                 let unsigned_tx_hash = hash_rlp_data(rlp_encoded_tx);
-                let Some(payload) = Scalar::from_bytes(unsigned_tx_hash) else {
-                    anyhow::bail!("Failed to convert unsigned_tx_hash to scalar: {unsigned_tx_hash:?}");
-                };
+                let payload = Scalar::from_bytes(unsigned_tx_hash).or_else(|| {
+                    None
+                })?;
 
                 if payload > *MAX_SECP256K1_SCALAR {
                     tracing::warn!("payload exceeds secp256k1 curve order: {payload:?}");
-                    anyhow::bail!("payload exceeds secp256k1 curve order");
+                    return None;
                 }
 
-                Ok(IndexedSignRequest::sign_bidirectional(
+                Some(IndexedSignRequest::sign_bidirectional(
                     sign_id,
                     SignArgs {
                         entropy,
@@ -627,7 +627,7 @@ impl SolanaSignEvent {
 fn build_sign_request(
     sign_event: SolanaSignEvent,
     tx_sig: Vec<u8>,
-) -> anyhow::Result<IndexedSignRequest> {
+) -> Option<IndexedSignRequest> {
     let mut entropy = [0u8; 32];
     entropy.copy_from_slice(&tx_sig[..32]);
     sign_event.generate_sign_request(entropy)
@@ -1023,8 +1023,9 @@ async fn emit_events(
     match SolanaEvents::parse(tx, program_id, logs)? {
         SolanaEvents::Sign(events) => {
             for ev in events {
-                let req = build_sign_request(ev, signature.as_ref().to_vec())?;
-                events_tx.send(ChainEvent::SignRequest(req)).await?;
+                if let Some(req) = build_sign_request(ev, signature.as_ref().to_vec()) {
+                    events_tx.send(ChainEvent::SignRequest(req)).await?;
+                }
             }
         }
         SolanaEvents::Respond {

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -273,7 +273,21 @@ impl SignatureEvent for SignBidirectionalEvent {
             },
             Chain::Solana,
             crate::util::current_unix_timestamp(),
-            crate::stream::ops::SignBidirectionalEvent::Solana(self.clone()),
+            crate::stream::ops::SignBidirectionalEvent {
+                sender: self.sender.to_bytes(),
+                serialized_transaction: self.serialized_transaction.clone(),
+                caip2_id: self.caip2_id.clone(),
+                key_version: self.key_version,
+                deposit: self.deposit,
+                path: self.path.clone(),
+                algo: self.algo.clone(),
+                dest: self.dest.clone(),
+                params: self.params.clone(),
+                output_deserialization_schema: self.output_deserialization_schema.clone(),
+                respond_serialization_schema: self.respond_serialization_schema.clone(),
+                chain: Chain::Solana,
+                chain_ctx: None,
+            },
         ))
     }
 

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -144,168 +144,7 @@ pub struct SolSignRequest {
     pub key_version: u32,
 }
 
-pub trait SolanaSignatureEvent {
-    fn generate_request_id(&self) -> [u8; 32];
-    fn generate_sign_request(&self, entropy: [u8; 32]) -> anyhow::Result<IndexedSignRequest>;
-    fn source_chain(&self) -> Chain;
-    fn sender_string(&self) -> String;
-}
-
-impl SolanaSignatureEvent for SignatureRequestedEvent {
-    fn generate_request_id(&self) -> [u8; 32] {
-        ethabi_request_id(
-            self.sender_string(),
-            self.payload,
-            self.path.clone(),
-            self.key_version,
-            self.chain_id.clone(),
-            self.algo.clone(),
-            self.dest.clone(),
-            self.params.clone(),
-        )
-    }
-
-    fn generate_sign_request(&self, entropy: [u8; 32]) -> anyhow::Result<IndexedSignRequest> {
-        tracing::info!("found solana event: {:?}", self);
-        if self.deposit == 0 {
-            tracing::warn!("deposit is 0, skipping sign request");
-            anyhow::bail!("deposit is 0");
-        }
-
-        if self.key_version > LATEST_MPC_KEY_VERSION {
-            tracing::warn!("unsupported key version: {}", self.key_version);
-            anyhow::bail!("unsupported key version");
-        }
-
-        let Some(payload) = Scalar::from_bytes(self.payload) else {
-            tracing::warn!(
-                "solana `sign` did not produce payload hash correctly: {:?}",
-                self.payload,
-            );
-            anyhow::bail!("failed to convert event payload hash to scalar");
-        };
-
-        if payload > *MAX_SECP256K1_SCALAR {
-            tracing::warn!("payload exceeds secp256k1 curve order: {payload:?}");
-            anyhow::bail!("payload exceeds secp256k1 curve order");
-        }
-
-        // Call the existing derive_epsilon_sol function with the correct parameters
-        // to match the TypeScript implementation
-        let epsilon = derive_epsilon_sol(self.key_version, &self.sender_string(), &self.path);
-
-        let sign_id = SignId::new(self.generate_request_id());
-        tracing::info!(?sign_id, "solana signature requested");
-
-        Ok(IndexedSignRequest::sign(
-            sign_id,
-            SignArgs {
-                entropy,
-                epsilon,
-                payload,
-                path: self.path.clone(),
-                key_version: self.key_version,
-            },
-            Chain::Solana,
-            crate::util::current_unix_timestamp(),
-        ))
-    }
-
-    fn source_chain(&self) -> Chain {
-        Chain::Solana
-    }
-
-    fn sender_string(&self) -> String {
-        self.sender.to_string()
-    }
-}
-
-impl SolanaSignatureEvent for SignBidirectionalEvent {
-    fn generate_request_id(&self) -> [u8; 32] {
-        // Match TypeScript implementation using ABI encoding
-        let encoded = (
-            self.sender.to_string(),
-            self.serialized_transaction.clone(),
-            self.caip2_id.clone(),
-            self.key_version,
-            self.path.clone(),
-            self.algo.clone(),
-            self.dest.clone(),
-            self.params.clone(),
-        )
-            .abi_encode_packed();
-
-        keccak::hash(&encoded).to_bytes()
-    }
-
-    fn generate_sign_request(&self, entropy: [u8; 32]) -> anyhow::Result<IndexedSignRequest> {
-        tracing::info!("found solana event: {:?}", self);
-        if self.deposit == 0 {
-            tracing::warn!("deposit is 0, skipping sign request");
-            anyhow::bail!("deposit is 0");
-        }
-
-        if self.key_version > LATEST_MPC_KEY_VERSION {
-            tracing::warn!("unsupported key version: {}", self.key_version);
-            anyhow::bail!("unsupported key version");
-        }
-
-        let request_id = self.generate_request_id();
-        let rlp_encoded_tx = self.serialized_transaction.clone();
-
-        // Call the existing derive_epsilon_sol function with the correct parameters
-        // to match the TypeScript implementation
-        let epsilon = derive_epsilon_sol(self.key_version, &self.sender_string(), &self.path);
-
-        let sign_id = SignId::new(request_id);
-        tracing::info!(?sign_id, "solana signature requested");
-        let unsigned_tx_hash = hash_rlp_data(rlp_encoded_tx);
-        let Some(payload) = Scalar::from_bytes(unsigned_tx_hash) else {
-            anyhow::bail!("Failed to convert unsigned_tx_hash to scalar: {unsigned_tx_hash:?}");
-        };
-
-        if payload > *MAX_SECP256K1_SCALAR {
-            tracing::warn!("payload exceeds secp256k1 curve order: {payload:?}");
-            anyhow::bail!("payload exceeds secp256k1 curve order");
-        }
-
-        Ok(IndexedSignRequest::sign_bidirectional(
-            sign_id,
-            SignArgs {
-                entropy,
-                epsilon,
-                payload,
-                path: self.path.clone(),
-                key_version: self.key_version,
-            },
-            Chain::Solana,
-            crate::util::current_unix_timestamp(),
-            crate::stream::ops::SignBidirectionalEvent {
-                sender: self.sender.to_bytes(),
-                serialized_transaction: self.serialized_transaction.clone(),
-                caip2_id: self.caip2_id.clone(),
-                key_version: self.key_version,
-                deposit: self.deposit,
-                path: self.path.clone(),
-                algo: self.algo.clone(),
-                dest: self.dest.clone(),
-                params: self.params.clone(),
-                output_deserialization_schema: self.output_deserialization_schema.clone(),
-                respond_serialization_schema: self.respond_serialization_schema.clone(),
-                chain: Chain::Solana,
-                chain_ctx: None,
-            },
-        ))
-    }
-
-    fn source_chain(&self) -> Chain {
-        Chain::Solana
-    }
-
-    fn sender_string(&self) -> String {
-        self.sender.to_string()
-    }
-}
+// SolanaSignatureEvent trait removed
 
 type Result<T> = anyhow::Result<T>;
 
@@ -646,16 +485,152 @@ pub enum SolanaSignEvent {
     SignBidirectional(SignBidirectionalEvent),
 }
 
+impl SolanaSignEvent {
+    pub fn generate_request_id(&self) -> [u8; 32] {
+        match self {
+            SolanaSignEvent::SignatureRequested(ev) => {
+                ethabi_request_id(
+                    ev.sender.to_string(),
+                    ev.payload,
+                    ev.path.clone(),
+                    ev.key_version,
+                    ev.chain_id.clone(),
+                    ev.algo.clone(),
+                    ev.dest.clone(),
+                    ev.params.clone(),
+                )
+            }
+            SolanaSignEvent::SignBidirectional(ev) => {
+                let encoded = (
+                    ev.sender.to_string(),
+                    ev.serialized_transaction.clone(),
+                    ev.caip2_id.clone(),
+                    ev.key_version,
+                    ev.path.clone(),
+                    ev.algo.clone(),
+                    ev.dest.clone(),
+                    ev.params.clone(),
+                )
+                    .abi_encode_packed();
+
+                keccak::hash(&encoded).to_bytes()
+            }
+        }
+    }
+
+    pub fn generate_sign_request(&self, entropy: [u8; 32]) -> anyhow::Result<IndexedSignRequest> {
+        match self {
+            SolanaSignEvent::SignatureRequested(ev) => {
+                tracing::info!("found solana event: {:?}", ev);
+                if ev.deposit == 0 {
+                    tracing::warn!("deposit is 0, skipping sign request");
+                    anyhow::bail!("deposit is 0");
+                }
+
+                if ev.key_version > LATEST_MPC_KEY_VERSION {
+                    tracing::warn!("unsupported key version: {}", ev.key_version);
+                    anyhow::bail!("unsupported key version");
+                }
+
+                let Some(payload) = Scalar::from_bytes(ev.payload) else {
+                    tracing::warn!(
+                        "solana `sign` did not produce payload hash correctly: {:?}",
+                        ev.payload,
+                    );
+                    anyhow::bail!("failed to convert event payload hash to scalar");
+                };
+
+                if payload > *MAX_SECP256K1_SCALAR {
+                    tracing::warn!("payload exceeds secp256k1 curve order: {payload:?}");
+                    anyhow::bail!("payload exceeds secp256k1 curve order");
+                }
+
+                let epsilon = derive_epsilon_sol(ev.key_version, &ev.sender.to_string(), &ev.path);
+
+                let sign_id = SignId::new(self.generate_request_id());
+                tracing::info!(?sign_id, "solana signature requested");
+
+                Ok(IndexedSignRequest::sign(
+                    sign_id,
+                    SignArgs {
+                        entropy,
+                        epsilon,
+                        payload,
+                        path: ev.path.clone(),
+                        key_version: ev.key_version,
+                    },
+                    Chain::Solana,
+                    crate::util::current_unix_timestamp(),
+                ))
+            }
+            SolanaSignEvent::SignBidirectional(ev) => {
+                tracing::info!("found solana event: {:?}", ev);
+                if ev.deposit == 0 {
+                    tracing::warn!("deposit is 0, skipping sign request");
+                    anyhow::bail!("deposit is 0");
+                }
+
+                if ev.key_version > LATEST_MPC_KEY_VERSION {
+                    tracing::warn!("unsupported key version: {}", ev.key_version);
+                    anyhow::bail!("unsupported key version");
+                }
+
+                let request_id = self.generate_request_id();
+                let rlp_encoded_tx = ev.serialized_transaction.clone();
+
+                let epsilon = derive_epsilon_sol(ev.key_version, &ev.sender.to_string(), &ev.path);
+
+                let sign_id = SignId::new(request_id);
+                tracing::info!(?sign_id, "solana signature requested");
+                let unsigned_tx_hash = hash_rlp_data(rlp_encoded_tx);
+                let Some(payload) = Scalar::from_bytes(unsigned_tx_hash) else {
+                    anyhow::bail!("Failed to convert unsigned_tx_hash to scalar: {unsigned_tx_hash:?}");
+                };
+
+                if payload > *MAX_SECP256K1_SCALAR {
+                    tracing::warn!("payload exceeds secp256k1 curve order: {payload:?}");
+                    anyhow::bail!("payload exceeds secp256k1 curve order");
+                }
+
+                Ok(IndexedSignRequest::sign_bidirectional(
+                    sign_id,
+                    SignArgs {
+                        entropy,
+                        epsilon,
+                        payload,
+                        path: ev.path.clone(),
+                        key_version: ev.key_version,
+                    },
+                    Chain::Solana,
+                    crate::util::current_unix_timestamp(),
+                    crate::stream::ops::SignBidirectionalEvent {
+                        sender: ev.sender.to_bytes(),
+                        serialized_transaction: ev.serialized_transaction.clone(),
+                        caip2_id: ev.caip2_id.clone(),
+                        key_version: ev.key_version,
+                        deposit: ev.deposit,
+                        path: ev.path.clone(),
+                        algo: ev.algo.clone(),
+                        dest: ev.dest.clone(),
+                        params: ev.params.clone(),
+                        output_deserialization_schema: ev.output_deserialization_schema.clone(),
+                        respond_serialization_schema: ev.respond_serialization_schema.clone(),
+                        chain: Chain::Solana,
+                        chain_ctx: None,
+                    },
+                ))
+            }
+        }
+    }
+}
+
 fn build_sign_request(
     sign_event: SolanaSignEvent,
     tx_sig: Vec<u8>,
 ) -> anyhow::Result<IndexedSignRequest> {
     let mut entropy = [0u8; 32];
     entropy.copy_from_slice(&tx_sig[..32]);
-    match sign_event {
-        SolanaSignEvent::SignatureRequested(ev) => ev.generate_sign_request(entropy),
-        SolanaSignEvent::SignBidirectional(ev) => ev.generate_sign_request(entropy),
-    }
+    sign_event.generate_sign_request(entropy)
 }
 
 /// Subscribe to the live WS feed, preprocess events into `ChainEvent`s, and buffer them
@@ -1223,7 +1198,7 @@ mod tests {
         };
 
         assert_eq!(
-            hex::encode(event.generate_request_id()),
+            hex::encode(SolanaSignEvent::SignatureRequested(event).generate_request_id()),
             "7f7aee49c2a994cc17f85058f7e0b19a44603d619a7e738522f9aa329e457879"
         );
     }

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -1,7 +1,7 @@
 use crate::backlog::Backlog;
 use crate::protocol::{Chain, IndexedSignRequest};
 use crate::sign_bidirectional::hash_rlp_data;
-use crate::stream::ops::{SignatureEvent, SignatureEventBox};
+
 use crate::stream::{ChainEvent, ChainIndexer, ChainStream};
 use crate::util::ethabi_request_id;
 use crate::util::retry::{retry_async, RetryConfig, RetryError, RetryReason};
@@ -144,7 +144,14 @@ pub struct SolSignRequest {
     pub key_version: u32,
 }
 
-impl SignatureEvent for SignatureRequestedEvent {
+pub trait SolanaSignatureEvent {
+    fn generate_request_id(&self) -> [u8; 32];
+    fn generate_sign_request(&self, entropy: [u8; 32]) -> anyhow::Result<IndexedSignRequest>;
+    fn source_chain(&self) -> Chain;
+    fn sender_string(&self) -> String;
+}
+
+impl SolanaSignatureEvent for SignatureRequestedEvent {
     fn generate_request_id(&self) -> [u8; 32] {
         ethabi_request_id(
             self.sender_string(),
@@ -213,7 +220,7 @@ impl SignatureEvent for SignatureRequestedEvent {
     }
 }
 
-impl SignatureEvent for SignBidirectionalEvent {
+impl SolanaSignatureEvent for SignBidirectionalEvent {
     fn generate_request_id(&self) -> [u8; 32] {
         // Match TypeScript implementation using ABI encoding
         let encoded = (
@@ -634,13 +641,21 @@ impl SolanaIndexer {
     }
 }
 
+pub enum SolanaSignEvent {
+    SignatureRequested(SignatureRequestedEvent),
+    SignBidirectional(SignBidirectionalEvent),
+}
+
 fn build_sign_request(
-    sign_event: SignatureEventBox,
+    sign_event: SolanaSignEvent,
     tx_sig: Vec<u8>,
 ) -> anyhow::Result<IndexedSignRequest> {
     let mut entropy = [0u8; 32];
     entropy.copy_from_slice(&tx_sig[..32]);
-    sign_event.generate_sign_request(entropy)
+    match sign_event {
+        SolanaSignEvent::SignatureRequested(ev) => ev.generate_sign_request(entropy),
+        SolanaSignEvent::SignBidirectional(ev) => ev.generate_sign_request(entropy),
+    }
 }
 
 /// Subscribe to the live WS feed, preprocess events into `ChainEvent`s, and buffer them
@@ -678,7 +693,7 @@ async fn subscribe_and_buffer_live_events(
 fn parse_cpi_events(
     tx: &EncodedTransactionWithStatusMeta,
     target_program_id: &Pubkey,
-) -> Result<Vec<SignatureEventBox>> {
+) -> Result<Vec<SolanaSignEvent>> {
     use solana_transaction_status::{UiInstruction, UiParsedInstruction};
 
     let Some(meta) = &tx.meta else {
@@ -686,10 +701,10 @@ fn parse_cpi_events(
     };
 
     let target_program_str = target_program_id.to_string();
-    let mut out = Vec::<SignatureEventBox>::new();
+    let mut out = Vec::<SolanaSignEvent>::new();
 
     // Small helper closure to try decoding both event types from raw data
-    let try_parse_events = |data: &str| -> Result<Vec<SignatureEventBox>> {
+    let try_parse_events = |data: &str| -> Result<Vec<SolanaSignEvent>> {
         let Ok(ix_data) = solana_sdk::bs58::decode(data).into_vec() else {
             tracing::warn!("Failed to decode instruction data for target program");
             return Ok(Vec::new());
@@ -708,7 +723,7 @@ fn parse_cpi_events(
         // handle both event types
         if event_discriminator == SignatureRequestedEvent::DISCRIMINATOR {
             match SignatureRequestedEvent::deserialize(&mut &event_data[..]) {
-                Ok(ev) => acc.push(Box::new(ev) as SignatureEventBox),
+                Ok(ev) => acc.push(SolanaSignEvent::SignatureRequested(ev)),
                 Err(e) => tracing::warn!("Failed to deserialize SignatureRequestedEvent: {e}"),
             }
         } else if event_discriminator == SignBidirectionalEvent::DISCRIMINATOR {
@@ -719,7 +734,7 @@ fn parse_cpi_events(
                     if let Err(e) = Chain::from_caip2_chain_id(&ev.caip2_id) {
                         tracing::warn!("invalid caip2 chain id in sign bidirectional event: {e:?}")
                     } else {
-                        acc.push(Box::new(ev) as SignatureEventBox)
+                        acc.push(SolanaSignEvent::SignBidirectional(ev))
                     }
                 }
                 Err(e) => {
@@ -995,7 +1010,7 @@ fn parse_cpi_respond_events(
 }
 
 enum SolanaEvents {
-    Sign(Vec<SignatureEventBox>),
+    Sign(Vec<SolanaSignEvent>),
     Respond {
         bidirectional: Vec<RespondBidirectionalEvent>,
         responded: Vec<SignatureRespondedEvent>,

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -483,6 +483,25 @@ pub enum SolanaSignEvent {
 }
 
 impl SolanaSignEvent {
+    fn is_valid(&self, sign_id: SignId) -> bool {
+        let (deposit, key_version) = match self {
+            SolanaSignEvent::SignatureRequested(ev) => (ev.deposit, ev.key_version),
+            SolanaSignEvent::SignBidirectional(ev) => (ev.deposit, ev.key_version),
+        };
+
+        if deposit == 0 {
+            tracing::warn!(?sign_id, "deposit is 0, skipping sign request");
+            return false;
+        }
+
+        if key_version > LATEST_MPC_KEY_VERSION {
+            tracing::warn!(?sign_id, "unsupported key version: {}", key_version);
+            return false;
+        }
+
+        true
+    }
+
     pub fn generate_request_id(&self) -> [u8; 32] {
         match self {
             SolanaSignEvent::SignatureRequested(ev) => ethabi_request_id(
@@ -514,21 +533,16 @@ impl SolanaSignEvent {
     }
 
     pub fn generate_sign_request(&self, entropy: [u8; 32]) -> Option<IndexedSignRequest> {
+        let sign_id = SignId::new(self.generate_request_id());
+        if !self.is_valid(sign_id) {
+            return None;
+        }
+
         match self {
             SolanaSignEvent::SignatureRequested(ev) => {
-                tracing::info!(?ev, "found solana event");
-                if ev.deposit == 0 {
-                    tracing::warn!("deposit is 0, skipping sign request");
-                    return None;
-                }
-
-                if ev.key_version > LATEST_MPC_KEY_VERSION {
-                    tracing::warn!("unsupported key version: {}", ev.key_version);
-                    return None;
-                }
-
                 let payload = Scalar::from_bytes(ev.payload).or_else(|| {
                     tracing::warn!(
+                        ?sign_id,
                         "solana `sign` did not produce payload hash correctly: {:?}",
                         ev.payload,
                     );
@@ -536,15 +550,12 @@ impl SolanaSignEvent {
                 })?;
 
                 if payload > *MAX_SECP256K1_SCALAR {
-                    tracing::warn!("payload exceeds secp256k1 curve order: {payload:?}");
+                    tracing::warn!(?sign_id, ?payload, "payload exceeds secp256k1 curve order");
                     return None;
                 }
 
-                let epsilon = derive_epsilon_sol(ev.key_version, &ev.sender.to_string(), &ev.path);
-
-                let sign_id = SignId::new(self.generate_request_id());
                 tracing::info!(?sign_id, "solana signature requested");
-
+                let epsilon = derive_epsilon_sol(ev.key_version, &ev.sender.to_string(), &ev.path);
                 Some(IndexedSignRequest::sign(
                     sign_id,
                     SignArgs {
@@ -559,20 +570,7 @@ impl SolanaSignEvent {
                 ))
             }
             SolanaSignEvent::SignBidirectional(ev) => {
-                tracing::info!(?ev, "found solana event");
-                if ev.deposit == 0 {
-                    tracing::warn!("deposit is 0, skipping sign request");
-                    return None;
-                }
-
-                if ev.key_version > LATEST_MPC_KEY_VERSION {
-                    tracing::warn!("unsupported key version: {}", ev.key_version);
-                    return None;
-                }
-
-                let request_id = self.generate_request_id();
                 let epsilon = derive_epsilon_sol(ev.key_version, &ev.sender.to_string(), &ev.path);
-                let sign_id = SignId::new(request_id);
                 tracing::info!(?sign_id, "solana bidirectional signature requested");
                 let unsigned_tx_hash = hash_rlp_data(&ev.serialized_transaction);
                 let payload = Scalar::from_bytes(unsigned_tx_hash)?;
@@ -612,12 +610,12 @@ impl SolanaSignEvent {
             }
         }
     }
-}
 
-fn build_sign_request(sign_event: SolanaSignEvent, tx_sig: Vec<u8>) -> Option<IndexedSignRequest> {
-    let mut entropy = [0u8; 32];
-    entropy.copy_from_slice(&tx_sig[..32]);
-    sign_event.generate_sign_request(entropy)
+    fn build_sign_request(self, tx_sig: &[u8]) -> Option<IndexedSignRequest> {
+        let mut entropy = [0u8; 32];
+        entropy.copy_from_slice(&tx_sig[..32]);
+        self.generate_sign_request(entropy)
+    }
 }
 
 /// Subscribe to the live WS feed, preprocess events into `ChainEvent`s, and buffer them
@@ -1009,8 +1007,9 @@ async fn emit_events(
 ) -> anyhow::Result<()> {
     match SolanaEvents::parse(tx, program_id, logs)? {
         SolanaEvents::Sign(events) => {
+            let signature = signature.as_ref().to_vec();
             for ev in events {
-                if let Some(req) = build_sign_request(ev, signature.as_ref().to_vec()) {
+                if let Some(req) = ev.build_sign_request(&signature) {
                     events_tx.send(ChainEvent::SignRequest(req)).await?;
                 }
             }

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -516,7 +516,7 @@ impl SolanaSignEvent {
     pub fn generate_sign_request(&self, entropy: [u8; 32]) -> Option<IndexedSignRequest> {
         match self {
             SolanaSignEvent::SignatureRequested(ev) => {
-                tracing::info!("found solana event: {:?}", ev);
+                tracing::info!(?ev, "found solana event");
                 if ev.deposit == 0 {
                     tracing::warn!("deposit is 0, skipping sign request");
                     return None;
@@ -559,7 +559,7 @@ impl SolanaSignEvent {
                 ))
             }
             SolanaSignEvent::SignBidirectional(ev) => {
-                tracing::info!("found solana event: {:?}", ev);
+                tracing::info!(?ev, "found solana event");
                 if ev.deposit == 0 {
                     tracing::warn!("deposit is 0, skipping sign request");
                     return None;
@@ -571,17 +571,14 @@ impl SolanaSignEvent {
                 }
 
                 let request_id = self.generate_request_id();
-                let rlp_encoded_tx = ev.serialized_transaction.clone();
-
                 let epsilon = derive_epsilon_sol(ev.key_version, &ev.sender.to_string(), &ev.path);
-
                 let sign_id = SignId::new(request_id);
-                tracing::info!(?sign_id, "solana signature requested");
-                let unsigned_tx_hash = hash_rlp_data(rlp_encoded_tx);
-                let payload = Scalar::from_bytes(unsigned_tx_hash).or_else(|| None)?;
+                tracing::info!(?sign_id, "solana bidirectional signature requested");
+                let unsigned_tx_hash = hash_rlp_data(&ev.serialized_transaction);
+                let payload = Scalar::from_bytes(unsigned_tx_hash)?;
 
                 if payload > *MAX_SECP256K1_SCALAR {
-                    tracing::warn!("payload exceeds secp256k1 curve order: {payload:?}");
+                    tracing::warn!(?payload, "payload exceeds secp256k1 curve order");
                     return None;
                 }
 
@@ -1023,8 +1020,8 @@ async fn emit_events(
             responded,
         } => {
             for ev in bidirectional {
-                let signature = to_mpc_signature(ev.signature.clone())
-                    .context("failed to parse Solana signature")?;
+                let signature =
+                    to_mpc_signature(&ev.signature).context("failed to parse Solana signature")?;
                 let _ = events_tx
                     .send(ChainEvent::RespondBidirectional(
                         crate::stream::ops::RespondBidirectionalEvent {
@@ -1037,8 +1034,8 @@ async fn emit_events(
             }
 
             for ev in responded {
-                let signature = to_mpc_signature(ev.signature.clone())
-                    .context("failed to parse Solana signature")?;
+                let signature =
+                    to_mpc_signature(&ev.signature).context("failed to parse Solana signature")?;
                 let _ = events_tx
                     .send(ChainEvent::Respond(
                         crate::stream::ops::SignatureRespondedEvent {
@@ -1078,7 +1075,7 @@ fn cleanup_seen_cache(seen: &mut HashMap<Signature, Instant>, ttl: Duration) {
 }
 
 pub fn to_mpc_signature(
-    sig: signet_program::Signature,
+    sig: &signet_program::Signature,
 ) -> anyhow::Result<mpc_primitives::Signature> {
     // Create a 65-byte uncompressed point representation (0x04 || x || y)
     let mut big_r = [0u8; 65];

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -1044,15 +1044,24 @@ async fn emit_events(
             for ev in bidirectional {
                 let _ = events_tx
                     .send(ChainEvent::RespondBidirectional(
-                        crate::stream::ops::RespondBidirectionalEvent::Solana(ev),
+                        crate::stream::ops::RespondBidirectionalEvent {
+                            request_id: ev.request_id,
+                            chain: crate::protocol::Chain::Solana,
+                        },
                     ))
                     .await;
             }
 
             for ev in responded {
+                let signature = to_mpc_signature(ev.signature.clone())
+                    .context("failed to parse Solana signature")?;
                 let _ = events_tx
                     .send(ChainEvent::Respond(
-                        crate::stream::ops::SignatureRespondedEvent::Solana(ev),
+                        crate::stream::ops::SignatureRespondedEvent {
+                            request_id: ev.request_id,
+                            signature,
+                            chain: Chain::Solana,
+                        },
                     ))
                     .await;
             }

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -2062,15 +2062,23 @@ async fn try_publish_canton(
     }))?;
 
     let (choice, command_id, choice_argument) = match &action.indexed.kind {
-        SignKind::SignBidirectional(crate::stream::ops::SignBidirectionalEvent::Canton(event)) => (
-            "Respond",
-            format!("mpc-respond-{request_id_hex}"),
-            serde_json::json!({
-                "signEventCid": &event.sign_event_contract_id,
-                "requestId": request_id_hex,
-                "signature": canton_signature,
-            }),
-        ),
+        SignKind::SignBidirectional(event) if event.chain == Chain::Canton => {
+            let chain_ctx_bytes = event
+                .chain_ctx
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("missing chain_ctx on Canton sign request"))?;
+            let ctx: crate::indexer_canton::CantonChainCtx = borsh::from_slice(chain_ctx_bytes)
+                .map_err(|e| anyhow::anyhow!("failed to deserialize CantonChainCtx: {e}"))?;
+            (
+                "Respond",
+                format!("mpc-respond-{request_id_hex}"),
+                serde_json::json!({
+                    "signEventCid": ctx.sign_event_contract_id,
+                    "requestId": request_id_hex,
+                    "signature": canton_signature,
+                }),
+            )
+        }
         SignKind::RespondBidirectional(respond_tx) => {
             let chain_ctx_bytes = respond_tx
                 .chain_ctx

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -271,9 +271,9 @@ impl TransactionOutput {
     }
 }
 
-pub fn hash_rlp_data(rlp_data: Vec<u8>) -> [u8; 32] {
+pub fn hash_rlp_data(rlp_data: &[u8]) -> [u8; 32] {
     let mut hasher = Keccak256::new();
-    hasher.update(&rlp_data);
+    hasher.update(rlp_data);
     hasher.finalize().into()
 }
 

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -60,13 +60,13 @@ impl std::fmt::Debug for ChainEvent {
                 .finish(),
             ChainEvent::Respond(ev) => f
                 .debug_tuple("Respond")
-                .field(&ev.request_id())
-                .field(&ev.source_chain().as_str())
+                .field(&ev.request_id)
+                .field(&ev.chain.as_str())
                 .finish(),
             ChainEvent::RespondBidirectional(ev) => f
                 .debug_tuple("RespondBidirectional")
-                .field(&ev.request_id())
-                .field(&ev.source_chain().as_str())
+                .field(&ev.request_id)
+                .field(&ev.chain.as_str())
                 .finish(),
             ChainEvent::CatchupCompleted => write!(f, "CatchupCompleted"),
             ChainEvent::Block(b) => write!(f, "Block({b})"),
@@ -324,9 +324,9 @@ mod tests {
     use crate::protocol::{Chain, IndexedSignRequest};
     use crate::rpc::{ContractStateWatcher, RpcAction, RpcChannel};
     use crate::storage::checkpoint_storage::CheckpointStorage;
-    use crate::stream::ops::{EthereumSignatureRespondedEvent, SignatureRespondedEvent};
+    use crate::stream::ops::SignatureRespondedEvent;
     use crate::util::current_unix_timestamp;
-    use alloy::primitives::Address;
+    use k256::elliptic_curve::sec1::FromEncodedPoint;
     use k256::{AffinePoint, Scalar};
     use mockito::Server;
     use mpc_primitives::SignArgs;
@@ -626,19 +626,15 @@ mod tests {
         );
 
         // Prepare a respond event that matches the sign id
-        let sig_responded =
-            SignatureRespondedEvent::Solana(signet_program::SignatureRespondedEvent {
-                request_id: sign_id.request_id,
-                responder: solana_sdk::pubkey::Pubkey::new_unique(),
-                signature: signet_program::Signature {
-                    big_r: signet_program::AffinePoint {
-                        x: [0u8; 32],
-                        y: [0u8; 32],
-                    },
-                    s: [0u8; 32],
-                    recovery_id: 0,
-                },
-            });
+        let sig_responded = SignatureRespondedEvent {
+            request_id: sign_id.request_id,
+            signature: mpc_primitives::Signature {
+                big_r: k256::AffinePoint::GENERATOR,
+                s: k256::Scalar::ZERO,
+                recovery_id: 0,
+            },
+            chain: Chain::Solana,
+        };
         let client = SolanaTestStream::new(vec![
             Some(ChainEvent::CatchupCompleted),
             Some(ChainEvent::SignRequest(indexed.clone())),
@@ -693,9 +689,7 @@ mod tests {
     #[tokio::test]
     async fn test_stream_handles_sign_bidirectional_block_and_recover() {
         use crate::sign_bidirectional::SignStatus;
-        use crate::stream::ops::RespondBidirectionalEvent as RBE;
         use crate::stream::ops::SignBidirectionalEvent as SBE;
-        use crate::stream::ops::SignatureRespondedEvent as SRE;
 
         // shared storage so checkpoint persistence is visible to recovered backlog
         let storage = crate::storage::checkpoint_storage::CheckpointStorage::in_memory();
@@ -874,18 +868,19 @@ mod tests {
         let mut s_arr = [0u8; 32];
         s_arr.copy_from_slice(&s_bytes);
 
-        let sig_responded = SRE::Solana(signet_program::SignatureRespondedEvent {
+        let big_r = k256::AffinePoint::from_encoded_point(
+            &k256::EncodedPoint::from_affine_coordinates(x_bytes.into(), y_bytes.into(), false),
+        )
+        .unwrap();
+        let sig_responded = SignatureRespondedEvent {
             request_id: sign_id.request_id,
-            responder: solana_sdk::pubkey::Pubkey::new_unique(),
-            signature: signet_program::Signature {
-                big_r: signet_program::AffinePoint {
-                    x: big_r_x,
-                    y: big_r_y,
-                },
-                s: s_arr,
+            signature: mpc_primitives::Signature {
+                big_r,
+                s: k256::Scalar::from(1u64),
                 recovery_id: 0,
             },
-        });
+            chain: Chain::Solana,
+        };
         events_tx
             .send(ChainEvent::Respond(sig_responded))
             .await
@@ -950,19 +945,10 @@ mod tests {
 
         // now send a RespondBidirectional event to complete the request
         // RespondBidirectional should also carry a valid signature
-        let respond_bidirectional = RBE::Solana(signet_program::RespondBidirectionalEvent {
+        let respond_bidirectional = crate::stream::ops::RespondBidirectionalEvent {
             request_id: sign_id.request_id,
-            responder: solana_sdk::pubkey::Pubkey::new_unique(),
-            serialized_output: vec![],
-            signature: signet_program::Signature {
-                big_r: signet_program::AffinePoint {
-                    x: big_r_x,
-                    y: big_r_y,
-                },
-                s: s_arr,
-                recovery_id: 0,
-            },
-        });
+            chain: Chain::Solana,
+        };
         events_tx
             .send(ChainEvent::RespondBidirectional(respond_bidirectional))
             .await
@@ -1012,11 +998,15 @@ mod tests {
             .await;
         seeded_backlog.checkpoint(Chain::Ethereum).await;
 
-        let respond = SignatureRespondedEvent::Ethereum(EthereumSignatureRespondedEvent {
+        let respond = SignatureRespondedEvent {
             request_id: sign_id.request_id,
-            responder: Address::ZERO,
-            signature: Signature::new(k256::ProjectivePoint::GENERATOR.to_affine(), Scalar::ONE, 0),
-        });
+            signature: mpc_primitives::Signature::new(
+                k256::ProjectivePoint::GENERATOR.to_affine(),
+                Scalar::ONE,
+                0,
+            ),
+            chain: Chain::Ethereum,
+        };
 
         let client = EthereumTestStream::new(vec![
             Some(ChainEvent::Respond(respond)),

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -696,7 +696,6 @@ mod tests {
         use crate::stream::ops::RespondBidirectionalEvent as RBE;
         use crate::stream::ops::SignBidirectionalEvent as SBE;
         use crate::stream::ops::SignatureRespondedEvent as SRE;
-        use signet_program::SignBidirectionalEvent;
 
         // shared storage so checkpoint persistence is visible to recovered backlog
         let storage = crate::storage::checkpoint_storage::CheckpointStorage::in_memory();
@@ -805,17 +804,18 @@ mod tests {
         rlp_s.append(&0u64);
         let unsigned_rlp = rlp_s.out().to_vec();
 
-        let sign_bidir = SignBidirectionalEvent {
+        let sign_bidir = SBE {
             sender: Default::default(),
             serialized_transaction: unsigned_rlp,
-            dest: Chain::Ethereum.to_string(),
             caip2_id: Chain::Ethereum.caip2_chain_id().to_string(),
             key_version: 0,
             deposit: 0,
             path: "".to_string(),
             algo: "".to_string(),
+            dest: Chain::Ethereum.to_string(),
             params: "".to_string(),
-            program_id,
+            chain: Chain::Solana,
+            chain_ctx: Some(program_id.to_bytes().to_vec()),
             output_deserialization_schema: vec![],
             respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
         };
@@ -825,7 +825,7 @@ mod tests {
             args.clone(),
             Chain::Solana,
             current_unix_timestamp(),
-            SBE::Solana(sign_bidir.clone()),
+            sign_bidir,
         );
 
         events_tx.send(ChainEvent::CatchupCompleted).await.unwrap();

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -1,11 +1,7 @@
 use crate::backlog::Backlog;
-use crate::indexer_canton::{
-    CantonRespondBidirectionalEvent, CantonSignBidirectionalRequestedEvent,
-    CantonSignatureRespondedEvent,
-};
+use crate::indexer_canton::{CantonRespondBidirectionalEvent, CantonSignatureRespondedEvent};
 use crate::indexer_hydration::{
-    HydrationRespondBidirectionalEvent, HydrationSignBidirectionalRequestedEvent,
-    HydrationSignatureRespondedEvent,
+    HydrationRespondBidirectionalEvent, HydrationSignatureRespondedEvent,
 };
 use crate::mesh::{wait_threshold_active, MeshState};
 use crate::metrics::requests::record_indexing_step_reached;
@@ -23,151 +19,106 @@ use mpc_primitives::{SignId, Signature};
 use tokio::sync::{mpsc, watch};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[allow(clippy::large_enum_variant)]
-pub enum SignBidirectionalEvent {
-    Solana(signet_program::SignBidirectionalEvent),
-    Hydration(HydrationSignBidirectionalRequestedEvent),
-    Canton(CantonSignBidirectionalRequestedEvent),
+pub struct SignBidirectionalEvent {
+    pub sender: [u8; 32],
+    pub serialized_transaction: Vec<u8>,
+    pub caip2_id: String,
+    pub key_version: u32,
+    pub deposit: u64,
+    pub path: String,
+    pub algo: String,
+    pub dest: String,
+    pub params: String,
+    pub output_deserialization_schema: Vec<u8>,
+    pub respond_serialization_schema: Vec<u8>,
+    pub chain: Chain,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chain_ctx: Option<Vec<u8>>,
 }
 
 impl SignBidirectionalEvent {
     pub fn sender(&self) -> [u8; 32] {
-        match self {
-            SignBidirectionalEvent::Solana(event) => event.sender.to_bytes(),
-            SignBidirectionalEvent::Hydration(event) => event.sender,
-            SignBidirectionalEvent::Canton(event) => event.sender,
-        }
+        self.sender
     }
 
     pub(crate) fn sender_string(&self) -> anyhow::Result<String> {
-        match self {
-            SignBidirectionalEvent::Canton(event) => Ok(hex::encode(event.sender)),
-            _ => sender_string(self.sender(), self.source_chain()),
+        match self.chain {
+            Chain::Canton => Ok(hex::encode(self.sender)),
+            _ => sender_string(self.sender, self.chain),
         }
     }
 
     pub(crate) fn source_chain(&self) -> Chain {
-        match self {
-            SignBidirectionalEvent::Solana(_) => Chain::Solana,
-            SignBidirectionalEvent::Hydration(_) => Chain::Hydration,
-            SignBidirectionalEvent::Canton(_) => Chain::Canton,
-        }
+        self.chain
     }
 
     pub(crate) fn chain_ctx(&self) -> Option<Vec<u8>> {
-        match self {
-            SignBidirectionalEvent::Canton(event) => {
-                let ctx = crate::indexer_canton::CantonChainCtx {
-                    sign_event_contract_id: event.sign_event_contract_id.clone(),
-                };
-                Some(borsh::to_vec(&ctx).expect("CantonChainCtx Borsh serialization is infallible"))
-            }
-            _ => None,
-        }
+        self.chain_ctx.clone()
     }
 
     pub fn path(&self) -> String {
-        match self {
-            SignBidirectionalEvent::Solana(event) => event.path.clone(),
-            SignBidirectionalEvent::Hydration(event) => event.path.clone(),
-            SignBidirectionalEvent::Canton(event) => event.path.clone(),
-        }
+        self.path.clone()
     }
 
     pub fn dest(&self) -> String {
-        match self {
-            SignBidirectionalEvent::Solana(event) => event.dest.clone(),
-            SignBidirectionalEvent::Hydration(event) => event.dest.clone(),
-            SignBidirectionalEvent::Canton(event) => event.dest.clone(),
-        }
+        self.dest.clone()
     }
 
     pub(crate) fn algo(&self) -> String {
-        match self {
-            SignBidirectionalEvent::Solana(event) => event.algo.clone(),
-            SignBidirectionalEvent::Hydration(event) => event.algo.clone(),
-            SignBidirectionalEvent::Canton(event) => event.algo.clone(),
-        }
+        self.algo.clone()
     }
 
     pub fn params(&self) -> String {
-        match self {
-            SignBidirectionalEvent::Solana(event) => event.params.clone(),
-            SignBidirectionalEvent::Hydration(event) => event.params.clone(),
-            SignBidirectionalEvent::Canton(event) => event.params.clone(),
-        }
+        self.params.clone()
     }
 
     pub fn output_deserialization_schema(&self) -> Vec<u8> {
-        match self {
-            SignBidirectionalEvent::Solana(event) => event.output_deserialization_schema.clone(),
-            SignBidirectionalEvent::Hydration(event) => event.output_deserialization_schema.clone(),
-            SignBidirectionalEvent::Canton(event) => event.output_deserialization_schema.clone(),
-        }
+        self.output_deserialization_schema.clone()
     }
 
     pub fn respond_serialization_schema(&self) -> Vec<u8> {
-        match self {
-            SignBidirectionalEvent::Solana(event) => event.respond_serialization_schema.clone(),
-            SignBidirectionalEvent::Hydration(event) => event.respond_serialization_schema.clone(),
-            SignBidirectionalEvent::Canton(event) => event.respond_serialization_schema.clone(),
-        }
+        self.respond_serialization_schema.clone()
     }
 
     pub fn key_version(&self) -> u32 {
-        match self {
-            SignBidirectionalEvent::Solana(event) => event.key_version,
-            SignBidirectionalEvent::Hydration(event) => event.key_version,
-            SignBidirectionalEvent::Canton(event) => event.key_version,
-        }
+        self.key_version
     }
 
     pub(crate) fn deposit(&self) -> u64 {
-        match self {
-            SignBidirectionalEvent::Solana(event) => event.deposit,
-            SignBidirectionalEvent::Hydration(event) => event.deposit,
-            SignBidirectionalEvent::Canton(_) => 0,
-        }
+        self.deposit
     }
 
     pub fn serialized_transaction(&self) -> Vec<u8> {
-        match self {
-            SignBidirectionalEvent::Solana(event) => event.serialized_transaction.clone(),
-            SignBidirectionalEvent::Hydration(event) => event.serialized_transaction.clone(),
-            SignBidirectionalEvent::Canton(event) => event.serialized_transaction.clone(),
-        }
+        self.serialized_transaction.clone()
     }
 
     pub fn caip2_id(&self) -> String {
-        match self {
-            SignBidirectionalEvent::Solana(event) => event.caip2_id.clone(),
-            SignBidirectionalEvent::Hydration(event) => event.caip2_id.clone(),
-            SignBidirectionalEvent::Canton(event) => event.caip2_id.clone(),
-        }
+        self.caip2_id.clone()
     }
 
     pub fn epsilon(&self) -> anyhow::Result<Scalar> {
-        match self {
-            SignBidirectionalEvent::Solana(_) => Ok(mpc_crypto::kdf::derive_epsilon_sol(
-                self.key_version(),
+        match self.chain {
+            Chain::Solana => Ok(mpc_crypto::kdf::derive_epsilon_sol(
+                self.key_version,
                 &self.sender_string()?,
-                &self.path(),
+                &self.path,
             )),
-            SignBidirectionalEvent::Hydration(_) => Ok(mpc_crypto::kdf::derive_epsilon_hydration(
-                self.key_version(),
+            Chain::Hydration => Ok(mpc_crypto::kdf::derive_epsilon_hydration(
+                self.key_version,
                 &self.sender_string()?,
-                &self.path(),
+                &self.path,
             )),
-            SignBidirectionalEvent::Canton(_) => Ok(mpc_crypto::kdf::derive_epsilon_canton(
-                self.key_version(),
+            Chain::Canton => Ok(mpc_crypto::kdf::derive_epsilon_canton(
+                self.key_version,
                 &self.sender_string()?,
-                &self.path(),
+                &self.path,
             )),
+            _ => anyhow::bail!("Unsupported chain for epsilon derivation: {:?}", self.chain),
         }
     }
 
     pub fn target_chain(&self) -> Result<Chain, mpc_primitives::ChainFromError> {
-        Chain::from_caip2_chain_id(&self.caip2_id())
+        Chain::from_caip2_chain_id(&self.caip2_id)
     }
 }
 
@@ -743,25 +694,31 @@ mod tests {
         sign_id: SignId,
         sign_event_contract_id: &str,
     ) -> IndexedSignRequest {
+        let ctx = crate::indexer_canton::CantonChainCtx {
+            sign_event_contract_id: sign_event_contract_id.to_string(),
+        };
+        let chain_ctx =
+            Some(borsh::to_vec(&ctx).expect("CantonChainCtx Borsh serialization is infallible"));
         IndexedSignRequest::sign_bidirectional(
             sign_id,
             test_sign_args(sign_id.request_id[0]),
             Chain::Canton,
             current_unix_timestamp(),
-            SignBidirectionalEvent::Canton(CantonSignBidirectionalRequestedEvent {
-                sign_event_contract_id: sign_event_contract_id.to_string(),
+            SignBidirectionalEvent {
                 sender: [7u8; 32],
-                request_id: sign_id.request_id,
                 serialized_transaction: vec![1, 2, 3],
                 caip2_id: Chain::Ethereum.caip2_chain_id().to_string(),
                 key_version: 1,
+                deposit: 0,
                 path: "test_path".to_string(),
                 algo: "ECDSA".to_string(),
                 dest: "0x1234567890123456789012345678901234567890".to_string(),
                 params: "{}".to_string(),
                 output_deserialization_schema: vec![],
                 respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
-            }),
+                chain: Chain::Canton,
+                chain_ctx,
+            },
         )
     }
 
@@ -1195,7 +1152,7 @@ mod tests {
                 args,
                 Chain::Ethereum,
                 current_unix_timestamp(),
-                SignBidirectionalEvent::Solana(signet_program::SignBidirectionalEvent {
+                SignBidirectionalEvent {
                     sender: Default::default(),
                     serialized_transaction: unsigned_rlp,
                     dest: "0x1234567890123456789012345678901234567890".to_string(),
@@ -1205,10 +1162,11 @@ mod tests {
                     path: "m/0".to_string(),
                     algo: "ECDSA".to_string(),
                     params: "{}".to_string(),
-                    program_id: Pubkey::new_unique(),
+                    chain: Chain::Solana,
+                    chain_ctx: Some(Pubkey::new_unique().to_bytes().to_vec()),
                     output_deserialization_schema: vec![],
                     respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
-                }),
+                },
             ))
             .await;
 
@@ -1415,7 +1373,7 @@ mod tests {
                 test_sign_args(14),
                 Chain::Ethereum,
                 current_unix_timestamp(),
-                SignBidirectionalEvent::Solana(signet_program::SignBidirectionalEvent {
+                SignBidirectionalEvent {
                     sender: Default::default(),
                     serialized_transaction: unsigned_rlp,
                     dest: tx.dest.clone(),
@@ -1425,10 +1383,11 @@ mod tests {
                     path: tx.path.clone(),
                     algo: tx.algo.clone(),
                     params: tx.params.clone(),
-                    program_id: Pubkey::new_unique(),
+                    chain: Chain::Solana,
+                    chain_ctx: Some(Pubkey::new_unique().to_bytes().to_vec()),
                     output_deserialization_schema: tx.output_deserialization_schema.clone(),
                     respond_serialization_schema: tx.respond_serialization_schema.clone(),
-                }),
+                },
             ))
             .await;
 

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -80,42 +80,7 @@ pub struct SignatureRespondedEvent {
     pub chain: Chain,
 }
 
-pub(crate) trait SignatureEvent: std::fmt::Debug {
-    fn generate_request_id(&self) -> [u8; 32];
-    fn generate_sign_request(&self, entropy: [u8; 32]) -> anyhow::Result<IndexedSignRequest>;
-    fn source_chain(&self) -> Chain;
-    fn sender_string(&self) -> String;
-}
 
-pub(crate) type SignatureEventBox = Box<dyn SignatureEvent + Send>;
-
-pub(crate) async fn process_sign_event(
-    sign_event: SignatureEventBox,
-    entropy: [u8; 32],
-    sign_tx: mpsc::Sender<Sign>,
-    backlog: Backlog,
-    caught_up: bool,
-) -> anyhow::Result<()> {
-    let sign_request = sign_event.generate_sign_request(entropy)?;
-    record_indexing_step_reached(sign_event.source_chain());
-
-    if matches!(sign_request.kind, SignKind::RespondBidirectional(_)) {
-        anyhow::bail!(
-            "unexpected sign kind: RespondBidirectional should not be generated from a sign event"
-        );
-    }
-
-    backlog.insert(sign_request.clone()).await;
-
-    if caught_up {
-        if let Err(err) = sign_tx.send(Sign::Request(sign_request)).await {
-            let chain = sign_event.source_chain();
-            tracing::error!(?err, %chain, "failed to send sign request into queue");
-        }
-    }
-
-    Ok(())
-}
 
 pub(crate) async fn process_sign_request(
     sign_request: IndexedSignRequest,

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -1,8 +1,5 @@
 use crate::backlog::Backlog;
-use crate::indexer_canton::{CantonRespondBidirectionalEvent, CantonSignatureRespondedEvent};
-use crate::indexer_hydration::{
-    HydrationRespondBidirectionalEvent, HydrationSignatureRespondedEvent,
-};
+
 use crate::mesh::{wait_threshold_active, MeshState};
 use crate::metrics::requests::record_indexing_step_reached;
 use crate::node_client::NodeClient;
@@ -12,7 +9,6 @@ use crate::rpc::{ContractStateWatcher, RpcChannel};
 use crate::sign_bidirectional::{BidirectionalTx, BidirectionalTxId, SignStatus};
 use crate::stream::ExecutionOutcome;
 
-use alloy::primitives::keccak256;
 use anchor_lang::prelude::Pubkey;
 use k256::Scalar;
 use mpc_primitives::{SignId, Signature};
@@ -48,6 +44,7 @@ impl SignBidirectionalEvent {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn source_chain(&self) -> Chain {
         self.chain
     }
@@ -122,107 +119,30 @@ impl SignBidirectionalEvent {
     }
 }
 
-#[derive(Clone)]
-pub enum RespondBidirectionalEvent {
-    Solana(signet_program::RespondBidirectionalEvent),
-    Hydration(HydrationRespondBidirectionalEvent),
-    Canton(CantonRespondBidirectionalEvent),
-}
-
-impl RespondBidirectionalEvent {
-    pub fn request_id(&self) -> [u8; 32] {
-        match self {
-            RespondBidirectionalEvent::Solana(event) => event.request_id,
-            RespondBidirectionalEvent::Hydration(event) => event.request_id,
-            RespondBidirectionalEvent::Canton(event) => event.request_id,
-        }
-    }
-
-    pub fn responder(&self) -> [u8; 32] {
-        match self {
-            RespondBidirectionalEvent::Solana(event) => event.responder.to_bytes(),
-            RespondBidirectionalEvent::Hydration(event) => event.responder,
-            // Canton party IDs are variable-length strings; hash fits them into [u8; 32].
-            RespondBidirectionalEvent::Canton(event) => {
-                keccak256(event.responder.as_bytes()).into()
-            }
-        }
-    }
-
-    pub fn serialized_output(&self) -> Vec<u8> {
-        match self {
-            RespondBidirectionalEvent::Solana(event) => event.serialized_output.clone(),
-            RespondBidirectionalEvent::Hydration(event) => event.serialized_output.clone(),
-            RespondBidirectionalEvent::Canton(event) => event.serialized_output.clone(),
-        }
-    }
-
-    pub fn signature(&self) -> Signature {
-        match self {
-            RespondBidirectionalEvent::Solana(event) => {
-                crate::indexer_sol::to_mpc_signature(event.signature.clone()).unwrap()
-            }
-            RespondBidirectionalEvent::Hydration(event) => event.signature,
-            RespondBidirectionalEvent::Canton(event) => event.signature,
-        }
-    }
-
-    pub fn source_chain(&self) -> Chain {
-        match self {
-            RespondBidirectionalEvent::Solana(_) => Chain::Solana,
-            RespondBidirectionalEvent::Hydration(_) => Chain::Hydration,
-            RespondBidirectionalEvent::Canton(_) => Chain::Canton,
-        }
-    }
-}
-
 #[derive(Clone, Debug)]
-pub struct EthereumSignatureRespondedEvent {
+pub struct RespondBidirectionalEvent {
     pub request_id: [u8; 32],
-    pub responder: alloy::primitives::Address,
-    /// Parsed MPC signature from Ethereum logs.
-    pub signature: Signature,
+    pub chain: Chain,
 }
 
 #[derive(Clone, Debug)]
-pub enum SignatureRespondedEvent {
-    Solana(signet_program::SignatureRespondedEvent),
-    Hydration(HydrationSignatureRespondedEvent),
-    /// Minimal Ethereum respond event representation (used to emit Respond events
-    /// from the Ethereum indexer without performing backlog mutations in the client).
-    Ethereum(EthereumSignatureRespondedEvent),
-    Canton(CantonSignatureRespondedEvent),
+pub struct SignatureRespondedEvent {
+    pub request_id: [u8; 32],
+    pub signature: Signature,
+    pub chain: Chain,
 }
 
 impl SignatureRespondedEvent {
     pub fn source_chain(&self) -> Chain {
-        match self {
-            SignatureRespondedEvent::Solana(_) => Chain::Solana,
-            SignatureRespondedEvent::Hydration(_) => Chain::Hydration,
-            SignatureRespondedEvent::Ethereum(_) => Chain::Ethereum,
-            SignatureRespondedEvent::Canton(_) => Chain::Canton,
-        }
+        self.chain
     }
 
     pub fn request_id(&self) -> [u8; 32] {
-        match self {
-            SignatureRespondedEvent::Solana(event) => event.request_id,
-            SignatureRespondedEvent::Hydration(event) => event.request_id,
-            SignatureRespondedEvent::Ethereum(event) => event.request_id,
-            SignatureRespondedEvent::Canton(event) => event.request_id,
-        }
+        self.request_id
     }
 
-    /// Convert the contained event into an `mpc_primitives::Signature`.
     pub fn signature(&self) -> Signature {
-        match self {
-            SignatureRespondedEvent::Solana(event) => {
-                crate::indexer_sol::to_mpc_signature(event.signature.clone()).unwrap()
-            }
-            SignatureRespondedEvent::Hydration(event) => event.signature,
-            SignatureRespondedEvent::Ethereum(event) => event.signature,
-            SignatureRespondedEvent::Canton(event) => event.signature,
-        }
+        self.signature
     }
 }
 
@@ -483,13 +403,9 @@ pub(crate) async fn process_respond_bidirectional_event(
     backlog: &Backlog,
     caught_up: bool,
 ) -> anyhow::Result<()> {
-    let sign_id = SignId::new(event.request_id());
+    let sign_id = SignId::new(event.request_id);
     tracing::info!(?sign_id, "processing RespondBidirectionalEvent");
-    if backlog
-        .remove(event.source_chain(), &sign_id)
-        .await
-        .is_some()
-    {
+    if backlog.remove(event.chain, &sign_id).await.is_some() {
         tracing::info!(?sign_id, "bidirectional tx completed");
     } else {
         tracing::warn!(?sign_id, "bidirectional tx not found on completion");
@@ -723,22 +639,23 @@ mod tests {
     }
 
     #[test]
-    fn ethereum_signature_respond_event_conversion() {
+    fn signature_respond_event_conversion() {
         let big_r = ProjectivePoint::GENERATOR.to_affine();
         let s_scalar = Scalar::from(5u64);
         let recovery_id: u8 = 1;
 
-        let eth_event = EthereumSignatureRespondedEvent {
+        let event = SignatureRespondedEvent {
             request_id: [0u8; 32],
-            responder: alloy::primitives::Address::from_slice(&[0u8; 20]),
             signature: Signature::new(big_r, s_scalar, recovery_id),
+            chain: Chain::Ethereum,
         };
 
         // check fields
-        let sig = eth_event.signature;
+        let sig = event.signature();
         assert_eq!(sig.recovery_id, recovery_id);
         assert_eq!(sig.s, s_scalar);
         assert_eq!(sig.big_r, big_r);
+        assert_eq!(event.source_chain(), Chain::Ethereum);
     }
 
     #[tokio::test]
@@ -1170,11 +1087,11 @@ mod tests {
             ))
             .await;
 
-        let event = SignatureRespondedEvent::Ethereum(EthereumSignatureRespondedEvent {
+        let event = SignatureRespondedEvent {
             request_id: sign_id.request_id,
-            responder: alloy::primitives::Address::from_slice(&[0u8; 20]),
             signature: Signature::new(ProjectivePoint::GENERATOR.to_affine(), Scalar::ONE, 0),
-        });
+            chain: Chain::Ethereum,
+        };
 
         let account_id: AccountId = "test.near".parse().unwrap();
         let public_key = ProjectivePoint::GENERATOR.to_affine();
@@ -1294,11 +1211,11 @@ mod tests {
             ))
             .await;
 
-        let event = SignatureRespondedEvent::Ethereum(EthereumSignatureRespondedEvent {
+        let event = SignatureRespondedEvent {
             request_id: sign_id.request_id,
-            responder: alloy::primitives::Address::from_slice(&[0u8; 20]),
             signature: Signature::new(ProjectivePoint::GENERATOR.to_affine(), Scalar::ONE, 0),
-        });
+            chain: Chain::Ethereum,
+        };
 
         let account_id: AccountId = "test.near".parse().unwrap();
         let public_key = ProjectivePoint::GENERATOR.to_affine();
@@ -1409,11 +1326,11 @@ mod tests {
             )
             .await;
 
-        let event = SignatureRespondedEvent::Ethereum(EthereumSignatureRespondedEvent {
+        let event = SignatureRespondedEvent {
             request_id: sign_id.request_id,
-            responder: alloy::primitives::Address::from_slice(&[0u8; 20]),
             signature: Signature::new(ProjectivePoint::GENERATOR.to_affine(), Scalar::ONE, 0),
-        });
+            chain: Chain::Ethereum,
+        };
 
         let account_id: AccountId = "test.near".parse().unwrap();
         let public_key = ProjectivePoint::GENERATOR.to_affine();
@@ -1754,18 +1671,9 @@ mod tests {
     }
 
     fn respond_event(sign_id: SignId) -> RespondBidirectionalEvent {
-        RespondBidirectionalEvent::Solana(signet_program::RespondBidirectionalEvent {
+        RespondBidirectionalEvent {
             request_id: sign_id.request_id,
-            responder: Pubkey::new_unique(),
-            serialized_output: vec![1, 2, 3],
-            signature: signet_program::Signature {
-                big_r: signet_program::AffinePoint {
-                    x: [0u8; 32],
-                    y: [0u8; 32],
-                },
-                s: [1u8; 32],
-                recovery_id: 0,
-            },
-        })
+            chain: Chain::Solana,
+        }
     }
 }

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -33,64 +33,11 @@ pub struct SignBidirectionalEvent {
 }
 
 impl SignBidirectionalEvent {
-    pub fn sender(&self) -> [u8; 32] {
-        self.sender
-    }
-
     pub(crate) fn sender_string(&self) -> anyhow::Result<String> {
         match self.chain {
             Chain::Canton => Ok(hex::encode(self.sender)),
             _ => sender_string(self.sender, self.chain),
         }
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn source_chain(&self) -> Chain {
-        self.chain
-    }
-
-    pub(crate) fn chain_ctx(&self) -> Option<Vec<u8>> {
-        self.chain_ctx.clone()
-    }
-
-    pub fn path(&self) -> String {
-        self.path.clone()
-    }
-
-    pub fn dest(&self) -> String {
-        self.dest.clone()
-    }
-
-    pub(crate) fn algo(&self) -> String {
-        self.algo.clone()
-    }
-
-    pub fn params(&self) -> String {
-        self.params.clone()
-    }
-
-    pub fn output_deserialization_schema(&self) -> Vec<u8> {
-        self.output_deserialization_schema.clone()
-    }
-
-    pub fn respond_serialization_schema(&self) -> Vec<u8> {
-        self.respond_serialization_schema.clone()
-    }
-
-    pub fn key_version(&self) -> u32 {
-        self.key_version
-    }
-
-    pub(crate) fn deposit(&self) -> u64 {
-        self.deposit
-    }
-
-    pub fn serialized_transaction(&self) -> Vec<u8> {
-        self.serialized_transaction.clone()
-    }
-
-    pub fn caip2_id(&self) -> String {
-        self.caip2_id.clone()
     }
 
     pub fn epsilon(&self) -> anyhow::Result<Scalar> {
@@ -126,39 +73,11 @@ pub struct RespondBidirectionalEvent {
     pub chain: Chain,
 }
 
-impl RespondBidirectionalEvent {
-    pub fn source_chain(&self) -> Chain {
-        self.chain
-    }
-
-    pub fn request_id(&self) -> [u8; 32] {
-        self.request_id
-    }
-
-    pub fn signature(&self) -> Signature {
-        self.signature
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct SignatureRespondedEvent {
     pub request_id: [u8; 32],
     pub signature: Signature,
     pub chain: Chain,
-}
-
-impl SignatureRespondedEvent {
-    pub fn source_chain(&self) -> Chain {
-        self.chain
-    }
-
-    pub fn request_id(&self) -> [u8; 32] {
-        self.request_id
-    }
-
-    pub fn signature(&self) -> Signature {
-        self.signature
-    }
 }
 
 pub(crate) trait SignatureEvent: std::fmt::Debug {
@@ -320,8 +239,8 @@ pub(crate) async fn process_respond_event(
     backlog: &Backlog,
     caught_up: bool,
 ) -> anyhow::Result<()> {
-    let sign_id = SignId::new(respond_event.request_id());
-    let source_chain = respond_event.source_chain();
+    let sign_id = SignId::new(respond_event.request_id);
+    let source_chain = respond_event.chain;
     let Some(entry) = backlog.get(source_chain, &sign_id).await else {
         tracing::info!(
             ?sign_id,
@@ -331,7 +250,7 @@ pub(crate) async fn process_respond_event(
         return Ok(());
     };
 
-    let responded_signature = respond_event.signature();
+    let responded_signature = respond_event.signature;
 
     verify_entry_signature(root_pk, &entry, &responded_signature, sign_id)?;
 
@@ -375,7 +294,7 @@ pub(crate) async fn process_respond_event(
 
     // Sign and hash the transaction to get the correct tx_id and nonce
     let (signed_tx_hash, nonce) = crate::sign_bidirectional::sign_and_hash_transaction(
-        &event.serialized_transaction(),
+        &event.serialized_transaction,
         mpc_sig,
     )?;
 
@@ -383,20 +302,20 @@ pub(crate) async fn process_respond_event(
 
     let bidirectional_tx = BidirectionalTx {
         id: tx_id,
-        sender: event.sender(),
-        serialized_transaction: event.serialized_transaction(),
+        sender: event.sender,
+        serialized_transaction: event.serialized_transaction.clone(),
         source_chain,
         target_chain,
-        caip2_id: event.caip2_id(),
-        key_version: event.key_version(),
-        deposit: event.deposit(),
-        path: event.path(),
-        algo: event.algo(),
-        dest: event.dest(),
-        params: event.params(),
-        output_deserialization_schema: event.output_deserialization_schema(),
-        respond_serialization_schema: event.respond_serialization_schema(),
-        request_id: respond_event.request_id(),
+        caip2_id: event.caip2_id.clone(),
+        key_version: event.key_version,
+        deposit: event.deposit,
+        path: event.path.clone(),
+        algo: event.algo.clone(),
+        dest: event.dest.clone(),
+        params: event.params.clone(),
+        output_deserialization_schema: event.output_deserialization_schema.clone(),
+        respond_serialization_schema: event.respond_serialization_schema.clone(),
+        request_id: respond_event.request_id,
         from_address,
         nonce,
     };
@@ -518,7 +437,7 @@ pub async fn process_execution_confirmed(
         .get(pending_tx.source_chain, &unwatched_sign_id)
         .await
         .and_then(|entry| match entry.request.kind {
-            SignKind::SignBidirectional(event) => event.chain_ctx(),
+            SignKind::SignBidirectional(event) => event.chain_ctx,
             _ => None,
         });
 
@@ -708,11 +627,11 @@ mod tests {
         };
 
         // check fields
-        let sig = event.signature();
+        let sig = event.signature;
         assert_eq!(sig.recovery_id, recovery_id);
         assert_eq!(sig.s, s_scalar);
         assert_eq!(sig.big_r, big_r);
-        assert_eq!(event.source_chain(), Chain::Ethereum);
+        assert_eq!(event.chain, Chain::Ethereum);
     }
 
     #[tokio::test]

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -80,8 +80,6 @@ pub struct SignatureRespondedEvent {
     pub chain: Chain,
 }
 
-
-
 pub(crate) async fn process_sign_request(
     sign_request: IndexedSignRequest,
     sign_tx: mpsc::Sender<Sign>,

--- a/chain-signatures/node/src/util/mod.rs
+++ b/chain-signatures/node/src/util/mod.rs
@@ -110,14 +110,14 @@ pub fn current_unix_timestamp() -> u64 {
 /// exactly like the legacy `ethabi` path so request IDs stay stable.
 #[allow(clippy::too_many_arguments)]
 pub fn ethabi_request_id(
-    sender: String,
+    sender: &str,
     payload: [u8; 32],
-    path: String,
+    path: &str,
     key_version: u32,
-    chain_id: String,
-    algo: String,
-    dest: String,
-    params: String,
+    chain_id: &str,
+    algo: &str,
+    dest: &str,
+    params: &str,
 ) -> [u8; 32] {
     const HEAD_WORDS: usize = 8;
     const WORD_SIZE: usize = 32;

--- a/integration-tests/src/mpc_fixture/mock_stream.rs
+++ b/integration-tests/src/mpc_fixture/mock_stream.rs
@@ -1,10 +1,8 @@
 use async_trait::async_trait;
-use elliptic_curve::sec1::ToEncodedPoint;
 use mpc_node::protocol::{IndexedSignRequest, SignKind};
 use mpc_node::rpc::RpcAction;
 use mpc_node::stream::{ChainEvent, ChainIndexer, ChainStream};
 use mpc_primitives::Chain;
-use solana_sdk::pubkey::Pubkey;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
@@ -159,15 +157,11 @@ impl InnerMockStream {
                 continue;
             }
 
-            // type conversions that would usually happen in RPC publishing -> Solana contract -> CPI event library
-            let big_r = publish_action.signature.big_r.to_encoded_point(false);
-            let sol_event = signet_program::SignatureRespondedEvent {
+            let respond_event = mpc_node::stream::ops::SignatureRespondedEvent {
                 request_id: publish_action.indexed.id.request_id,
-                responder: Pubkey::new_unique(),
-                signature: mpc_node::util::mpc_to_sol_signature(&publish_action.signature, big_r),
+                signature: publish_action.signature,
+                chain: Chain::Solana,
             };
-
-            let respond_event = mpc_node::stream::ops::SignatureRespondedEvent::Solana(sol_event);
 
             block.push(ChainEvent::Respond(respond_event));
         }

--- a/integration-tests/tests/cases/canton_stream.rs
+++ b/integration-tests/tests/cases/canton_stream.rs
@@ -72,23 +72,24 @@ async fn test_canton_stream_parse_sign_event() -> Result<()> {
         panic!("expected SignBidirectional, got {:?}", event.kind);
     };
 
-    let expected_hash = mpc_node::sign_bidirectional::hash_rlp_data(bidir.serialized_transaction());
+    let expected_hash =
+        mpc_node::sign_bidirectional::hash_rlp_data(bidir.serialized_transaction.clone());
     let expected_payload = <k256::Scalar as ScalarExt>::from_bytes(expected_hash)
         .expect("test tx hash must be a valid scalar");
     assert_eq!(
         event.args.payload, expected_payload,
         "payload should match keccak256 of normalized serialized_transaction"
     );
-    assert_eq!(bidir.caip2_id(), expected_event.caip2_id);
-    assert_eq!(bidir.dest(), expected_event.dest);
-    assert_eq!(bidir.key_version(), expected_event.key_version);
-    assert_eq!(bidir.path(), expected_event.path);
+    assert_eq!(bidir.caip2_id, expected_event.caip2_id);
+    assert_eq!(bidir.dest, expected_event.dest);
+    assert_eq!(bidir.key_version, expected_event.key_version);
+    assert_eq!(bidir.path, expected_event.path);
     assert_eq!(
-        bidir.output_deserialization_schema(),
+        bidir.output_deserialization_schema,
         expected_event.output_deserialization_schema.as_bytes()
     );
     assert_eq!(
-        bidir.respond_serialization_schema(),
+        bidir.respond_serialization_schema,
         expected_event.respond_serialization_schema.as_bytes()
     );
     Ok(())
@@ -447,13 +448,13 @@ async fn test_canton_stream_parse_sign_bidirectional_fields() -> Result<()> {
         panic!("expected SignBidirectional, got {:?}", req.kind);
     };
 
-    assert_eq!(bidir.caip2_id(), expected_event.caip2_id);
-    assert_eq!(bidir.dest(), expected_event.dest);
-    assert_eq!(bidir.path(), expected_event.path);
-    assert_eq!(bidir.key_version(), expected_event.key_version);
+    assert_eq!(bidir.caip2_id, expected_event.caip2_id);
+    assert_eq!(bidir.dest, expected_event.dest);
+    assert_eq!(bidir.path, expected_event.path);
+    assert_eq!(bidir.key_version, expected_event.key_version);
     let expected_sender = hex::decode(&expected_event.sender)?;
     assert_eq!(
-        bidir.sender(),
+        bidir.sender,
         <[u8; 32]>::try_from(expected_sender.as_slice())?
     );
     assert_eq!(bidir.chain, Chain::Canton, "expected Canton chain");
@@ -463,15 +464,15 @@ async fn test_canton_stream_parse_sign_bidirectional_fields() -> Result<()> {
         "caip2_id should parse to Chain::Ethereum"
     );
     assert_eq!(
-        bidir.output_deserialization_schema(),
+        bidir.output_deserialization_schema,
         expected_event.output_deserialization_schema.as_bytes()
     );
     assert_eq!(
-        bidir.respond_serialization_schema(),
+        bidir.respond_serialization_schema,
         expected_event.respond_serialization_schema.as_bytes()
     );
     assert!(
-        !bidir.serialized_transaction().is_empty(),
+        !bidir.serialized_transaction.is_empty(),
         "RLP-encoded tx should not be empty"
     );
     Ok(())

--- a/integration-tests/tests/cases/canton_stream.rs
+++ b/integration-tests/tests/cases/canton_stream.rs
@@ -6,7 +6,6 @@ use mpc_node::backlog::Backlog;
 use mpc_node::indexer_canton::contracts::{CantonSignature, EcdsaSigData};
 use mpc_node::indexer_canton::{der_encode_signature, CantonStream};
 use mpc_node::protocol::{Chain, IndexedSignRequest, SignKind};
-use mpc_node::stream::ops::SignatureRespondedEvent;
 use mpc_node::stream::{catchup_then_livestream, ChainEvent, ChainStream};
 use mpc_primitives::{ScalarExt, Signature, LATEST_MPC_KEY_VERSION};
 use serde_json::json;
@@ -408,7 +407,8 @@ async fn test_canton_stream_sign_and_respond_flow() -> Result<()> {
     let mut saw_respond = false;
     for _ in 0..10 {
         match timeout(Duration::from_secs(5), stream.next_event()).await {
-            Ok(Some(ChainEvent::Respond(SignatureRespondedEvent::Canton(ev)))) => {
+            Ok(Some(ChainEvent::Respond(ev))) => {
+                assert_eq!(ev.chain, mpc_primitives::Chain::Canton);
                 assert_eq!(hex::encode(ev.request_id), request_id);
                 assert_eq!(ev.signature.big_r, expected_big_r);
                 assert_eq!(ev.signature.s, expected_s);

--- a/integration-tests/tests/cases/canton_stream.rs
+++ b/integration-tests/tests/cases/canton_stream.rs
@@ -6,6 +6,7 @@ use mpc_node::backlog::Backlog;
 use mpc_node::indexer_canton::contracts::{CantonSignature, EcdsaSigData};
 use mpc_node::indexer_canton::{der_encode_signature, CantonStream};
 use mpc_node::protocol::{Chain, IndexedSignRequest, SignKind};
+use mpc_node::sign_bidirectional::hash_rlp_data;
 use mpc_node::stream::{catchup_then_livestream, ChainEvent, ChainStream};
 use mpc_primitives::{ScalarExt, Signature, LATEST_MPC_KEY_VERSION};
 use serde_json::json;
@@ -72,8 +73,7 @@ async fn test_canton_stream_parse_sign_event() -> Result<()> {
         panic!("expected SignBidirectional, got {:?}", event.kind);
     };
 
-    let expected_hash =
-        mpc_node::sign_bidirectional::hash_rlp_data(bidir.serialized_transaction.clone());
+    let expected_hash = hash_rlp_data(&bidir.serialized_transaction);
     let expected_payload = <k256::Scalar as ScalarExt>::from_bytes(expected_hash)
         .expect("test tx hash must be a valid scalar");
     assert_eq!(

--- a/integration-tests/tests/cases/canton_stream.rs
+++ b/integration-tests/tests/cases/canton_stream.rs
@@ -363,9 +363,15 @@ async fn test_canton_stream_sign_and_respond_flow() -> Result<()> {
     assert_eq!(sign_event.chain, Chain::Canton);
     let request_id = hex::encode(sign_event.id.request_id);
     let sign_event_cid = match &sign_event.kind {
-        SignKind::SignBidirectional(mpc_node::stream::ops::SignBidirectionalEvent::Canton(
-            canton_event,
-        )) => canton_event.sign_event_contract_id.clone(),
+        SignKind::SignBidirectional(event) if event.chain == Chain::Canton => {
+            let chain_ctx_bytes = event
+                .chain_ctx
+                .as_deref()
+                .expect("missing chain_ctx on Canton sign request");
+            let ctx: mpc_node::indexer_canton::CantonChainCtx =
+                borsh::from_slice(chain_ctx_bytes).expect("failed to deserialize CantonChainCtx");
+            ctx.sign_event_contract_id.clone()
+        }
         _ => panic!("expected Canton SignBidirectional event"),
     };
 
@@ -450,13 +456,7 @@ async fn test_canton_stream_parse_sign_bidirectional_fields() -> Result<()> {
         bidir.sender(),
         <[u8; 32]>::try_from(expected_sender.as_slice())?
     );
-    assert!(
-        matches!(
-            bidir,
-            mpc_node::stream::ops::SignBidirectionalEvent::Canton(_)
-        ),
-        "expected Canton variant"
-    );
+    assert_eq!(bidir.chain, Chain::Canton, "expected Canton chain");
     assert_eq!(
         bidir.target_chain()?,
         Chain::Ethereum,

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -18,7 +18,6 @@ use mpc_node::rpc::{ContractStateWatcher, RpcChannel};
 use mpc_node::sign_bidirectional::{PublishState, SignStatus};
 use mpc_node::storage::checkpoint_storage::CheckpointStorage;
 use mpc_node::stream::ops::SignBidirectionalEvent as NodeSignBidirectionalEvent;
-use mpc_node::stream::ops::SignatureRespondedEvent;
 use mpc_node::stream::{catchup_then_livestream, run_stream, ChainEvent, ChainStream};
 use mpc_node::util::current_unix_timestamp;
 use mpc_primitives::{SignArgs, SignId, LATEST_MPC_KEY_VERSION};
@@ -1109,7 +1108,8 @@ async fn test_ethereum_stream_sign_and_respond_flow() -> Result<()> {
     let mut saw_respond = false;
     for _ in 0..8 {
         match next_event_within(&mut stream, Duration::from_secs(10)).await? {
-            ChainEvent::Respond(SignatureRespondedEvent::Ethereum(ev)) => {
+            ChainEvent::Respond(ev) => {
+                assert_eq!(ev.chain, mpc_primitives::Chain::Ethereum);
                 assert_eq!(ev.request_id, sign_req.id.request_id);
                 assert_eq!(ev.signature.big_r, expected_big_r);
                 assert_eq!(ev.signature.s, expected_s);

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -318,20 +318,21 @@ fn test_bidirectional_event() -> NodeSignBidirectionalEvent {
     rlp_s.append(&0u64);
     rlp_s.append(&0u64);
 
-    NodeSignBidirectionalEvent::Solana(signet_program::SignBidirectionalEvent {
-        sender: solana_sdk::pubkey::Pubkey::new_unique(),
+    NodeSignBidirectionalEvent {
+        sender: solana_sdk::pubkey::Pubkey::new_unique().to_bytes(),
         serialized_transaction: rlp_s.out().to_vec(),
-        dest: Chain::Ethereum.to_string(),
         caip2_id: "eip155:31337".to_string(),
         key_version: LATEST_MPC_KEY_VERSION,
         deposit: 1,
         path: "bidirectional-test-path".to_string(),
         algo: "secp256k1".to_string(),
+        dest: Chain::Ethereum.to_string(),
         params: "{}".to_string(),
-        program_id: solana_sdk::pubkey::Pubkey::new_unique(),
+        chain: Chain::Solana,
+        chain_ctx: Some(solana_sdk::pubkey::Pubkey::new_unique().to_bytes().to_vec()),
         output_deserialization_schema: vec![],
         respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
-    })
+    }
 }
 
 struct StartedEthereumStream {

--- a/integration-tests/tests/cases/mpc_with_stream.rs
+++ b/integration-tests/tests/cases/mpc_with_stream.rs
@@ -258,7 +258,7 @@ async fn run_stale_task_test(drop_respond_event: bool) {
             2,
             Box::new(move |event: &ChainEvent| {
                 if let ChainEvent::Respond(respond) = event {
-                    if respond.request_id() == bad_sign_id.request_id {
+                    if respond.request_id == bad_sign_id.request_id {
                         return EventDelivery::Drop;
                     }
                 }


### PR DESCRIPTION
removes a couple types over multiple chain that are a bit verbose. These don't break serialization so it's good to go