### PR TITLE
refactor: decouple indexers from metrics

### DIFF
--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -4,6 +4,7 @@ use crate::gcp::GcpService;
 use crate::indexer_eth::EthereumStream;
 use crate::indexer_sol::SolanaStream;
 use crate::mesh::Mesh;
+use crate::metrics::indexers::PrometheusChainTelemetry;
 use crate::node_client::{self, NodeClient};
 use crate::protocol::message::MessageChannel;
 use crate::protocol::presignature::Presignature;
@@ -414,7 +415,8 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 eth_configured = eth.is_some(),
                 "initializing ethereum indexer stream"
             );
-            match EthereumStream::new(eth, backlog.clone()).await {
+            let eth_telemetry = PrometheusChainTelemetry::new(Chain::Ethereum);
+            match EthereumStream::new(eth, backlog.clone(), eth_telemetry.clone()).await {
                 Ok(eth_stream) => {
                     tracing::info!("ethereum indexer stream created successfully");
                     tokio::spawn(run_stream(
@@ -422,6 +424,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                         sign_tx.clone(),
                         rpc_channel.clone(),
                         backlog.clone(),
+                        eth_telemetry.clone(),
                         contract_watcher.clone(),
                         mesh_state.clone(),
                         client.clone(),
@@ -433,27 +436,34 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 }
             };
 
+            let solana_telemetry = PrometheusChainTelemetry::new(Chain::Solana);
             if let Some(sol_stream) = SolanaStream::new(sol.clone(), backlog.clone()) {
                 tokio::spawn(run_stream(
                     sol_stream,
                     sign_tx.clone(),
                     rpc_channel.clone(),
                     backlog.clone(),
+                    solana_telemetry.clone(),
                     contract_watcher.clone(),
                     mesh_state.clone(),
                     client.clone(),
                     checkpoints_rx[Chain::Solana].clone(),
                 ));
             }
+
+            let hydration_telemetry = PrometheusChainTelemetry::new(Chain::Hydration);
             tokio::spawn(indexer_hydration::run(
                 hydration,
                 sign_tx.clone(),
                 backlog.clone(),
+                hydration_telemetry,
                 contract_watcher.clone(),
                 mesh_state.clone(),
                 client.clone(),
                 checkpoints_rx[Chain::Hydration].clone(),
             ));
+
+            let canton_telemetry = PrometheusChainTelemetry::new(Chain::Canton);
             if let Some(canton_stream) = indexer_canton::CantonStream::new(canton, backlog.clone())
             {
                 tokio::spawn(run_stream(
@@ -461,6 +471,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                     sign_tx.clone(),
                     rpc_channel.clone(),
                     backlog.clone(),
+                    canton_telemetry,
                     contract_watcher.clone(),
                     mesh_state.clone(),
                     client.clone(),

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -424,7 +424,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                         sign_tx.clone(),
                         rpc_channel.clone(),
                         backlog.clone(),
-                        eth_telemetry.clone(),
+                        eth_telemetry,
                         contract_watcher.clone(),
                         mesh_state.clone(),
                         client.clone(),
@@ -437,13 +437,15 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             };
 
             let solana_telemetry = PrometheusChainTelemetry::new(Chain::Solana);
-            if let Some(sol_stream) = SolanaStream::new(sol.clone(), backlog.clone()) {
+            if let Some(sol_stream) =
+                SolanaStream::new(sol.clone(), backlog.clone(), solana_telemetry.clone())
+            {
                 tokio::spawn(run_stream(
                     sol_stream,
                     sign_tx.clone(),
                     rpc_channel.clone(),
                     backlog.clone(),
-                    solana_telemetry.clone(),
+                    solana_telemetry,
                     contract_watcher.clone(),
                     mesh_state.clone(),
                     client.clone(),

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -466,7 +466,8 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             ));
 
             let canton_telemetry = PrometheusChainTelemetry::new(Chain::Canton);
-            if let Some(canton_stream) = indexer_canton::CantonStream::new(canton, backlog.clone())
+            if let Some(canton_stream) =
+                indexer_canton::CantonStream::new(canton, backlog.clone(), canton_telemetry.clone())
             {
                 tokio::spawn(run_stream(
                     canton_stream,

--- a/chain-signatures/node/src/indexer.rs
+++ b/chain-signatures/node/src/indexer.rs
@@ -183,11 +183,6 @@ async fn poll_pending_requests(ctx: &mut Context) -> anyhow::Result<()> {
     // Update timestamp to indicate we're still running
     ctx.indexer.update_timestamp();
 
-    // Update metrics
-    crate::metrics::indexers::LATEST_BLOCK_NUMBER
-        .with_label_values(&[Chain::NEAR.as_str(), "indexed"])
-        .set(latest_height as i64);
-
     // Send all new requests
     for request in new_requests {
         tracing::info!(

--- a/chain-signatures/node/src/indexer_canton/stream.rs
+++ b/chain-signatures/node/src/indexer_canton/stream.rs
@@ -7,8 +7,8 @@ use async_trait::async_trait;
 use futures_util::stream::{self, SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use mpc_primitives::{
-    ChainEvent, RespondBidirectionalEvent, ScalarExt, Signature, SignatureRespondedEvent,
-    StateManager,
+    ChainEvent, ChainTelemetry, RespondBidirectionalEvent, ScalarExt, Signature,
+    SignatureRespondedEvent, StateManager,
 };
 use std::collections::HashSet;
 use std::ops::Range;
@@ -26,15 +26,16 @@ type CantonWs = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
 type CantonWsRead = SplitStream<CantonWs>;
 type CantonWsWrite = SplitSink<CantonWs, Message>;
 
-pub struct CantonStream<S: StateManager> {
+pub struct CantonStream<S: StateManager, T: ChainTelemetry> {
     config: CantonConfig,
     state_manager: S,
+    telemetry: T,
     events_rx: mpsc::Receiver<ChainEvent>,
     events_tx: Option<mpsc::Sender<ChainEvent>>,
 }
 
-impl<S: StateManager> CantonStream<S> {
-    pub fn new(config: Option<CantonConfig>, state_manager: S) -> Option<Self> {
+impl<S: StateManager, T: ChainTelemetry> CantonStream<S, T> {
+    pub fn new(config: Option<CantonConfig>, state_manager: S, telemetry: T) -> Option<Self> {
         let config = match config {
             Some(c) => c,
             None => {
@@ -48,6 +49,7 @@ impl<S: StateManager> CantonStream<S> {
         Some(CantonStream {
             config,
             state_manager,
+            telemetry,
             events_rx,
             events_tx: Some(events_tx),
         })
@@ -55,8 +57,8 @@ impl<S: StateManager> CantonStream<S> {
 }
 
 #[async_trait]
-impl<S: StateManager> ChainStream for CantonStream<S> {
-    type Indexer = CantonIndexer<S>;
+impl<S: StateManager, T: ChainTelemetry> ChainStream for CantonStream<S, T> {
+    type Indexer = CantonIndexer<S, T>;
 
     async fn start(&mut self) -> anyhow::Result<Self::Indexer> {
         let Some(events_tx) = self.events_tx.take() else {
@@ -67,6 +69,7 @@ impl<S: StateManager> ChainStream for CantonStream<S> {
         Ok(Self::Indexer::new(
             client,
             self.state_manager.clone(),
+            self.telemetry.clone(),
             events_tx,
         ))
     }
@@ -185,23 +188,26 @@ impl CantonConnection {
     }
 }
 
-pub struct CantonIndexer<S: StateManager> {
+pub struct CantonIndexer<S: StateManager, T: ChainTelemetry> {
     client: CantonClient,
     state_manager: S,
+    telemetry: T,
     events_tx: mpsc::Sender<ChainEvent>,
     ws_conn: CantonConnection,
     last_seen_offset: u64,
 }
 
-impl<S: StateManager> CantonIndexer<S> {
+impl<S: StateManager, T: ChainTelemetry> CantonIndexer<S, T> {
     pub fn new(
         client: CantonClient,
         state_manager: S,
+        telemetry: T,
         events_tx: mpsc::Sender<ChainEvent>,
     ) -> Self {
         Self {
             client,
             state_manager,
+            telemetry,
             events_tx,
             ws_conn: CantonConnection::Disconnected,
             last_seen_offset: 0,
@@ -296,6 +302,9 @@ impl<S: StateManager> CantonIndexer<S> {
             ledger_api::Update::OffsetCheckpoint { value } => value.offset,
         };
 
+        // Update the telemetry with the latest block number seen by the indexer
+        self.telemetry.block_indexed(offset);
+
         self.events_tx.send(ChainEvent::Block(offset)).await?;
         self.last_seen_offset = offset;
         Ok(offset)
@@ -347,7 +356,7 @@ fn catchup_offset_range(checkpoint: u64, anchor_height: u64) -> Range<u64> {
 }
 
 #[async_trait]
-impl<S: StateManager> ChainIndexer for CantonIndexer<S> {
+impl<S: StateManager, T: ChainTelemetry> ChainIndexer for CantonIndexer<S, T> {
     const CHAIN: Chain = Chain::Canton;
     type Block = u64;
     type Iter = stream::Iter<Range<u64>>;

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -22,9 +22,9 @@ use k256::elliptic_curve::sec1::FromEncodedPoint;
 use k256::{AffinePoint as K256AffinePoint, EncodedPoint, FieldBytes, Scalar};
 use mpc_crypto::{kdf::derive_epsilon_eth, ScalarExt as _};
 use mpc_primitives::{
-    BidirectionalTx, BidirectionalTxId, ChainEvent, ExecutionOutcome, IndexedSignRequest, SignArgs,
-    SignId, Signature as MpcSignature, SignatureRespondedEvent, StateManager,
-    LATEST_MPC_KEY_VERSION, MAX_SECP256K1_SCALAR,
+    BidirectionalTx, BidirectionalTxId, ChainEvent, ChainTelemetry, ExecutionOutcome,
+    IndexedSignRequest, SignArgs, SignId, Signature as MpcSignature, SignatureRespondedEvent,
+    StateManager, LATEST_MPC_KEY_VERSION, MAX_SECP256K1_SCALAR,
 };
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
@@ -836,9 +836,10 @@ impl EthereumClient {
     }
 }
 
-pub struct EthereumIndexer<S: StateManager> {
+pub struct EthereumIndexer<S: StateManager, T: ChainTelemetry> {
     eth: EthConfig,
     state_manager: S,
+    telemetry: T,
     client: Arc<EthereumClient>,
     events_tx: mpsc::Sender<ChainEvent>,
     contract_address: Address,
@@ -856,10 +857,11 @@ enum BackfillOutcome {
     Observed { event: Option<ChainEvent> },
 }
 
-impl<S: StateManager> EthereumIndexer<S> {
+impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     pub async fn new(
         eth: EthConfig,
         state_manager: S,
+        telemetry: T,
         events_tx: mpsc::Sender<ChainEvent>,
     ) -> anyhow::Result<Self> {
         let client = Arc::new(EthereumClient::new(eth.clone()).await?);
@@ -871,6 +873,7 @@ impl<S: StateManager> EthereumIndexer<S> {
         Ok(Self {
             eth,
             state_manager,
+            telemetry,
             client,
             events_tx,
             contract_address,
@@ -932,11 +935,8 @@ impl<S: StateManager> EthereumIndexer<S> {
 
     /// Process the block and emit relevant ChainEvents from the block.
     async fn process_block(&self, block: &Block) -> anyhow::Result<()> {
-        let block_number = block.header.number;
-        crate::metrics::indexers::LATEST_BLOCK_NUMBER
-            .with_label_values(&[Chain::Ethereum.as_str(), "indexed"])
-            .set(block_number as i64);
-
+        // Emit telemetry for the indexed block number
+        self.telemetry.indexed(block.header.number);
         let processed = self.parse_block(block).await?;
         self.emit_processed_block(processed).await?;
 
@@ -1383,7 +1383,7 @@ impl<S: StateManager> EthereumIndexer<S> {
 }
 
 #[async_trait]
-impl<S: StateManager> ChainIndexer for EthereumIndexer<S> {
+impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> {
     const CHAIN: Chain = Chain::Ethereum;
     type Block = MaybeBlock;
     type Iter = std::pin::Pin<Box<dyn stream::Stream<Item = Self::Block> + Send + 'static>>;
@@ -1492,13 +1492,17 @@ impl<S: StateManager> ChainIndexer for EthereumIndexer<S> {
 /// Ethereum indexer stream implementing the `ChainStream` trait.
 /// Construction is side-effect free; the shared `run_stream()` loop calls
 /// `start()` after recovery has completed.
-pub struct EthereumStream<S: StateManager> {
+pub struct EthereumStream<S: StateManager, T: ChainTelemetry> {
     events_rx: Option<mpsc::Receiver<ChainEvent>>,
-    start_state: Option<EthereumIndexer<S>>,
+    start_state: Option<EthereumIndexer<S, T>>,
 }
 
-impl<S: StateManager> EthereumStream<S> {
-    pub async fn new(eth: Option<EthConfig>, state_manager: S) -> anyhow::Result<Self> {
+impl<S: StateManager, T: ChainTelemetry> EthereumStream<S, T> {
+    pub async fn new(
+        eth: Option<EthConfig>,
+        state_manager: S,
+        telemetry: T,
+    ) -> anyhow::Result<Self> {
         let Some(eth) = eth else {
             tracing::warn!(
                 "ethereum indexer is disabled: no EthConfig provided \
@@ -1512,7 +1516,7 @@ impl<S: StateManager> EthereumStream<S> {
         );
 
         let (events_tx, events_rx) = crate::stream::channel();
-        let indexer = EthereumIndexer::new(eth, state_manager, events_tx).await?;
+        let indexer = EthereumIndexer::new(eth, state_manager, telemetry, events_tx).await?;
 
         Ok(Self {
             events_rx: Some(events_rx),
@@ -1522,8 +1526,8 @@ impl<S: StateManager> EthereumStream<S> {
 }
 
 #[async_trait]
-impl<S: StateManager> ChainStream for EthereumStream<S> {
-    type Indexer = EthereumIndexer<S>;
+impl<S: StateManager, T: ChainTelemetry> ChainStream for EthereumStream<S, T> {
+    type Indexer = EthereumIndexer<S, T>;
 
     async fn start(&mut self) -> anyhow::Result<Self::Indexer> {
         self.start_state
@@ -1551,8 +1555,8 @@ mod tests {
     use alloy::rpc::types::BlockId;
     use mockito::{Matcher, Server};
     use mpc_primitives::{
-        BidirectionalTx, BidirectionalTxId, ChainEvent, ExecutionOutcome, SignId,
-        LATEST_MPC_KEY_VERSION,
+        BidirectionalTx, BidirectionalTxId, ChainEvent, ExecutionOutcome, NoopChainTelemetry,
+        SignId, LATEST_MPC_KEY_VERSION,
     };
     use serde_json::json;
     use std::sync::Arc;
@@ -1652,6 +1656,7 @@ mod tests {
                 light_client: false,
             },
             state_manager,
+            telemetry: NoopChainTelemetry,
             client: Arc::new(EthereumClient::DirectRpc(
                 super::indexer_eth_direct_rpc::RpcEthereumClient::new(&server.url()),
             )),
@@ -1691,6 +1696,7 @@ mod tests {
                 light_client: false,
             },
             state_manager,
+            telemetry: NoopChainTelemetry,
             client: Arc::new(EthereumClient::DirectRpc(
                 super::indexer_eth_direct_rpc::RpcEthereumClient::new("http://127.0.0.1:1"),
             )),
@@ -2044,6 +2050,7 @@ mod tests {
                 light_client: false,
             },
             state_manager,
+            telemetry: NoopChainTelemetry,
             client: Arc::new(EthereumClient::DirectRpc(
                 super::indexer_eth_direct_rpc::RpcEthereumClient::new(&server.url()),
             )),

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -936,7 +936,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     /// Process the block and emit relevant ChainEvents from the block.
     async fn process_block(&self, block: &Block) -> anyhow::Result<()> {
         // Emit telemetry for the indexed block number
-        self.telemetry.indexed(block.header.number);
+        self.telemetry.block_indexed(block.header.number);
         let processed = self.parse_block(block).await?;
         self.emit_processed_block(processed).await?;
 

--- a/chain-signatures/node/src/indexer_hydration.rs
+++ b/chain-signatures/node/src/indexer_hydration.rs
@@ -666,7 +666,7 @@ pub async fn run<T: ChainTelemetry>(
         }
 
         // Update Prometheus metrics
-        telemetry.indexed(number.into());
+        telemetry.block_indexed(number.into());
     }
 }
 

--- a/chain-signatures/node/src/indexer_hydration.rs
+++ b/chain-signatures/node/src/indexer_hydration.rs
@@ -367,6 +367,7 @@ pub(crate) fn ss58_address_from_account32(sender: [u8; 32]) -> String {
     acc.to_ss58check_with_version(Ss58AddressFormatRegistry::PolkadotAccount.into())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run<T: ChainTelemetry>(
     hydration: Option<HydrationConfig>,
     sign_tx: mpsc::Sender<Sign>,

--- a/chain-signatures/node/src/indexer_hydration.rs
+++ b/chain-signatures/node/src/indexer_hydration.rs
@@ -12,7 +12,7 @@ use k256::elliptic_curve::sec1::FromEncodedPoint;
 use k256::{AffinePoint, EncodedPoint, FieldBytes, Scalar};
 use mpc_crypto::ScalarExt as _;
 use mpc_primitives::{
-    CheckpointDigest, IndexedSignRequest, RespondBidirectionalEvent, SignArgs,
+    ChainTelemetry, CheckpointDigest, IndexedSignRequest, RespondBidirectionalEvent, SignArgs,
     SignBidirectionalEvent, SignId, Signature, SignatureRespondedEvent, LATEST_MPC_KEY_VERSION,
     MAX_SECP256K1_SCALAR,
 };
@@ -367,10 +367,11 @@ pub(crate) fn ss58_address_from_account32(sender: [u8; 32]) -> String {
     acc.to_ss58check_with_version(Ss58AddressFormatRegistry::PolkadotAccount.into())
 }
 
-pub async fn run(
+pub async fn run<T: ChainTelemetry>(
     hydration: Option<HydrationConfig>,
     sign_tx: mpsc::Sender<Sign>,
     backlog: Backlog,
+    telemetry: T,
     mut contract_watcher: ContractStateWatcher,
     mut mesh_state: watch::Receiver<MeshState>,
     node_client: NodeClient,
@@ -664,9 +665,8 @@ pub async fn run(
             }
         }
 
-        crate::metrics::indexers::LATEST_BLOCK_NUMBER
-            .with_label_values(&[crate::protocol::Chain::Hydration.as_str(), "indexed"])
-            .set(number as i64);
+        // Update Prometheus metrics
+        telemetry.indexed(number.into());
     }
 }
 

--- a/chain-signatures/node/src/indexer_sol.rs
+++ b/chain-signatures/node/src/indexer_sol.rs
@@ -25,8 +25,8 @@ use k256::{AffinePoint, Scalar};
 use mpc_crypto::kdf::derive_epsilon_sol;
 use mpc_crypto::ScalarExt as _;
 use mpc_primitives::{
-    ChainEvent, IndexedSignRequest, SignArgs, SignId, StateManager, LATEST_MPC_KEY_VERSION,
-    MAX_SECP256K1_SCALAR,
+    ChainEvent, ChainTelemetry, IndexedSignRequest, SignArgs, SignId, StateManager,
+    LATEST_MPC_KEY_VERSION, MAX_SECP256K1_SCALAR,
 };
 use serde::{Deserialize, Serialize};
 use signet_program::{
@@ -127,29 +127,31 @@ pub struct SolSignRequest {
 }
 
 /// Solana stream that implements the new ChainStream abstraction
-pub struct SolanaStream<S: StateManager> {
+pub struct SolanaStream<S: StateManager, T: ChainTelemetry> {
     rx: Option<mpsc::Receiver<ChainEvent>>,
-    start_state: Option<SolanaStreamStartState<S>>,
+    start_state: Option<SolanaStreamStartState<S, T>>,
     tasks: Vec<tokio::task::JoinHandle<()>>,
 }
 
-pub struct SolanaIndexer<S: StateManager> {
+pub struct SolanaIndexer<S: StateManager, T: ChainTelemetry> {
     pub program_id: Pubkey,
     pub client: SolanaClient,
     pub events_tx: mpsc::Sender<ChainEvent>,
     pub state_manager: S,
+    pub telemetry: T,
     pub live_rx: Option<mpsc::Receiver<ChainEvent>>,
 }
 
-struct SolanaStreamStartState<S: StateManager> {
+struct SolanaStreamStartState<S: StateManager, T: ChainTelemetry> {
     program_id: Pubkey,
     rpc_http_url: String,
     rpc_ws_url: String,
     state_manager: S,
+    telemetry: T,
     tx: mpsc::Sender<ChainEvent>,
 }
 
-impl<S: StateManager> Drop for SolanaStream<S> {
+impl<S: StateManager, T: ChainTelemetry> Drop for SolanaStream<S, T> {
     fn drop(&mut self) {
         for task in &self.tasks {
             task.abort();
@@ -157,8 +159,8 @@ impl<S: StateManager> Drop for SolanaStream<S> {
     }
 }
 
-impl<S: StateManager> SolanaStream<S> {
-    pub fn new(sol: Option<SolConfig>, state_manager: S) -> Option<Self> {
+impl<S: StateManager, T: ChainTelemetry> SolanaStream<S, T> {
+    pub fn new(sol: Option<SolConfig>, state_manager: S, telemetry: T) -> Option<Self> {
         let Some(sol) = sol else {
             tracing::warn!("solana indexer is disabled");
             return None;
@@ -178,6 +180,7 @@ impl<S: StateManager> SolanaStream<S> {
                 rpc_http_url: sol.rpc_http_url.clone(),
                 rpc_ws_url: sol.rpc_ws_url.clone(),
                 state_manager,
+                telemetry,
                 tx,
             }),
             tasks: Vec::new(),
@@ -186,8 +189,8 @@ impl<S: StateManager> SolanaStream<S> {
 }
 
 #[async_trait]
-impl<S: StateManager> ChainStream for SolanaStream<S> {
-    type Indexer = SolanaIndexer<S>;
+impl<S: StateManager, T: ChainTelemetry> ChainStream for SolanaStream<S, T> {
+    type Indexer = SolanaIndexer<S, T>;
 
     async fn start(&mut self) -> anyhow::Result<Self::Indexer> {
         let Some(start_state) = self.start_state.take() else {
@@ -205,6 +208,7 @@ impl<S: StateManager> ChainStream for SolanaStream<S> {
             client,
             events_tx: start_state.tx.clone(),
             state_manager: start_state.state_manager,
+            telemetry: start_state.telemetry,
             live_rx: None,
         };
 
@@ -220,7 +224,7 @@ impl<S: StateManager> ChainStream for SolanaStream<S> {
 }
 
 #[async_trait]
-impl<S: StateManager> ChainIndexer for SolanaIndexer<S> {
+impl<S: StateManager, T: ChainTelemetry> ChainIndexer for SolanaIndexer<S, T> {
     const CHAIN: Chain = Chain::Solana;
     type Block = (u64, SolanaCatchupBlock);
     type Iter = Pin<Box<dyn Stream<Item = Self::Block> + Send + 'static>>;
@@ -242,6 +246,7 @@ impl<S: StateManager> ChainIndexer for SolanaIndexer<S> {
             rpc_ws_url,
             live_tx,
             anchor_tx,
+            self.telemetry.clone(),
         ));
 
         // Wait for the first slot observed on the live feed to use as anchor.
@@ -321,8 +326,11 @@ impl<S: StateManager> ChainIndexer for SolanaIndexer<S> {
     }
 }
 
-impl<S: StateManager> SolanaIndexer<S> {
+impl<S: StateManager, T: ChainTelemetry> SolanaIndexer<S, T> {
     async fn process_block(&mut self, height: u64, block: &UiConfirmedBlock) -> anyhow::Result<()> {
+        // Update indexed block metrics
+        self.telemetry.block_indexed(height);
+
         let Some(transactions) = &block.transactions else {
             self.events_tx.send(ChainEvent::Block(height)).await?;
             return Ok(());
@@ -497,12 +505,13 @@ impl SolanaSignEvent {
 /// The anchor is resolved inside `subscribe_to_program_events` immediately after the WS
 /// subscription is established — ensuring the subscription is live before we anchor, so
 /// catchup covers `[persisted_block, anchor)` with no gaps.
-async fn subscribe_and_buffer_live_events(
+async fn subscribe_and_buffer_live_events<T: ChainTelemetry>(
     program_id: Pubkey,
     rpc_url: String,
     ws_url: String,
     live_tx: mpsc::Sender<ChainEvent>,
     anchor_tx: oneshot::Sender<u64>,
+    telemetry: T,
 ) {
     let rpc = RpcClient::new(rpc_url);
     let mut anchor_tx = Some(anchor_tx);
@@ -510,9 +519,15 @@ async fn subscribe_and_buffer_live_events(
         // TODO: if solana ever fails and needs to retry, we actually need to do catchup
         // again. This requires potentially complicating the coordination we have on the
         // high level of run_stream. Issue: https://github.com/sig-net/mpc/issues/811
-        let result =
-            subscribe_to_program_events(program_id, &rpc, &ws_url, live_tx.clone(), &mut anchor_tx)
-                .await;
+        let result = subscribe_to_program_events(
+            program_id,
+            &rpc,
+            &ws_url,
+            live_tx.clone(),
+            &mut anchor_tx,
+            telemetry.clone(),
+        )
+        .await;
 
         if let Err(err) = result {
             tracing::warn!("Live solana subscription failed: {:?}", err);
@@ -613,12 +628,13 @@ fn parse_cpi_events(
     Ok(out)
 }
 
-async fn subscribe_to_program_events(
+async fn subscribe_to_program_events<T: ChainTelemetry>(
     program_id: Pubkey,
     rpc_client: &RpcClient,
     ws_url: &str,
     events_tx: mpsc::Sender<ChainEvent>,
     anchor_tx: &mut Option<oneshot::Sender<u64>>,
+    telemetry: T,
 ) -> anyhow::Result<()> {
     let pubsub_client = PubsubClient::new(ws_url).await?;
 
@@ -673,6 +689,10 @@ async fn subscribe_to_program_events(
                         last_ws_msg = Instant::now();
 
                         let slot = response.context.slot;
+
+                        // Update indexed block metrics
+                        telemetry.block_indexed(slot);
+
                         let logs = &response.value.logs;
                         if response.value.err.is_some() || !has_log_starts_with(logs, &program_invoke_log) {
                             // block is not relevant to our program, skip but still
@@ -1060,6 +1080,7 @@ mod tests {
     use crate::backlog::Backlog;
 
     use super::*;
+    use mpc_primitives::NoopChainTelemetry;
     use solana_sdk::commitment_config::CommitmentLevel;
     use solana_sdk::pubkey::Pubkey;
     use solana_transaction_status::{TransactionDetails, UiTransactionStatusMeta};
@@ -1230,6 +1251,7 @@ mod tests {
             client,
             events_tx,
             state_manager,
+            telemetry: NoopChainTelemetry,
             live_rx: None,
         };
 

--- a/chain-signatures/node/src/metrics/indexers.rs
+++ b/chain-signatures/node/src/metrics/indexers.rs
@@ -1,13 +1,13 @@
-use std::sync::LazyLock;
-
+use mpc_primitives::{Chain, ChainTelemetry};
 use prometheus::IntGaugeVec;
+use std::sync::LazyLock;
 
 use super::try_create_int_gauge_vec_with_node_account_id;
 
 /// Possible status options:
 ///     - "indexed" - latest block number seen by the indexer
 ///     - "finalized" - latest block number seen as finalized by the indexer
-pub(crate) static LATEST_BLOCK_NUMBER: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+static LATEST_BLOCK_NUMBER: LazyLock<IntGaugeVec> = LazyLock::new(|| {
     try_create_int_gauge_vec_with_node_account_id(
         "multichain_latest_block_number",
         "Latest block number seen by the node",
@@ -15,3 +15,28 @@ pub(crate) static LATEST_BLOCK_NUMBER: LazyLock<IntGaugeVec> = LazyLock::new(|| 
     )
     .unwrap()
 });
+
+#[derive(Clone)]
+pub struct PrometheusChainTelemetry {
+    chain: Chain,
+}
+
+impl PrometheusChainTelemetry {
+    pub fn new(chain: Chain) -> Self {
+        Self { chain }
+    }
+}
+
+impl ChainTelemetry for PrometheusChainTelemetry {
+    fn indexed(&self, block: u64) {
+        LATEST_BLOCK_NUMBER
+            .with_label_values(&[self.chain.as_str(), "indexed"])
+            .set(block as i64);
+    }
+
+    fn finalized(&self, block: u64) {
+        LATEST_BLOCK_NUMBER
+            .with_label_values(&[self.chain.as_str(), "finalized"])
+            .set(block as i64);
+    }
+}

--- a/chain-signatures/node/src/metrics/indexers.rs
+++ b/chain-signatures/node/src/metrics/indexers.rs
@@ -28,15 +28,15 @@ impl PrometheusChainTelemetry {
 }
 
 impl ChainTelemetry for PrometheusChainTelemetry {
-    fn indexed(&self, block: u64) {
+    fn block_indexed(&self, block_number: u64) {
         LATEST_BLOCK_NUMBER
             .with_label_values(&[self.chain.as_str(), "indexed"])
-            .set(block as i64);
+            .set(block_number as i64);
     }
 
-    fn finalized(&self, block: u64) {
+    fn block_finalized(&self, block_number: u64) {
         LATEST_BLOCK_NUMBER
             .with_label_values(&[self.chain.as_str(), "finalized"])
-            .set(block as i64);
+            .set(block_number as i64);
     }
 }

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -15,7 +15,7 @@ pub use crate::stream::pipeline::ChainPipeline;
 
 use async_trait::async_trait;
 use futures_util::Stream;
-use mpc_primitives::{ChainEvent, CheckpointDigest};
+use mpc_primitives::{ChainEvent, ChainTelemetry, CheckpointDigest};
 use std::time::Duration;
 use tokio::sync::{mpsc, watch};
 
@@ -88,11 +88,12 @@ pub trait ChainStream: Send + 'static {
 
 /// Shared indexer loop: recovers backlog then processes events from the stream
 #[allow(clippy::too_many_arguments)]
-pub async fn run_stream<S: ChainStream>(
+pub async fn run_stream<S: ChainStream, T: ChainTelemetry>(
     mut stream: S,
     sign_tx: mpsc::Sender<Sign>,
     rpc: RpcChannel,
     backlog: Backlog,
+    telemetry: T,
     mut contract_watcher: ContractStateWatcher,
     mesh_state: watch::Receiver<MeshState>,
     node_client: NodeClient,
@@ -170,7 +171,7 @@ pub async fn run_stream<S: ChainStream>(
                         }
                     }
                     ChainEvent::Block(block) => {
-                        process_block_event(chain, block, &backlog, &sign_tx, caught_up).await;
+                        process_block_event(chain, block, &backlog, &sign_tx, caught_up, &telemetry).await;
                     }
                     ChainEvent::ExecutionConfirmed {
                         tx_id,
@@ -223,8 +224,8 @@ mod tests {
     use k256::{AffinePoint, Scalar};
     use mockito::Server;
     use mpc_primitives::{
-        CheckpointDigest, IndexedSignRequest, SignArgs, SignId, Signature, SignatureRespondedEvent,
-        StateManager,
+        CheckpointDigest, IndexedSignRequest, NoopChainTelemetry, SignArgs, SignId, Signature,
+        SignatureRespondedEvent, StateManager,
     };
     use near_primitives::types::AccountId;
     use std::collections::HashMap;
@@ -584,6 +585,7 @@ mod tests {
             sign_tx.clone(),
             rpc,
             backlog.clone(),
+            NoopChainTelemetry,
             contract_watcher,
             mesh_state_rx,
             node_client,
@@ -699,6 +701,7 @@ mod tests {
                 sign_tx_for_run,
                 rpc,
                 backlog_for_run,
+                NoopChainTelemetry,
                 contract_watcher,
                 mesh_state_rx,
                 node_client,
@@ -1020,6 +1023,7 @@ mod tests {
             sign_tx,
             rpc,
             backlog.clone(),
+            NoopChainTelemetry,
             contract_watcher,
             mesh_state_rx,
             node_client,
@@ -1118,6 +1122,7 @@ mod tests {
             sign_tx,
             rpc,
             backlog.clone(),
+            NoopChainTelemetry,
             contract_watcher,
             mesh_state_rx,
             node_client,
@@ -1199,6 +1204,7 @@ mod tests {
                 sign_tx,
                 rpc,
                 backlog,
+                NoopChainTelemetry,
                 contract_watcher,
                 mesh_state_rx,
                 node_client,
@@ -1282,6 +1288,7 @@ mod tests {
                 sign_tx,
                 rpc,
                 backlog,
+                NoopChainTelemetry,
                 contract_watcher,
                 mesh_state_rx,
                 node_client,

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -1,4 +1,5 @@
 use crate::backlog::Backlog;
+// TODO: use ChainTelemetry trait method instead
 use crate::metrics::requests::record_indexing_step_reached;
 use crate::protocol::{Chain, IndexedSignRequest, Sign};
 use crate::respond_bidirectional::CompletedTx;
@@ -6,8 +7,8 @@ use crate::rpc::{ContractStateWatcher, RpcChannel};
 use crate::sign_bidirectional::{SignBidirectionalEventExt, SignStatus};
 use anchor_lang::prelude::Pubkey;
 use mpc_primitives::{
-    BidirectionalTx, BidirectionalTxId, ExecutionOutcome, RespondBidirectionalEvent, SignId,
-    SignKind, Signature, SignatureRespondedEvent,
+    BidirectionalTx, BidirectionalTxId, ChainTelemetry, ExecutionOutcome,
+    RespondBidirectionalEvent, SignId, SignKind, Signature, SignatureRespondedEvent,
 };
 use tokio::sync::mpsc;
 
@@ -381,17 +382,16 @@ pub async fn process_execution_confirmed(
     Ok(())
 }
 
-pub(crate) async fn process_block_event(
+pub(crate) async fn process_block_event<T: ChainTelemetry>(
     chain: Chain,
     block: u64,
     backlog: &Backlog,
     sign_tx: &mpsc::Sender<Sign>,
     caught_up: bool,
+    telemetry: &T,
 ) {
     let Some(checkpoint) = backlog.set_processed_block(chain, block).await else {
-        crate::metrics::indexers::LATEST_BLOCK_NUMBER
-            .with_label_values(&[chain.as_str(), "finalized"])
-            .set(block as i64);
+        telemetry.finalized(block);
         return;
     };
 
@@ -412,9 +412,7 @@ pub(crate) async fn process_block_event(
         }
     }
 
-    crate::metrics::indexers::LATEST_BLOCK_NUMBER
-        .with_label_values(&[chain.as_str(), "finalized"])
-        .set(block as i64);
+    telemetry.finalized(block);
 }
 
 /// Decode a [u8; 32] sender into its canonical on-chain address string.

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -1,5 +1,4 @@
 use crate::backlog::Backlog;
-// TODO: use ChainTelemetry trait method instead
 use crate::metrics::requests::record_indexing_step_reached;
 use crate::protocol::{Chain, IndexedSignRequest, Sign};
 use crate::respond_bidirectional::CompletedTx;

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -390,7 +390,7 @@ pub(crate) async fn process_block_event<T: ChainTelemetry>(
     telemetry: &T,
 ) {
     let Some(checkpoint) = backlog.set_processed_block(chain, block).await else {
-        telemetry.finalized(block);
+        telemetry.block_finalized(block);
         return;
     };
 
@@ -411,7 +411,7 @@ pub(crate) async fn process_block_event<T: ChainTelemetry>(
         }
     }
 
-    telemetry.finalized(block);
+    telemetry.block_finalized(block);
 }
 
 /// Decode a [u8; 32] sender into its canonical on-chain address string.

--- a/chain-signatures/primitives/src/lib.rs
+++ b/chain-signatures/primitives/src/lib.rs
@@ -17,7 +17,7 @@ pub use crypto::{
 };
 pub use events::{ChainEvent, ExecutionOutcome, SignatureRespondedEvent};
 pub use requests::{IndexedSignRequest, SignKind};
-pub use traits::StateManager;
+pub use traits::{ChainTelemetry, NoopChainTelemetry, StateManager};
 
 pub const LATEST_MPC_KEY_VERSION: u32 = 1;
 pub const LEGACY_MPC_KEY_VERSION_0: u32 = 0;

--- a/chain-signatures/primitives/src/traits.rs
+++ b/chain-signatures/primitives/src/traits.rs
@@ -22,10 +22,10 @@ pub trait StateManager: Send + Sync + Clone + 'static {
 /// Interface for the Indexer to report telemetry data.
 pub trait ChainTelemetry: Send + Sync + Clone + 'static {
     /// Records that a block was parsed at the live tip
-    fn indexed(&self, block: u64);
+    fn block_indexed(&self, block_number: u64);
 
     /// Records that a block has reached finality/consensus
-    fn finalized(&self, block: u64);
+    fn block_finalized(&self, block_number: u64);
 }
 
 /// No-op implementation for tests
@@ -33,6 +33,6 @@ pub trait ChainTelemetry: Send + Sync + Clone + 'static {
 pub struct NoopChainTelemetry;
 
 impl ChainTelemetry for NoopChainTelemetry {
-    fn indexed(&self, _block: u64) {}
-    fn finalized(&self, _block: u64) {}
+    fn block_indexed(&self, _block_number: u64) {}
+    fn block_finalized(&self, _block_number: u64) {}
 }

--- a/chain-signatures/primitives/src/traits.rs
+++ b/chain-signatures/primitives/src/traits.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use crate::{BidirectionalTx, BidirectionalTxId, Chain, SignId};
 
+// TODO: Move these traits to a separate crate (mpc-indexer-core) later
+
 /// Interface for the Indexer to query and update state.
 /// Currently implemented by the Backlog
 #[async_trait::async_trait]
@@ -15,4 +17,22 @@ pub trait StateManager: Send + Sync + Clone + 'static {
         &self,
         chain: Chain,
     ) -> HashMap<BidirectionalTxId, (SignId, BidirectionalTx)>;
+}
+
+/// Interface for the Indexer to report telemetry data.
+pub trait ChainTelemetry: Send + Sync + Clone + 'static {
+    /// Records that a block was parsed at the live tip
+    fn indexed(&self, block: u64);
+
+    /// Records that a block has reached finality/consensus
+    fn finalized(&self, block: u64);
+}
+
+/// No-op implementation for tests
+#[derive(Clone, Default)]
+pub struct NoopChainTelemetry;
+
+impl ChainTelemetry for NoopChainTelemetry {
+    fn indexed(&self, _block: u64) {}
+    fn finalized(&self, _block: u64) {}
 }

--- a/integration-tests/src/mpc_fixture/fixture_tasks.rs
+++ b/integration-tests/src/mpc_fixture/fixture_tasks.rs
@@ -14,7 +14,7 @@ use mpc_node::protocol::message::{MessageOutbox, SendMessage, SignedMessage};
 use mpc_node::protocol::Sign;
 use mpc_node::rpc::{ContractStateWatcher, RpcAction, RpcChannel};
 use mpc_node::stream::run_stream;
-use mpc_primitives::CheckpointDigest;
+use mpc_primitives::{CheckpointDigest, NoopChainTelemetry};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc::{self, Receiver, Sender};
@@ -119,6 +119,7 @@ pub(super) fn start_mock_stream_tasks(
             sign_tx.clone(),
             rpc.clone(),
             backlog.clone(),
+            NoopChainTelemetry,
             contract_watcher.clone(),
             mesh_state.clone(),
             // Only used for backlog recovery - not implemented in component tests yet

--- a/integration-tests/tests/cases/canton_stream.rs
+++ b/integration-tests/tests/cases/canton_stream.rs
@@ -11,8 +11,8 @@ use mpc_node::protocol::{Chain, IndexedSignRequest};
 use mpc_node::sign_bidirectional::{hash_rlp_data, SignBidirectionalEventExt};
 use mpc_node::stream::{ChainPipeline, ChainStream, ChainStreaming};
 use mpc_primitives::{
-    ChainEvent, CheckpointDigest, ScalarExt, SignKind, Signature, StateManager,
-    LATEST_MPC_KEY_VERSION,
+    ChainEvent, ChainTelemetry, CheckpointDigest, NoopChainTelemetry, ScalarExt, SignKind,
+    Signature, StateManager, LATEST_MPC_KEY_VERSION,
 };
 use serde_json::json;
 use serial_test::serial;
@@ -26,9 +26,9 @@ use tokio::time::timeout;
 async fn stream_canton(
     sandbox: &CantonSandbox,
     backlog: Backlog,
-) -> Result<CantonStream<impl StateManager>> {
+) -> Result<CantonStream<impl StateManager, impl ChainTelemetry>> {
     let config = sandbox.get_config();
-    let mut stream = CantonStream::new(Some(config), backlog.clone())
+    let mut stream = CantonStream::new(Some(config), backlog.clone(), NoopChainTelemetry)
         .context("failed to create CantonStream")?;
     let indexer = ChainStream::start(&mut stream).await?;
     let (_cp_tx, cp_rx) = tokio::sync::watch::channel(CheckpointDigest::default());
@@ -64,7 +64,7 @@ async fn stream_canton(
 
 /// Poll stream for a SignRequest event with timeout.
 async fn wait_for_sign_request(
-    stream: &mut CantonStream<impl StateManager>,
+    stream: &mut CantonStream<impl StateManager, impl ChainTelemetry>,
     timeout_secs: u64,
 ) -> Result<IndexedSignRequest> {
     timeout(Duration::from_secs(timeout_secs), async {

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -20,8 +20,9 @@ use mpc_node::storage::checkpoint_storage::CheckpointStorage;
 use mpc_node::stream::{run_stream, ChainPipeline, ChainStream, ChainStreaming};
 use mpc_node::util::current_unix_timestamp;
 use mpc_primitives::{
-    ChainEvent, CheckpointDigest, SignArgs, SignBidirectionalEvent as NodeSignBidirectionalEvent,
-    SignId, SignKind, StateManager, LATEST_MPC_KEY_VERSION,
+    ChainEvent, ChainTelemetry, CheckpointDigest, NoopChainTelemetry, SignArgs,
+    SignBidirectionalEvent as NodeSignBidirectionalEvent, SignId, SignKind, StateManager,
+    LATEST_MPC_KEY_VERSION,
 };
 use near_primitives::types::AccountId;
 use std::time::Duration;
@@ -339,27 +340,27 @@ fn test_bidirectional_event() -> NodeSignBidirectionalEvent {
     }
 }
 
-struct StartedEthereumStream<S: StateManager> {
-    stream: EthereumStream<S>,
+struct StartedEthereumStream<S: StateManager, T: ChainTelemetry> {
+    stream: EthereumStream<S, T>,
     _indexer_task: tokio::task::JoinHandle<()>,
 }
 
-impl<S: StateManager> std::ops::Deref for StartedEthereumStream<S> {
-    type Target = EthereumStream<S>;
+impl<S: StateManager, T: ChainTelemetry> std::ops::Deref for StartedEthereumStream<S, T> {
+    type Target = EthereumStream<S, T>;
 
     fn deref(&self) -> &Self::Target {
         &self.stream
     }
 }
 
-impl<S: StateManager> std::ops::DerefMut for StartedEthereumStream<S> {
+impl<S: StateManager, T: ChainTelemetry> std::ops::DerefMut for StartedEthereumStream<S, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.stream
     }
 }
 
-async fn next_event_within<S: StateManager>(
-    client: &mut StartedEthereumStream<S>,
+async fn next_event_within<S: StateManager, T: ChainTelemetry>(
+    client: &mut StartedEthereumStream<S, T>,
     duration: Duration,
 ) -> Result<ChainEvent> {
     timeout(duration, async {
@@ -378,8 +379,9 @@ async fn next_event_within<S: StateManager>(
 async fn stream_ethereum(
     ctx: &EthereumTestEnvironment,
     backlog: Backlog,
-) -> Result<StartedEthereumStream<impl StateManager>> {
-    let mut stream = EthereumStream::new(Some(ctx.config(true)), backlog.clone()).await?;
+) -> Result<StartedEthereumStream<impl StateManager, NoopChainTelemetry>> {
+    let mut stream =
+        EthereumStream::new(Some(ctx.config(true)), backlog.clone(), NoopChainTelemetry).await?;
     let indexer = stream.start().await?;
     let (_cp_tx, cp_rx) = watch::channel(CheckpointDigest::default());
     let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
@@ -443,7 +445,8 @@ async fn test_ethereum_stream_resume_starts_after_checkpoint_height() -> Result<
     }
 
     let backlog = Backlog::persisted(storage);
-    let stream = EthereumStream::new(Some(ctx.config(true)), backlog.clone()).await?;
+    let stream =
+        EthereumStream::new(Some(ctx.config(true)), backlog.clone(), NoopChainTelemetry).await?;
     let (sign_tx, mut sign_rx) = mpsc::channel(16);
     let (contract_watcher, _contract_tx) = ContractStateWatcher::with_running(
         &"test.near".parse::<AccountId>().unwrap(),
@@ -465,6 +468,7 @@ async fn test_ethereum_stream_resume_starts_after_checkpoint_height() -> Result<
         sign_tx,
         rpc,
         backlog,
+        NoopChainTelemetry,
         contract_watcher,
         mesh_rx,
         NodeClient::new(&Default::default()),
@@ -620,7 +624,8 @@ async fn test_ethereum_stream_linear_catchup_from_checkpoint() -> Result<()> {
     let catchup_payload = [0x55; 32];
     submit_sign_request(&ctx, catchup_payload, "catchup-linear-path").await?;
 
-    let stream = EthereumStream::new(Some(ctx.config(true)), backlog.clone()).await?;
+    let stream =
+        EthereumStream::new(Some(ctx.config(true)), backlog.clone(), NoopChainTelemetry).await?;
     let (sign_tx, mut sign_rx) = mpsc::channel(16);
     let (contract_watcher, _contract_tx) = ContractStateWatcher::with_running(
         &"test.near".parse::<AccountId>().unwrap(),
@@ -642,6 +647,7 @@ async fn test_ethereum_stream_linear_catchup_from_checkpoint() -> Result<()> {
         sign_tx,
         rpc,
         backlog.clone(),
+        NoopChainTelemetry,
         contract_watcher,
         mesh_rx,
         NodeClient::new(&Default::default()),
@@ -807,7 +813,8 @@ async fn test_ethereum_stream_backfills_late_execution_watcher_after_catchup() -
         ))
         .await;
 
-    let stream = EthereumStream::new(Some(ctx.config(true)), backlog.clone()).await?;
+    let stream =
+        EthereumStream::new(Some(ctx.config(true)), backlog.clone(), NoopChainTelemetry).await?;
     let (sign_tx, mut sign_rx) = mpsc::channel(16);
     let (contract_watcher, _contract_tx) = ContractStateWatcher::with_running(
         &"test.near".parse::<AccountId>().unwrap(),
@@ -829,6 +836,7 @@ async fn test_ethereum_stream_backfills_late_execution_watcher_after_catchup() -
         sign_tx,
         rpc,
         backlog.clone(),
+        NoopChainTelemetry,
         contract_watcher,
         mesh_rx,
         NodeClient::new(&Default::default()),

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -14,7 +14,9 @@ use mpc_node::rpc::{ContractStateWatcher, RpcAction, RpcChannel};
 use mpc_node::sign_bidirectional::{PublishState, SignStatus};
 use mpc_node::storage::checkpoint_storage::CheckpointStorage;
 use mpc_node::stream::{run_stream, ChainPipeline, ChainStream, ChainStreaming};
-use mpc_primitives::{ChainEvent, SignArgs, SignId, Signature, LATEST_MPC_KEY_VERSION};
+use mpc_primitives::{
+    ChainEvent, NoopChainTelemetry, SignArgs, SignId, Signature, LATEST_MPC_KEY_VERSION,
+};
 use mpc_primitives::{CheckpointDigest, StateManager};
 use near_primitives::types::AccountId;
 use solana_sdk::signer::Signer;
@@ -504,6 +506,7 @@ async fn test_solana_stream_republishes_pending_publish_after_checkpoint_recover
             sign_tx,
             rpc,
             recovered_backlog,
+            NoopChainTelemetry,
             contract_watcher,
             mesh_rx,
             node_client,

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -15,7 +15,8 @@ use mpc_node::sign_bidirectional::{PublishState, SignStatus};
 use mpc_node::storage::checkpoint_storage::CheckpointStorage;
 use mpc_node::stream::{run_stream, ChainPipeline, ChainStream, ChainStreaming};
 use mpc_primitives::{
-    ChainEvent, NoopChainTelemetry, SignArgs, SignId, Signature, LATEST_MPC_KEY_VERSION,
+    ChainEvent, ChainTelemetry, NoopChainTelemetry, SignArgs, SignId, Signature,
+    LATEST_MPC_KEY_VERSION,
 };
 use mpc_primitives::{CheckpointDigest, StateManager};
 use near_primitives::types::AccountId;
@@ -40,7 +41,9 @@ fn test_dependencies() -> (Backlog, watch::Receiver<MeshState>, NodeClient) {
     (backlog, mesh_rx, node_client)
 }
 
-async fn stream_solana(config: SolConfig) -> Result<SolanaStream<impl StateManager>> {
+async fn stream_solana(
+    config: SolConfig,
+) -> Result<SolanaStream<impl StateManager, impl ChainTelemetry>> {
     let (backlog, _, _) = test_dependencies();
     stream_solana_with_backlog(config, backlog).await
 }
@@ -48,8 +51,8 @@ async fn stream_solana(config: SolConfig) -> Result<SolanaStream<impl StateManag
 async fn stream_solana_with_backlog(
     config: SolConfig,
     backlog: Backlog,
-) -> Result<SolanaStream<impl StateManager>> {
-    let mut stream = SolanaStream::new(Some(config), backlog.clone())
+) -> Result<SolanaStream<impl StateManager, impl ChainTelemetry>> {
+    let mut stream = SolanaStream::new(Some(config), backlog.clone(), NoopChainTelemetry)
         .context("failed to create SolanaStream")?;
     let indexer = ChainStream::start(&mut stream).await?;
     let (_cp_tx, cp_rx) = watch::channel(CheckpointDigest::default());
@@ -88,8 +91,8 @@ async fn stream_solana_with_backlog(
 }
 
 /// Helper to wait for a specific event type, skipping block events
-async fn wait_for_sign_request<S: StateManager>(
-    stream: &mut SolanaStream<S>,
+async fn wait_for_sign_request<S: StateManager, T: ChainTelemetry>(
+    stream: &mut SolanaStream<S, T>,
 ) -> Result<IndexedSignRequest> {
     loop {
         match timeout(Duration::from_secs(6), stream.next_event()).await {
@@ -475,7 +478,7 @@ async fn test_solana_stream_republishes_pending_publish_after_checkpoint_recover
     seeded_backlog.checkpoint(Chain::Solana).await;
 
     let recovered_backlog = Backlog::persisted(storage);
-    let stream = SolanaStream::new(Some(config), recovered_backlog.clone())
+    let stream = SolanaStream::new(Some(config), recovered_backlog.clone(), NoopChainTelemetry)
         .context("failed to create SolanaStream")?;
 
     let (sign_tx, mut sign_rx) = mpsc::channel::<Sign>(4);


### PR DESCRIPTION
Decouple metric updates from indexers:

- Introduce `ChainTelemetry` trait, add implementations: `PrometheusChainTelemetry` (default), `NoopTelemetry` (for tests)
- Update Ethereum, Solana, Canton, Hydration indexers and `run_stream` to accept generic `telemetry` parameter (`T: ChainTelemetry`)
- Remove `Indexed` update from Near indexer since it's only used for integration tests