### PR TITLE
refactor: remove runner script, make integration tests setup process explicit, add `justfile` for integration tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,11 +14,6 @@ rustflags = [
   "-C", "link-arg=dynamic_lookup",
 ]
 
-# This is basically a prebuild script used to build the node/contract before running
-# integration-tests.
-[target.'cfg(not(target = "wasm32-unknown-unknown"))']
-runner = "./setup.sh"
-
 [alias]
 build-node = "build -p mpc-node --release --features helios"
 build-test = "build -p integration-tests --tests"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: component-test-2
+          shared-key: component-test
           cache-targets: true
           cache-on-failure: false
           # Prevent every PR from uploading multi-GB caches
@@ -70,7 +70,7 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
-      - name: Presetup binaries
+      - name: Build integration test artifacts
         run: ./setup.sh
         env:
           MPC_ENABLE_HELIOS: 1
@@ -161,21 +161,21 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: integration-test-2
+          shared-key: integration-test
           cache-targets: true
           cache-on-failure: false
           # Prevent every PR from uploading multi-GB caches
           save-if: ${{ github.ref == 'refs/heads/develop' }}
 
-      - name: Build Chain-Signatures Contract
-        run: ./build-contract.sh
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Build integration test artifacts
+        run: ./setup.sh
 
       - name: Build eth contract
         working-directory: ./chain-signatures/contract-eth
         run: npm ci && npx hardhat compile
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
 
       # Build the tests before actually running them to see how long the tests take to run by itself
       # instead of including the build time in the test time report on Github.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -19,8 +19,6 @@ rustup target add wasm32-unknown-unknown
 rustup target add wasm32-unknown-unknown --toolchain 1.81.0
 ```
 
-Alternatively, you may run all tests sequentially with `cargo test -p integration-tests --jobs 1 -- --test-threads 1`.
-
 ## Basic guide
 
 Running integration tests requires you to have redis and sandbox docker images present on your machine:
@@ -31,22 +29,37 @@ docker pull redis:7.4.2
 
 In case of authorization issues make sure you have logged into docker using your [access token](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic).
 
-### ⚠️ First-Time Setup
+### Building integration test artifacts
 
-`cargo nextest` runs tests in parallel, running it immediately on a fresh clone can cause multiple background processes to try to compile the WASM smart contract (or download toolchains) at the exact same time, resulting in corrupted caches or `can't find crate for core` errors.
+Integration tests require:
 
-To prevent this, **always pre-build the tests sequentially on your first run**:
+- the WASM contract artifact
+- the local mpc-node binary
+
+Build them once before your first test run, or whenever you change contract or node code:
 
 ```bash
-# Run 1 job to safely cache the WASM contract and heavy dependencies
-cargo nextest run -p integration-tests --profile fixture -j 1
+# Setup artifacts
+./setup.sh
+
+# Run tests
+cargo nextest run -p integration-tests
 ```
 
-Once that completes successfully, you can run the tests normally (in parallel):
+If you use Helios:
+```bash
+MPC_ENABLE_HELIOS=1 ./setup.sh
+```
 
+`setup.sh` performs the pre-build steps required by the integration test environment
+(contract WASM compilation and local node binary compilation). 
+
+Once the artifacts are built, run tests normally:
 ```BASH
 cargo nextest run -p integration-tests
 ```
+
+Alternatively, you may run all tests sequentially with `cargo test -p integration-tests --jobs 1 -- --test-threads 1`.
 
 For a faster iteration loop during development, run only the lightweight MPC fixture tests
 (no full cluster or Docker containers needed beyond Redis):

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -19,6 +19,16 @@ rustup target add wasm32-unknown-unknown
 rustup target add wasm32-unknown-unknown --toolchain 1.81.0
 ```
 
+3. Install [just](https://just.systems/man/en/packages.html):
+
+```bash
+# Linux/macOS
+curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/.cargo/bin
+
+# Cargo
+cargo install just
+```
+
 ## Basic guide
 
 Running integration tests requires you to have redis and sandbox docker images present on your machine:
@@ -29,49 +39,25 @@ docker pull redis:7.4.2
 
 In case of authorization issues make sure you have logged into docker using your [access token](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic).
 
-### Building integration test artifacts
+### Running tests
 
-Integration tests require:
+Each `just` test recipe automatically runs setup (WASM contract + node binary compilation) before executing tests. Run `just` with no arguments to list all available recipes.
 
-- the WASM contract artifact
-- the local mpc-node binary
+| Command | Full recipe | Description |
+|---|---|---|
+| `just s` | `just setup` | Build artifacts |
+| `just t` | `just test` | All integration tests |
+| `just tf` | `just test-fixture` | Fixture tests only (no full cluster) |
+| `just tc` | `just test-cluster` | Full cluster tests only |
+| `just ts` | `just test-seq` | All tests, sequential single-threaded |
+| `just to <name>` | `just test-one <name>` | Single test, keeps containers alive |
+| `just tk` | `just test-keep` | All tests, keeps containers alive |
 
-Build them once before your first test run, or whenever you change contract or node code:
+To use Helios, append `helios=1` to any command:
 
 ```bash
-# Setup artifacts
-./setup.sh
-
-# Run tests
-cargo nextest run -p integration-tests
-```
-
-If you use Helios:
-```bash
-MPC_ENABLE_HELIOS=1 ./setup.sh
-```
-
-`setup.sh` performs the pre-build steps required by the integration test environment
-(contract WASM compilation and local node binary compilation). 
-
-Once the artifacts are built, run tests normally:
-```BASH
-cargo nextest run -p integration-tests
-```
-
-Alternatively, you may run all tests sequentially with `cargo test -p integration-tests --jobs 1 -- --test-threads 1`.
-
-For a faster iteration loop during development, run only the lightweight MPC fixture tests
-(no full cluster or Docker containers needed beyond Redis):
-
-```BASH
-cargo nextest run -p integration-tests --profile fixture
-```
-
-To run only the full cluster tests:
-
-```BASH
-cargo nextest run -p integration-tests --profile cluster
+just t helios=1
+just to test_basic_action helios=1
 ```
 
 The available profiles and their concurrency settings are defined in [`.config/nextest.toml`](../.config/nextest.toml).
@@ -138,10 +124,11 @@ artifacts into git.
 
 ### I want to run a test, but keep the docker containers from being destroyed
 
-You can pass environment variable `TESTCONTAINERS=keep` to keep all of the docker containers. For example:
+Use `just tk` to keep all containers after a full test run, or `just to <name>` for a single test:
 
 ```bash
-$ TESTCONTAINERS=keep cargo nextest run -p integration-tests
+just tk
+just to test_basic_action
 ```
 
 ### There are no logs anymore, how do I debug?
@@ -149,7 +136,7 @@ $ TESTCONTAINERS=keep cargo nextest run -p integration-tests
 The easiest way is to run one isolated test of your choosing while keeping the containers (see above):
 
 ```bash
-$ TESTCONTAINERS=keep cargo nextest run -p integration-tests -E 'test(test_basic_action)'
+just to test_basic_action
 ```
 
 Now, you can do `docker ps` and it should list all of containers related to your test (the most recent ones are always at the top, so lookout for those). For example:

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -41,23 +41,23 @@ In case of authorization issues make sure you have logged into docker using your
 
 ### Running tests
 
-Each `just` test recipe automatically runs setup (WASM contract + node binary compilation) before executing tests. Run `just` with no arguments to list all available recipes.
+Each `just` test recipe automatically runs setup (WASM contract + node binary compilation) before executing tests. Pass an optional `filter` to run matching tests only, and `helios=1` to build with Helios. Run `just` with no arguments to list all available recipes.
 
 | Command | Full recipe | Description |
 |---|---|---|
 | `just s` | `just setup` | Build artifacts |
-| `just t` | `just test` | All integration tests |
-| `just tf` | `just test-fixture` | Fixture tests only (no full cluster) |
-| `just tc` | `just test-cluster` | Full cluster tests only |
-| `just ts` | `just test-seq` | All tests, sequential single-threaded |
+| `just t [filter]` | `just test` | All integration tests |
+| `just tf [filter]` | `just test-fixture` | Fixture tests only (no full cluster) |
+| `just tc [filter]` | `just test-cluster` | Full cluster tests only |
+| `just ts [filter]` | `just test-seq` | All tests, sequential single-threaded |
 | `just to <name>` | `just test-one <name>` | Single test, keeps containers alive |
-| `just tk` | `just test-keep` | All tests, keeps containers alive |
-
-To use Helios, append `helios=1` to any command:
+| `just tk [filter]` | `just test-keep` | All tests, keeps containers alive |
 
 ```bash
-just t helios=1
-just to test_basic_action helios=1
+just t                               # run all tests
+just t my_module                     # run matching tests only
+just t my_module helios=1            # run matching tests with Helios
+just to test_basic_action helios=1.  # run specific test with Helios
 ```
 
 The available profiles and their concurrency settings are defined in [`.config/nextest.toml`](../.config/nextest.toml).

--- a/integration-tests/justfile
+++ b/integration-tests/justfile
@@ -8,36 +8,41 @@ default:
 # Build WASM contract + local mpc-node binary
 # Pass helios=1 to enable Helios: just setup helios=1
 setup helios="":
-    {{ if helios != "" { "MPC_ENABLE_HELIOS=1 ./setup.sh" } else { "./setup.sh" } }}
+    {{ if helios != "" { "MPC_ENABLE_HELIOS=1 ../setup.sh" } else { "../setup.sh" } }}
 alias s := setup
 
 # Run all integration tests
-test helios="": (setup helios)
-    cargo nextest run -p integration-tests
+# Usage: just t [filter] [helios=1]
+test filter="" helios="": (setup helios)
+    cargo nextest run -p integration-tests {{ if filter != "" { "-E 'test(" + filter + ")'" } else { "" } }}
 alias t := test
 
 # Run only lightweight fixture tests (no full cluster or Docker beyond Redis)
-test-fixture helios="": (setup helios)
-    cargo nextest run -p integration-tests --profile fixture
+# Usage: just tf [filter] [helios=1]
+test-fixture filter="" helios="": (setup helios)
+    cargo nextest run -p integration-tests --profile fixture {{ if filter != "" { "-E 'test(" + filter + ")'" } else { "" } }}
 alias tf := test-fixture
 
 # Run only full cluster tests
-test-cluster helios="": (setup helios)
-    cargo nextest run -p integration-tests --profile cluster
+# Usage: just tc [filter] [helios=1]
+test-cluster filter="" helios="": (setup helios)
+    cargo nextest run -p integration-tests --profile cluster {{ if filter != "" { "-E 'test(" + filter + ")'" } else { "" } }}
 alias tc := test-cluster
 
 # Run a single test by name, keeping containers alive for inspection
-# Usage: just to test_basic_action [helios=1]
+# Usage: just to <name> [helios=1]
 test-one name helios="": (setup helios)
     TESTCONTAINERS=keep cargo nextest run -p integration-tests -E 'test({{name}})'
 alias to := test-one
 
 # Run all tests keeping containers alive
-test-keep helios="": (setup helios)
-    TESTCONTAINERS=keep cargo nextest run -p integration-tests
+# Usage: just tk [filter] [helios=1]
+test-keep filter="" helios="": (setup helios)
+    TESTCONTAINERS=keep cargo nextest run -p integration-tests {{ if filter != "" { "-E 'test(" + filter + ")'" } else { "" } }}
 alias tk := test-keep
 
 # Run all tests sequentially (single-threaded)
-test-seq helios="": (setup helios)
-    cargo test -p integration-tests --jobs 1 -- --test-threads 1
+# Usage: just ts [filter] [helios=1]
+test-seq filter="" helios="": (setup helios)
+    cargo test -p integration-tests --jobs 1 -- --test-threads 1 {{ if filter != "" { filter } else { "" } }}
 alias ts := test-seq

--- a/integration-tests/justfile
+++ b/integration-tests/justfile
@@ -1,0 +1,43 @@
+# MPC integration test runner
+# Install just: https://just.systems/man/en/packages.html
+
+# List available recipes
+default:
+    @just --list
+
+# Build WASM contract + local mpc-node binary
+# Pass helios=1 to enable Helios: just setup helios=1
+setup helios="":
+    {{ if helios != "" { "MPC_ENABLE_HELIOS=1 ./setup.sh" } else { "./setup.sh" } }}
+alias s := setup
+
+# Run all integration tests
+test helios="": (setup helios)
+    cargo nextest run -p integration-tests
+alias t := test
+
+# Run only lightweight fixture tests (no full cluster or Docker beyond Redis)
+test-fixture helios="": (setup helios)
+    cargo nextest run -p integration-tests --profile fixture
+alias tf := test-fixture
+
+# Run only full cluster tests
+test-cluster helios="": (setup helios)
+    cargo nextest run -p integration-tests --profile cluster
+alias tc := test-cluster
+
+# Run a single test by name, keeping containers alive for inspection
+# Usage: just to test_basic_action [helios=1]
+test-one name helios="": (setup helios)
+    TESTCONTAINERS=keep cargo nextest run -p integration-tests -E 'test({{name}})'
+alias to := test-one
+
+# Run all tests keeping containers alive
+test-keep helios="": (setup helios)
+    TESTCONTAINERS=keep cargo nextest run -p integration-tests
+alias tk := test-keep
+
+# Run all tests sequentially (single-threaded)
+test-seq helios="": (setup helios)
+    cargo test -p integration-tests --jobs 1 -- --test-threads 1
+alias ts := test-seq


### PR DESCRIPTION
Remove the implicit Cargo runner used for integration tests and make artifact generation explicit. Full local integration suite now runs faster (~1360s → ~1044s, ~23% improvement). CI behavior remains the same.