### PR TITLE
fix: prevent `eth_account_sk` leakage to stdout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5479,7 +5479,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -7416,6 +7416,7 @@ dependencies = [
  "redis",
  "reqwest 0.11.27",
  "rlp",
+ "secrecy 0.10.3",
  "semver 1.0.26",
  "serde",
  "serde-aux",
@@ -11106,7 +11107,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11530,6 +11531,15 @@ name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
 ]
@@ -14386,7 +14396,7 @@ dependencies = [
  "scale-info",
  "schnorrkel",
  "secp256k1 0.28.2",
- "secrecy",
+ "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
  "sp-crypto-hashing",

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -98,6 +98,7 @@ alloy-primitives.workspace = true
 rlp.workspace = true
 
 maud = { version = "0.27.0", optional = true }
+secrecy = "0.10.3"
 
 [dev-dependencies]
 mockito.workspace = true

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -26,6 +26,7 @@ use local_ip_address::local_ip;
 use mpc_keys::hpke;
 use near_account_id::AccountId;
 use near_crypto::{InMemorySigner, PublicKey, SecretKey};
+use secrecy::ExposeSecret;
 use sha3::Digest;
 use tokio::sync::{mpsc, watch};
 use url::Url;
@@ -280,8 +281,10 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let (contract_watcher, contract_state_tx) = ContractStateWatcher::new(&account_id);
 
             let eth_account_address = eth.eth_account_sk.as_ref().map(|sk| {
-                let signer: alloy_signer_local::PrivateKeySigner =
-                    sk.parse().expect("cannot parse Eth account sk");
+                let signer: alloy_signer_local::PrivateKeySigner = sk
+                    .expose_secret()
+                    .parse()
+                    .expect("cannot parse Eth account sk");
                 format!("{}", signer.address())
             });
             let sol_payer_address = sol.sol_account_sk.as_ref().map(|sk| {

--- a/chain-signatures/node/src/config.rs
+++ b/chain-signatures/node/src/config.rs
@@ -82,10 +82,21 @@ pub struct LocalConfig {
     pub over: OverrideConfig,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct NetworkConfig {
     pub sign_sk: near_crypto::SecretKey,
     pub cipher_sk: hpke::SecretKey,
+}
+
+/// Custom Debug implementation to avoid printing the secret keys in logs.
+/// Underlying crates probably redact already, but it's better to be 100% sure
+impl std::fmt::Debug for NetworkConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NetworkConfig")
+            .field("sign_sk", &"<hidden>")
+            .field("cipher_sk", &"<hidden>")
+            .finish()
+    }
 }
 
 impl Default for NetworkConfig {

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -25,6 +25,7 @@ use mpc_crypto::{kdf::derive_epsilon_eth, ScalarExt as _};
 use mpc_primitives::{
     SignArgs, SignId, Signature as MpcSignature, LATEST_MPC_KEY_VERSION, MAX_SECP256K1_SCALAR,
 };
+use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -181,7 +182,7 @@ pub struct EthArgs {
         env("MPC_ETH_ACCOUNT_SK"),
         requires_all = ["eth_execution_rpc_http_url", "eth_contract_address"]
     )]
-    pub eth_account_sk: Option<String>,
+    pub eth_account_sk: Option<SecretString>,
     /// The contract address to watch without the `0x` prefix
     #[clap(long, env("MPC_ETH_CONTRACT_ADDRESS"), requires = "eth_account_sk")]
     pub eth_contract_address: Option<String>,
@@ -247,7 +248,10 @@ impl EthArgs {
     pub fn into_str_args(self) -> Vec<String> {
         let mut args = Vec::with_capacity(10);
         if let Some(eth_account_sk) = self.eth_account_sk {
-            args.extend(["--eth-account-sk".to_string(), eth_account_sk]);
+            args.extend([
+                "--eth-account-sk".to_string(),
+                eth_account_sk.expose_secret().to_string(),
+            ]);
         }
         if let Some(eth_consensus_rpc_http_url) = self.eth_consensus_rpc_http_url {
             args.extend([
@@ -294,7 +298,7 @@ impl EthArgs {
         }
 
         Some(EthConfig {
-            account_sk: self.eth_account_sk?,
+            account_sk: self.eth_account_sk?.expose_secret().to_string(), // this is safe because  EthConfig has custom Debug implementation that redacts the account_sk field
             consensus_rpc_http_url: self.eth_consensus_rpc_http_url.unwrap_or_default(),
             execution_rpc_http_url: self.eth_execution_rpc_http_url.unwrap(),
             contract_address: self.eth_contract_address.unwrap(),
@@ -312,7 +316,7 @@ impl EthArgs {
     pub fn from_config(config: Option<EthConfig>) -> Self {
         match config {
             Some(config) if !config.account_sk.is_empty() => Self {
-                eth_account_sk: Some(config.account_sk),
+                eth_account_sk: Some(config.account_sk.into()),
                 eth_consensus_rpc_http_url: Some(config.consensus_rpc_http_url),
                 eth_execution_rpc_http_url: Some(config.execution_rpc_http_url),
                 eth_contract_address: Some(config.contract_address),

--- a/chain-signatures/primitives/src/lib.rs
+++ b/chain-signatures/primitives/src/lib.rs
@@ -110,7 +110,7 @@ pub struct SignArgs {
 impl std::fmt::Debug for SignArgs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SignArgs")
-            .field("entropy", &hex::encode(self.entropy))
+            .field("entropy", &hex::encode(&self.entropy[..4])) // not a secret atm, but better truncate for readability and logging safety in the future (if it becomes one)
             .field("epsilon", &self.epsilon)
             .field("payload", &self.payload)
             .field("path", &self.path)


### PR DESCRIPTION
I noticed there is a risk of accidental leak of `eth_account_sk` to stdout (If Clap fails to parse an argument or someone logs the `Cli` or `Config` structs).
This PR adds `secrecy` crate and introduces `SecretString` for `eth_account_sk`. Plus few other minor secret-related enhancements