### PR TITLE
bug: remove eth duplicate indexed count

### DIFF
--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -1011,15 +1011,6 @@ impl EthereumIndexer {
             .collect_execution_confirmations(block_number, block_receipts)
             .await?;
 
-        for _request in &sign_requests {
-            record_request_latency_since(
-                Chain::Ethereum,
-                SignRequestStep::Indexing,
-                "ok",
-                block_timestamp,
-            );
-        }
-
         // Always forward the processed block to the "finalization" stage so it can emit
         // `ChainEvent::Block` even when there are no relevant contract logs.
         Ok(BlockAndRequests::new(

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -5,6 +5,7 @@ pub mod indexer_eth_helios;
 
 use crate::backlog::Backlog;
 use crate::indexer_eth::abi::{ChainSignatures, SignatureRequestedEncoding};
+use crate::metrics::requests::{record_request_latency_since, SignRequestStep};
 use crate::protocol::Chain;
 use crate::respond_bidirectional::CompletedTx;
 use crate::stream::{ChainIndexer, ChainStream};
@@ -1009,6 +1010,15 @@ impl EthereumIndexer {
         let exec_events = self
             .collect_execution_confirmations(block_number, block_receipts)
             .await?;
+
+        for _request in &sign_requests {
+            record_request_latency_since(
+                Chain::Ethereum,
+                SignRequestStep::Indexing,
+                "ok",
+                block_timestamp,
+            );
+        }
 
         // Always forward the processed block to the "finalization" stage so it can emit
         // `ChainEvent::Block` even when there are no relevant contract logs.

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -5,7 +5,6 @@ pub mod indexer_eth_helios;
 
 use crate::backlog::Backlog;
 use crate::indexer_eth::abi::{ChainSignatures, SignatureRequestedEncoding};
-use crate::metrics::requests::{record_request_latency_since, SignRequestStep};
 use crate::protocol::Chain;
 use crate::respond_bidirectional::CompletedTx;
 use crate::stream::{ChainIndexer, ChainStream};

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -20,7 +20,7 @@ pub(crate) async fn process_sign_request(
     backlog: Backlog,
     caught_up: bool,
 ) -> anyhow::Result<()> {
-    // ethereum has indexer delay due to finality, its indexing latency is not zero, so we don't emit it here. We emit it in prase_block() in eth indexer.
+    // Ethereum records its own indexing latency (includes finality delay) from the block timestamp in `parse_block`.
     if sign_request.chain != Chain::Ethereum {
         record_indexing_step_reached(sign_request.chain);
     }

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -20,7 +20,10 @@ pub(crate) async fn process_sign_request(
     backlog: Backlog,
     caught_up: bool,
 ) -> anyhow::Result<()> {
-    record_indexing_step_reached(sign_request.chain);
+    // ethereum has indexer delay due to finality, its indexing latency is not zero, so we don't emit it here. We emit it in prase_block() in eth indexer.
+    if sign_request.chain != Chain::Ethereum {
+        record_indexing_step_reached(sign_request.chain);
+    }
 
     if matches!(sign_request.kind, SignKind::RespondBidirectional(_)) {
         anyhow::bail!("Unexpected sign request kind");


### PR DESCRIPTION
https://github.com/sig-net/mpc/issues/895

Eth already emits the indexing step latency in eth indexer([code](https://github.com/sig-net/mpc/blob/5089606801980067bdfbf84b6252afcf7e67a58e/chain-signatures/node/src/indexer_eth/mod.rs#L1015)), it needs to be there because eth has a finality delay from block timestamp. 

This PR removes the indexing step latency emit for Ethereum in streams so it does not double count.

Coming up, we should actually try to observe the latency between block time and actual indexing for other chains too, as sometimes there could be indexer lag due to node being slow, and this would be a good metric to watch: https://github.com/sig-net/mpc/issues/897