### PR TITLE
1.16.4 and CHECKPOINT_VERSION v10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7311,7 +7311,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "mpc-contract"
-version = "1.16.4"
+version = "1.16.5"
 dependencies = [
  "anyhow",
  "borsh 1.5.7",
@@ -7333,7 +7333,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-crypto"
-version = "1.16.4"
+version = "1.16.5"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7347,7 +7347,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-keys"
-version = "1.16.4"
+version = "1.16.5"
 dependencies = [
  "borsh 1.5.7",
  "hex",
@@ -7358,7 +7358,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-node"
-version = "1.16.4"
+version = "1.16.5"
 dependencies = [
  "alloy",
  "alloy-dyn-abi",
@@ -7448,7 +7448,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-primitives"
-version = "1.16.4"
+version = "1.16.5"
 dependencies = [
  "borsh 1.5.7",
  "ciborium",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7311,7 +7311,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "mpc-contract"
-version = "1.16.5"
+version = "1.16.4"
 dependencies = [
  "anyhow",
  "borsh 1.5.7",
@@ -7333,7 +7333,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-crypto"
-version = "1.16.5"
+version = "1.16.4"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7347,7 +7347,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-keys"
-version = "1.16.5"
+version = "1.16.4"
 dependencies = [
  "borsh 1.5.7",
  "hex",
@@ -7358,7 +7358,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-node"
-version = "1.16.5"
+version = "1.16.4"
 dependencies = [
  "alloy",
  "alloy-dyn-abi",
@@ -7448,7 +7448,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-primitives"
-version = "1.16.5"
+version = "1.16.4"
 dependencies = [
  "borsh 1.5.7",
  "ciborium",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7311,7 +7311,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "mpc-contract"
-version = "1.16.3"
+version = "1.16.4"
 dependencies = [
  "anyhow",
  "borsh 1.5.7",
@@ -7333,7 +7333,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-crypto"
-version = "1.16.3"
+version = "1.16.4"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7347,7 +7347,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-keys"
-version = "1.16.3"
+version = "1.16.4"
 dependencies = [
  "borsh 1.5.7",
  "hex",
@@ -7358,7 +7358,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-node"
-version = "1.16.3"
+version = "1.16.4"
 dependencies = [
  "alloy",
  "alloy-dyn-abi",
@@ -7448,7 +7448,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-primitives"
-version = "1.16.3"
+version = "1.16.4"
 dependencies = [
  "borsh 1.5.7",
  "ciborium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["infra/scripts/generate_keys"]
 resolver = "2"
 
 [workspace.package]
-version = "1.16.3"
+version = "1.16.4"
 
 [workspace.dependencies]
 alloy = { version = "=1.0.38", features = ["contract", "json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["infra/scripts/generate_keys"]
 resolver = "2"
 
 [workspace.package]
-version = "1.16.4"
+version = "1.16.5"
 
 [workspace.dependencies]
 alloy = { version = "=1.0.38", features = ["contract", "json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["infra/scripts/generate_keys"]
 resolver = "2"
 
 [workspace.package]
-version = "1.16.5"
+version = "1.16.4"
 
 [workspace.dependencies]
 alloy = { version = "=1.0.38", features = ["contract", "json"] }

--- a/chain-signatures/node/src/storage/checkpoint_storage.rs
+++ b/chain-signatures/node/src/storage/checkpoint_storage.rs
@@ -10,7 +10,7 @@ use tokio::sync::RwLock;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-const CHECKPOINT_VERSION: &str = "v9";
+const CHECKPOINT_VERSION: &str = "v10";
 
 #[derive(Clone, Debug)]
 pub enum CheckpointStorage {

--- a/chain-signatures/node/src/storage/checkpoint_storage.rs
+++ b/chain-signatures/node/src/storage/checkpoint_storage.rs
@@ -10,7 +10,7 @@ use tokio::sync::RwLock;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-const CHECKPOINT_VERSION: &str = "v10";
+const CHECKPOINT_VERSION: &str = "v11";
 
 #[derive(Clone, Debug)]
 pub enum CheckpointStorage {


### PR DESCRIPTION
@ChaoticTempest, we can postpone this merge if we want to make sure we fix backlog issues without resetting it.