### PR TITLE
feat: secret storage enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6577,9 +6577,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -7042,9 +7042,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -7433,6 +7433,7 @@ dependencies = [
  "sp-trie",
  "subxt",
  "sysinfo",
+ "tempfile",
  "test-log",
  "thiserror 1.0.69",
  "tokio",
@@ -10939,15 +10940,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15597,15 +15598,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.5",
- "windows-sys 0.59.0",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17521,7 +17522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "rustix 1.0.5",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -102,6 +102,7 @@ secrecy = "0.10.3"
 
 [dev-dependencies]
 mockito.workspace = true
+tempfile = "3.27.0"
 test-log = { version = "0.2.12", features = ["log", "trace"] }
 
 [features]

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -30,7 +30,7 @@ use crate::protocol::signature::SignatureSpawnerTask;
 use crate::respond_bidirectional::RespondBidirectionalTx;
 use crate::rpc::ContractStateWatcher;
 use crate::storage::presignature_storage::PresignatureStorage;
-use crate::storage::secret_storage::SecretNodeStorageBox;
+use crate::storage::secret_storage::SecretNodeStorageVariant;
 use crate::storage::triple_storage::TripleStorage;
 
 use near_account_id::AccountId;
@@ -42,7 +42,7 @@ use tokio::sync::{mpsc, watch};
 
 pub struct MpcSignProtocol {
     pub(crate) my_account_id: AccountId,
-    pub(crate) secret_storage: SecretNodeStorageBox,
+    pub(crate) secret_storage: SecretNodeStorageVariant,
     pub(crate) triple_storage: TripleStorage,
     pub(crate) presignature_storage: PresignatureStorage,
     pub(crate) sign_task: SignatureSpawnerTask,

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, Instant};
 
 pub const RESHARING_READY_BROADCAST_INTERVAL: Duration = Duration::from_secs(10);
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 pub struct PersistentNodeData {
     pub epoch: u64,
     pub private_share: SecretKeyShare,

--- a/chain-signatures/node/src/protocol/test_setup.rs
+++ b/chain-signatures/node/src/protocol/test_setup.rs
@@ -4,13 +4,13 @@ use crate::mesh::MeshState;
 use crate::protocol::signature::SignatureSpawnerTask;
 use crate::protocol::{MessageChannel, MpcSignProtocol, Sign};
 use crate::rpc::{ContractStateWatcher, RpcChannel};
-use crate::storage::secret_storage::SecretNodeStorageBox;
+use crate::storage::secret_storage::SecretNodeStorageVariant;
 use crate::storage::{PresignatureStorage, TripleStorage};
 use near_sdk::AccountId;
 use tokio::sync::{mpsc, watch};
 
 pub struct TestProtocolStorage {
-    pub secret_storage: SecretNodeStorageBox,
+    pub secret_storage: SecretNodeStorageVariant,
     pub triple_storage: TripleStorage,
     pub presignature_storage: PresignatureStorage,
 }

--- a/chain-signatures/node/src/storage/secret_storage.rs
+++ b/chain-signatures/node/src/storage/secret_storage.rs
@@ -224,3 +224,135 @@ pub fn test_store(
     };
     SecretNodeStorageVariant::Memory(store)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::SecretKeyShare;
+    use k256::elliptic_curve::group::GroupEncoding;
+    use mpc_crypto::PublicKey;
+    use mpc_primitives::ScalarExt;
+
+    /// Helper function to create a test account ID.
+    fn make_test_account_id() -> AccountId {
+        "test.near".parse().unwrap()
+    }
+
+    /// Creates a test secret key share.
+    fn make_test_secret_key_share() -> SecretKeyShare {
+        SecretKeyShare::from_bytes([0u8; 32].into()).unwrap().into()
+    }
+
+    /// Creates a test public key.
+    fn make_test_public_key() -> PublicKey {
+        PublicKey::from_bytes((&[0u8; 33]).into()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn disk_load_nonexistent_file_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nonexistent.json");
+
+        let storage = DiskNodeStorage { path };
+
+        let result = storage.load().await.unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn disk_store_and_load_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("node_data.json");
+
+        let mut storage = DiskNodeStorage { path };
+
+        let expected = PersistentNodeData {
+            epoch: 42,
+            private_share: make_test_secret_key_share(),
+            public_key: make_test_public_key(),
+        };
+
+        storage.store(&expected).await.unwrap();
+
+        let loaded = storage.load().await.unwrap();
+
+        assert_eq!(loaded, Some(expected));
+    }
+
+    #[tokio::test]
+    async fn disk_load_invalid_json_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("node_data.json");
+
+        tokio::fs::write(&path, b"not a valid json").await.unwrap();
+
+        let storage = DiskNodeStorage { path };
+
+        assert!(storage.load().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn memory_store_and_load_round_trip() {
+        let mut storage = MemoryNodeStorage::default();
+
+        let expected = PersistentNodeData {
+            epoch: 42,
+            private_share: make_test_secret_key_share(),
+            public_key: make_test_public_key(),
+        };
+
+        storage.store(&expected).await.unwrap();
+
+        let loaded = storage.load().await.unwrap();
+
+        assert_eq!(loaded, Some(expected));
+    }
+
+    #[test]
+    fn init_uses_memory_when_no_storage_configured() {
+        let opts = Options {
+            sk_share_secret_id: None,
+            sk_share_local_path: None,
+            env: "test".to_string(),
+            gcp_project_id: "test-project".to_string(),
+            redis_url: "redis://localhost".to_string(),
+        };
+
+        let storage = init(None, &opts, &make_test_account_id());
+
+        assert!(matches!(storage, SecretNodeStorageVariant::Memory(_)));
+    }
+
+    #[test]
+    fn init_uses_disk_when_local_path_provided() {
+        let opts = Options {
+            sk_share_local_path: Some("/tmp/share".into()),
+            sk_share_secret_id: None,
+            env: "test".to_string(),
+            gcp_project_id: "test-project".to_string(),
+            redis_url: "redis://localhost".to_string(),
+        };
+
+        let storage = init(None, &opts, &make_test_account_id());
+
+        assert!(matches!(storage, SecretNodeStorageVariant::Disk(_)));
+    }
+
+    #[tokio::test]
+    async fn init_uses_gcp_when_secret_id_present() {
+        let opts = Options {
+            sk_share_secret_id: Some("secret-id".to_string()),
+            sk_share_local_path: None,
+            env: "test".to_string(),
+            gcp_project_id: "test-project".to_string(),
+            redis_url: "redis://localhost".to_string(),
+        };
+        let account_id = make_test_account_id();
+        let gcp_service = GcpService::init(&account_id, &opts).await.unwrap();
+
+        let storage = init(Some(&gcp_service), &opts, &account_id);
+
+        assert!(matches!(storage, SecretNodeStorageVariant::Gcp(_)));
+    }
+}

--- a/chain-signatures/node/src/storage/secret_storage.rs
+++ b/chain-signatures/node/src/storage/secret_storage.rs
@@ -240,7 +240,7 @@ mod tests {
 
     /// Creates a test secret key share.
     fn make_test_secret_key_share() -> SecretKeyShare {
-        SecretKeyShare::from_bytes([0u8; 32].into()).unwrap().into()
+        SecretKeyShare::from_bytes([0u8; 32]).unwrap().into()
     }
 
     /// Creates a test public key.

--- a/chain-signatures/node/src/storage/secret_storage.rs
+++ b/chain-signatures/node/src/storage/secret_storage.rs
@@ -240,7 +240,7 @@ mod tests {
 
     /// Creates a test secret key share.
     fn make_test_secret_key_share() -> SecretKeyShare {
-        SecretKeyShare::from_bytes([0u8; 32]).unwrap().into()
+        SecretKeyShare::from_bytes([0u8; 32]).unwrap()
     }
 
     /// Creates a test public key.

--- a/chain-signatures/node/src/storage/secret_storage.rs
+++ b/chain-signatures/node/src/storage/secret_storage.rs
@@ -127,9 +127,15 @@ impl SecretNodeStorage for DiskNodeStorage {
 
                 Ok(Some(data))
             }
-            _ => {
+            // If the file is not found, treat it as if there is no existing data, rather than an error
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 tracing::info!("loading PersistentNodeData using DiskNodeStorage: no file");
                 Ok(None)
+            }
+            // Propagate other types of errors
+            Err(e) => {
+                tracing::error!(%e, "failed to load PersistentNodeData");
+                Err(e.into())
             }
         }
     }

--- a/chain-signatures/node/src/storage/secret_storage.rs
+++ b/chain-signatures/node/src/storage/secret_storage.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use tokio::fs::File;
+use tokio::fs::{self, File};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::gcp::{GcpService, SecretResult};
@@ -102,11 +102,22 @@ impl DiskNodeStorage {
 impl SecretNodeStorage for DiskNodeStorage {
     async fn store(&mut self, data: &PersistentNodeData) -> SecretResult<()> {
         tracing::info!("storing PersistentNodeData using DiskNodeStorage");
-        let mut file = File::create(self.path.as_os_str()).await?;
+
         // Serialize the person object to JSON and convert directly to bytes
         let json_bytes = serde_json::to_vec(data)?;
-        // Write the serialized JSON bytes to the file
+
+        // Write the JSON bytes to a temporary file first to ensure atomicitys, then rename it to the target path
+        let tmp_path = self.path.with_extension("tmp");
+
+        let mut file = File::create(&tmp_path).await?;
         file.write_all(&json_bytes).await?;
+
+        // Ensure all data is flushed to disk before renaming
+        file.sync_all().await?;
+
+        drop(file);
+
+        fs::rename(&tmp_path, &self.path).await?;
 
         Ok(())
     }

--- a/chain-signatures/node/src/storage/secret_storage.rs
+++ b/chain-signatures/node/src/storage/secret_storage.rs
@@ -11,12 +11,16 @@ use near_account_id::AccountId;
 
 #[async_trait]
 pub trait SecretNodeStorage {
+    /// Stores the given `PersistentNodeData` securely.
     async fn store(&mut self, data: &PersistentNodeData) -> SecretResult<()>;
+    /// Loads the `PersistentNodeData` if it exists.
+    /// Returns `Ok(None)` if the data does not exist.
     async fn load(&self) -> SecretResult<Option<PersistentNodeData>>;
 }
 
+/// In-memory implementation of `SecretNodeStorage`.
 #[derive(Default)]
-struct MemoryNodeStorage {
+pub struct MemoryNodeStorage {
     node_data: Option<PersistentNodeData>,
 }
 
@@ -34,7 +38,8 @@ impl SecretNodeStorage for MemoryNodeStorage {
     }
 }
 
-struct SecretManagerNodeStorage {
+/// GCP Secret Manager implementation of `SecretNodeStorage`.
+pub struct SecretManagerNodeStorage {
     secret_manager: SecretManagerService,
     sk_share_secret_id: String,
 }
@@ -80,7 +85,8 @@ impl SecretNodeStorage for SecretManagerNodeStorage {
     }
 }
 
-struct DiskNodeStorage {
+/// Local disk storage implementation of `SecretNodeStorage`.
+pub struct DiskNodeStorage {
     path: PathBuf,
 }
 
@@ -129,29 +135,58 @@ impl SecretNodeStorage for DiskNodeStorage {
     }
 }
 
-pub type SecretNodeStorageBox = Box<dyn SecretNodeStorage + Send + Sync>;
+/// Enum representing the different variants of secret node storage.
+pub enum SecretNodeStorageVariant {
+    /// In-memory storage variant, primarily for testing or ephemeral use cases.
+    Memory(MemoryNodeStorage),
+    /// Google Cloud Secret Manager storage variant
+    Gcp(SecretManagerNodeStorage),
+    /// Local disk storage variant, storing secrets in a file on the local filesystem.
+    Disk(DiskNodeStorage),
+}
 
+impl SecretNodeStorageVariant {
+    /// Stores the given `PersistentNodeData` using the underlying storage mechanism.
+    pub async fn store(&mut self, data: &PersistentNodeData) -> SecretResult<()> {
+        match self {
+            SecretNodeStorageVariant::Memory(s) => s.store(data).await,
+            SecretNodeStorageVariant::Gcp(s) => s.store(data).await,
+            SecretNodeStorageVariant::Disk(s) => s.store(data).await,
+        }
+    }
+
+    /// Loads the `PersistentNodeData` from the underlying storage mechanism, if it exists.
+    pub async fn load(&self) -> SecretResult<Option<PersistentNodeData>> {
+        match self {
+            SecretNodeStorageVariant::Memory(s) => s.load().await,
+            SecretNodeStorageVariant::Gcp(s) => s.load().await,
+            SecretNodeStorageVariant::Disk(s) => s.load().await,
+        }
+    }
+}
+
+/// Initializes the appropriate `SecretNodeStorageVariant` based on the provided options and GCP service.
 pub fn init(
     gcp_service: Option<&GcpService>,
     opts: &Options,
     account_id: &AccountId,
-) -> SecretNodeStorageBox {
+) -> SecretNodeStorageVariant {
     match gcp_service {
         Some(gcp) if opts.sk_share_secret_id.is_some() => {
             tracing::info!("using SecretManagerNodeStorage");
-            Box::new(SecretManagerNodeStorage::new(
+            SecretNodeStorageVariant::Gcp(SecretManagerNodeStorage::new(
                 &gcp.secret_manager.clone(),
-                opts.clone().sk_share_secret_id.unwrap().clone(),
-            )) as SecretNodeStorageBox
+                opts.sk_share_secret_id.clone().unwrap(),
+            ))
         }
         _ => {
             if let Some(sk_share_local_path) = &opts.sk_share_local_path {
                 let path = format!("{sk_share_local_path}-{account_id}");
                 tracing::info!("using DiskNodeStorage with path: {}", path);
-                Box::new(DiskNodeStorage::new(&path)) as SecretNodeStorageBox
+                SecretNodeStorageVariant::Disk(DiskNodeStorage::new(&path))
             } else {
                 tracing::info!("using MemoryNodeStorage");
-                Box::<MemoryNodeStorage>::default() as SecretNodeStorageBox
+                SecretNodeStorageVariant::Memory(MemoryNodeStorage::default())
             }
         }
     }
@@ -162,7 +197,7 @@ pub fn test_store(
     epoch: u64,
     private_share: crate::types::SecretKeyShare,
     public_key: mpc_crypto::PublicKey,
-) -> SecretNodeStorageBox {
+) -> SecretNodeStorageVariant {
     let store = MemoryNodeStorage {
         node_data: Some(PersistentNodeData {
             epoch,
@@ -170,5 +205,5 @@ pub fn test_store(
             public_key,
         }),
     };
-    Box::new(store) as SecretNodeStorageBox
+    SecretNodeStorageVariant::Memory(store)
 }


### PR DESCRIPTION
Some changes to `storage/secret_storage.rs` to improve correctness and durability. No public API changes.

1. Replace `SecretNodeStorageBox` and dynamic dispatch with `SecretNodeStorageVariant` enum - not a huge runtime impact, but seems better for type visibility.
2. Update `store` method for `DiskNodeStorage` to use atomic rename (avoid risk of secret key lost or corrupted)
3. Update `load` method for `DiskNodeStorage` to differentiate between `NotFound` and other errors (PermissionDenied, Corrupted JSON, etc.)
4. Implement unit tests + add doc comments