### PR TITLE
refactor: eliminate cross-chain lock contention in `Backlog`

### DIFF
--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -2047,15 +2047,17 @@ mod tests {
     async fn test_total_pending_increments_on_insert() {
         let backlog = Backlog::new();
         let tx = create_test_tx(1);
-        
-        backlog.insert(create_indexed_request(
-            SignId::new(tx.request_id),
-            Chain::Ethereum,
-            create_test_args(1),
-            SignKind::Sign,
-            0,
-        )).await;
-        
+
+        backlog
+            .insert(create_indexed_request(
+                SignId::new(tx.request_id),
+                Chain::Ethereum,
+                create_test_args(1),
+                SignKind::Sign,
+                0,
+            ))
+            .await;
+
         assert_eq!(backlog.len(), 1);
         assert!(!backlog.is_empty());
     }
@@ -2071,35 +2073,43 @@ mod tests {
             SignKind::Sign,
             0,
         );
-        
+
         // Insert first time
         backlog.insert(request.clone()).await;
         assert_eq!(backlog.len(), 1);
 
         // Insert exactly the same ID again (overwrites)
         backlog.insert(request).await;
-        assert_eq!(backlog.len(), 1, "Duplicate insert should not increment total");
+        assert_eq!(
+            backlog.len(),
+            1,
+            "Duplicate insert should not increment total"
+        );
     }
 
     #[tokio::test]
     async fn test_total_pending_counts_across_chains() {
         let backlog = Backlog::new();
-        
-        backlog.insert(create_indexed_request(
-            SignId::new(create_test_tx(1).request_id),
-            Chain::Ethereum,
-            create_test_args(1),
-            SignKind::Sign,
-            0,
-        )).await;
 
-        backlog.insert(create_indexed_request(
-            SignId::new(create_test_tx(2).request_id),
-            Chain::Solana,
-            create_test_args(2),
-            SignKind::Sign,
-            0,
-        )).await;
+        backlog
+            .insert(create_indexed_request(
+                SignId::new(create_test_tx(1).request_id),
+                Chain::Ethereum,
+                create_test_args(1),
+                SignKind::Sign,
+                0,
+            ))
+            .await;
+
+        backlog
+            .insert(create_indexed_request(
+                SignId::new(create_test_tx(2).request_id),
+                Chain::Solana,
+                create_test_args(2),
+                SignKind::Sign,
+                0,
+            ))
+            .await;
 
         assert_eq!(backlog.len(), 2);
     }
@@ -2108,14 +2118,16 @@ mod tests {
     async fn test_total_pending_decrements_on_remove() {
         let backlog = Backlog::new();
         let sign_id = SignId::new(create_test_tx(1).request_id);
-        
-        backlog.insert(create_indexed_request(
-            sign_id,
-            Chain::Ethereum,
-            create_test_args(1),
-            SignKind::Sign,
-            0,
-        )).await;
+
+        backlog
+            .insert(create_indexed_request(
+                sign_id,
+                Chain::Ethereum,
+                create_test_args(1),
+                SignKind::Sign,
+                0,
+            ))
+            .await;
         assert_eq!(backlog.len(), 1);
 
         backlog.remove(Chain::Ethereum, &sign_id).await;
@@ -2128,32 +2140,40 @@ mod tests {
         let backlog = Backlog::new();
         let sign_id1 = SignId::new(create_test_tx(1).request_id);
         let sign_id2 = SignId::new(create_test_tx(2).request_id); // Not inserted
-        
-        backlog.insert(create_indexed_request(
-            sign_id1,
-            Chain::Ethereum,
-            create_test_args(1),
-            SignKind::Sign,
-            0,
-        )).await;
+
+        backlog
+            .insert(create_indexed_request(
+                sign_id1,
+                Chain::Ethereum,
+                create_test_args(1),
+                SignKind::Sign,
+                0,
+            ))
+            .await;
 
         backlog.remove(Chain::Ethereum, &sign_id2).await;
-        assert_eq!(backlog.len(), 1, "Removing non-existent ID should not decrement total");
+        assert_eq!(
+            backlog.len(),
+            1,
+            "Removing non-existent ID should not decrement total"
+        );
     }
 
     #[tokio::test]
     async fn test_total_pending_updates_on_clean_recovery() {
         let backlog = Backlog::new();
-        
+
         // Populate 3 requests and create a checkpoint
         for i in 1..=3 {
-            backlog.insert(create_indexed_request(
-                SignId::new(create_test_tx(i).request_id),
-                Chain::Ethereum,
-                create_test_args(i),
-                SignKind::Sign,
-                0,
-            )).await;
+            backlog
+                .insert(create_indexed_request(
+                    SignId::new(create_test_tx(i).request_id),
+                    Chain::Ethereum,
+                    create_test_args(i),
+                    SignKind::Sign,
+                    0,
+                ))
+                .await;
         }
         backlog.set_processed_block(Chain::Ethereum, 10).await;
         let checkpoint = backlog.checkpoint(Chain::Ethereum).await;
@@ -2161,47 +2181,57 @@ mod tests {
         // Clean backlog recovers the checkpoint
         let recovered = Backlog::new();
         assert_eq!(recovered.len(), 0);
-        
-        recovered.recover_by_checkpoint(checkpoint).await.expect("failed to recover");
-        
+
+        recovered
+            .recover_by_checkpoint(checkpoint)
+            .await
+            .expect("failed to recover");
+
         assert_eq!(recovered.len(), 3);
     }
 
     #[tokio::test]
     async fn test_total_pending_updates_on_dirty_recovery() {
         let backlog = Backlog::new();
-        
+
         // Populate 3 requests and create a checkpoint
         for i in 1..=3 {
-            backlog.insert(create_indexed_request(
-                SignId::new(create_test_tx(i).request_id),
-                Chain::Ethereum,
-                create_test_args(i),
-                SignKind::Sign,
-                0,
-            )).await;
+            backlog
+                .insert(create_indexed_request(
+                    SignId::new(create_test_tx(i).request_id),
+                    Chain::Ethereum,
+                    create_test_args(i),
+                    SignKind::Sign,
+                    0,
+                ))
+                .await;
         }
         backlog.set_processed_block(Chain::Ethereum, 10).await;
         let checkpoint = backlog.checkpoint(Chain::Ethereum).await;
 
         // Dirty backlog has 1 entirely different request before recovery
         let dirty_backlog = Backlog::new();
-        dirty_backlog.insert(create_indexed_request(
-            SignId::new([99u8; 32]),
-            Chain::Ethereum,
-            create_test_args(99),
-            SignKind::Sign,
-            0,
-        )).await;
-        
+        dirty_backlog
+            .insert(create_indexed_request(
+                SignId::new([99u8; 32]),
+                Chain::Ethereum,
+                create_test_args(99),
+                SignKind::Sign,
+                0,
+            ))
+            .await;
+
         assert_eq!(dirty_backlog.len(), 1);
-        
+
         // Recover from checkpoint (should overwrite the dirty state)
-        dirty_backlog.recover_by_checkpoint(checkpoint).await.expect("failed to recover");
-        
+        dirty_backlog
+            .recover_by_checkpoint(checkpoint)
+            .await
+            .expect("failed to recover");
+
         assert_eq!(
-            dirty_backlog.len(), 
-            3, 
+            dirty_backlog.len(),
+            3,
             "Total should reflect exactly the restored checkpoint size, ignoring the overwritten dirty state"
         );
     }

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -224,8 +224,11 @@ struct HistoricalCheckpoint {
 /// publish queues.
 #[derive(Debug, Clone)]
 pub struct Backlog {
+    /// Storage for checkpoints, which can be in-memory or persisted to disk
     storage: CheckpointStorage,
+    /// Pending requests indexed by chain
     requests: Arc<HashMap<Chain, RwLock<PendingRequests>>>,
+    /// Execution watchers indexed by chain
     execution_watchers: Arc<HashMap<Chain, RwLock<ExecutionWatchers>>>,
     /// Historical checkpoints kept for 30 minutes, indexed by chain
     historical_checkpoints: Arc<HashMap<Chain, RwLock<Vec<HistoricalCheckpoint>>>>,
@@ -244,6 +247,7 @@ impl Backlog {
         Self::persisted(CheckpointStorage::in_memory())
     }
 
+    /// Initialize the backlog with storage and pre-allocate maps for all chains
     pub fn persisted(storage: CheckpointStorage) -> Self {
         let mut requests = HashMap::new();
         let mut execution_watchers = HashMap::new();
@@ -292,6 +296,7 @@ impl Backlog {
             .expect("chain should be initialized within `persisted` method")
     }
 
+    /// Remember a checkpoint in the historical checkpoints list and clean up old checkpoints
     async fn remember_checkpoint(&self, checkpoint: &Checkpoint) {
         let mut historical = self.checkpoints(&checkpoint.chain).write().await;
         historical.push(HistoricalCheckpoint {
@@ -301,6 +306,7 @@ impl Backlog {
         historical.retain(|hcp| hcp.created_at.elapsed() < RETENTION_DURATION);
     }
 
+    /// Insert a new Sign request into the backlog for the specified chain.
     pub async fn insert(&self, request: IndexedSignRequest) -> Option<BacklogEntry> {
         let chain = request.chain;
         let id = request.id;
@@ -320,6 +326,7 @@ impl Backlog {
         prev
     }
 
+    /// Remove a Sign request from the backlog for the specified chain.
     pub async fn remove(&self, chain: Chain, id: &SignId) -> Option<BacklogEntry> {
         let (removed, len) = {
             let mut pending = self.pending(&chain).write().await;
@@ -336,6 +343,7 @@ impl Backlog {
         removed
     }
 
+    /// Get a Sign request from the backlog for the specified chain.
     pub async fn get(&self, chain: Chain, id: &SignId) -> Option<BacklogEntry> {
         self.pending(&chain).read().await.get(id).cloned()
     }
@@ -350,6 +358,7 @@ impl Backlog {
         self.len().await == 0
     }
 
+    /// Observe the backlog size for a specific chain and update metrics accordingly
     fn observe_backlog_size(&self, chain: Chain, len: usize) {
         crate::metrics::requests::BACKLOG_SIZE
             .with_label_values(&[chain.as_str()])
@@ -377,6 +386,8 @@ impl Backlog {
         requeueable
     }
 
+    /// Returns backlog requests for a chain that are ready to be published.
+    /// Sorted by indexed timestamp and request id.
     pub async fn publishable_requests(
         &self,
         chain: Chain,
@@ -405,10 +416,12 @@ impl Backlog {
         publishable
     }
 
+    /// Returns backlog requests for a chain that are still pending generation
     pub async fn pending_generations(&self, chain: Chain) -> HashMap<SignId, BacklogEntry> {
         self.pending(&chain).read().await.pending_generations()
     }
 
+    /// Returns backlog requests for a chain that are still pending generation for bidirectional transactions
     pub async fn pending_generation_bidirectionals(
         &self,
         chain: Chain,
@@ -419,6 +432,7 @@ impl Backlog {
             .pending_generation_bidirectionals()
     }
 
+    /// Returns backlog entries that are pending execution for a given chain and request id
     pub async fn pending_execution(&self, chain: Chain, id: &SignId) -> Option<BacklogEntry> {
         self.pending(&chain)
             .read()
@@ -427,10 +441,12 @@ impl Backlog {
             .cloned()
     }
 
+    /// Returns the number of pending requests for a specific chain
     pub async fn len_by_chain(&self, chain: Chain) -> usize {
         self.pending(&chain).read().await.len()
     }
 
+    /// Marks a request as publishing for a specific chain and request id, with the given publish state.
     pub async fn mark_publishing(
         &self,
         chain: Chain,
@@ -568,6 +584,7 @@ impl Backlog {
             .await
     }
 
+    /// Set the processed block height for a specific chain and checkpoint on interval.
     pub async fn set_processed_block_interval(
         &self,
         chain: Chain,
@@ -584,7 +601,7 @@ impl Backlog {
             "backlog updated processed block height"
         );
 
-        // create a checkpoint on interval
+        // Create a checkpoint on interval
         if height.is_multiple_of(interval) {
             let tx_count = pending.len();
             drop(pending);
@@ -610,6 +627,7 @@ impl Backlog {
         checkpoint
     }
 
+    /// Get the latest checkpoint for a specific chain.
     pub async fn latest_checkpoint(&self, chain: Chain) -> Option<Checkpoint> {
         self.checkpoints(&chain)
             .read()
@@ -704,6 +722,7 @@ impl Backlog {
         Ok(())
     }
 
+    /// Recover backlog state by selecting checkpoints from active participants in the mesh network.
     pub async fn recover(
         &self,
         mesh_state: &MeshState,

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -349,13 +349,13 @@ impl Backlog {
     }
 
     /// Returns the number of pending requests in total
-    pub async fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.total_pending.load(Ordering::Relaxed)
     }
 
     /// Returns true if there are no pending requests
-    pub async fn is_empty(&self) -> bool {
-        self.len().await == 0
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     /// Observe the backlog size for a specific chain and update metrics accordingly
@@ -2046,8 +2046,8 @@ mod tests {
     #[tokio::test]
     async fn test_total_pending_initial_state() {
         let backlog = Backlog::new();
-        assert_eq!(backlog.len().await, 0);
-        assert!(backlog.is_empty().await);
+        assert_eq!(backlog.len(), 0);
+        assert!(backlog.is_empty());
     }
 
     #[tokio::test]
@@ -2063,8 +2063,8 @@ mod tests {
             0,
         )).await;
         
-        assert_eq!(backlog.len().await, 1);
-        assert!(!backlog.is_empty().await);
+        assert_eq!(backlog.len(), 1);
+        assert!(!backlog.is_empty());
     }
 
     #[tokio::test]
@@ -2081,11 +2081,11 @@ mod tests {
         
         // Insert first time
         backlog.insert(request.clone()).await;
-        assert_eq!(backlog.len().await, 1);
+        assert_eq!(backlog.len(), 1);
 
         // Insert exactly the same ID again (overwrites)
         backlog.insert(request).await;
-        assert_eq!(backlog.len().await, 1, "Duplicate insert should not increment total");
+        assert_eq!(backlog.len(), 1, "Duplicate insert should not increment total");
     }
 
     #[tokio::test]
@@ -2108,7 +2108,7 @@ mod tests {
             0,
         )).await;
 
-        assert_eq!(backlog.len().await, 2);
+        assert_eq!(backlog.len(), 2);
     }
 
     #[tokio::test]
@@ -2123,11 +2123,11 @@ mod tests {
             SignKind::Sign,
             0,
         )).await;
-        assert_eq!(backlog.len().await, 1);
+        assert_eq!(backlog.len(), 1);
 
         backlog.remove(Chain::Ethereum, &sign_id).await;
-        assert_eq!(backlog.len().await, 0);
-        assert!(backlog.is_empty().await);
+        assert_eq!(backlog.len(), 0);
+        assert!(backlog.is_empty());
     }
 
     #[tokio::test]
@@ -2145,7 +2145,7 @@ mod tests {
         )).await;
 
         backlog.remove(Chain::Ethereum, &sign_id2).await;
-        assert_eq!(backlog.len().await, 1, "Removing non-existent ID should not decrement total");
+        assert_eq!(backlog.len(), 1, "Removing non-existent ID should not decrement total");
     }
 
     #[tokio::test]
@@ -2167,11 +2167,11 @@ mod tests {
 
         // Clean backlog recovers the checkpoint
         let recovered = Backlog::new();
-        assert_eq!(recovered.len().await, 0);
+        assert_eq!(recovered.len(), 0);
         
         recovered.recover_by_checkpoint(checkpoint).await.expect("failed to recover");
         
-        assert_eq!(recovered.len().await, 3);
+        assert_eq!(recovered.len(), 3);
     }
 
     #[tokio::test]
@@ -2201,13 +2201,13 @@ mod tests {
             0,
         )).await;
         
-        assert_eq!(dirty_backlog.len().await, 1);
+        assert_eq!(dirty_backlog.len(), 1);
         
         // Recover from checkpoint (should overwrite the dirty state)
         dirty_backlog.recover_by_checkpoint(checkpoint).await.expect("failed to recover");
         
         assert_eq!(
-            dirty_backlog.len().await, 
+            dirty_backlog.len(), 
             3, 
             "Total should reflect exactly the restored checkpoint size, ignoring the overwritten dirty state"
         );

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -263,13 +263,35 @@ impl Backlog {
         }
     }
 
-    async fn remember_checkpoint(&self, checkpoint: &Checkpoint) {
-        let mut historical = self
-            .historical_checkpoints
-            .get(&checkpoint.chain)
+    /// Get the pending requests for a specific chain. 
+    /// Panics if the chain is not initialized, which should never happen since we pre-allocate for all chains in `persisted`.
+    #[inline]
+    fn pending(&self, chain: &Chain) -> &RwLock<PendingRequests> {
+        self.requests
+            .get(chain)
             .expect("chain should be initialized within `persisted` method")
-            .write()
-            .await;
+    }
+
+    /// Get the execution watchers for a specific chain.
+    /// Panics if the chain is not initialized, which should never happen since we pre-allocate for all chains in `persisted`.
+    #[inline]
+    fn watchers(&self, chain: &Chain) -> &RwLock<ExecutionWatchers> {
+        self.execution_watchers
+            .get(chain)
+            .expect("chain should be initialized within `persisted` method")
+    }
+
+    /// Get the historical checkpoints for a specific chain.
+    /// Panics if the chain is not initialized, which should never happen since we pre-allocate for all chains in `persisted`.
+    #[inline]
+    fn checkpoints(&self, chain: &Chain) -> &RwLock<Vec<HistoricalCheckpoint>> {
+        self.historical_checkpoints
+            .get(chain)
+            .expect("chain should be initialized within `persisted` method")
+    }
+
+    async fn remember_checkpoint(&self, checkpoint: &Checkpoint) {
+        let mut historical = self.checkpoints(&checkpoint.chain).write().await;
         historical.push(HistoricalCheckpoint {
             checkpoint: checkpoint.clone(),
             created_at: Instant::now(),
@@ -282,12 +304,7 @@ impl Backlog {
         let id = request.id;
         let entry = BacklogEntry::new(request);
         let (prev, len) = {
-            let mut pending = self
-                .requests
-                .get(&chain)
-                .expect("chain should be initialized within `persisted` method")
-                .write()
-                .await;
+            let mut pending = self.pending(&chain).write().await;
             let p = pending.insert(id, entry);
             (p, pending.len())
         };
@@ -298,12 +315,7 @@ impl Backlog {
 
     pub async fn remove(&self, chain: Chain, id: &SignId) -> Option<BacklogEntry> {
         let (removed, len) = {
-            let mut pending = self
-                .requests
-                .get(&chain)
-                .expect("chain should be initialized within `persisted` method")
-                .write()
-                .await;
+            let mut pending = self.pending(&chain).write().await;
             let rem = pending.remove(id);
             (rem, pending.len())
         };
@@ -313,13 +325,7 @@ impl Backlog {
     }
 
     pub async fn get(&self, chain: Chain, id: &SignId) -> Option<BacklogEntry> {
-        self.requests
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
-            .read()
-            .await
-            .get(id)
-            .cloned()
+        self.pending(&chain).read().await.get(id).cloned()
     }
 
     /// Returns the number of pending requests in total
@@ -352,12 +358,7 @@ impl Backlog {
     /// Returns backlog requests for a chain that are still eligible to be
     /// enqueued for processing after catchup completes.
     pub async fn take_requeueable_requests(&self, chain: Chain) -> Vec<IndexedSignRequest> {
-        let pending = self
-            .requests
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
-            .write()
-            .await;
+        let pending = self.pending(&chain).write().await;
 
         let mut requeueable: Vec<_> = pending
             .requests
@@ -379,12 +380,7 @@ impl Backlog {
         &self,
         chain: Chain,
     ) -> Vec<(IndexedSignRequest, PublishState)> {
-        let pending = self
-            .requests
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
-            .write()
-            .await;
+        let pending = self.pending(&chain).write().await;
 
         let mut publishable: Vec<_> = pending
             .requests
@@ -409,30 +405,21 @@ impl Backlog {
     }
 
     pub async fn pending_generations(&self, chain: Chain) -> HashMap<SignId, BacklogEntry> {
-        self.requests
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
-            .read()
-            .await
-            .pending_generations()
+        self.pending(&chain).read().await.pending_generations()
     }
 
     pub async fn pending_generation_bidirectionals(
         &self,
         chain: Chain,
     ) -> HashMap<SignId, BacklogEntry> {
-        self.requests
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
+        self.pending(&chain)
             .read()
             .await
             .pending_generation_bidirectionals()
     }
 
     pub async fn pending_execution(&self, chain: Chain, id: &SignId) -> Option<BacklogEntry> {
-        self.requests
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
+        self.pending(&chain)
             .read()
             .await
             .pending_execution(id)
@@ -440,12 +427,7 @@ impl Backlog {
     }
 
     pub async fn len_by_chain(&self, chain: Chain) -> usize {
-        self.requests
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
-            .read()
-            .await
-            .len()
+        self.pending(&chain).read().await.len()
     }
 
     pub async fn mark_publishing(
@@ -478,12 +460,7 @@ impl Backlog {
         id: &SignId,
         request: IndexedSignRequest,
     ) -> Result<(), BacklogError> {
-        let mut pending = self
-            .requests
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
-            .write()
-            .await;
+        let mut pending = self.pending(&chain).write().await;
 
         let Some(entry) = pending.requests.get_mut(id) else {
             return Err(BacklogError::NotFound { chain, id: *id });
@@ -499,12 +476,7 @@ impl Backlog {
         sign_id: SignId,
         tx: BidirectionalTx,
     ) -> Option<(SignId, BidirectionalTx)> {
-        let mut entry = self
-            .execution_watchers
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
-            .write()
-            .await;
+        let mut entry = self.watchers(&chain).write().await;
 
         entry
             .insert(tx.id, ExecutionWatcher { sign_id, tx })
@@ -517,12 +489,7 @@ impl Backlog {
         chain: Chain,
         tx_id: &BidirectionalTxId,
     ) -> Option<(SignId, BidirectionalTx)> {
-        let mut entry = self
-            .execution_watchers
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
-            .write()
-            .await;
+        let mut entry = self.watchers(&chain).write().await;
 
         entry
             .remove(tx_id)
@@ -535,12 +502,7 @@ impl Backlog {
         &self,
         chain: Chain,
     ) -> HashMap<BidirectionalTxId, (SignId, BidirectionalTx)> {
-        self.execution_watchers
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
-            .read()
-            .await
-            .all()
+        self.watchers(&chain).read().await.all()
     }
 
     /// Update the status of a tracked bidirectional transaction on the source chain.
@@ -550,12 +512,7 @@ impl Backlog {
         id: &SignId,
         status: SignStatus,
     ) -> Option<BacklogEntry> {
-        let mut pending = self
-            .requests
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
-            .write()
-            .await;
+        let mut pending = self.pending(&chain).write().await;
 
         let Some(entry) = pending.requests.get_mut(id) else {
             tracing::warn!(
@@ -580,12 +537,7 @@ impl Backlog {
         bidirectional_tx: BidirectionalTx,
     ) -> Result<(), BacklogError> {
         // Update the transaction in the backlog from Sign to Bidirectional
-        let mut pending = self
-            .requests
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
-            .write()
-            .await;
+        let mut pending = self.pending(&chain).write().await;
 
         let entry = pending
             .requests
@@ -604,12 +556,7 @@ impl Backlog {
 
     /// Get the processed block height for a specific chain
     pub async fn processed_block(&self, chain: Chain) -> Option<u64> {
-        self.requests
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
-            .read()
-            .await
-            .processed_block_height()
+        self.pending(&chain).read().await.processed_block_height()
     }
 
     /// Set the processed block height for a specific chain.
@@ -626,12 +573,7 @@ impl Backlog {
         height: u64,
         interval: u64,
     ) -> Option<Checkpoint> {
-        let mut pending = self
-            .requests
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
-            .write()
-            .await;
+        let mut pending = self.pending(&chain).write().await;
         pending.set_processed_block(height);
 
         tracing::trace!(
@@ -656,13 +598,7 @@ impl Backlog {
 
     /// Create a checkpoint of the current backlog state for a specific chain
     pub async fn checkpoint(&self, chain: Chain) -> Checkpoint {
-        let checkpoint = self
-            .requests
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
-            .read()
-            .await
-            .checkpoint(chain);
+        let checkpoint = self.pending(&chain).read().await.checkpoint(chain);
 
         self.remember_checkpoint(&checkpoint).await;
 
@@ -674,9 +610,7 @@ impl Backlog {
     }
 
     pub async fn latest_checkpoint(&self, chain: Chain) -> Option<Checkpoint> {
-        self.historical_checkpoints
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
+        self.checkpoints(&chain)
             .read()
             .await
             .iter()
@@ -686,13 +620,7 @@ impl Backlog {
 
     /// Find a historical checkpoint by hash
     pub async fn find_checkpoint_by_hash(&self, chain: Chain, hash: u64) -> Option<Checkpoint> {
-        let checkpoints = self
-            .historical_checkpoints
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
-            .read()
-            .await
-            .clone(); // TODO: consider if we can avoid cloning
+        let checkpoints = self.checkpoints(&chain).read().await.clone(); // TODO: consider if we can avoid cloning
 
         for hcp in checkpoints {
             let mut hasher = hash_map::DefaultHasher::new();
@@ -715,12 +643,7 @@ impl Backlog {
             "recovering from checkpoint"
         );
 
-        let mut pending = self
-            .requests
-            .get(&checkpoint.chain)
-            .expect("chain should be initialized within `persisted` method")
-            .write()
-            .await;
+        let mut pending = self.pending(&checkpoint.chain).write().await;
 
         let previous_height = pending.processed_block_height().unwrap_or(0);
         let checkpoint_height = checkpoint.block_height;
@@ -756,13 +679,7 @@ impl Backlog {
         // Need to set the checkpoint as latest in our historical checkpoints
         // when we initially recover for this particular chain.
         if checkpoint_height > previous_height {
-            let checkpoint = self
-                .requests
-                .get(&chain)
-                .expect("chain should be initialized within `persisted` method")
-                .read()
-                .await
-                .checkpoint(chain);
+            let checkpoint = self.pending(&chain).read().await.checkpoint(chain);
 
             self.remember_checkpoint(&checkpoint).await;
         }
@@ -853,8 +770,6 @@ pub enum BacklogError {
     NotFound { chain: Chain, id: SignId },
     #[error("chain not initialized: {chain:?}")]
     ChainNotInitialized { chain: Chain },
-    #[error("chain not found")]
-    ChainNotFound,
     #[error("transaction not found")]
     TransactionNotFound,
     #[error("cannot mark publishing for current backlog state")]

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -668,7 +668,7 @@ impl Backlog {
                 old_block = previous_height,
                 new_block = checkpoint_height,
                 cleared_requests = cleared,
-                restored_requests = pending.len(),
+                restored_requests = restored,
                 "successfully recovered from checkpoint"
             );
 
@@ -2021,6 +2021,176 @@ mod tests {
         assert_eq!(
             entry.execution_tx().map(|execution| execution.id),
             Some(tx.id)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_total_pending_initial_state() {
+        let backlog = Backlog::new();
+        assert_eq!(backlog.len().await, 0);
+        assert!(backlog.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn test_total_pending_increments_on_insert() {
+        let backlog = Backlog::new();
+        let tx = create_test_tx(1);
+        
+        backlog.insert(create_indexed_request(
+            SignId::new(tx.request_id),
+            Chain::Ethereum,
+            create_test_args(1),
+            SignKind::Sign,
+            0,
+        )).await;
+        
+        assert_eq!(backlog.len().await, 1);
+        assert!(!backlog.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn test_total_pending_ignores_duplicate_inserts() {
+        let backlog = Backlog::new();
+        let tx = create_test_tx(1);
+        let request = create_indexed_request(
+            SignId::new(tx.request_id),
+            Chain::Ethereum,
+            create_test_args(1),
+            SignKind::Sign,
+            0,
+        );
+        
+        // Insert first time
+        backlog.insert(request.clone()).await;
+        assert_eq!(backlog.len().await, 1);
+
+        // Insert exactly the same ID again (overwrites)
+        backlog.insert(request).await;
+        assert_eq!(backlog.len().await, 1, "Duplicate insert should not increment total");
+    }
+
+    #[tokio::test]
+    async fn test_total_pending_counts_across_chains() {
+        let backlog = Backlog::new();
+        
+        backlog.insert(create_indexed_request(
+            SignId::new(create_test_tx(1).request_id),
+            Chain::Ethereum,
+            create_test_args(1),
+            SignKind::Sign,
+            0,
+        )).await;
+
+        backlog.insert(create_indexed_request(
+            SignId::new(create_test_tx(2).request_id),
+            Chain::Solana,
+            create_test_args(2),
+            SignKind::Sign,
+            0,
+        )).await;
+
+        assert_eq!(backlog.len().await, 2);
+    }
+
+    #[tokio::test]
+    async fn test_total_pending_decrements_on_remove() {
+        let backlog = Backlog::new();
+        let sign_id = SignId::new(create_test_tx(1).request_id);
+        
+        backlog.insert(create_indexed_request(
+            sign_id,
+            Chain::Ethereum,
+            create_test_args(1),
+            SignKind::Sign,
+            0,
+        )).await;
+        assert_eq!(backlog.len().await, 1);
+
+        backlog.remove(Chain::Ethereum, &sign_id).await;
+        assert_eq!(backlog.len().await, 0);
+        assert!(backlog.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn test_total_pending_ignores_invalid_removes() {
+        let backlog = Backlog::new();
+        let sign_id1 = SignId::new(create_test_tx(1).request_id);
+        let sign_id2 = SignId::new(create_test_tx(2).request_id); // Not inserted
+        
+        backlog.insert(create_indexed_request(
+            sign_id1,
+            Chain::Ethereum,
+            create_test_args(1),
+            SignKind::Sign,
+            0,
+        )).await;
+
+        backlog.remove(Chain::Ethereum, &sign_id2).await;
+        assert_eq!(backlog.len().await, 1, "Removing non-existent ID should not decrement total");
+    }
+
+    #[tokio::test]
+    async fn test_total_pending_updates_on_clean_recovery() {
+        let backlog = Backlog::new();
+        
+        // Populate 3 requests and create a checkpoint
+        for i in 1..=3 {
+            backlog.insert(create_indexed_request(
+                SignId::new(create_test_tx(i).request_id),
+                Chain::Ethereum,
+                create_test_args(i),
+                SignKind::Sign,
+                0,
+            )).await;
+        }
+        backlog.set_processed_block(Chain::Ethereum, 10).await;
+        let checkpoint = backlog.checkpoint(Chain::Ethereum).await;
+
+        // Clean backlog recovers the checkpoint
+        let recovered = Backlog::new();
+        assert_eq!(recovered.len().await, 0);
+        
+        recovered.recover_by_checkpoint(checkpoint).await.expect("failed to recover");
+        
+        assert_eq!(recovered.len().await, 3);
+    }
+
+    #[tokio::test]
+    async fn test_total_pending_updates_on_dirty_recovery() {
+        let backlog = Backlog::new();
+        
+        // Populate 3 requests and create a checkpoint
+        for i in 1..=3 {
+            backlog.insert(create_indexed_request(
+                SignId::new(create_test_tx(i).request_id),
+                Chain::Ethereum,
+                create_test_args(i),
+                SignKind::Sign,
+                0,
+            )).await;
+        }
+        backlog.set_processed_block(Chain::Ethereum, 10).await;
+        let checkpoint = backlog.checkpoint(Chain::Ethereum).await;
+
+        // Dirty backlog has 1 entirely different request before recovery
+        let dirty_backlog = Backlog::new();
+        dirty_backlog.insert(create_indexed_request(
+            SignId::new([99u8; 32]),
+            Chain::Ethereum,
+            create_test_args(99),
+            SignKind::Sign,
+            0,
+        )).await;
+        
+        assert_eq!(dirty_backlog.len().await, 1);
+        
+        // Recover from checkpoint (should overwrite the dirty state)
+        dirty_backlog.recover_by_checkpoint(checkpoint).await.expect("failed to recover");
+        
+        assert_eq!(
+            dirty_backlog.len().await, 
+            3, 
+            "Total should reflect exactly the restored checkpoint size, ignoring the overwritten dirty state"
         );
     }
 }

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -453,12 +453,7 @@ impl Backlog {
         id: &SignId,
         publish: PublishState,
     ) -> Result<(), BacklogError> {
-        let mut pending = self
-            .requests
-            .get(&chain)
-            .expect("chain should be initialized within `persisted` method")
-            .write()
-            .await;
+        let mut pending = self.pending(&chain).write().await;
 
         let Some(entry) = pending.requests.get_mut(id) else {
             return Err(BacklogError::NotFound { chain, id: *id });

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -519,7 +519,7 @@ impl Backlog {
     ) -> Option<(SignId, BidirectionalTx)> {
         let mut entry = self
             .execution_watchers
-            .get_mut(&chain)
+            .get(&chain)
             .expect("chain should be initialized within `persisted` method")
             .write()
             .await;

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -8,12 +8,11 @@ use crate::sign_bidirectional::{BidirectionalTx, BidirectionalTxId, PublishState
 use crate::storage::checkpoint_storage::CheckpointStorage;
 
 use anyhow::Context;
-use futures_util::future::join_all;
-use futures_util::{stream, StreamExt};
 use mpc_primitives::{PendingTx, SignId};
 use sha3::{Digest, Sha3_256};
 use std::collections::{hash_map, HashMap};
 use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
@@ -230,6 +229,8 @@ pub struct Backlog {
     execution_watchers: Arc<HashMap<Chain, RwLock<ExecutionWatchers>>>,
     /// Historical checkpoints kept for 30 minutes, indexed by chain
     historical_checkpoints: Arc<HashMap<Chain, RwLock<Vec<HistoricalCheckpoint>>>>,
+    /// Total number of pending requests across all chains, wrapped in Arc to make clonable
+    total_pending: Arc<AtomicUsize>,
 }
 
 impl Default for Backlog {
@@ -260,10 +261,11 @@ impl Backlog {
             requests: Arc::new(requests),
             execution_watchers: Arc::new(execution_watchers),
             historical_checkpoints: Arc::new(historical_checkpoints),
+            total_pending: Arc::new(AtomicUsize::new(0)),
         }
     }
 
-    /// Get the pending requests for a specific chain. 
+    /// Get the pending requests for a specific chain.
     /// Panics if the chain is not initialized, which should never happen since we pre-allocate for all chains in `persisted`.
     #[inline]
     fn pending(&self, chain: &Chain) -> &RwLock<PendingRequests> {
@@ -309,6 +311,11 @@ impl Backlog {
             (p, pending.len())
         };
 
+        // Only increment total pending if this is a new entry
+        if prev.is_none() {
+            self.total_pending.fetch_add(1, Ordering::Relaxed);
+        }
+
         self.observe_backlog_size(chain, len);
         prev
     }
@@ -320,6 +327,11 @@ impl Backlog {
             (rem, pending.len())
         };
 
+        // Only decrement total pending if an entry was actually removed
+        if removed.is_some() {
+            self.total_pending.fetch_sub(1, Ordering::Relaxed);
+        }
+
         self.observe_backlog_size(chain, len);
         removed
     }
@@ -330,23 +342,12 @@ impl Backlog {
 
     /// Returns the number of pending requests in total
     pub async fn len(&self) -> usize {
-        // TODO: think about making this more efficient
-        join_all(
-            self.requests
-                .values()
-                .map(|lock| async { lock.read().await.len() }),
-        )
-        .await
-        .into_iter()
-        .sum()
+        self.total_pending.load(Ordering::Relaxed)
     }
 
     /// Returns true if there are no pending requests
     pub async fn is_empty(&self) -> bool {
-        // TODO: think about making this more efficient
-        stream::iter(self.requests.values())
-            .all(|lock| async { lock.read().await.requests.is_empty() })
-            .await
+        self.len().await == 0
     }
 
     fn observe_backlog_size(&self, chain: Chain, len: usize) {

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -652,7 +652,15 @@ impl Backlog {
         // Execution watchers are ephemeral, we need to get all the execution watchers here
         let execution_to_watch = if checkpoint_height > previous_height {
             let cleared = pending.len();
-            *pending = PendingRequests::from_checkpoint(checkpoint)?;
+            let new_pending = PendingRequests::from_checkpoint(checkpoint)?;
+            let restored = new_pending.len();
+
+            *pending = new_pending;
+
+            // Update total pending count based on the difference between cleared and restored requests
+            self.total_pending.fetch_sub(cleared, Ordering::Relaxed);
+            self.total_pending.fetch_add(restored, Ordering::Relaxed);
+
             let execution_to_watch = pending.pending_executions();
 
             tracing::info!(

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -621,9 +621,9 @@ impl Backlog {
 
     /// Find a historical checkpoint by hash
     pub async fn find_checkpoint_by_hash(&self, chain: Chain, hash: u64) -> Option<Checkpoint> {
-        let checkpoints = self.checkpoints(&chain).read().await.clone(); // TODO: consider if we can avoid cloning
+        let checkpoints = self.checkpoints(&chain).read().await;
 
-        for hcp in checkpoints {
+        for hcp in checkpoints.iter() {
             let mut hasher = hash_map::DefaultHasher::new();
             hcp.checkpoint.hash(&mut hasher);
             if hasher.finish() == hash {

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -8,6 +8,8 @@ use crate::sign_bidirectional::{BidirectionalTx, BidirectionalTxId, PublishState
 use crate::storage::checkpoint_storage::CheckpointStorage;
 
 use anyhow::Context;
+use futures_util::future::join_all;
+use futures_util::{stream, StreamExt};
 use mpc_primitives::{PendingTx, SignId};
 use sha3::{Digest, Sha3_256};
 use std::collections::{hash_map, HashMap};
@@ -224,10 +226,10 @@ struct HistoricalCheckpoint {
 #[derive(Debug, Clone)]
 pub struct Backlog {
     storage: CheckpointStorage,
-    requests: Arc<RwLock<HashMap<Chain, PendingRequests>>>,
-    execution_watchers: Arc<RwLock<HashMap<Chain, ExecutionWatchers>>>,
+    requests: Arc<HashMap<Chain, RwLock<PendingRequests>>>,
+    execution_watchers: Arc<HashMap<Chain, RwLock<ExecutionWatchers>>>,
     /// Historical checkpoints kept for 30 minutes, indexed by chain
-    historical_checkpoints: Arc<RwLock<HashMap<Chain, Vec<HistoricalCheckpoint>>>>,
+    historical_checkpoints: Arc<HashMap<Chain, RwLock<Vec<HistoricalCheckpoint>>>>,
 }
 
 impl Default for Backlog {
@@ -242,17 +244,32 @@ impl Backlog {
     }
 
     pub fn persisted(storage: CheckpointStorage) -> Self {
+        let mut requests = HashMap::new();
+        let mut execution_watchers = HashMap::new();
+        let mut historical_checkpoints = HashMap::new();
+
+        // Pre-allocate the maps for all chains
+        for chain in Chain::iter() {
+            requests.insert(chain, RwLock::new(PendingRequests::new()));
+            execution_watchers.insert(chain, RwLock::new(ExecutionWatchers::default()));
+            historical_checkpoints.insert(chain, RwLock::new(Vec::new()));
+        }
+
         Self {
             storage,
-            requests: Arc::new(RwLock::new(HashMap::new())),
-            execution_watchers: Arc::new(RwLock::new(HashMap::new())),
-            historical_checkpoints: Arc::new(RwLock::new(HashMap::new())),
+            requests: Arc::new(requests),
+            execution_watchers: Arc::new(execution_watchers),
+            historical_checkpoints: Arc::new(historical_checkpoints),
         }
     }
 
     async fn remember_checkpoint(&self, checkpoint: &Checkpoint) {
-        let mut historical = self.historical_checkpoints.write().await;
-        let historical = historical.entry(checkpoint.chain).or_insert_with(Vec::new);
+        let mut historical = self
+            .historical_checkpoints
+            .get(&checkpoint.chain)
+            .expect("chain should be initialized within `persisted` method")
+            .write()
+            .await;
         historical.push(HistoricalCheckpoint {
             checkpoint: checkpoint.clone(),
             created_at: Instant::now(),
@@ -265,8 +282,12 @@ impl Backlog {
         let id = request.id;
         let entry = BacklogEntry::new(request);
         let (prev, len) = {
-            let mut requests = self.requests.write().await;
-            let pending = requests.entry(chain).or_insert_with(PendingRequests::new);
+            let mut pending = self
+                .requests
+                .get(&chain)
+                .expect("chain should be initialized within `persisted` method")
+                .write()
+                .await;
             let p = pending.insert(id, entry);
             (p, pending.len())
         };
@@ -277,8 +298,12 @@ impl Backlog {
 
     pub async fn remove(&self, chain: Chain, id: &SignId) -> Option<BacklogEntry> {
         let (removed, len) = {
-            let mut requests = self.requests.write().await;
-            let pending = requests.entry(chain).or_insert_with(PendingRequests::new);
+            let mut pending = self
+                .requests
+                .get(&chain)
+                .expect("chain should be initialized within `persisted` method")
+                .write()
+                .await;
             let rem = pending.remove(id);
             (rem, pending.len())
         };
@@ -289,25 +314,33 @@ impl Backlog {
 
     pub async fn get(&self, chain: Chain, id: &SignId) -> Option<BacklogEntry> {
         self.requests
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
             .read()
             .await
-            .get(&chain)
-            .and_then(|pending_requests| pending_requests.get(id).cloned())
+            .get(id)
+            .cloned()
     }
 
     /// Returns the number of pending requests in total
     pub async fn len(&self) -> usize {
-        self.requests
-            .read()
-            .await
-            .values()
-            .map(|requests| requests.len())
-            .sum()
+        // TODO: think about making this more efficient
+        join_all(
+            self.requests
+                .values()
+                .map(|lock| async { lock.read().await.len() }),
+        )
+        .await
+        .into_iter()
+        .sum()
     }
 
     /// Returns true if there are no pending requests
     pub async fn is_empty(&self) -> bool {
-        self.requests.read().await.is_empty()
+        // TODO: think about making this more efficient
+        stream::iter(self.requests.values())
+            .all(|lock| async { lock.read().await.requests.is_empty() })
+            .await
     }
 
     fn observe_backlog_size(&self, chain: Chain, len: usize) {
@@ -319,10 +352,12 @@ impl Backlog {
     /// Returns backlog requests for a chain that are still eligible to be
     /// enqueued for processing after catchup completes.
     pub async fn take_requeueable_requests(&self, chain: Chain) -> Vec<IndexedSignRequest> {
-        let requests = self.requests.read().await;
-        let Some(pending) = requests.get(&chain) else {
-            return Vec::new();
-        };
+        let pending = self
+            .requests
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
+            .write()
+            .await;
 
         let mut requeueable: Vec<_> = pending
             .requests
@@ -344,10 +379,12 @@ impl Backlog {
         &self,
         chain: Chain,
     ) -> Vec<(IndexedSignRequest, PublishState)> {
-        let requests = self.requests.read().await;
-        let Some(pending) = requests.get(&chain) else {
-            return Vec::new();
-        };
+        let pending = self
+            .requests
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
+            .write()
+            .await;
 
         let mut publishable: Vec<_> = pending
             .requests
@@ -373,11 +410,11 @@ impl Backlog {
 
     pub async fn pending_generations(&self, chain: Chain) -> HashMap<SignId, BacklogEntry> {
         self.requests
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
             .read()
             .await
-            .get(&chain)
-            .map(PendingRequests::pending_generations)
-            .unwrap_or_default()
+            .pending_generations()
     }
 
     pub async fn pending_generation_bidirectionals(
@@ -385,28 +422,30 @@ impl Backlog {
         chain: Chain,
     ) -> HashMap<SignId, BacklogEntry> {
         self.requests
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
             .read()
             .await
-            .get(&chain)
-            .map(PendingRequests::pending_generation_bidirectionals)
-            .unwrap_or_default()
+            .pending_generation_bidirectionals()
     }
 
     pub async fn pending_execution(&self, chain: Chain, id: &SignId) -> Option<BacklogEntry> {
         self.requests
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
             .read()
             .await
-            .get(&chain)
-            .and_then(|requests| requests.pending_execution(id).cloned())
+            .pending_execution(id)
+            .cloned()
     }
 
     pub async fn len_by_chain(&self, chain: Chain) -> usize {
         self.requests
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
             .read()
             .await
-            .get(&chain)
-            .map(|requests| requests.len())
-            .unwrap_or(0)
+            .len()
     }
 
     pub async fn mark_publishing(
@@ -415,10 +454,13 @@ impl Backlog {
         id: &SignId,
         publish: PublishState,
     ) -> Result<(), BacklogError> {
-        let mut requests = self.requests.write().await;
-        let Some(pending) = requests.get_mut(&chain) else {
-            return Err(BacklogError::ChainNotFound);
-        };
+        let mut pending = self
+            .requests
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
+            .write()
+            .await;
+
         let Some(entry) = pending.requests.get_mut(id) else {
             return Err(BacklogError::NotFound { chain, id: *id });
         };
@@ -436,10 +478,13 @@ impl Backlog {
         id: &SignId,
         request: IndexedSignRequest,
     ) -> Result<(), BacklogError> {
-        let mut requests = self.requests.write().await;
-        let Some(pending) = requests.get_mut(&chain) else {
-            return Err(BacklogError::ChainNotFound);
-        };
+        let mut pending = self
+            .requests
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
+            .write()
+            .await;
+
         let Some(entry) = pending.requests.get_mut(id) else {
             return Err(BacklogError::NotFound { chain, id: *id });
         };
@@ -454,8 +499,13 @@ impl Backlog {
         sign_id: SignId,
         tx: BidirectionalTx,
     ) -> Option<(SignId, BidirectionalTx)> {
-        let mut watchers = self.execution_watchers.write().await;
-        let entry = watchers.entry(chain).or_default();
+        let mut entry = self
+            .execution_watchers
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
+            .write()
+            .await;
+
         entry
             .insert(tx.id, ExecutionWatcher { sign_id, tx })
             .map(|previous| (previous.sign_id, previous.tx))
@@ -467,10 +517,15 @@ impl Backlog {
         chain: Chain,
         tx_id: &BidirectionalTxId,
     ) -> Option<(SignId, BidirectionalTx)> {
-        let mut watchers = self.execution_watchers.write().await;
-        watchers
+        let mut entry = self
+            .execution_watchers
             .get_mut(&chain)
-            .and_then(|entry| entry.remove(tx_id))
+            .expect("chain should be initialized within `persisted` method")
+            .write()
+            .await;
+
+        entry
+            .remove(tx_id)
             .map(|watcher| (watcher.sign_id, watcher.tx))
     }
 
@@ -481,11 +536,11 @@ impl Backlog {
         chain: Chain,
     ) -> HashMap<BidirectionalTxId, (SignId, BidirectionalTx)> {
         self.execution_watchers
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
             .read()
             .await
-            .get(&chain)
-            .map(ExecutionWatchers::all)
-            .unwrap_or_default()
+            .all()
     }
 
     /// Update the status of a tracked bidirectional transaction on the source chain.
@@ -495,11 +550,13 @@ impl Backlog {
         id: &SignId,
         status: SignStatus,
     ) -> Option<BacklogEntry> {
-        let mut requests = self.requests.write().await;
-        let Some(pending) = requests.get_mut(&chain) else {
-            tracing::warn!(?chain, ?id, ?status, "set_status: chain not found");
-            return None;
-        };
+        let mut pending = self
+            .requests
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
+            .write()
+            .await;
+
         let Some(entry) = pending.requests.get_mut(id) else {
             tracing::warn!(
                 ?chain,
@@ -523,10 +580,12 @@ impl Backlog {
         bidirectional_tx: BidirectionalTx,
     ) -> Result<(), BacklogError> {
         // Update the transaction in the backlog from Sign to Bidirectional
-        let mut requests = self.requests.write().await;
-        let pending = requests
-            .get_mut(&chain)
-            .ok_or(BacklogError::ChainNotFound)?;
+        let mut pending = self
+            .requests
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
+            .write()
+            .await;
 
         let entry = pending
             .requests
@@ -537,7 +596,7 @@ impl Backlog {
 
         // Registration successful, now register the execution watcher on the target chain
         let target_chain = bidirectional_tx.target_chain;
-        drop(requests);
+        drop(pending);
         self.watch_execution(target_chain, sign_id, bidirectional_tx)
             .await;
         Ok(())
@@ -546,10 +605,11 @@ impl Backlog {
     /// Get the processed block height for a specific chain
     pub async fn processed_block(&self, chain: Chain) -> Option<u64> {
         self.requests
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
             .read()
             .await
-            .get(&chain)
-            .and_then(|pr| pr.processed_block_height())
+            .processed_block_height()
     }
 
     /// Set the processed block height for a specific chain.
@@ -566,8 +626,12 @@ impl Backlog {
         height: u64,
         interval: u64,
     ) -> Option<Checkpoint> {
-        let mut requests = self.requests.write().await;
-        let pending = requests.entry(chain).or_default();
+        let mut pending = self
+            .requests
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
+            .write()
+            .await;
         pending.set_processed_block(height);
 
         tracing::trace!(
@@ -580,7 +644,7 @@ impl Backlog {
         // create a checkpoint on interval
         if height.is_multiple_of(interval) {
             let tx_count = pending.len();
-            drop(requests);
+            drop(pending);
             let checkpoint = self.checkpoint(chain).await;
             tracing::info!(?chain, height, tx_count, ?checkpoint, "creating checkpoint");
 
@@ -594,11 +658,11 @@ impl Backlog {
     pub async fn checkpoint(&self, chain: Chain) -> Checkpoint {
         let checkpoint = self
             .requests
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
             .read()
             .await
-            .get(&chain)
-            .map(|pr| pr.checkpoint(chain))
-            .unwrap_or_else(|| Checkpoint::empty(chain));
+            .checkpoint(chain);
 
         self.remember_checkpoint(&checkpoint).await;
 
@@ -610,25 +674,31 @@ impl Backlog {
     }
 
     pub async fn latest_checkpoint(&self, chain: Chain) -> Option<Checkpoint> {
-        let historical = self.historical_checkpoints.read().await;
-        historical.get(&chain).and_then(|checkpoints| {
-            checkpoints
-                .iter()
-                .max_by_key(|hcp| hcp.checkpoint.block_height)
-                .map(|hcp| hcp.checkpoint.clone())
-        })
+        self.historical_checkpoints
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
+            .read()
+            .await
+            .iter()
+            .max_by_key(|hcp| hcp.checkpoint.block_height)
+            .map(|hcp| hcp.checkpoint.clone())
     }
 
     /// Find a historical checkpoint by hash
     pub async fn find_checkpoint_by_hash(&self, chain: Chain, hash: u64) -> Option<Checkpoint> {
-        let historical = self.historical_checkpoints.read().await;
-        if let Some(checkpoints) = historical.get(&chain) {
-            for hcp in checkpoints {
-                let mut hasher = hash_map::DefaultHasher::new();
-                hcp.checkpoint.hash(&mut hasher);
-                if hasher.finish() == hash {
-                    return Some(hcp.checkpoint.clone());
-                }
+        let checkpoints = self
+            .historical_checkpoints
+            .get(&chain)
+            .expect("chain should be initialized within `persisted` method")
+            .read()
+            .await
+            .clone(); // TODO: consider if we can avoid cloning
+
+        for hcp in checkpoints {
+            let mut hasher = hash_map::DefaultHasher::new();
+            hcp.checkpoint.hash(&mut hasher);
+            if hasher.finish() == hash {
+                return Some(hcp.checkpoint.clone());
             }
         }
         None
@@ -645,10 +715,12 @@ impl Backlog {
             "recovering from checkpoint"
         );
 
-        let mut requests = self.requests.write().await;
-        let pending = requests
-            .entry(checkpoint.chain)
-            .or_insert_with(PendingRequests::new);
+        let mut pending = self
+            .requests
+            .get(&checkpoint.chain)
+            .expect("chain should be initialized within `persisted` method")
+            .write()
+            .await;
 
         let previous_height = pending.processed_block_height().unwrap_or(0);
         let checkpoint_height = checkpoint.block_height;
@@ -679,20 +751,20 @@ impl Backlog {
 
             Vec::new()
         };
-        drop(requests);
+        drop(pending);
 
         // Need to set the checkpoint as latest in our historical checkpoints
         // when we initially recover for this particular chain.
         if checkpoint_height > previous_height {
             let checkpoint = self
                 .requests
+                .get(&chain)
+                .expect("chain should be initialized within `persisted` method")
                 .read()
                 .await
-                .get(&chain)
-                .map(|pending| pending.checkpoint(chain));
-            if let Some(checkpoint) = checkpoint {
-                self.remember_checkpoint(&checkpoint).await;
-            }
+                .checkpoint(chain);
+
+            self.remember_checkpoint(&checkpoint).await;
         }
 
         // now repopulate our execution watchers

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -2044,13 +2044,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_total_pending_initial_state() {
-        let backlog = Backlog::new();
-        assert_eq!(backlog.len(), 0);
-        assert!(backlog.is_empty());
-    }
-
-    #[tokio::test]
     async fn test_total_pending_increments_on_insert() {
         let backlog = Backlog::new();
         let tx = create_test_tx(1);


### PR DESCRIPTION
This PR updates lock mechanism in `Backlog` to allow multiple indexers read and update their specific chains concurrently

- Remove `RwLock` on `HashMap` in `requests`, `execution_watchers` and `historical_checkpoints` and put lock on items per `Chain` instead
- Add pre-allocations for each `Chain` in `persisted` method, remove `ChainNotFound` error (we're now certain `Chain` is present after initialization)
- Add `total_pending` field on `Backlog` (to keep `len` and `is_empty` methods sync and lock-free), add unit tests for different scenarios
- Add more doc comments