### PR TITLE
refactor: decouple `backlog` from indexers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7453,6 +7453,7 @@ dependencies = [
 name = "mpc-primitives"
 version = "1.16.4"
 dependencies = [
+ "async-trait",
  "borsh 1.5.7",
  "ciborium",
  "enum-map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ version = "1.16.4"
 [workspace.dependencies]
 alloy = { version = "=1.0.38", features = ["contract", "json"] }
 anyhow = { version = "1.0.95", features = ["backtrace"] }
+async-trait = "0.1"
 backon = "0.4"
 borsh = { version = "1.5.3", features = ["derive"] }
 enum-map = "2.7.3"

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -8,7 +8,7 @@ name = "mpc-node"
 path = "src/main.rs"
 
 [dependencies]
-async-trait = "0.1"
+async-trait.workspace = true
 axum = "0.7.9"
 axum-extra = "0.9.6"
 chrono = "0.4.24"

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -6,6 +6,7 @@ use crate::storage::checkpoint_storage::{CheckpointStorage, MAX_RECENT_CHECKPOIN
 use anyhow::Context;
 use mpc_primitives::{
     BidirectionalTx, BidirectionalTxId, Chain, IndexedSignRequest, PendingTx, SignId, SignKind,
+    StateManager,
 };
 use std::collections::{hash_map, BTreeMap, HashMap};
 use std::hash::{Hash, Hasher};
@@ -473,15 +474,6 @@ impl Backlog {
             .map(|watcher| (watcher.sign_id, watcher.tx))
     }
 
-    /// Get the set of bidirectional transactions currently awaiting execution on the
-    /// specified destination chain.
-    pub async fn execution_watchers(
-        &self,
-        chain: Chain,
-    ) -> HashMap<BidirectionalTxId, (SignId, BidirectionalTx)> {
-        self.watchers(&chain).read().await.all()
-    }
-
     /// Update the status of a tracked bidirectional transaction on the source chain.
     pub async fn set_status(
         &self,
@@ -529,11 +521,6 @@ impl Backlog {
         self.watch_execution(target_chain, sign_id, bidirectional_tx)
             .await;
         Ok(())
-    }
-
-    /// Get the processed block height for a specific chain
-    pub async fn processed_block(&self, chain: Chain) -> Option<u64> {
-        self.pending(&chain).read().await.processed_block_height()
     }
 
     /// Set the processed block height for a specific chain.
@@ -681,6 +668,21 @@ impl Backlog {
         }
 
         Ok(())
+    }
+}
+
+/// Implement the StateManager trait for Backlog to provide access to processed block height and execution watchers for indexers
+#[async_trait::async_trait]
+impl StateManager for Backlog {
+    async fn get_processed_block(&self, chain: Chain) -> Option<u64> {
+        self.pending(&chain).read().await.processed_block_height()
+    }
+
+    async fn get_execution_watchers(
+        &self,
+        chain: Chain,
+    ) -> HashMap<BidirectionalTxId, (SignId, BidirectionalTx)> {
+        self.watchers(&chain).read().await.all()
     }
 }
 
@@ -1421,7 +1423,7 @@ mod tests {
             .await
             .expect("failed to recover");
 
-        let watchers = recovered.execution_watchers(Chain::Ethereum).await;
+        let watchers = recovered.get_execution_watchers(Chain::Ethereum).await;
         assert_eq!(watchers.len(), 1);
         assert!(watchers.contains_key(&tx.id));
     }

--- a/chain-signatures/node/src/indexer_canton/stream.rs
+++ b/chain-signatures/node/src/indexer_canton/stream.rs
@@ -1,4 +1,3 @@
-use crate::backlog::Backlog;
 use crate::protocol::Chain;
 use crate::rpc::CantonClient;
 use crate::stream::{ChainIndexer, ChainStream};
@@ -27,15 +26,15 @@ type CantonWs = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
 type CantonWsRead = SplitStream<CantonWs>;
 type CantonWsWrite = SplitSink<CantonWs, Message>;
 
-pub struct CantonStream {
+pub struct CantonStream<S: StateManager> {
     config: CantonConfig,
-    backlog: Backlog,
+    state_manager: S,
     events_rx: mpsc::Receiver<ChainEvent>,
     events_tx: Option<mpsc::Sender<ChainEvent>>,
 }
 
-impl CantonStream {
-    pub fn new(config: Option<CantonConfig>, backlog: Backlog) -> Option<Self> {
+impl<S: StateManager> CantonStream<S> {
+    pub fn new(config: Option<CantonConfig>, state_manager: S) -> Option<Self> {
         let config = match config {
             Some(c) => c,
             None => {
@@ -48,7 +47,7 @@ impl CantonStream {
 
         Some(CantonStream {
             config,
-            backlog,
+            state_manager,
             events_rx,
             events_tx: Some(events_tx),
         })
@@ -56,8 +55,8 @@ impl CantonStream {
 }
 
 #[async_trait]
-impl ChainStream for CantonStream {
-    type Indexer = CantonIndexer;
+impl<S: StateManager> ChainStream for CantonStream<S> {
+    type Indexer = CantonIndexer<S>;
 
     async fn start(&mut self) -> anyhow::Result<Self::Indexer> {
         let Some(events_tx) = self.events_tx.take() else {
@@ -65,7 +64,11 @@ impl ChainStream for CantonStream {
         };
 
         let client = CantonClient::new(&self.config).await?;
-        Ok(Self::Indexer::new(client, self.backlog.clone(), events_tx))
+        Ok(Self::Indexer::new(
+            client,
+            self.state_manager.clone(),
+            events_tx,
+        ))
     }
 
     async fn next_event(&mut self) -> Option<ChainEvent> {
@@ -182,23 +185,23 @@ impl CantonConnection {
     }
 }
 
-pub struct CantonIndexer {
+pub struct CantonIndexer<S: StateManager> {
     client: CantonClient,
-    backlog: Backlog,
+    state_manager: S,
     events_tx: mpsc::Sender<ChainEvent>,
     ws_conn: CantonConnection,
     last_seen_offset: u64,
 }
 
-impl CantonIndexer {
+impl<S: StateManager> CantonIndexer<S> {
     pub fn new(
         client: CantonClient,
-        backlog: Backlog,
+        state_manager: S,
         events_tx: mpsc::Sender<ChainEvent>,
     ) -> Self {
         Self {
             client,
-            backlog,
+            state_manager,
             events_tx,
             ws_conn: CantonConnection::Disconnected,
             last_seen_offset: 0,
@@ -344,14 +347,14 @@ fn catchup_offset_range(checkpoint: u64, anchor_height: u64) -> Range<u64> {
 }
 
 #[async_trait]
-impl ChainIndexer for CantonIndexer {
+impl<S: StateManager> ChainIndexer for CantonIndexer<S> {
     const CHAIN: Chain = Chain::Canton;
     type Block = u64;
     type Iter = stream::Iter<Range<u64>>;
 
     async fn livestream(&mut self) -> anyhow::Result<Option<u64>> {
         let checkpoint = self
-            .backlog
+            .state_manager
             .get_processed_block(Chain::Canton)
             .await
             .unwrap_or(0);

--- a/chain-signatures/node/src/indexer_canton/stream.rs
+++ b/chain-signatures/node/src/indexer_canton/stream.rs
@@ -9,6 +9,7 @@ use futures_util::stream::{self, SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use mpc_primitives::{
     ChainEvent, RespondBidirectionalEvent, ScalarExt, Signature, SignatureRespondedEvent,
+    StateManager,
 };
 use std::collections::HashSet;
 use std::ops::Range;
@@ -351,7 +352,7 @@ impl ChainIndexer for CantonIndexer {
     async fn livestream(&mut self) -> anyhow::Result<Option<u64>> {
         let checkpoint = self
             .backlog
-            .processed_block(Chain::Canton)
+            .get_processed_block(Chain::Canton)
             .await
             .unwrap_or(0);
         self.last_seen_offset = checkpoint;

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -3,7 +3,6 @@ pub mod indexer_eth_direct_rpc;
 #[cfg(feature = "helios")]
 pub mod indexer_eth_helios;
 
-use crate::backlog::Backlog;
 use crate::indexer_eth::abi::{ChainSignatures, SignatureRequestedEncoding};
 use crate::metrics::requests::{record_request_latency_since, SignRequestStep};
 use crate::protocol::Chain;
@@ -837,9 +836,9 @@ impl EthereumClient {
     }
 }
 
-pub struct EthereumIndexer {
+pub struct EthereumIndexer<S: StateManager> {
     eth: EthConfig,
-    backlog: Backlog,
+    state_manager: S,
     client: Arc<EthereumClient>,
     events_tx: mpsc::Sender<ChainEvent>,
     contract_address: Address,
@@ -857,10 +856,10 @@ enum BackfillOutcome {
     Observed { event: Option<ChainEvent> },
 }
 
-impl EthereumIndexer {
+impl<S: StateManager> EthereumIndexer<S> {
     pub async fn new(
         eth: EthConfig,
-        backlog: Backlog,
+        state_manager: S,
         events_tx: mpsc::Sender<ChainEvent>,
     ) -> anyhow::Result<Self> {
         let client = Arc::new(EthereumClient::new(eth.clone()).await?);
@@ -871,7 +870,7 @@ impl EthereumIndexer {
 
         Ok(Self {
             eth,
-            backlog,
+            state_manager,
             client,
             events_tx,
             contract_address,
@@ -1174,7 +1173,10 @@ impl EthereumIndexer {
         let mut events = Vec::new();
         let mut resolved_tx_ids = HashSet::new();
 
-        let watchers = self.backlog.get_execution_watchers(Chain::Ethereum).await;
+        let watchers = self
+            .state_manager
+            .get_execution_watchers(Chain::Ethereum)
+            .await;
         tracing::info!(
             watchers_count = watchers.len(),
             block_number,
@@ -1218,7 +1220,10 @@ impl EthereumIndexer {
         }
 
         // Staleness checks (nonce too low)
-        let remaining_pending = self.backlog.get_execution_watchers(Chain::Ethereum).await;
+        let remaining_pending = self
+            .state_manager
+            .get_execution_watchers(Chain::Ethereum)
+            .await;
 
         for (tx_id, (sign_id, tx)) in remaining_pending {
             if resolved_tx_ids.contains(&tx_id) || observed_tx_ids.contains(&tx_id) {
@@ -1378,7 +1383,7 @@ impl EthereumIndexer {
 }
 
 #[async_trait]
-impl ChainIndexer for EthereumIndexer {
+impl<S: StateManager> ChainIndexer for EthereumIndexer<S> {
     const CHAIN: Chain = Chain::Ethereum;
     type Block = MaybeBlock;
     type Iter = std::pin::Pin<Box<dyn stream::Stream<Item = Self::Block> + Send + 'static>>;
@@ -1414,7 +1419,7 @@ impl ChainIndexer for EthereumIndexer {
         // the history of the network in case where we do not have a checkpoint.
         // https://github.com/sig-net/mpc/issues/777
         let current_block = self
-            .backlog
+            .state_manager
             .get_processed_block(Chain::Ethereum)
             .await
             .map(|n| n.saturating_add(1))
@@ -1487,13 +1492,13 @@ impl ChainIndexer for EthereumIndexer {
 /// Ethereum indexer stream implementing the `ChainStream` trait.
 /// Construction is side-effect free; the shared `run_stream()` loop calls
 /// `start()` after recovery has completed.
-pub struct EthereumStream {
+pub struct EthereumStream<S: StateManager> {
     events_rx: Option<mpsc::Receiver<ChainEvent>>,
-    start_state: Option<EthereumIndexer>,
+    start_state: Option<EthereumIndexer<S>>,
 }
 
-impl EthereumStream {
-    pub async fn new(eth: Option<EthConfig>, backlog: Backlog) -> anyhow::Result<Self> {
+impl<S: StateManager> EthereumStream<S> {
+    pub async fn new(eth: Option<EthConfig>, state_manager: S) -> anyhow::Result<Self> {
         let Some(eth) = eth else {
             tracing::warn!(
                 "ethereum indexer is disabled: no EthConfig provided \
@@ -1507,7 +1512,7 @@ impl EthereumStream {
         );
 
         let (events_tx, events_rx) = crate::stream::channel();
-        let indexer = EthereumIndexer::new(eth, backlog, events_tx).await?;
+        let indexer = EthereumIndexer::new(eth, state_manager, events_tx).await?;
 
         Ok(Self {
             events_rx: Some(events_rx),
@@ -1517,8 +1522,8 @@ impl EthereumStream {
 }
 
 #[async_trait]
-impl ChainStream for EthereumStream {
-    type Indexer = EthereumIndexer;
+impl<S: StateManager> ChainStream for EthereumStream<S> {
+    type Indexer = EthereumIndexer<S>;
 
     async fn start(&mut self) -> anyhow::Result<Self::Indexer> {
         self.start_state
@@ -1607,7 +1612,7 @@ mod tests {
     #[tokio::test]
     async fn missing_catchup_block_is_refetched() {
         let mut server = Server::new_async().await;
-        let backlog = Backlog::new();
+        let state_manager = Backlog::new();
         let (events_tx, mut events_rx) = mpsc::channel(1);
 
         server
@@ -1646,7 +1651,7 @@ mod tests {
                 optimistic_requests: true,
                 light_client: false,
             },
-            backlog,
+            state_manager,
             client: Arc::new(EthereumClient::DirectRpc(
                 super::indexer_eth_direct_rpc::RpcEthereumClient::new(&server.url()),
             )),
@@ -1671,7 +1676,7 @@ mod tests {
 
     #[tokio::test]
     async fn missing_catchup_block_returns_error_when_refetch_fails() {
-        let backlog = Backlog::new();
+        let state_manager = Backlog::new();
         let (events_tx, mut events_rx) = mpsc::channel(1);
         let mut indexer = EthereumIndexer {
             eth: EthConfig {
@@ -1685,7 +1690,7 @@ mod tests {
                 optimistic_requests: true,
                 light_client: false,
             },
-            backlog,
+            state_manager,
             client: Arc::new(EthereumClient::DirectRpc(
                 super::indexer_eth_direct_rpc::RpcEthereumClient::new("http://127.0.0.1:1"),
             )),
@@ -2000,7 +2005,7 @@ mod tests {
             .create_async()
             .await;
 
-        let backlog = Backlog::new();
+        let state_manager = Backlog::new();
         let sign_id = SignId::new([0x55; 32]);
         let tx = BidirectionalTx {
             id: BidirectionalTxId(tx_hash.0),
@@ -2021,7 +2026,9 @@ mod tests {
             from_address: **from_address,
             nonce: 0,
         };
-        backlog.watch_execution(Chain::Ethereum, sign_id, tx).await;
+        state_manager
+            .watch_execution(Chain::Ethereum, sign_id, tx)
+            .await;
 
         let (events_tx, _events_rx) = mpsc::channel(1);
         let indexer = EthereumIndexer {
@@ -2036,7 +2043,7 @@ mod tests {
                 optimistic_requests: true,
                 light_client: false,
             },
-            backlog,
+            state_manager,
             client: Arc::new(EthereumClient::DirectRpc(
                 super::indexer_eth_direct_rpc::RpcEthereumClient::new(&server.url()),
             )),

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -24,8 +24,8 @@ use k256::{AffinePoint as K256AffinePoint, EncodedPoint, FieldBytes, Scalar};
 use mpc_crypto::{kdf::derive_epsilon_eth, ScalarExt as _};
 use mpc_primitives::{
     BidirectionalTx, BidirectionalTxId, ChainEvent, ExecutionOutcome, IndexedSignRequest, SignArgs,
-    SignId, Signature as MpcSignature, SignatureRespondedEvent, LATEST_MPC_KEY_VERSION,
-    MAX_SECP256K1_SCALAR,
+    SignId, Signature as MpcSignature, SignatureRespondedEvent, StateManager,
+    LATEST_MPC_KEY_VERSION, MAX_SECP256K1_SCALAR,
 };
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
@@ -1174,7 +1174,7 @@ impl EthereumIndexer {
         let mut events = Vec::new();
         let mut resolved_tx_ids = HashSet::new();
 
-        let watchers = self.backlog.execution_watchers(Chain::Ethereum).await;
+        let watchers = self.backlog.get_execution_watchers(Chain::Ethereum).await;
         tracing::info!(
             watchers_count = watchers.len(),
             block_number,
@@ -1218,7 +1218,7 @@ impl EthereumIndexer {
         }
 
         // Staleness checks (nonce too low)
-        let remaining_pending = self.backlog.execution_watchers(Chain::Ethereum).await;
+        let remaining_pending = self.backlog.get_execution_watchers(Chain::Ethereum).await;
 
         for (tx_id, (sign_id, tx)) in remaining_pending {
             if resolved_tx_ids.contains(&tx_id) || observed_tx_ids.contains(&tx_id) {
@@ -1415,7 +1415,7 @@ impl ChainIndexer for EthereumIndexer {
         // https://github.com/sig-net/mpc/issues/777
         let current_block = self
             .backlog
-            .processed_block(Chain::Ethereum)
+            .get_processed_block(Chain::Ethereum)
             .await
             .map(|n| n.saturating_add(1))
             .unwrap_or(anchor_height);

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -26,7 +26,8 @@ use k256::{AffinePoint, Scalar};
 use mpc_crypto::kdf::derive_epsilon_sol;
 use mpc_crypto::ScalarExt as _;
 use mpc_primitives::{
-    ChainEvent, IndexedSignRequest, SignArgs, SignId, LATEST_MPC_KEY_VERSION, MAX_SECP256K1_SCALAR,
+    ChainEvent, IndexedSignRequest, SignArgs, SignId, StateManager, LATEST_MPC_KEY_VERSION,
+    MAX_SECP256K1_SCALAR,
 };
 use serde::{Deserialize, Serialize};
 use signet_program::{
@@ -253,7 +254,7 @@ impl ChainIndexer for SolanaIndexer {
         // TODO: https://github.com/sig-net/mpc/issues/777
         let start_slot = self
             .backlog
-            .processed_block(Chain::Solana)
+            .get_processed_block(Chain::Solana)
             .await
             .map(|n| n.saturating_add(1))
             .unwrap_or(anchor_height);

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -1,4 +1,3 @@
-use crate::backlog::Backlog;
 use crate::protocol::Chain;
 use crate::sign_bidirectional::hash_rlp_data;
 use crate::solana_client::{SolanaCatchupBlock, SolanaClient, MAX_CONCURRENT_CHUNK_SIZE};
@@ -128,29 +127,29 @@ pub struct SolSignRequest {
 }
 
 /// Solana stream that implements the new ChainStream abstraction
-pub struct SolanaStream {
+pub struct SolanaStream<S: StateManager> {
     rx: Option<mpsc::Receiver<ChainEvent>>,
-    start_state: Option<SolanaStreamStartState>,
+    start_state: Option<SolanaStreamStartState<S>>,
     tasks: Vec<tokio::task::JoinHandle<()>>,
 }
 
-pub struct SolanaIndexer {
+pub struct SolanaIndexer<S: StateManager> {
     pub program_id: Pubkey,
     pub client: SolanaClient,
     pub events_tx: mpsc::Sender<ChainEvent>,
-    pub backlog: Backlog,
+    pub state_manager: S,
     pub live_rx: Option<mpsc::Receiver<ChainEvent>>,
 }
 
-struct SolanaStreamStartState {
+struct SolanaStreamStartState<S: StateManager> {
     program_id: Pubkey,
     rpc_http_url: String,
     rpc_ws_url: String,
-    backlog: Backlog,
+    state_manager: S,
     tx: mpsc::Sender<ChainEvent>,
 }
 
-impl Drop for SolanaStream {
+impl<S: StateManager> Drop for SolanaStream<S> {
     fn drop(&mut self) {
         for task in &self.tasks {
             task.abort();
@@ -158,8 +157,8 @@ impl Drop for SolanaStream {
     }
 }
 
-impl SolanaStream {
-    pub fn new(sol: Option<SolConfig>, backlog: Backlog) -> Option<Self> {
+impl<S: StateManager> SolanaStream<S> {
+    pub fn new(sol: Option<SolConfig>, state_manager: S) -> Option<Self> {
         let Some(sol) = sol else {
             tracing::warn!("solana indexer is disabled");
             return None;
@@ -178,7 +177,7 @@ impl SolanaStream {
                 program_id,
                 rpc_http_url: sol.rpc_http_url.clone(),
                 rpc_ws_url: sol.rpc_ws_url.clone(),
-                backlog,
+                state_manager,
                 tx,
             }),
             tasks: Vec::new(),
@@ -187,8 +186,8 @@ impl SolanaStream {
 }
 
 #[async_trait]
-impl ChainStream for SolanaStream {
-    type Indexer = SolanaIndexer;
+impl<S: StateManager> ChainStream for SolanaStream<S> {
+    type Indexer = SolanaIndexer<S>;
 
     async fn start(&mut self) -> anyhow::Result<Self::Indexer> {
         let Some(start_state) = self.start_state.take() else {
@@ -205,7 +204,7 @@ impl ChainStream for SolanaStream {
             program_id: start_state.program_id,
             client,
             events_tx: start_state.tx.clone(),
-            backlog: start_state.backlog.clone(),
+            state_manager: start_state.state_manager,
             live_rx: None,
         };
 
@@ -221,7 +220,7 @@ impl ChainStream for SolanaStream {
 }
 
 #[async_trait]
-impl ChainIndexer for SolanaIndexer {
+impl<S: StateManager> ChainIndexer for SolanaIndexer<S> {
     const CHAIN: Chain = Chain::Solana;
     type Block = (u64, SolanaCatchupBlock);
     type Iter = Pin<Box<dyn Stream<Item = Self::Block> + Send + 'static>>;
@@ -253,7 +252,7 @@ impl ChainIndexer for SolanaIndexer {
         // Get the last persisted processed block height from backlog
         // TODO: https://github.com/sig-net/mpc/issues/777
         let start_slot = self
-            .backlog
+            .state_manager
             .get_processed_block(Chain::Solana)
             .await
             .map(|n| n.saturating_add(1))
@@ -322,7 +321,7 @@ impl ChainIndexer for SolanaIndexer {
     }
 }
 
-impl SolanaIndexer {
+impl<S: StateManager> SolanaIndexer<S> {
     async fn process_block(&mut self, height: u64, block: &UiConfirmedBlock) -> anyhow::Result<()> {
         let Some(transactions) = &block.transactions else {
             self.events_tx.send(ChainEvent::Block(height)).await?;
@@ -1058,6 +1057,8 @@ async fn get_tx(
 mod tests {
     use std::collections::BTreeMap;
 
+    use crate::backlog::Backlog;
+
     use super::*;
     use solana_sdk::commitment_config::CommitmentLevel;
     use solana_sdk::pubkey::Pubkey;
@@ -1215,7 +1216,7 @@ mod tests {
         let http_url = format!("https://solana-devnet.g.alchemy.com/v2/{api_key}");
         let ws_url = format!("wss://solana-devnet.g.alchemy.com/v2/{api_key}");
 
-        let backlog = Backlog::new();
+        let state_manager = Backlog::new();
         let (events_tx, mut events_rx) = mpsc::channel(1_000_000);
 
         let client = SolanaClient::for_indexer(
@@ -1228,7 +1229,7 @@ mod tests {
             program_id: Pubkey::from_str(&sol_addr).unwrap(),
             client,
             events_tx,
-            backlog,
+            state_manager,
             live_rx: None,
         };
 
@@ -1246,7 +1247,7 @@ mod tests {
         tracing::debug!("Starting catchup from slot: {start_slot} (~1 week behind)");
 
         indexer
-            .backlog
+            .state_manager
             .set_processed_block_interval(Chain::Solana, start_slot.saturating_sub(1), 1)
             .await;
 

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -224,6 +224,7 @@ mod tests {
     use mockito::Server;
     use mpc_primitives::{
         CheckpointDigest, IndexedSignRequest, SignArgs, SignId, Signature, SignatureRespondedEvent,
+        StateManager,
     };
     use near_primitives::types::AccountId;
     use std::collections::HashMap;
@@ -802,7 +803,7 @@ mod tests {
         let target_chain = Chain::Ethereum;
         timeout(Duration::from_secs(1), async {
             loop {
-                let watchers = backlog.execution_watchers(target_chain).await;
+                let watchers = backlog.get_execution_watchers(target_chain).await;
                 if watchers.values().any(|(s, _)| *s == sign_id) {
                     break;
                 }
@@ -814,7 +815,7 @@ mod tests {
 
         // mark status as PendingExecution so it will be included in checkpoints
         let execution = backlog
-            .execution_watchers(target_chain)
+            .get_execution_watchers(target_chain)
             .await
             .into_iter()
             .find_map(|(_, (watched_sign_id, watched_tx))| {
@@ -848,8 +849,8 @@ mod tests {
             .await
             .expect("recovery failed");
 
-        let old_watchers = backlog.execution_watchers(target_chain).await;
-        let new_watchers = recovered.execution_watchers(target_chain).await;
+        let old_watchers = backlog.get_execution_watchers(target_chain).await;
+        let new_watchers = recovered.get_execution_watchers(target_chain).await;
         assert_eq!(old_watchers.len(), new_watchers.len());
         for (tx_id, (s, _)) in old_watchers {
             assert!(new_watchers.contains_key(&tx_id));

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -447,7 +447,9 @@ mod tests {
     use alloy::primitives::{Address, B256};
     use cait_sith::protocol::Participant;
     use k256::{ProjectivePoint, Scalar};
-    use mpc_primitives::{RespondBidirectionalTx, SignArgs, SignBidirectionalEvent, SignKind};
+    use mpc_primitives::{
+        RespondBidirectionalTx, SignArgs, SignBidirectionalEvent, SignKind, StateManager,
+    };
     use near_primitives::types::AccountId;
     use solana_sdk::pubkey::Pubkey;
     use std::time::Duration;
@@ -647,7 +649,7 @@ mod tests {
         // Call the handler with a Success and empty output
         let tx_id = tx.id;
         // ensure watcher exists before processing
-        let before_watchers = backlog.execution_watchers(tx.target_chain).await;
+        let before_watchers = backlog.get_execution_watchers(tx.target_chain).await;
         assert!(before_watchers.contains_key(&tx.id));
         process_execution_confirmed(
             tx_id,
@@ -664,7 +666,7 @@ mod tests {
         .unwrap();
 
         // Watcher should be removed
-        let watchers = backlog.execution_watchers(tx.target_chain).await;
+        let watchers = backlog.get_execution_watchers(tx.target_chain).await;
         tracing::info!(?watchers, "watchers after execution confirmed");
         assert!(watchers.is_empty());
 
@@ -768,7 +770,10 @@ mod tests {
         let no_second = timeout(Duration::from_millis(100), sign_rx.recv()).await;
         assert!(matches!(no_second, Err(_) | Ok(None)));
 
-        assert!(backlog.execution_watchers(tx.target_chain).await.is_empty());
+        assert!(backlog
+            .get_execution_watchers(tx.target_chain)
+            .await
+            .is_empty());
     }
 
     #[tokio::test]
@@ -822,7 +827,10 @@ mod tests {
             tx_after.request.kind,
             SignKind::RespondBidirectional(_)
         ));
-        assert!(backlog.execution_watchers(tx.target_chain).await.is_empty());
+        assert!(backlog
+            .get_execution_watchers(tx.target_chain)
+            .await
+            .is_empty());
 
         let msg = timeout(Duration::from_secs(1), sign_rx.recv())
             .await
@@ -1303,7 +1311,7 @@ mod tests {
             .expect("pending execution entries should store the execution transaction")
             .id;
 
-        let watchers = backlog.execution_watchers(Chain::Solana).await;
+        let watchers = backlog.get_execution_watchers(Chain::Solana).await;
         assert_eq!(watchers.len(), 1);
         assert!(watchers.contains_key(&execution_tx_id));
     }
@@ -1374,7 +1382,7 @@ mod tests {
         .unwrap();
 
         // Watcher removed
-        let watchers = backlog.execution_watchers(tx.target_chain).await;
+        let watchers = backlog.get_execution_watchers(tx.target_chain).await;
         assert!(watchers.is_empty());
 
         // Source chain should now wait for final bidirectional response.
@@ -1529,7 +1537,10 @@ mod tests {
             assert_eq!(decoded.sign_event_contract_id, sign_event_contract_id);
         };
 
-        assert!(backlog.execution_watchers(tx.target_chain).await.is_empty());
+        assert!(backlog
+            .get_execution_watchers(tx.target_chain)
+            .await
+            .is_empty());
         let tx_after = backlog.get(tx.source_chain, &sign_id).await.unwrap();
         assert_eq!(
             tx_after.status(),

--- a/chain-signatures/primitives/Cargo.toml
+++ b/chain-signatures/primitives/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
+async-trait.workspace = true
 borsh.workspace = true
 ciborium.workspace = true
 enum-map.workspace = true

--- a/chain-signatures/primitives/src/lib.rs
+++ b/chain-signatures/primitives/src/lib.rs
@@ -4,6 +4,7 @@ mod chain;
 mod crypto;
 mod events;
 mod requests;
+mod traits;
 
 pub use backlog::{Checkpoint, CheckpointDigest, ConsensusCheckpointDigest, PendingTx};
 pub use bidirectional::{
@@ -16,6 +17,7 @@ pub use crypto::{
 };
 pub use events::{ChainEvent, ExecutionOutcome, SignatureRespondedEvent};
 pub use requests::{IndexedSignRequest, SignKind};
+pub use traits::StateManager;
 
 pub const LATEST_MPC_KEY_VERSION: u32 = 1;
 pub const LEGACY_MPC_KEY_VERSION_0: u32 = 0;

--- a/chain-signatures/primitives/src/traits.rs
+++ b/chain-signatures/primitives/src/traits.rs
@@ -1,0 +1,18 @@
+use std::collections::HashMap;
+
+use crate::{BidirectionalTx, BidirectionalTxId, Chain, SignId};
+
+/// Interface for the Indexer to query and update state.
+/// Currently implemented by the Backlog
+#[async_trait::async_trait]
+pub trait StateManager: Send + Sync + Clone + 'static {
+    /// Get the processed block height for a specific chain
+    async fn get_processed_block(&self, chain: Chain) -> Option<u64>;
+
+    /// Get the set of bidirectional transactions currently awaiting execution on the
+    /// specified destination chain.
+    async fn get_execution_watchers(
+        &self,
+        chain: Chain,
+    ) -> HashMap<BidirectionalTxId, (SignId, BidirectionalTx)>;
+}

--- a/integration-tests/tests/cases/canton_stream.rs
+++ b/integration-tests/tests/cases/canton_stream.rs
@@ -23,7 +23,10 @@ use tokio::time::timeout;
 
 /// Create a CantonStream from the sandbox config with an externally-provided Backlog.
 /// Accepts Backlog as parameter (needed for checkpoint tests).
-async fn stream_canton(sandbox: &CantonSandbox, backlog: Backlog) -> Result<CantonStream> {
+async fn stream_canton(
+    sandbox: &CantonSandbox,
+    backlog: Backlog,
+) -> Result<CantonStream<impl StateManager>> {
     let config = sandbox.get_config();
     let mut stream = CantonStream::new(Some(config), backlog.clone())
         .context("failed to create CantonStream")?;
@@ -61,7 +64,7 @@ async fn stream_canton(sandbox: &CantonSandbox, backlog: Backlog) -> Result<Cant
 
 /// Poll stream for a SignRequest event with timeout.
 async fn wait_for_sign_request(
-    stream: &mut CantonStream,
+    stream: &mut CantonStream<impl StateManager>,
     timeout_secs: u64,
 ) -> Result<IndexedSignRequest> {
     timeout(Duration::from_secs(timeout_secs), async {

--- a/integration-tests/tests/cases/canton_stream.rs
+++ b/integration-tests/tests/cases/canton_stream.rs
@@ -11,7 +11,8 @@ use mpc_node::protocol::{Chain, IndexedSignRequest};
 use mpc_node::sign_bidirectional::{hash_rlp_data, SignBidirectionalEventExt};
 use mpc_node::stream::{ChainPipeline, ChainStream, ChainStreaming};
 use mpc_primitives::{
-    ChainEvent, CheckpointDigest, ScalarExt, SignKind, Signature, LATEST_MPC_KEY_VERSION,
+    ChainEvent, CheckpointDigest, ScalarExt, SignKind, Signature, StateManager,
+    LATEST_MPC_KEY_VERSION,
 };
 use serde_json::json;
 use serial_test::serial;
@@ -308,7 +309,7 @@ async fn test_canton_stream_checkpoint_persistence() -> Result<()> {
 
     // Verify the backlog actually persisted the block height
     assert_eq!(
-        backlog.processed_block(Chain::Canton).await,
+        backlog.get_processed_block(Chain::Canton).await,
         Some(checkpoint_height),
         "backlog should retain checkpoint height after stream1 is dropped"
     );

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -339,27 +339,27 @@ fn test_bidirectional_event() -> NodeSignBidirectionalEvent {
     }
 }
 
-struct StartedEthereumStream {
-    stream: EthereumStream,
+struct StartedEthereumStream<S: StateManager> {
+    stream: EthereumStream<S>,
     _indexer_task: tokio::task::JoinHandle<()>,
 }
 
-impl std::ops::Deref for StartedEthereumStream {
-    type Target = EthereumStream;
+impl<S: StateManager> std::ops::Deref for StartedEthereumStream<S> {
+    type Target = EthereumStream<S>;
 
     fn deref(&self) -> &Self::Target {
         &self.stream
     }
 }
 
-impl std::ops::DerefMut for StartedEthereumStream {
+impl<S: StateManager> std::ops::DerefMut for StartedEthereumStream<S> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.stream
     }
 }
 
-async fn next_event_within(
-    client: &mut StartedEthereumStream,
+async fn next_event_within<S: StateManager>(
+    client: &mut StartedEthereumStream<S>,
     duration: Duration,
 ) -> Result<ChainEvent> {
     timeout(duration, async {
@@ -378,7 +378,7 @@ async fn next_event_within(
 async fn stream_ethereum(
     ctx: &EthereumTestEnvironment,
     backlog: Backlog,
-) -> Result<StartedEthereumStream> {
+) -> Result<StartedEthereumStream<impl StateManager>> {
     let mut stream = EthereumStream::new(Some(ctx.config(true)), backlog.clone()).await?;
     let indexer = stream.start().await?;
     let (_cp_tx, cp_rx) = watch::channel(CheckpointDigest::default());

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -21,7 +21,7 @@ use mpc_node::stream::{run_stream, ChainPipeline, ChainStream, ChainStreaming};
 use mpc_node::util::current_unix_timestamp;
 use mpc_primitives::{
     ChainEvent, CheckpointDigest, SignArgs, SignBidirectionalEvent as NodeSignBidirectionalEvent,
-    SignId, SignKind, LATEST_MPC_KEY_VERSION,
+    SignId, SignKind, StateManager, LATEST_MPC_KEY_VERSION,
 };
 use near_primitives::types::AccountId;
 use std::time::Duration;
@@ -854,7 +854,10 @@ async fn test_ethereum_stream_backfills_late_execution_watcher_after_catchup() -
 
     timeout(Duration::from_secs(20), async {
         loop {
-            let processed_block = backlog.processed_block(Chain::Ethereum).await.unwrap_or(0);
+            let processed_block = backlog
+                .get_processed_block(Chain::Ethereum)
+                .await
+                .unwrap_or(0);
             if processed_block >= tx_block {
                 break;
             }
@@ -937,7 +940,7 @@ async fn test_ethereum_stream_backfills_late_execution_watcher_after_catchup() -
         other => panic!("expected Sign::Request from late watcher backfill, got {other:?}"),
     }
 
-    let watchers = backlog.execution_watchers(Chain::Ethereum).await;
+    let watchers = backlog.get_execution_watchers(Chain::Ethereum).await;
     assert!(
         watchers.is_empty(),
         "late watcher should be cleared after backfill"

--- a/integration-tests/tests/cases/mpc_with_stream.rs
+++ b/integration-tests/tests/cases/mpc_with_stream.rs
@@ -118,7 +118,7 @@ async fn check_channel_contention(
         }
     }
 
-    let timeout = Duration::from_secs(120);
+    let timeout = Duration::from_secs(150);
     let start = std::time::Instant::now();
     let actions = loop {
         let rpc_actions = network.output.rpc_actions.lock().await;

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -38,12 +38,15 @@ fn test_dependencies() -> (Backlog, watch::Receiver<MeshState>, NodeClient) {
     (backlog, mesh_rx, node_client)
 }
 
-async fn stream_solana(config: SolConfig) -> Result<SolanaStream> {
+async fn stream_solana(config: SolConfig) -> Result<SolanaStream<impl StateManager>> {
     let (backlog, _, _) = test_dependencies();
     stream_solana_with_backlog(config, backlog).await
 }
 
-async fn stream_solana_with_backlog(config: SolConfig, backlog: Backlog) -> Result<SolanaStream> {
+async fn stream_solana_with_backlog(
+    config: SolConfig,
+    backlog: Backlog,
+) -> Result<SolanaStream<impl StateManager>> {
     let mut stream = SolanaStream::new(Some(config), backlog.clone())
         .context("failed to create SolanaStream")?;
     let indexer = ChainStream::start(&mut stream).await?;
@@ -83,7 +86,9 @@ async fn stream_solana_with_backlog(config: SolConfig, backlog: Backlog) -> Resu
 }
 
 /// Helper to wait for a specific event type, skipping block events
-async fn wait_for_sign_request(stream: &mut SolanaStream) -> Result<IndexedSignRequest> {
+async fn wait_for_sign_request<S: StateManager>(
+    stream: &mut SolanaStream<S>,
+) -> Result<IndexedSignRequest> {
     loop {
         match timeout(Duration::from_secs(6), stream.next_event()).await {
             Ok(Some(ChainEvent::SignRequest(req))) => return Ok(req),

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -14,8 +14,8 @@ use mpc_node::rpc::{ContractStateWatcher, RpcAction, RpcChannel};
 use mpc_node::sign_bidirectional::{PublishState, SignStatus};
 use mpc_node::storage::checkpoint_storage::CheckpointStorage;
 use mpc_node::stream::{run_stream, ChainPipeline, ChainStream, ChainStreaming};
-use mpc_primitives::CheckpointDigest;
 use mpc_primitives::{ChainEvent, SignArgs, SignId, Signature, LATEST_MPC_KEY_VERSION};
+use mpc_primitives::{CheckpointDigest, StateManager};
 use near_primitives::types::AccountId;
 use solana_sdk::signer::Signer;
 use tokio::sync::mpsc;
@@ -385,7 +385,7 @@ async fn test_solana_stream_checkpoint_persistence() -> Result<()> {
     let mut stream2 = stream_solana_with_backlog(config, backlog.clone()).await?;
 
     // Verify the backlog was persisted
-    let persisted_block = backlog.processed_block(Chain::Solana).await;
+    let persisted_block = backlog.get_processed_block(Chain::Solana).await;
     assert_eq!(
         persisted_block, checkpoint_block,
         "backlog did not persist the checkpoint block"


### PR DESCRIPTION
This PR decouples Canton, Solana and Ethereum indexers from `Backlog` in order to extract indexers into isolated crates later.

- Introduce `StateManager` trait in `mpc-primitives`. 
- Add implementation for `Backlog`. Currently has only two methods: `get_processed_block` and `get_execution_watchers` (what indexers currently need). 
- Update Indexer structs to use generics instead of `Backlog` directly.