### PR TITLE
test: Bypass CPU exhaustion in integration tests

### DIFF
--- a/integration-tests/src/cluster/spawner.rs
+++ b/integration-tests/src/cluster/spawner.rs
@@ -424,7 +424,7 @@ impl ClusterSpawner {
 
     pub async fn prespawn_sandbox(&mut self) -> anyhow::Result<&Worker<Sandbox>> {
         if self.worker.is_none() {
-            self.worker = Some(near_workspaces::sandbox().await?);
+            self.worker = Some(spawn_sandbox_with_retry().await?);
         }
         Ok(self.worker.as_ref().unwrap())
     }
@@ -432,7 +432,7 @@ impl ClusterSpawner {
     pub async fn take_worker(&mut self) -> Worker<Sandbox> {
         match self.worker.take() {
             Some(worker) => worker,
-            None => near_workspaces::sandbox().await.unwrap(),
+            None => spawn_sandbox_with_retry().await.expect("failed to spawn sandbox"),
         }
     }
 
@@ -513,4 +513,21 @@ impl IntoFuture for ClusterSpawner {
             Ok(cluster)
         })
     }
+}
+
+/// Spawn a near sandbox with retry logic to handle potential transient failures (i.e., due to CPU contention)
+async fn spawn_sandbox_with_retry() -> anyhow::Result<Worker<Sandbox>> {
+    let mut last_err = None;
+    for attempt in 1..=5 {
+        match near_workspaces::sandbox().await {
+            Ok(worker) => return Ok(worker),
+            Err(e) => {
+                tracing::warn!(attempt, "failed to spawn near sandbox within timeout, retrying: {e}");
+                last_err = Some(e);
+                // Give the OS a moment to breathe before trying again
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            }
+        }
+    }
+    anyhow::bail!("failed to spawn near sandbox after 5 attempts: {:?}", last_err)
 }

--- a/integration-tests/src/cluster/spawner.rs
+++ b/integration-tests/src/cluster/spawner.rs
@@ -432,7 +432,9 @@ impl ClusterSpawner {
     pub async fn take_worker(&mut self) -> Worker<Sandbox> {
         match self.worker.take() {
             Some(worker) => worker,
-            None => spawn_sandbox_with_retry().await.expect("failed to spawn sandbox"),
+            None => spawn_sandbox_with_retry()
+                .await
+                .expect("failed to spawn sandbox"),
         }
     }
 
@@ -522,12 +524,18 @@ async fn spawn_sandbox_with_retry() -> anyhow::Result<Worker<Sandbox>> {
         match near_workspaces::sandbox().await {
             Ok(worker) => return Ok(worker),
             Err(e) => {
-                tracing::warn!(attempt, "failed to spawn near sandbox within timeout, retrying: {e}");
+                tracing::warn!(
+                    attempt,
+                    "failed to spawn near sandbox within timeout, retrying: {e}"
+                );
                 last_err = Some(e);
                 // Give the OS a moment to breathe before trying again
                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;
             }
         }
     }
-    anyhow::bail!("failed to spawn near sandbox after 5 attempts: {:?}", last_err)
+    anyhow::bail!(
+        "failed to spawn near sandbox after 5 attempts: {:?}",
+        last_err
+    )
 }

--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -19,7 +19,7 @@ use tokio::time::Duration;
 
 #[test(tokio::test)]
 async fn test_signature_ethereum() -> Result<()> {
-    let cluster = cluster::spawn().disable_prestockpile().ethereum().await?;
+    let cluster = cluster::spawn().ethereum().await?;
     cluster.wait().signable().await?;
 
     let ctx = cluster.nodes.ctx();
@@ -165,7 +165,7 @@ async fn test_proper_indexer_checkpoint() -> Result<()> {
         std::env::set_var(name, value);
     }
 
-    let cluster = cluster::spawn().disable_prestockpile().ethereum().await?;
+    let cluster = cluster::spawn().ethereum().await?;
     cluster.wait().signable().await?;
 
     let ctx = cluster.nodes.ctx();

--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -393,7 +393,8 @@ async fn test_checkpoint_recovery_after_offline() -> anyhow::Result<()> {
 
     tracing::info!("bringing offline node back online");
     cluster.restart_node(offline_config).await?;
-    cluster.wait().signable().await?;
+    // Does not have to be signable, just need Indexer to sync
+    cluster.wait().nodes_running().await?;
 
     // Verify the restarted node recovers to the same checkpoint via node consensus
     let node_recovered_checkpoint = wait_node_checkpoint(

--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -382,7 +382,7 @@ async fn test_checkpoint_recovery_after_offline() -> anyhow::Result<()> {
         active_idx,
         Chain::Ethereum,
         initial_checkpoint.block_height + 1,
-        Duration::from_secs(90),
+        Duration::from_secs(120),
     )
     .await?;
 

--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -426,7 +426,7 @@ async fn test_checkpoint_recovery_after_offline() -> anyhow::Result<()> {
             node_recovered_checkpoint
                 .block_height
                 .max(node_active_checkpoint.block_height),
-            Duration::from_secs(45),
+            Duration::from_secs(90),
         )
         .await?;
 
@@ -440,7 +440,7 @@ async fn test_checkpoint_recovery_after_offline() -> anyhow::Result<()> {
         active_idx,
         Chain::Ethereum,
         active_checkpoint_after_restart.block_height,
-        Duration::from_secs(30),
+        Duration::from_secs(60),
     )
     .await?;
 


### PR DESCRIPTION
Few changes to address CPU spikes due to integration test running in parallel:

- Enable prestockpile in `test_signature_ethereum` and `test_proper_indexer_checkpoint` (removed `.disable_prestockpile()`). I think it's ok for these two to use pre-computed Triples, let me know if I am wrong.
- Replace `.signable()` with `.nodes_running()` in `test_checkpoint_recovery_after_offline`. We only care if Indexer can catch up.
- Increase timeouts in `test_checkpoint_recovery_after_offline` (the slowest test, often times out)
- Implement `spawn_sandbox_with_retry` helper to absorb random CPU spikes