### PR TITLE
fix: race condition with setting `me` in protocol storage

### DIFF
--- a/chain-signatures/node/src/protocol/sync/mod.rs
+++ b/chain-signatures/node/src/protocol/sync/mod.rs
@@ -158,21 +158,16 @@ impl SyncTask {
 
     pub async fn run(mut self) {
         tracing::info!("sync task has been started");
-        // Polling loop for participant info from contract state
-        let mut watcher_interval = tokio::time::interval(Duration::from_millis(500));
         // Trigger sync broadcasts to peers in need_sync state
         let mut sync_interval = tokio::time::interval(Duration::from_millis(200));
         // Poll whether any ongoing sync task has completed
         let mut sync_check_interval = tokio::time::interval(Duration::from_millis(100));
 
         // Do NOT start until we have our own participant info
-        let (threshold, me) = loop {
-            watcher_interval.tick().await;
-            if let Some(info) = self.contract.info().await {
-                break info;
-            }
-        };
-        tracing::info!(?me, "starting sync loop...");
+        tracing::info!("sync waiting for participant info");
+        let start = Instant::now();
+        let (threshold, me) = self.contract.wait_info().await;
+        tracing::info!(?me, elapsed = ?start.elapsed(), "starting sync loop...");
 
         self.triples.set_me(me);
         self.presignatures.set_me(me);

--- a/chain-signatures/node/src/protocol/sync/mod.rs
+++ b/chain-signatures/node/src/protocol/sync/mod.rs
@@ -174,6 +174,9 @@ impl SyncTask {
         };
         tracing::info!(?me, "starting sync loop...");
 
+        self.triples.set_me(me);
+        self.presignatures.set_me(me);
+
         let mut broadcast = Option::<(Instant, JoinHandle<_>)>::None;
         loop {
             tokio::select! {

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -361,7 +361,7 @@ impl ContractStateWatcher {
         }
     }
 
-    pub async fn wait_info(&self) -> (usize, Participant) {
+    pub async fn wait_info(&mut self) -> (usize, Participant) {
         loop {
             if let Some((threshold, participant)) = self.info().await {
                 return (threshold, participant);

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -361,6 +361,15 @@ impl ContractStateWatcher {
         }
     }
 
+    pub async fn wait_info(&self) -> (usize, Participant) {
+        loop {
+            if let Some((threshold, participant)) = self.info().await {
+                return (threshold, participant);
+            }
+            let _ = self.contract_state.changed().await;
+        }
+    }
+
     pub async fn participant_map(&self) -> ParticipantMap {
         let Some(state) = self.state().clone() else {
             return ParticipantMap::Zero;


### PR DESCRIPTION
This fixes a race condition in sync that utilizes the protocol storage before anyone has set_me