### PR TITLE
refactor: Update Solana indexer to fetch blocks concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6016,6 +6016,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "futures",
+ "futures-util",
  "generic-array",
  "hex",
  "hyper 0.14.32",

--- a/chain-signatures/node/src/indexer_canton/stream.rs
+++ b/chain-signatures/node/src/indexer_canton/stream.rs
@@ -5,7 +5,7 @@ use crate::stream::{ChainIndexer, ChainStream};
 
 use alloy::primitives::keccak256;
 use async_trait::async_trait;
-use futures_util::stream::{SplitSink, SplitStream};
+use futures_util::stream::{self, SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use mpc_primitives::{
     ChainEvent, RespondBidirectionalEvent, ScalarExt, Signature, SignatureRespondedEvent,
@@ -311,7 +311,7 @@ fn catchup_offset_range(checkpoint: u64, anchor_height: u64) -> Range<u64> {
 impl ChainIndexer for CantonIndexer {
     const CHAIN: Chain = Chain::Canton;
     type Block = u64;
-    type Iter = Range<u64>;
+    type Iter = stream::Iter<Range<u64>>;
 
     async fn livestream(&mut self) -> anyhow::Result<Option<u64>> {
         let checkpoint = self
@@ -327,7 +327,7 @@ impl ChainIndexer for CantonIndexer {
 
     async fn catchup_range(&self, anchor_height: u64) -> Self::Iter {
         // After a reconnect, we resume from last_seen_offset, so catchup should start there.
-        catchup_offset_range(self.last_seen_offset, anchor_height)
+        stream::iter(catchup_offset_range(self.last_seen_offset, anchor_height))
     }
 
     async fn process_catchup(&mut self, &item: &Self::Block) -> anyhow::Result<()> {

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -8,7 +8,7 @@ use crate::indexer_eth::abi::{ChainSignatures, SignatureRequestedEncoding};
 use crate::metrics::requests::{record_request_latency_since, SignRequestStep};
 use crate::protocol::Chain;
 use crate::respond_bidirectional::CompletedTx;
-use crate::stream::{AsyncCatchupIter, ChainIndexer, ChainStream};
+use crate::stream::{ChainIndexer, ChainStream};
 use crate::util::retry;
 
 use alloy::eips::BlockNumberOrTag;
@@ -18,6 +18,7 @@ use alloy::rpc::types::{Block, BlockId, Log};
 use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use async_trait::async_trait;
+use futures_util::stream;
 use k256::elliptic_curve::sec1::FromEncodedPoint;
 use k256::{AffinePoint as K256AffinePoint, EncodedPoint, FieldBytes, Scalar};
 use mpc_crypto::{kdf::derive_epsilon_eth, ScalarExt as _};
@@ -77,15 +78,10 @@ impl CatchupIter {
         self.buffered_blocks = self.client.get_blocks(&batch_block_ids).await.into_iter();
         self.next_block = batch_end;
     }
-}
 
-#[async_trait]
-impl AsyncCatchupIter for CatchupIter {
-    type Item = MaybeBlock;
-
-    async fn next(&mut self) -> Option<Self::Item> {
+    pub async fn next(&mut self) -> Option<MaybeBlock> {
         loop {
-            if let Some(block) = Iterator::next(&mut self.buffered_blocks) {
+            if let Some(block) = self.buffered_blocks.next() {
                 return Some(block);
             }
 
@@ -1385,7 +1381,7 @@ impl EthereumIndexer {
 impl ChainIndexer for EthereumIndexer {
     const CHAIN: Chain = Chain::Ethereum;
     type Block = MaybeBlock;
-    type Iter = CatchupIter;
+    type Iter = std::pin::Pin<Box<dyn stream::Stream<Item = Self::Block> + Send + 'static>>;
 
     async fn livestream(&mut self) -> anyhow::Result<Option<u64>> {
         let start_block_number = loop {
@@ -1427,7 +1423,15 @@ impl ChainIndexer for EthereumIndexer {
             .client
             .clamp_oldest_supported(current_block, anchor_height);
 
-        CatchupIter::new(self.client.clone(), catchup_start, anchor_height)
+        let catchup_iter = CatchupIter::new(self.client.clone(), catchup_start, anchor_height);
+
+        // Convert the async state machine into a Stream
+        let stream = stream::unfold(catchup_iter, |mut state| async move {
+            let item = state.next().await;
+            item.map(|block| (block, state))
+        });
+
+        Box::pin(stream)
     }
 
     async fn process_catchup(&mut self, block: &Self::Block) -> anyhow::Result<()> {
@@ -1536,7 +1540,7 @@ mod tests {
     #[cfg(feature = "helios")]
     use crate::indexer_eth::indexer_eth_helios;
     use crate::protocol::Chain;
-    use crate::stream::{AsyncCatchupIter, ChainIndexer};
+    use crate::stream::ChainIndexer;
     use alloy::eips::BlockNumberOrTag;
     use alloy::primitives::{address, b256, Address};
     use alloy::rpc::types::BlockId;

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -17,7 +17,7 @@ use anchor_client::anchor_lang::AnchorDeserialize;
 use anchor_lang::solana_program::keccak;
 use anchor_lang::Discriminator;
 use async_trait::async_trait;
-use futures_util::StreamExt;
+use futures_util::stream::{self, StreamExt};
 use k256::elliptic_curve::sec1::FromEncodedPoint;
 use k256::{AffinePoint, Scalar};
 use mpc_crypto::kdf::derive_epsilon_sol;
@@ -250,7 +250,7 @@ impl ChainStream for SolanaStream {
 impl ChainIndexer for SolanaIndexer {
     const CHAIN: Chain = Chain::Solana;
     type Block = (u64, SolanaCatchupBlock);
-    type Iter = btree_map::IntoIter<u64, SolanaCatchupBlock>;
+    type Iter = stream::Iter<btree_map::IntoIter<u64, SolanaCatchupBlock>>;
 
     async fn livestream(&mut self) -> anyhow::Result<Option<u64>> {
         let (live_tx, live_rx) = crate::stream::channel();
@@ -286,7 +286,7 @@ impl ChainIndexer for SolanaIndexer {
             .unwrap_or(anchor_height);
         let end_slot = anchor_height.saturating_sub(1); // We want to catch up to just before the anchor
         if start_slot > end_slot {
-            return BTreeMap::new().into_iter();
+            return stream::iter(BTreeMap::new().into_iter());
         }
 
         // This fetches a sparse list of transactions based on whether our program received
@@ -310,10 +310,9 @@ impl ChainIndexer for SolanaIndexer {
                     ?err,
                     "failed to query solana signature history; falling back to sparse catchup"
                 );
-                return self
-                    .fetch_sparse_blocks(start_slot, end_slot)
-                    .await
-                    .into_iter();
+
+                let blocks = self.fetch_sparse_blocks(start_slot, end_slot).await;
+                return stream::iter(blocks.into_iter());
             }
         };
 
@@ -343,7 +342,7 @@ impl ChainIndexer for SolanaIndexer {
             items.extend(self.fetch_sparse_blocks(start_slot, mid_slot).await);
         }
 
-        items.into_iter()
+        stream::iter(items.into_iter())
     }
 
     async fn process_catchup(&mut self, (slot, block): &Self::Block) -> anyhow::Result<()> {

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -320,7 +320,7 @@ impl ChainIndexer for SolanaIndexer {
 
                 // Stream blocks in chunks
                 let slots = self.get_all_sparse_slots(start_slot, end_slot).await;
-                return self.build_concurrent_catchup_stream(slots);
+                return self.build_ordered_catchup_stream(slots);
             }
         };
 
@@ -355,7 +355,7 @@ impl ChainIndexer for SolanaIndexer {
         }
 
         // Fetch all blocks for the identified slots concurrently
-        self.build_concurrent_catchup_stream(slots.into_iter().collect())
+        self.build_ordered_catchup_stream(slots.into_iter().collect())
     }
 
     async fn process_catchup(&mut self, (slot, block): &Self::Block) -> anyhow::Result<()> {
@@ -452,8 +452,11 @@ impl SolanaIndexer {
     }
 
     /// Fetches blocks for the given slots concurrently, returning a stream of results as they arrive.
-    fn build_concurrent_catchup_stream(&self, slots: Vec<u64>) -> <Self as ChainIndexer>::Iter {
+    fn build_ordered_catchup_stream(&self, mut slots: Vec<u64>) -> <Self as ChainIndexer>::Iter {
         let rpc_client = Arc::new(self.rpc_client.clone());
+
+        // Sort the slots to ensure we yield blocks in order, even if some requests are slower than others.
+        slots.sort_unstable();
 
         let stream = futures_util::stream::iter(slots)
             .map(move |slot| {
@@ -1322,7 +1325,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fetch_sparse_blocks_chunks_large_range() {
+    async fn test_get_all_sparse_slots_chunks_large_range() {
         let mut server = Server::new_async().await;
         let backlog = Backlog::new();
         let (events_tx, _events_rx) = mpsc::channel(1);
@@ -1421,7 +1424,7 @@ mod tests {
             // Get the chunked slots
             let slots = indexer.get_all_sparse_slots(100000, 112000).await;
             // Feed them into the concurrent stream
-            let mut stream = indexer.build_concurrent_catchup_stream(slots);
+            let mut stream = indexer.build_ordered_catchup_stream(slots);
 
             // Collect the results
             let mut results = HashMap::new();

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -57,6 +57,10 @@ const CPI_RESPOND_EVENT_HINTS: &[&str] = &[
     "Program log: Instruction: RespondBidirectional",
 ];
 
+// TODO: investigate what is the optimal number. 
+// For now use reasonable default of 20
+const CONCURRENT_REQUESTS: usize = 20;
+
 #[derive(Clone)]
 pub struct SolConfig {
     /// The solana account secret key used to sign solana respond txn.
@@ -467,8 +471,7 @@ impl SolanaIndexer {
                     }
                 }
             })
-            // TODO: remove hardcoded value
-            .buffer_unordered(20);
+            .buffered(CONCURRENT_REQUESTS); // yields results back in strict order (unlike `buffer_unordered`)
 
         Box::pin(stream)
     }

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -57,7 +57,7 @@ const CPI_RESPOND_EVENT_HINTS: &[&str] = &[
     "Program log: Instruction: RespondBidirectional",
 ];
 
-// TODO: investigate what is the optimal number. 
+// TODO: investigate what is the optimal number.
 // For now use reasonable default of 20
 const CONCURRENT_REQUESTS: usize = 20;
 

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -7,9 +7,11 @@ use crate::util::ethabi_request_id;
 use crate::util::retry::{retry_async, RetryConfig, RetryError, RetryReason};
 use anyhow::Context;
 
-use std::collections::{btree_map, BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap};
 use std::fmt;
+use std::pin::Pin;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use alloy_sol_types::SolValue;
@@ -17,7 +19,8 @@ use anchor_client::anchor_lang::AnchorDeserialize;
 use anchor_lang::solana_program::keccak;
 use anchor_lang::Discriminator;
 use async_trait::async_trait;
-use futures_util::stream::{self, StreamExt};
+use futures_util::stream::StreamExt;
+use futures_util::Stream;
 use k256::elliptic_curve::sec1::FromEncodedPoint;
 use k256::{AffinePoint, Scalar};
 use mpc_crypto::kdf::derive_epsilon_sol;
@@ -158,7 +161,7 @@ pub struct SolanaStream {
 
 pub struct SolanaIndexer {
     program_id: Pubkey,
-    rpc_client: RpcClient,
+    rpc_client: Arc<RpcClient>,
     rpc_http_url: String,
     rpc_ws_url: String,
     events_tx: mpsc::Sender<ChainEvent>,
@@ -227,7 +230,7 @@ impl ChainStream for SolanaStream {
 
         let indexer = SolanaIndexer {
             program_id: start_state.program_id,
-            rpc_client: RpcClient::new(start_state.rpc_http_url.clone()),
+            rpc_client: Arc::new(RpcClient::new(start_state.rpc_http_url.clone())),
             rpc_http_url: start_state.rpc_http_url.clone(),
             rpc_ws_url: start_state.rpc_ws_url.clone(),
             events_tx: start_state.tx.clone(),
@@ -250,7 +253,7 @@ impl ChainStream for SolanaStream {
 impl ChainIndexer for SolanaIndexer {
     const CHAIN: Chain = Chain::Solana;
     type Block = (u64, SolanaCatchupBlock);
-    type Iter = stream::Iter<btree_map::IntoIter<u64, SolanaCatchupBlock>>;
+    type Iter = Pin<Box<dyn Stream<Item = Self::Block> + Send + 'static>>;
 
     async fn livestream(&mut self) -> anyhow::Result<Option<u64>> {
         let (live_tx, live_rx) = crate::stream::channel();
@@ -286,7 +289,7 @@ impl ChainIndexer for SolanaIndexer {
             .unwrap_or(anchor_height);
         let end_slot = anchor_height.saturating_sub(1); // We want to catch up to just before the anchor
         if start_slot > end_slot {
-            return stream::iter(BTreeMap::new().into_iter());
+            return Box::pin(futures_util::stream::empty());
         }
 
         // This fetches a sparse list of transactions based on whether our program received
@@ -311,8 +314,9 @@ impl ChainIndexer for SolanaIndexer {
                     "failed to query solana signature history; falling back to sparse catchup"
                 );
 
-                let blocks = self.fetch_sparse_blocks(start_slot, end_slot).await;
-                return stream::iter(blocks.into_iter());
+                // Stream blocks in chunks
+                let slots = self.get_all_sparse_slots(start_slot, end_slot).await;
+                return self.build_concurrent_catchup_stream(slots);
             }
         };
 
@@ -327,7 +331,6 @@ impl ChainIndexer for SolanaIndexer {
             slots.insert(sig.slot);
         }
         let mid_slot = mid_slot.map(|n| n.saturating_sub(1)).unwrap_or(start_slot);
-        let mut items = self.fetch_blocks_for_slots(slots).await;
 
         // NOTE: since we can only do fast catchup for up to 1000 signatures,
         // if we hit that limit and the earliest signature is significantly
@@ -339,10 +342,16 @@ impl ChainIndexer for SolanaIndexer {
                 mid_slot,
                 "solana signature history hit the 1000-signature limit; combining sparse blocks with signatures"
             );
-            items.extend(self.fetch_sparse_blocks(start_slot, mid_slot).await);
+
+            // Fetch the sparse blocks between start_slot and mid_slot and add them to the set of slots to catch up
+            let missing_slots = self.get_all_sparse_slots(start_slot, mid_slot).await;
+            for slot in missing_slots {
+                slots.insert(slot);
+            }
         }
 
-        stream::iter(items.into_iter())
+        // Fetch all blocks for the identified slots concurrently
+        self.build_concurrent_catchup_stream(slots.into_iter().collect())
     }
 
     async fn process_catchup(&mut self, (slot, block): &Self::Block) -> anyhow::Result<()> {
@@ -395,32 +404,6 @@ impl SolanaIndexer {
             .with_context(|| format!("failed to fetch Solana block for slot {slot}"))
     }
 
-    async fn fetch_blocks_for_slots(
-        &self,
-        slots: BTreeSet<u64>,
-    ) -> BTreeMap<u64, SolanaCatchupBlock> {
-        let mut blocks_by_height = BTreeMap::new();
-
-        for &slot in &slots {
-            match self.get_block(slot).await {
-                Ok(block) => {
-                    blocks_by_height.insert(slot, SolanaCatchupBlock::Block(block));
-                }
-                Err(err) => {
-                    tracing::warn!(?err, slot, "failed to fetch Solana block for catchup slot");
-                }
-            }
-        }
-
-        slots
-            .into_iter()
-            .map(|slot| match blocks_by_height.remove(&slot) {
-                Some(block) => (slot, block),
-                None => (slot, SolanaCatchupBlock::Missing),
-            })
-            .collect()
-    }
-
     async fn process_block(&mut self, height: u64, block: &UiConfirmedBlock) -> anyhow::Result<()> {
         let Some(transactions) = &block.transactions else {
             self.events_tx.send(ChainEvent::Block(height)).await?;
@@ -464,32 +447,45 @@ impl SolanaIndexer {
         }
     }
 
-    /// Fetches blocks from start_slot to end_slot. The range is inclusive `[start_slot, endslot]`
-    async fn fetch_sparse_blocks(
-        &self,
-        mut start_slot: u64,
-        end_slot: u64,
-    ) -> BTreeMap<u64, SolanaCatchupBlock> {
-        // TODO: https://github.com/sig-net/mpc/issues/869
-        // This can be gigantic. We should move to iterating over chunks instead of fetching
-        // all blocks for multiple chunks at once.
-        const MAX_CHUNK_SIZE: u64 = 10_000;
+    /// Fetches blocks for the given slots concurrently, returning a stream of results as they arrive.
+    fn build_concurrent_catchup_stream(&self, slots: Vec<u64>) -> <Self as ChainIndexer>::Iter {
+        let rpc_client = Arc::new(self.rpc_client.clone());
 
-        let mut block_slots = Vec::new();
+        let stream = futures_util::stream::iter(slots)
+            .map(move |slot| {
+                let rpc = rpc_client.clone();
+                async move {
+                    match rpc
+                        .get_block_with_config(slot, Self::block_fetch_config())
+                        .await
+                    {
+                        Ok(block) => (slot, SolanaCatchupBlock::Block(block)),
+                        Err(err) => {
+                            tracing::warn!(?err, slot, "failed to fetch Solana block for catchup");
+                            (slot, SolanaCatchupBlock::Missing)
+                        }
+                    }
+                }
+            })
+            // TODO: remove hardcoded value
+            .buffer_unordered(20);
+
+        Box::pin(stream)
+    }
+
+    /// Fetches all missing slots across a large range by chunking requests
+    async fn get_all_sparse_slots(&self, mut start_slot: u64, end_slot: u64) -> Vec<u64> {
+        const MAX_CHUNK_SIZE: u64 = 10_000;
+        let mut all_slots = Vec::new();
+
         while start_slot <= end_slot {
             let chunk_end = std::cmp::min(end_slot, start_slot.saturating_add(MAX_CHUNK_SIZE - 1));
             let chunk_slots = self.fetch_sparse_chunk(start_slot, chunk_end).await;
-            block_slots.extend(chunk_slots);
+            all_slots.extend(chunk_slots);
             start_slot = chunk_end.saturating_add(1);
         }
 
-        self.fetch_blocks_for_slots(
-            block_slots
-                .into_iter()
-                .filter(|slot| *slot <= end_slot)
-                .collect(),
-        )
-        .await
+        all_slots
     }
 }
 
@@ -1181,6 +1177,8 @@ async fn get_tx(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
     use mockito::{Matcher, Server};
     use serde_json::json;
@@ -1328,7 +1326,7 @@ mod tests {
 
         let indexer = SolanaIndexer {
             program_id: Pubkey::new_unique(),
-            rpc_client: RpcClient::new(server.url()),
+            rpc_client: Arc::new(RpcClient::new(server.url())),
             rpc_http_url: server.url(),
             rpc_ws_url: String::new(),
             events_tx,
@@ -1416,10 +1414,19 @@ mod tests {
             .create_async()
             .await;
 
-        let res_timeout = tokio::time::timeout(
-            Duration::from_secs(2),
-            indexer.fetch_sparse_blocks(100000, 112000),
-        )
+        let res_timeout = tokio::time::timeout(Duration::from_secs(2), async {
+            // Get the chunked slots
+            let slots = indexer.get_all_sparse_slots(100000, 112000).await;
+            // Feed them into the concurrent stream
+            let mut stream = indexer.build_concurrent_catchup_stream(slots);
+
+            // Collect the results
+            let mut results = HashMap::new();
+            while let Some((slot, block)) = stream.next().await {
+                results.insert(slot, block);
+            }
+            results
+        })
         .await;
 
         let res = res_timeout

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -8,6 +8,7 @@ use crate::stream::ops::{
     process_sign_request, recover_backlog, requeue_pending_sign_requests,
     resume_pending_publish_requests,
 };
+use futures_util::{Stream, StreamExt};
 use mpc_primitives::ChainEvent;
 
 pub mod ops;
@@ -24,30 +25,10 @@ pub fn channel() -> (mpsc::Sender<ChainEvent>, mpsc::Receiver<ChainEvent>) {
 }
 
 #[async_trait]
-pub trait AsyncCatchupIter: Send + 'static {
-    type Item: Send;
-
-    async fn next(&mut self) -> Option<Self::Item>;
-}
-
-#[async_trait]
-impl<I> AsyncCatchupIter for I
-where
-    I: Iterator + Send + 'static,
-    I::Item: Send,
-{
-    type Item = I::Item;
-
-    async fn next(&mut self) -> Option<Self::Item> {
-        Iterator::next(self)
-    }
-}
-
-#[async_trait]
 pub trait ChainIndexer: Send + 'static {
     const CHAIN: Chain;
     type Block: Send;
-    type Iter: AsyncCatchupIter<Item = Self::Block> + Send + 'static;
+    type Iter: Stream<Item = Self::Block> + Send + 'static;
 
     const RETRY_DELAY: Duration = Duration::from_millis(500);
 
@@ -116,8 +97,10 @@ pub async fn catchup_then_livestream<I: ChainIndexer>(mut indexer: I) {
     };
 
     tracing::info!(%chain, anchor_height, "livestream initialized => starting catchup");
-    let mut catchup_iter = indexer.catchup_range(anchor_height).await;
-    while let Some(catchup_item) = catchup_iter.next().await {
+    let catchup_stream = indexer.catchup_range(anchor_height).await;
+    // Pin the stream
+    tokio::pin!(catchup_stream);
+    while let Some(catchup_item) = catchup_stream.next().await {
         while let Err(err) = indexer.process_catchup(&catchup_item).await {
             tracing::warn!(?err, %chain, "catchup item processing failed; retrying");
             tokio::time::sleep(I::RETRY_DELAY).await;
@@ -314,14 +297,14 @@ mod tests {
                 const CHAIN: Chain = $chain;
 
                 type Block = ();
-                type Iter = std::iter::Empty<Self::Block>;
+                type Iter = futures_util::stream::Empty<Self::Block>;
 
                 async fn next(&mut self) -> Option<Self::Block> {
                     None
                 }
 
                 async fn catchup_range(&self, _anchor_height: u64) -> Self::Iter {
-                    std::iter::empty()
+                    futures_util::stream::empty()
                 }
 
                 async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {
@@ -421,7 +404,7 @@ mod tests {
     impl ChainIndexer for TestLinearIndexer {
         const CHAIN: Chain = Chain::Ethereum;
         type Block = u64;
-        type Iter = std::vec::IntoIter<Self::Block>;
+        type Iter = futures_util::stream::Iter<std::vec::IntoIter<Self::Block>>;
 
         const RETRY_DELAY: Duration = Duration::from_millis(1);
 
@@ -447,7 +430,7 @@ mod tests {
                 .map(|height| height + 1)
                 .unwrap_or(anchor_height);
             let items: Vec<Self::Block> = (start..anchor_height).collect();
-            items.into_iter()
+            futures_util::stream::iter(items.into_iter())
         }
 
         async fn process_catchup(&mut self, &height: &Self::Block) -> anyhow::Result<()> {
@@ -659,14 +642,14 @@ mod tests {
         impl ChainIndexer for DisabledChainIndexer {
             const CHAIN: Chain = Chain::Solana;
             type Block = ();
-            type Iter = std::iter::Empty<Self::Block>;
+            type Iter = futures_util::stream::Empty<Self::Block>;
 
             async fn next(&mut self) -> Option<Self::Block> {
                 None
             }
 
             async fn catchup_range(&self, _anchor_height: u64) -> Self::Iter {
-                std::iter::empty()
+                futures_util::stream::empty()
             }
 
             async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -28,7 +28,7 @@ pub fn channel() -> (mpsc::Sender<ChainEvent>, mpsc::Receiver<ChainEvent>) {
 pub trait ChainIndexer: Send + 'static {
     const CHAIN: Chain;
     type Block: Send;
-    type Iter: Stream<Item = Self::Block> + Send + 'static;
+    type Iter: Stream<Item = Self::Block> + Send + Unpin + 'static;
 
     const RETRY_DELAY: Duration = Duration::from_millis(500);
 

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -18,6 +18,7 @@ ciborium.workspace = true
 clap.workspace = true
 deadpool-redis.workspace = true
 futures = "0.3"
+futures-util.workspace = true
 generic-array = { version = "0.14.7", default-features = false }
 hex.workspace = true
 hyper.workspace = true

--- a/integration-tests/src/mpc_fixture/mock_stream.rs
+++ b/integration-tests/src/mpc_fixture/mock_stream.rs
@@ -35,10 +35,10 @@ pub struct MockIndexer {
 impl ChainIndexer for MockIndexer {
     const CHAIN: Chain = Chain::Solana;
     type Block = ();
-    type Iter = std::iter::Empty<()>;
+    type Iter = futures_util::stream::Empty<()>;
 
     async fn catchup_range(&self, _anchor_height: u64) -> Self::Iter {
-        std::iter::empty()
+        futures_util::stream::empty()
     }
 
     async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {

--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -382,7 +382,7 @@ async fn test_checkpoint_recovery_after_offline() -> anyhow::Result<()> {
         active_idx,
         Chain::Ethereum,
         initial_checkpoint.block_height + 1,
-        Duration::from_secs(90),
+        Duration::from_secs(120),
     )
     .await?;
 


### PR DESCRIPTION
- Replace `AsyncCatchupIter` with `futures_util::stream::Stream` in `ChainIndexer` trait. Update indexers accordingly
- Update Solana indexer to fetch catchup blocks concurrently using `futures::stream` API (will update other indexers in separate PRs)