### PR TITLE
fix: add lazy catchup process blocks to avoid OOM issues

### DIFF
--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -1,7 +1,7 @@
 use crate::backlog::Backlog;
 use crate::protocol::Chain;
 use crate::sign_bidirectional::hash_rlp_data;
-use crate::solana_client::{SolanaCatchupBlock, SolanaClient, MAX_CHUNK_SIZE};
+use crate::solana_client::{SolanaCatchupBlock, SolanaClient, MAX_CONCURRENT_CHUNK_SIZE};
 use crate::stream::{ChainIndexer, ChainStream};
 use crate::util::ethabi_request_id;
 use crate::util::retry::{retry_async, RetryConfig, RetryError, RetryReason};
@@ -279,7 +279,7 @@ impl ChainIndexer for SolanaIndexer {
                     }
 
                     let chunk_slots: BTreeSet<u64> = remaining_slots
-                        .drain(..std::cmp::min(MAX_CHUNK_SIZE, remaining_slots.len()))
+                        .drain(..std::cmp::min(MAX_CONCURRENT_CHUNK_SIZE, remaining_slots.len()))
                         .collect();
 
                     let blocks = client.fetch_blocks_for_slots(chunk_slots).await;

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -1,14 +1,14 @@
 use crate::backlog::Backlog;
 use crate::protocol::Chain;
 use crate::sign_bidirectional::hash_rlp_data;
-use crate::solana_client::{SolanaCatchupBlock, SolanaClient};
+use crate::solana_client::{SolanaCatchupBlock, SolanaClient, MAX_CHUNK_SIZE};
 use crate::stream::{ChainIndexer, ChainStream};
 use crate::util::ethabi_request_id;
 use crate::util::retry::{retry_async, RetryConfig, RetryError, RetryReason};
 
 pub use crate::solana_client::SolConfig;
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::pin::Pin;
 use std::str::FromStr;
 use std::time::{Duration, Instant};
@@ -263,8 +263,32 @@ impl ChainIndexer for SolanaIndexer {
         }
 
         let slots = self.client.fetch_slots(start_slot, end_slot).await;
-        let items = self.client.fetch_blocks_for_slots(slots).await;
-        Box::pin(futures_util::stream::iter(items.into_iter()))
+        let remaining_slots: VecDeque<u64> = slots.into_iter().collect();
+
+        let client = self.client.clone();
+        let stream = futures_util::stream::unfold(
+            (remaining_slots, client, VecDeque::new()),
+            |state| async move {
+                let (mut remaining_slots, client, mut current_chunk) = state;
+                loop {
+                    if let Some(block) = current_chunk.pop_front() {
+                        return Some((block, (remaining_slots, client, current_chunk)));
+                    }
+                    if remaining_slots.is_empty() {
+                        return None;
+                    }
+
+                    let chunk_slots: BTreeSet<u64> = remaining_slots
+                        .drain(..std::cmp::min(MAX_CHUNK_SIZE, remaining_slots.len()))
+                        .collect();
+
+                    let blocks = client.fetch_blocks_for_slots(chunk_slots).await;
+                    current_chunk = blocks.into_iter().collect();
+                }
+            },
+        );
+
+        Box::pin(stream)
     }
 
     async fn process_catchup(&mut self, (slot, block): &Self::Block) -> anyhow::Result<()> {

--- a/chain-signatures/node/src/solana_client.rs
+++ b/chain-signatures/node/src/solana_client.rs
@@ -21,7 +21,10 @@ const MAX_SIGNATURES_FOR_FAST_CATCHUP: usize = 1000;
 const MAX_CONCURRENT_FETCH: usize = 5;
 
 /// The max chunk size for fetching slots and blocks per batch.
-pub const MAX_CHUNK_SIZE: usize = 50;
+const MAX_CHUNK_SIZE: usize = 50;
+
+/// The max chunk size allowed for fetching concurrently.
+pub const MAX_CONCURRENT_CHUNK_SIZE: usize = MAX_CONCURRENT_FETCH * MAX_CHUNK_SIZE;
 
 #[derive(Clone)]
 pub struct SolConfig {

--- a/chain-signatures/node/src/solana_client.rs
+++ b/chain-signatures/node/src/solana_client.rs
@@ -17,6 +17,12 @@ use std::time::Duration;
 
 const MAX_SIGNATURES_FOR_FAST_CATCHUP: usize = 1000;
 
+/// The max amount of batches to fetch concurrently
+const MAX_CONCURRENT_FETCH: usize = 5;
+
+/// The max chunk size for fetching slots and blocks per batch.
+pub const MAX_CHUNK_SIZE: usize = 50;
+
 #[derive(Clone)]
 pub struct SolConfig {
     /// The solana account secret key used to sign solana respond txn.
@@ -340,9 +346,6 @@ impl SolanaClient {
         &self,
         slots: BTreeSet<u64>,
     ) -> BTreeMap<u64, SolanaCatchupBlock> {
-        const MAX_CONCURRENT_FETCH: usize = 5;
-        const MAX_CHUNK_SIZE: usize = 50;
-
         tracing::trace!(total_slots = slots.len(), "fetching blocks for slots...");
         let slots_vec: Vec<u64> = slots.into_iter().collect();
         let chunks: Vec<Vec<u64>> = slots_vec


### PR DESCRIPTION
This makes it so that we only fetch `MAX_CHUNK_SIZE` amount of blocks at a time when we go to process catchup. This avoid OOM issues when we have a large catchup window where before we would fetch all blocks. We still however fetch all slots in that window first, since we can only walk backwards for fetching slots relating to a program id.

Also resolves https://github.com/sig-net/mpc/issues/869 for solana