### PR TITLE
Revert "fix: backpressure drop messages on full"

### DIFF
--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -2,6 +2,8 @@ mod filter;
 mod sub;
 mod types;
 
+pub use sub::{Subscriber, POSIT_INBOX_CHANNEL_SIZE};
+
 use super::contract::primitives::{ParticipantMap, Participants};
 use super::presignature::PresignatureId;
 use super::triple::TripleId;
@@ -23,7 +25,6 @@ pub use crate::protocol::message::types::{
     PresignatureMessage, Protocols, ReadyMessage, ResharingMessage, SignatureMessage,
     TripleMessage,
 };
-pub use sub::{Subscriber, POSIT_INBOX_CHANNEL_SIZE};
 
 use cait_sith::protocol::Participant;
 use mpc_contract::config::ProtocolConfig;
@@ -95,67 +96,65 @@ impl MessageInbox {
             resharing: Subscriber::unsubscribed("resharing"),
             ready: Subscriber::unsubscribed("ready"),
             triple: HashMap::new(),
-            triple_init: Subscriber::unsubscribed_with_capacity(
-                "triple_posit",
-                sub::MAX_MESSAGE_POSIT_SUB_CHANNEL_SIZE,
-            ),
+            triple_init: Subscriber::unsubscribed("triple_posit"),
             presignature: HashMap::new(),
-            presignature_init: Subscriber::unsubscribed_with_capacity(
-                "presignature_posit",
-                sub::MAX_MESSAGE_POSIT_SUB_CHANNEL_SIZE,
-            ),
+            presignature_init: Subscriber::unsubscribed("presignature_posit"),
             signature: HashMap::new(),
-            signature_init: Subscriber::unsubscribed_with_capacity(
-                "signature_posit",
-                sub::MAX_MESSAGE_POSIT_SUB_CHANNEL_SIZE,
-            ),
+            signature_init: Subscriber::unsubscribed("signature_posit"),
         }
     }
 
-    fn send(&mut self, message: Message) {
+    async fn send(&mut self, message: Message) {
         match message {
             Message::Posit(message) => match message.id {
                 PositProtocolId::Triple(id) => {
                     let _ = self
                         .triple_init
-                        .try_send_lossy((id, message.from, message.action));
+                        .send((id, message.from, message.action))
+                        .await;
                     self.triple_init.report_capacity_global();
                 }
                 PositProtocolId::Presignature(id) => {
-                    let _ =
-                        self.presignature_init
-                            .try_send_lossy((id, message.from, message.action));
+                    let _ = self
+                        .presignature_init
+                        .send((id, message.from, message.action))
+                        .await;
                     self.presignature_init.report_capacity_global();
                 }
                 PositProtocolId::Signature(sign_id, presignature_id, round) => {
-                    let _ = self.signature_init.try_send_lossy((
-                        sign_id,
-                        presignature_id,
-                        round,
-                        message.from,
-                        message.action,
-                    ));
+                    let _ = self
+                        .signature_init
+                        .send((
+                            sign_id,
+                            presignature_id,
+                            round,
+                            message.from,
+                            message.action,
+                        ))
+                        .await;
                     self.signature_init.report_capacity_global();
                 }
             },
             Message::Generating(message) => {
-                let _ = self.generating.try_send_lossy(message);
+                let _ = self.generating.send(message).await;
                 self.generating.report_capacity_global();
             }
             Message::Resharing(message) => {
-                let _ = self.resharing.try_send_lossy(message);
+                let _ = self.resharing.send(message).await;
                 self.resharing.report_capacity_global();
             }
             Message::Ready(message) => {
-                let _ = self.ready.try_send_lossy(message);
+                let _ = self.ready.send(message).await;
                 self.ready.report_capacity_global();
             }
             Message::Triple(message) => {
+                // NOTE: not logging the error because this is simply just channel closure.
+                // The error message should be reported on the generator side.
                 let sub = self
                     .triple
                     .entry(message.id)
                     .or_insert_with(|| Subscriber::unsubscribed("triple_task"));
-                let _ = sub.try_send_lossy(message);
+                let _ = sub.send(message).await;
                 sub.report_capacity();
                 set_inbox_count("triple_task", self.triple.len());
             }
@@ -164,7 +163,7 @@ impl MessageInbox {
                     .presignature
                     .entry(message.id)
                     .or_insert_with(|| Subscriber::unsubscribed("presign_task"));
-                let _ = sub.try_send_lossy(message);
+                let _ = sub.send(message).await;
                 sub.report_capacity();
                 set_inbox_count("presign_task", self.presignature.len());
             }
@@ -173,7 +172,7 @@ impl MessageInbox {
                     .signature
                     .entry((message.id, message.presignature_id))
                     .or_insert_with(|| Subscriber::unsubscribed("sign_task"));
-                let _ = sub.try_send_lossy(message);
+                let _ = sub.send(message).await;
                 sub.report_capacity();
                 set_inbox_count("sign_task", self.signature.len());
             }
@@ -238,9 +237,9 @@ impl MessageInbox {
     }
 
     /// Publish messages to subscribers
-    fn publish(&mut self, messages: Vec<Message>) {
+    async fn publish(&mut self, messages: Vec<Message>) {
         for message in messages {
-            self.send(message);
+            self.send(message).await;
         }
     }
 
@@ -397,7 +396,7 @@ impl MessageInbox {
 
                     let messages = self.filter(messages);
                     let messages_len = messages.len();
-                    self.publish(messages);
+                    self.publish(messages).await;
 
                     crate::metrics::messaging::NUM_RECEIVED_ENCRYPTED_TOTAL
                         .inc_by(messages_len as f64);
@@ -1555,75 +1554,5 @@ mod tests {
         }
 
         inbox.abort();
-    }
-
-    #[tokio::test]
-    async fn test_signature_posit_backpressure_does_not_block_ready_messages() {
-        use crate::protocol::message::{
-            sub, MessageInbox, PositMessage, PositProtocolId, ReadyMessage,
-        };
-        use crate::protocol::posit::PositAction;
-        use tokio::sync::mpsc;
-
-        let (inbox_tx, inbox_rx) = mpsc::channel(1);
-        let (filter_tx, filter_rx) = mpsc::channel(1);
-        let (subscribe_tx, subscribe_rx) = mpsc::channel(1);
-        let mut inbox = MessageInbox::new(
-            inbox_tx,
-            inbox_rx,
-            filter_tx,
-            filter_rx,
-            subscribe_tx,
-            subscribe_rx,
-        );
-
-        // Override to a small capacity so we can easily fill it
-        inbox.signature_init = sub::Subscriber::unsubscribed_with_capacity("signature_posit", 1);
-
-        let (signature_req, signature_resp) =
-            sub::SubscribeRequest::subscribe(sub::SubscribeId::Signatures);
-        inbox.process_subscribe(signature_req);
-        let mut signature_posit_rx = match signature_resp.await.unwrap() {
-            sub::SubscribeResponse::SignaturePosit(rx) => rx,
-            _ => panic!("expected signature posit subscription"),
-        };
-
-        let (ready_req, ready_resp) = sub::SubscribeRequest::subscribe(sub::SubscribeId::Ready);
-        inbox.process_subscribe(ready_req);
-        let mut ready_rx = match ready_resp.await.unwrap() {
-            sub::SubscribeResponse::Ready(rx) => rx,
-            _ => panic!("expected ready subscription"),
-        };
-
-        let sign_id = SignId::new([9; 32]);
-        let from = Participant::from(0);
-        // Flood the signature posit channel beyond its capacity
-        let mut messages = Vec::with_capacity(sub::MAX_MESSAGE_SUB_CHANNEL_SIZE + 2);
-        for round in 0..=sub::MAX_MESSAGE_SUB_CHANNEL_SIZE {
-            messages.push(Message::Posit(PositMessage {
-                id: PositProtocolId::Signature(sign_id, 77, round),
-                from,
-                action: PositAction::Accept,
-            }));
-        }
-        messages.push(Message::Ready(ReadyMessage {
-            epoch: 1,
-            from,
-            nonce: 1,
-            token: 1,
-        }));
-
-        inbox.publish(messages);
-        let ready_message = tokio::time::timeout(Duration::from_millis(100), ready_rx.recv())
-            .await
-            .expect("ready message should not be blocked by signature posit backlog")
-            .expect("ready subscription unexpectedly closed");
-        assert_eq!(ready_message.epoch, 1);
-
-        let first_signature_posit = signature_posit_rx
-            .recv()
-            .await
-            .expect("signature posit subscription unexpectedly closed");
-        assert_eq!(first_signature_posit.0, sign_id);
     }
 }

--- a/chain-signatures/node/src/protocol/message/sub.rs
+++ b/chain-signatures/node/src/protocol/message/sub.rs
@@ -17,9 +17,6 @@ use crate::util::channel_len;
 
 /// This should be enough to hold a few messages in the inbox.
 pub const MAX_MESSAGE_SUB_CHANNEL_SIZE: usize = 4 * 1024;
-/// Posit channels can accumulate many small control-plane messages; use a large
-/// capacity to avoid backpressure or deadlock under high concurrency.
-pub const MAX_MESSAGE_POSIT_SUB_CHANNEL_SIZE: usize = 1 << 24;
 
 /// Small under test-feature so dead-letter inboxes fill quickly in clog tests.
 pub const POSIT_INBOX_CHANNEL_SIZE: usize = if cfg!(feature = "test-feature") {
@@ -193,45 +190,20 @@ impl<T> Subscriber<T> {
             SubscriberKind::Unknown => Ok(()),
         }
     }
-
-    pub fn try_send_lossy(&self, msg: T) -> Result<(), mpsc::error::SendError<T>> {
-        // TODO: https://github.com/sig-net/mpc/issues/864
-        // Need to drop messages in a more well defined manner than just dropping
-        // whatever message is latest. We'd likely need the latest vs the oldest
-        // since the oldest message would have a higher chance of being out of date.
-        let result = match &self.kind {
-            SubscriberKind::Subscribed(tx) | SubscriberKind::Unsubscribed(tx, _) => {
-                match tx.try_send(msg) {
-                    Ok(()) => Ok(()),
-                    Err(mpsc::error::TrySendError::Full(_)) => {
-                        tracing::warn!(
-                            subscriber = self.metrics.name,
-                            capacity = self.metrics.capacity,
-                            "dropping message: subscriber channel full"
-                        );
-                        Ok(())
-                    }
-                    Err(mpsc::error::TrySendError::Closed(msg)) => Err(mpsc::error::SendError(msg)),
-                }
-            }
-            SubscriberKind::Unknown => Ok(()),
-        };
-        self.report_capacity();
-        result
-    }
 }
+
 #[cfg(test)]
 mod tests {
     use super::Subscriber;
 
-    #[test]
-    fn estimated_queue_len_tracks_buffered_messages() {
+    #[tokio::test]
+    async fn estimated_queue_len_tracks_buffered_messages() {
         let sub = Subscriber::unsubscribed_with_capacity("test", 4);
 
         assert_eq!(sub.estimated_len(), 0);
 
-        sub.try_send_lossy(1u8).unwrap();
-        sub.try_send_lossy(2u8).unwrap();
+        sub.send(1u8).await.unwrap();
+        sub.send(2u8).await.unwrap();
 
         assert_eq!(sub.estimated_len(), 2);
     }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -1697,7 +1697,7 @@ impl SignatureSpawner {
     }
 
     /// Handle a posit message - routes to existing task or buffers if task not yet created
-    fn handle_posit(
+    async fn handle_posit(
         &mut self,
         me: Participant,
         sign_id: SignId,
@@ -1716,14 +1716,14 @@ impl SignatureSpawner {
                 crate::protocol::message::POSIT_INBOX_CHANNEL_SIZE,
             )
         });
-        if let Err(err) = inbox.try_send_lossy(SignTaskMessage::PositMessage {
-            presignature_id,
-            round,
-            from,
-            action,
-        }) {
-            tracing::error!(?err, ?sign_id, "failed to send posit message");
-        }
+        let _ = inbox
+            .send(SignTaskMessage::PositMessage {
+                presignature_id,
+                round,
+                from,
+                action,
+            })
+            .await;
         inbox.report_capacity();
     }
 
@@ -1829,7 +1829,7 @@ impl SignatureSpawner {
                     self.handle_request(&governance, sign, &protocol);
                 }
                 Some((sign_id, presignature_id, round, from, action)) = posits.recv() => {
-                    self.handle_posit(governance.me, sign_id, presignature_id, round, from, action);
+                    self.handle_posit(governance.me, sign_id, presignature_id, round, from, action).await;
                 }
                 Some(result) = self.tasks.join_next(), if !self.tasks.is_empty() => {
                     self.handle_task_exit(result);

--- a/integration-tests/tests/cases/mpc_with_stream.rs
+++ b/integration-tests/tests/cases/mpc_with_stream.rs
@@ -153,9 +153,9 @@ async fn test_channel_contention_1M_requests() {
     check_channel_contention(1000, 1000, 75, None).await;
 }
 
-/// A missed respond event leaves a stale task but does not clog other nodes' inboxes.
+/// A missed respond event leaves a stale task that clogs other nodes' inboxes.
 #[test(tokio::test(flavor = "multi_thread"))]
-async fn test_missed_respond_event_does_not_clog_inbox() {
+async fn test_missed_respond_event_clogs_inbox() {
     run_stale_task_test(true).await;
 }
 
@@ -298,11 +298,14 @@ async fn run_stale_task_test(drop_respond_event: bool) {
     }
 
     if drop_respond_event {
-        // Even with a missed respond event causing a stale task on node 2,
-        // all 20 requests must complete successfully because nodes 0 and 1 drop the stale posit messages.
-        assert_eq!(
-            completed, 20,
-            "expected all 20 requests to complete (backpressure dropping prevents clog), got {completed}"
+        // Clog: bad request must have been processed, but not all 20.
+        assert!(
+            completed > bad_request_seed,
+            "expected more than {bad_request_seed} successful requests (including the bad one), got {completed}"
+        );
+        assert!(
+            completed < 20,
+            "expected clog to prevent some requests, but all 20 completed"
         );
 
         // Bad request: nodes 0+1 generated, node 2 was excluded.
@@ -336,16 +339,90 @@ async fn run_stale_task_test(drop_respond_event: bool) {
             n2_bad.signature
         );
 
-        // Send a fresh request and verify it is successfully signed.
+        // Send a fresh request and verify nodes 0+1 are durably silent.
         let fresh_seed = completed + 100;
+        let new_sign_id = sign_request(fresh_seed).id;
+        let n2_bad_before = tracker_counts
+            .lock()
+            .unwrap()
+            .get(&(node_2, bad_sign_id))
+            .cloned()
+            .unwrap_or_default()
+            .posit;
+
         network
             .process_sign_requests(Chain::Solana, &[sign_request(fresh_seed)])
             .await;
 
-        let actions = network
-            .assert_actions(completed as usize + 1, Duration::from_secs(30))
-            .await;
-        assert_eq!(actions.len(), completed as usize + 1);
+        tokio::time::timeout(Duration::from_secs(120), async {
+            loop {
+                let ready = {
+                    let counts = tracker_counts.lock().unwrap();
+                    let bad_posits = counts
+                        .get(&(node_2, bad_sign_id))
+                        .map_or(0, |c| c.posit.saturating_sub(n2_bad_before));
+                    let new_posits = counts.get(&(node_2, new_sign_id)).map_or(0, |c| c.posit);
+                    bad_posits >= 2 && new_posits >= 2
+                };
+                if ready {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        })
+        .await
+        .expect("node 2 should be sending posit messages for both bad and new requests");
+
+        // Two snapshots with a quiet period prove durable silence.
+        let n0_snap1 = tracker_counts
+            .lock()
+            .unwrap()
+            .get(&(node_0, new_sign_id))
+            .cloned()
+            .unwrap_or_default();
+        let n1_snap1 = tracker_counts
+            .lock()
+            .unwrap()
+            .get(&(node_1, new_sign_id))
+            .cloned()
+            .unwrap_or_default();
+
+        let quiet_period = 2 * mpc_node::protocol::signature::organize_posit_timeout();
+        tokio::time::sleep(quiet_period).await;
+
+        let n0_snap2 = tracker_counts
+            .lock()
+            .unwrap()
+            .get(&(node_0, new_sign_id))
+            .cloned()
+            .unwrap_or_default();
+        let n1_snap2 = tracker_counts
+            .lock()
+            .unwrap()
+            .get(&(node_1, new_sign_id))
+            .cloned()
+            .unwrap_or_default();
+
+        assert_eq!(
+            n0_snap1.posit + n0_snap1.signature,
+            0,
+            "node 0 sent messages for new request — expected 0 (spawner clogged)"
+        );
+        assert_eq!(
+            n1_snap1.posit + n1_snap1.signature,
+            0,
+            "node 1 sent messages for new request — expected 0 (spawner clogged)"
+        );
+        assert_eq!(
+            n0_snap2.posit + n0_snap2.signature,
+            0,
+            "node 0 sent messages during quiet period — clog is not durable"
+        );
+        assert_eq!(
+            n1_snap2.posit + n1_snap2.signature,
+            0,
+            "node 1 sent messages during quiet period — clog is not durable"
+        );
     } else {
         // Respond event cleans up the stale task — all requests complete.
         assert_eq!(


### PR DESCRIPTION
This fix was discussed many times, and it is not ideal. Let's get rid of it once we have the proper fix.
@ChaoticTempest @ppca, please, let's define a proper way of fixing it.