### PR TITLE
refactor: centralize RPC retry logic

### DIFF
--- a/chain-signatures/node/src/indexer_eth/client.rs
+++ b/chain-signatures/node/src/indexer_eth/client.rs
@@ -110,7 +110,7 @@ impl EthereumClient {
 
         let res = retry_rpc!("get_blocks", ETH_RPC_BATCH_TIMEOUT, &self.retry_strategy, {
             match &self.inner {
-                    #[cfg(feature = "helios")]
+                #[cfg(feature = "helios")]
                 EthereumClientInner::Helios(client) => client.get_blocks(block_ids).await,
                 EthereumClientInner::DirectRpc(client) => client.get_blocks(block_ids).await,
             }
@@ -267,5 +267,119 @@ impl EthereumClient {
         } else {
             requested_start
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::indexer_eth::test_utils;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn get_block_returns_block_on_200() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(test_utils::block_response(1, 99).to_string())
+            .create_async()
+            .await;
+
+        let client = test_utils::create_test_ethereum_client(&server.url()).await;
+        let block = client
+            .get_block(BlockId::Number(BlockNumberOrTag::Number(99)))
+            .await;
+
+        assert!(block.is_some());
+        assert_eq!(block.unwrap().header.number, 99);
+    }
+
+    #[tokio::test]
+    async fn get_block_returns_none_on_null_result() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"jsonrpc":"2.0","id":1,"result":null}"#)
+            .create_async()
+            .await;
+
+        let client = test_utils::create_test_ethereum_client(&server.url()).await;
+        let block = client
+            .get_block(BlockId::Number(BlockNumberOrTag::Number(1)))
+            .await;
+
+        assert!(block.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_block_retries_on_500_then_succeeds() {
+        let mut server = mockito::Server::new_async().await;
+        // First call → 500, second call → valid block
+        let _fail = server
+            .mock("POST", "/")
+            .with_status(500)
+            .with_body("error")
+            .expect(1)
+            .create_async()
+            .await;
+        let _ok = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(test_utils::block_response(1, 7).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = test_utils::create_test_ethereum_client(&server.url()).await;
+        let block = client
+            .get_block(BlockId::Number(BlockNumberOrTag::Number(7)))
+            .await;
+
+        assert!(block.is_some());
+    }
+
+    #[tokio::test]
+    async fn get_block_retries_on_500_then_fails() {
+        let mut server = mockito::Server::new_async().await;
+        // Always return 500
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(500)
+            .with_body("error")
+            .expect(5) // should retry 5 times
+            .create_async()
+            .await;
+
+        let client = test_utils::create_test_ethereum_client(&server.url()).await;
+        let block = client
+            .get_block(BlockId::Number(BlockNumberOrTag::Number(8)))
+            .await;
+
+        assert!(block.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_block_does_not_retry_on_4xx() {
+        let mut server = mockito::Server::new_async().await;
+        // Always return 4xx
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(400)
+            .with_body("bad request")
+            .expect(1) // should not retry
+            .create_async()
+            .await;
+
+        let client = test_utils::create_test_ethereum_client(&server.url()).await;
+        let block = client
+            .get_block(BlockId::Number(BlockNumberOrTag::Number(9)))
+            .await;
+
+        assert!(block.is_none());
     }
 }

--- a/chain-signatures/node/src/indexer_eth/client.rs
+++ b/chain-signatures/node/src/indexer_eth/client.rs
@@ -1,12 +1,32 @@
+use std::time::Duration;
+
 use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::{Address, Bytes};
 use alloy::rpc::types::{Block, BlockId};
+use backon::ExponentialBuilder;
 
 use super::{indexer_eth_direct_rpc, BlockNumber, EthConfig, MaybeBlock};
-use crate::util::retry;
+// TODO: import from mpc-indexer-core later
+use crate::retry_rpc;
 
 #[cfg(feature = "helios")]
 use super::indexer_eth_helios;
+
+// Constants for Ethereum RPC client retry behavior
+const ETH_RPC_TIMEOUT: Duration = Duration::from_secs(2);
+const ETH_RPC_BATCH_TIMEOUT: Duration = Duration::from_secs(5);
+const ETH_RPC_MIN_DELAY: Duration = Duration::from_millis(500);
+const ETH_RPC_MAX_DELAY: Duration = Duration::from_secs(10);
+const ETH_RPC_MAX_RETRIES: usize = 5;
+
+/// Helper for consistent config
+fn eth_retry_strategy() -> ExponentialBuilder {
+    ExponentialBuilder::default()
+        .with_jitter()
+        .with_min_delay(ETH_RPC_MIN_DELAY)
+        .with_max_delay(ETH_RPC_MAX_DELAY)
+        .with_max_times(ETH_RPC_MAX_RETRIES)
+}
 
 #[derive(Clone)]
 pub enum EthereumClient {
@@ -49,36 +69,13 @@ impl EthereumClient {
     }
 
     pub async fn get_block(&self, block_id: BlockId) -> Option<Block> {
-        // Configure retry behaviour and delegate to shared retry_async helper.
-        let retry_config = retry::RetryConfig::default();
-        let get_block_op = |_attempt: usize| async {
+        let res = retry_rpc!("get_block", ETH_RPC_TIMEOUT, &eth_retry_strategy(), {
             match self {
                 #[cfg(feature = "helios")]
                 EthereumClient::Helios(client) => client.get_block(block_id).await,
                 EthereumClient::DirectRpc(client) => client.get_block(block_id).await,
             }
-        };
-
-        let res = retry::retry_async(
-            retry_config,
-            get_block_op,
-            |_attempt, _reason| true,
-            |attempt, reason, sleep_duration| match reason {
-                retry::RetryReason::Error(e) => {
-                    tracing::warn!(
-                        client = self.client_name(),
-                        "get_block failed (attempt {attempt}) for {block_id:?}: {e:#}; retrying in {sleep_duration:?}"
-                    );
-                }
-                retry::RetryReason::Timeout(t) => {
-                    tracing::warn!(
-                        client = self.client_name(),
-                        "get_block timed out after {t:?} (attempt {attempt}) for {block_id:?}; retrying in {sleep_duration:?}"
-                    );
-                }
-            },
-        )
-        .await;
+        });
 
         match res {
             Ok(Some(block)) => Some(block),
@@ -86,24 +83,8 @@ impl EthereumClient {
                 tracing::warn!(client = self.client_name(), "Block {block_id:?} not found");
                 None
             }
-            Err(retry::RetryError::Exhausted {
-                attempts,
-                last_error,
-            }) => {
-                tracing::warn!(
-                    client = self.client_name(),
-                    "get_block failed for {block_id:?}: {last_error:#}; exhausted after {attempts} attempts"
-                );
-                None
-            }
-            Err(retry::RetryError::TimeoutExhausted {
-                attempts,
-                last_timeout,
-            }) => {
-                tracing::warn!(
-                    client = self.client_name(),
-                    "get_block timed out for {block_id:?} (last timeout {last_timeout:?}); exhausted after {attempts} attempts"
-                );
+            Err(err) => {
+                tracing::warn!(client = self.client_name(), "{err}");
                 None
             }
         }
@@ -114,57 +95,23 @@ impl EthereumClient {
             return Vec::new();
         }
 
-        let retry_config = retry::RetryConfig::default();
-        let block_ids = block_ids.to_vec();
-        let get_blocks_op = |_attempt: usize| {
-            let block_ids = block_ids.clone();
-            async move {
+        let res = retry_rpc!(
+            "get_blocks",
+            ETH_RPC_BATCH_TIMEOUT,
+            &eth_retry_strategy(),
+            {
                 match self {
                     #[cfg(feature = "helios")]
-                    EthereumClient::Helios(client) => client.get_blocks(&block_ids).await,
-                    EthereumClient::DirectRpc(client) => client.get_blocks(&block_ids).await,
+                    EthereumClient::Helios(client) => client.get_blocks(block_ids).await,
+                    EthereumClient::DirectRpc(client) => client.get_blocks(block_ids).await,
                 }
             }
-        };
+        );
 
-        match retry::retry_async(
-            retry_config,
-            get_blocks_op,
-            |_attempt, _reason| true,
-            |attempt, reason, sleep_duration| match reason {
-                retry::RetryReason::Error(e) => {
-                    tracing::warn!(
-                        client = self.client_name(),
-                        num_blocks = block_ids.len(),
-                        "get_blocks failed (attempt {attempt}): {e:#}; retrying in {sleep_duration:?}"
-                    );
-                }
-                retry::RetryReason::Timeout(t) => {
-                    tracing::warn!(
-                        client = self.client_name(),
-                        num_blocks = block_ids.len(),
-                        "get_blocks timed out after {t:?} (attempt {attempt}); retrying in {sleep_duration:?}"
-                    );
-                }
-            },
-        )
-        .await
-        {
+        match res {
             Ok(blocks) => blocks,
-            Err(retry::RetryError::Exhausted { attempts, last_error }) => {
-                tracing::warn!(
-                    client = self.client_name(),
-                    num_blocks = block_ids.len(),
-                    "get_blocks failed: {last_error:#}; exhausted after {attempts} attempts"
-                );
-                block_ids.iter().copied().map(MaybeBlock::Missing).collect()
-            }
-            Err(retry::RetryError::TimeoutExhausted { attempts, last_timeout }) => {
-                tracing::warn!(
-                    client = self.client_name(),
-                    num_blocks = block_ids.len(),
-                    "get_blocks timed out (last timeout {last_timeout:?}); exhausted after {attempts} attempts"
-                );
+            Err(err) => {
+                tracing::warn!(client = self.client_name(), "{err}");
                 block_ids.iter().copied().map(MaybeBlock::Missing).collect()
             }
         }
@@ -174,19 +121,28 @@ impl EthereumClient {
         &self,
         block_id: BlockId,
     ) -> anyhow::Result<Option<Vec<alloy::rpc::types::TransactionReceipt>>> {
-        match self {
-            #[cfg(feature = "helios")]
-            EthereumClient::Helios(client) => client.get_block_receipts(block_id).await,
-            EthereumClient::DirectRpc(client) => client.get_block_receipts(block_id).await,
-        }
+        retry_rpc!(
+            "get_block_receipts",
+            ETH_RPC_TIMEOUT,
+            &eth_retry_strategy(),
+            {
+                match self {
+                    #[cfg(feature = "helios")]
+                    EthereumClient::Helios(client) => client.get_block_receipts(block_id).await,
+                    EthereumClient::DirectRpc(client) => client.get_block_receipts(block_id).await,
+                }
+            }
+        )
     }
 
     pub async fn get_nonce(&self, address: Address, block_id: BlockId) -> anyhow::Result<u64> {
-        match self {
-            #[cfg(feature = "helios")]
-            EthereumClient::Helios(client) => client.get_nonce(address, block_id).await,
-            EthereumClient::DirectRpc(client) => client.get_nonce(address, block_id).await,
-        }
+        retry_rpc!("get_nonce", ETH_RPC_TIMEOUT, &eth_retry_strategy(), {
+            match self {
+                #[cfg(feature = "helios")]
+                EthereumClient::Helios(client) => client.get_nonce(address, block_id).await,
+                EthereumClient::DirectRpc(client) => client.get_nonce(address, block_id).await,
+            }
+        })
     }
 
     pub fn block_number_from_id(block_id: BlockId) -> BlockNumber {
@@ -201,22 +157,42 @@ impl EthereumClient {
         &self,
         tx_hash: alloy::primitives::B256,
     ) -> anyhow::Result<Option<alloy::rpc::types::Transaction>> {
-        match self {
-            #[cfg(feature = "helios")]
-            EthereumClient::Helios(client) => client.get_transaction_by_hash(tx_hash).await,
-            EthereumClient::DirectRpc(client) => client.get_transaction_by_hash(tx_hash).await,
-        }
+        retry_rpc!(
+            "get_transaction_by_hash",
+            ETH_RPC_TIMEOUT,
+            &eth_retry_strategy(),
+            {
+                match self {
+                    #[cfg(feature = "helios")]
+                    EthereumClient::Helios(client) => client.get_transaction_by_hash(tx_hash).await,
+                    EthereumClient::DirectRpc(client) => {
+                        client.get_transaction_by_hash(tx_hash).await
+                    }
+                }
+            }
+        )
     }
 
     pub async fn trace_transaction_output(
         &self,
         tx_hash: alloy::primitives::B256,
     ) -> anyhow::Result<alloy::primitives::Bytes> {
-        match self {
-            #[cfg(feature = "helios")]
-            EthereumClient::Helios(client) => client.trace_transaction_output(tx_hash).await,
-            EthereumClient::DirectRpc(client) => client.trace_transaction_output(tx_hash).await,
-        }
+        retry_rpc!(
+            "trace_transaction_output",
+            ETH_RPC_TIMEOUT,
+            &eth_retry_strategy(),
+            {
+                match self {
+                    #[cfg(feature = "helios")]
+                    EthereumClient::Helios(client) => {
+                        client.trace_transaction_output(tx_hash).await
+                    }
+                    EthereumClient::DirectRpc(client) => {
+                        client.trace_transaction_output(tx_hash).await
+                    }
+                }
+            }
+        )
     }
 
     pub async fn call(
@@ -226,11 +202,17 @@ impl EthereumClient {
         data: Bytes,
         block_number: u64,
     ) -> anyhow::Result<Bytes> {
-        match self {
-            #[cfg(feature = "helios")]
-            EthereumClient::Helios(client) => client.call(from, to, data, block_number).await,
-            EthereumClient::DirectRpc(client) => client.call(from, to, data, block_number).await,
-        }
+        retry_rpc!("call", ETH_RPC_TIMEOUT, &eth_retry_strategy(), {
+            match self {
+                #[cfg(feature = "helios")]
+                EthereumClient::Helios(client) => {
+                    client.call(from, to, data.clone(), block_number).await
+                }
+                EthereumClient::DirectRpc(client) => {
+                    client.call(from, to, data.clone(), block_number).await
+                }
+            }
+        })
     }
 
     pub async fn get_latest_block_number(&self) -> Option<u64> {

--- a/chain-signatures/node/src/indexer_eth/client.rs
+++ b/chain-signatures/node/src/indexer_eth/client.rs
@@ -29,7 +29,13 @@ fn eth_retry_strategy() -> ExponentialBuilder {
 }
 
 #[derive(Clone)]
-pub enum EthereumClient {
+pub struct EthereumClient {
+    inner: EthereumClientInner,
+    retry_strategy: ExponentialBuilder,
+}
+
+#[derive(Clone)]
+pub enum EthereumClientInner {
     #[cfg(feature = "helios")]
     Helios(indexer_eth_helios::HeliosEthereumClient),
     DirectRpc(indexer_eth_direct_rpc::RpcEthereumClient),
@@ -37,43 +43,50 @@ pub enum EthereumClient {
 
 impl EthereumClient {
     pub async fn new(eth: EthConfig) -> anyhow::Result<EthereumClient> {
-        if eth.light_client {
+        Self::new_with_strategy(eth, eth_retry_strategy()).await
+    }
+
+    pub async fn new_with_strategy(
+        eth: EthConfig,
+        retry_strategy: ExponentialBuilder,
+    ) -> anyhow::Result<Self> {
+        let inner = if eth.light_client {
             #[cfg(feature = "helios")]
             {
-                return Ok(EthereumClient::Helios(
-                    indexer_eth_helios::build_client(eth.clone()).await?,
-                ));
+                EthereumClientInner::Helios(indexer_eth_helios::build_client(eth.clone()).await?)
             }
-
             #[cfg(not(feature = "helios"))]
             {
                 anyhow::bail!(
                     "ethereum light client requested, but mpc-node was built without helios feature"
                 );
             }
-        }
-
-        {
-            Ok(EthereumClient::DirectRpc(
-                indexer_eth_direct_rpc::RpcEthereumClient::new(&eth.execution_rpc_http_url),
+        } else {
+            EthereumClientInner::DirectRpc(indexer_eth_direct_rpc::RpcEthereumClient::new(
+                &eth.execution_rpc_http_url,
             ))
-        }
+        };
+
+        Ok(Self {
+            inner,
+            retry_strategy,
+        })
     }
 
     fn client_name(&self) -> &str {
-        match self {
+        match &self.inner {
             #[cfg(feature = "helios")]
-            EthereumClient::Helios(_) => "Helios",
-            EthereumClient::DirectRpc(_) => "DirectRpc",
+            EthereumClientInner::Helios(_) => "Helios",
+            EthereumClientInner::DirectRpc(_) => "DirectRpc",
         }
     }
 
     pub async fn get_block(&self, block_id: BlockId) -> Option<Block> {
-        let res = retry_rpc!("get_block", ETH_RPC_TIMEOUT, &eth_retry_strategy(), {
-            match self {
+        let res = retry_rpc!("get_block", ETH_RPC_TIMEOUT, &self.retry_strategy, {
+            match &self.inner {
                 #[cfg(feature = "helios")]
-                EthereumClient::Helios(client) => client.get_block(block_id).await,
-                EthereumClient::DirectRpc(client) => client.get_block(block_id).await,
+                EthereumClientInner::Helios(client) => client.get_block(block_id).await,
+                EthereumClientInner::DirectRpc(client) => client.get_block(block_id).await,
             }
         });
 
@@ -95,18 +108,13 @@ impl EthereumClient {
             return Vec::new();
         }
 
-        let res = retry_rpc!(
-            "get_blocks",
-            ETH_RPC_BATCH_TIMEOUT,
-            &eth_retry_strategy(),
-            {
-                match self {
+        let res = retry_rpc!("get_blocks", ETH_RPC_BATCH_TIMEOUT, &self.retry_strategy, {
+            match &self.inner {
                     #[cfg(feature = "helios")]
-                    EthereumClient::Helios(client) => client.get_blocks(block_ids).await,
-                    EthereumClient::DirectRpc(client) => client.get_blocks(block_ids).await,
-                }
+                EthereumClientInner::Helios(client) => client.get_blocks(block_ids).await,
+                EthereumClientInner::DirectRpc(client) => client.get_blocks(block_ids).await,
             }
-        );
+        });
 
         match res {
             Ok(blocks) => blocks,
@@ -124,23 +132,27 @@ impl EthereumClient {
         retry_rpc!(
             "get_block_receipts",
             ETH_RPC_TIMEOUT,
-            &eth_retry_strategy(),
+            &self.retry_strategy,
             {
-                match self {
+                match &self.inner {
                     #[cfg(feature = "helios")]
-                    EthereumClient::Helios(client) => client.get_block_receipts(block_id).await,
-                    EthereumClient::DirectRpc(client) => client.get_block_receipts(block_id).await,
+                    EthereumClientInner::Helios(client) => {
+                        client.get_block_receipts(block_id).await
+                    }
+                    EthereumClientInner::DirectRpc(client) => {
+                        client.get_block_receipts(block_id).await
+                    }
                 }
             }
         )
     }
 
     pub async fn get_nonce(&self, address: Address, block_id: BlockId) -> anyhow::Result<u64> {
-        retry_rpc!("get_nonce", ETH_RPC_TIMEOUT, &eth_retry_strategy(), {
-            match self {
+        retry_rpc!("get_nonce", ETH_RPC_TIMEOUT, &self.retry_strategy, {
+            match &self.inner {
                 #[cfg(feature = "helios")]
-                EthereumClient::Helios(client) => client.get_nonce(address, block_id).await,
-                EthereumClient::DirectRpc(client) => client.get_nonce(address, block_id).await,
+                EthereumClientInner::Helios(client) => client.get_nonce(address, block_id).await,
+                EthereumClientInner::DirectRpc(client) => client.get_nonce(address, block_id).await,
             }
         })
     }
@@ -160,12 +172,14 @@ impl EthereumClient {
         retry_rpc!(
             "get_transaction_by_hash",
             ETH_RPC_TIMEOUT,
-            &eth_retry_strategy(),
+            &self.retry_strategy,
             {
-                match self {
+                match &self.inner {
                     #[cfg(feature = "helios")]
-                    EthereumClient::Helios(client) => client.get_transaction_by_hash(tx_hash).await,
-                    EthereumClient::DirectRpc(client) => {
+                    EthereumClientInner::Helios(client) => {
+                        client.get_transaction_by_hash(tx_hash).await
+                    }
+                    EthereumClientInner::DirectRpc(client) => {
                         client.get_transaction_by_hash(tx_hash).await
                     }
                 }
@@ -180,14 +194,14 @@ impl EthereumClient {
         retry_rpc!(
             "trace_transaction_output",
             ETH_RPC_TIMEOUT,
-            &eth_retry_strategy(),
+            &self.retry_strategy,
             {
-                match self {
+                match &self.inner {
                     #[cfg(feature = "helios")]
-                    EthereumClient::Helios(client) => {
+                    EthereumClientInner::Helios(client) => {
                         client.trace_transaction_output(tx_hash).await
                     }
-                    EthereumClient::DirectRpc(client) => {
+                    EthereumClientInner::DirectRpc(client) => {
                         client.trace_transaction_output(tx_hash).await
                     }
                 }
@@ -202,13 +216,13 @@ impl EthereumClient {
         data: Bytes,
         block_number: u64,
     ) -> anyhow::Result<Bytes> {
-        retry_rpc!("call", ETH_RPC_TIMEOUT, &eth_retry_strategy(), {
-            match self {
+        retry_rpc!("call", ETH_RPC_TIMEOUT, &self.retry_strategy, {
+            match &self.inner {
                 #[cfg(feature = "helios")]
-                EthereumClient::Helios(client) => {
+                EthereumClientInner::Helios(client) => {
                     client.call(from, to, data.clone(), block_number).await
                 }
-                EthereumClient::DirectRpc(client) => {
+                EthereumClientInner::DirectRpc(client) => {
                     client.call(from, to, data.clone(), block_number).await
                 }
             }
@@ -226,10 +240,10 @@ impl EthereumClient {
         requested_start: u64,
         anchor_height: BlockNumber,
     ) -> BlockNumber {
-        let max_catchup_blocks = match self {
+        let max_catchup_blocks = match &self.inner {
             #[cfg(feature = "helios")]
-            EthereumClient::Helios(_) => indexer_eth_helios::MAX_CATCHUP_BLOCKS,
-            EthereumClient::DirectRpc(_) => indexer_eth_direct_rpc::MAX_CATCHUP_BLOCKS,
+            EthereumClientInner::Helios(_) => indexer_eth_helios::MAX_CATCHUP_BLOCKS,
+            EthereumClientInner::DirectRpc(_) => indexer_eth_direct_rpc::MAX_CATCHUP_BLOCKS,
         };
         Self::clamp_oldest_supported_with(requested_start, anchor_height, max_catchup_blocks)
     }

--- a/chain-signatures/node/src/indexer_eth/client.rs
+++ b/chain-signatures/node/src/indexer_eth/client.rs
@@ -5,7 +5,7 @@ use alloy::primitives::{Address, Bytes};
 use alloy::rpc::types::{Block, BlockId};
 
 use super::{indexer_eth_direct_rpc, BlockNumber, EthConfig, MaybeBlock};
-use crate::util::retry::{RetryConfig, retry_rpc};
+use crate::util::retry::{retry_rpc, RetryConfig};
 
 #[cfg(feature = "helios")]
 use super::indexer_eth_helios;

--- a/chain-signatures/node/src/indexer_eth/client.rs
+++ b/chain-signatures/node/src/indexer_eth/client.rs
@@ -3,11 +3,9 @@ use std::time::Duration;
 use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::{Address, Bytes};
 use alloy::rpc::types::{Block, BlockId};
-use backon::ExponentialBuilder;
 
 use super::{indexer_eth_direct_rpc, BlockNumber, EthConfig, MaybeBlock};
-use crate::retry_rpc;
-use create::util::retry::RetryConfig;
+use crate::util::retry::{RetryConfig, retry_rpc};
 
 #[cfg(feature = "helios")]
 use super::indexer_eth_helios;

--- a/chain-signatures/node/src/indexer_eth/client.rs
+++ b/chain-signatures/node/src/indexer_eth/client.rs
@@ -6,8 +6,8 @@ use alloy::rpc::types::{Block, BlockId};
 use backon::ExponentialBuilder;
 
 use super::{indexer_eth_direct_rpc, BlockNumber, EthConfig, MaybeBlock};
-// TODO: import from mpc-indexer-core later
 use crate::retry_rpc;
+use create::util::retry::RetryConfig;
 
 #[cfg(feature = "helios")]
 use super::indexer_eth_helios;
@@ -20,18 +20,19 @@ const ETH_RPC_MAX_DELAY: Duration = Duration::from_secs(10);
 const ETH_RPC_MAX_RETRIES: usize = 5;
 
 /// Helper for consistent config
-fn eth_retry_strategy() -> ExponentialBuilder {
-    ExponentialBuilder::default()
-        .with_jitter()
-        .with_min_delay(ETH_RPC_MIN_DELAY)
-        .with_max_delay(ETH_RPC_MAX_DELAY)
-        .with_max_times(ETH_RPC_MAX_RETRIES)
+fn default_eth_retry_strategy() -> RetryConfig {
+    RetryConfig {
+        min_delay: ETH_RPC_MIN_DELAY,
+        max_delay: ETH_RPC_MAX_DELAY,
+        max_times: ETH_RPC_MAX_RETRIES,
+        jitter: true,
+    }
 }
 
 #[derive(Clone)]
 pub struct EthereumClient {
     inner: EthereumClientInner,
-    retry_strategy: ExponentialBuilder,
+    retry_strategy: RetryConfig,
 }
 
 #[derive(Clone)]
@@ -43,12 +44,13 @@ pub enum EthereumClientInner {
 
 impl EthereumClient {
     pub async fn new(eth: EthConfig) -> anyhow::Result<EthereumClient> {
-        Self::new_with_strategy(eth, eth_retry_strategy()).await
+        Self::new_with_strategy(eth, default_eth_retry_strategy()).await
     }
 
+    /// Creates a new Ethereum client with the specified retry strategy.
     pub async fn new_with_strategy(
         eth: EthConfig,
-        retry_strategy: ExponentialBuilder,
+        retry_strategy: RetryConfig,
     ) -> anyhow::Result<Self> {
         let inner = if eth.light_client {
             #[cfg(feature = "helios")]
@@ -82,7 +84,7 @@ impl EthereumClient {
     }
 
     pub async fn get_block(&self, block_id: BlockId) -> Option<Block> {
-        let res = retry_rpc!("get_block", ETH_RPC_TIMEOUT, &self.retry_strategy, {
+        let res = retry_rpc!(ETH_RPC_TIMEOUT, self.retry_strategy, "get_block", {
             match &self.inner {
                 #[cfg(feature = "helios")]
                 EthereumClientInner::Helios(client) => client.get_block(block_id).await,
@@ -108,7 +110,7 @@ impl EthereumClient {
             return Vec::new();
         }
 
-        let res = retry_rpc!("get_blocks", ETH_RPC_BATCH_TIMEOUT, &self.retry_strategy, {
+        let res = retry_rpc!(ETH_RPC_BATCH_TIMEOUT, self.retry_strategy, "get_blocks", {
             match &self.inner {
                 #[cfg(feature = "helios")]
                 EthereumClientInner::Helios(client) => client.get_blocks(block_ids).await,
@@ -130,9 +132,9 @@ impl EthereumClient {
         block_id: BlockId,
     ) -> anyhow::Result<Option<Vec<alloy::rpc::types::TransactionReceipt>>> {
         retry_rpc!(
-            "get_block_receipts",
             ETH_RPC_TIMEOUT,
-            &self.retry_strategy,
+            self.retry_strategy,
+            "get_block_receipts",
             {
                 match &self.inner {
                     #[cfg(feature = "helios")]
@@ -148,7 +150,7 @@ impl EthereumClient {
     }
 
     pub async fn get_nonce(&self, address: Address, block_id: BlockId) -> anyhow::Result<u64> {
-        retry_rpc!("get_nonce", ETH_RPC_TIMEOUT, &self.retry_strategy, {
+        retry_rpc!(ETH_RPC_TIMEOUT, self.retry_strategy, "get_nonce", {
             match &self.inner {
                 #[cfg(feature = "helios")]
                 EthereumClientInner::Helios(client) => client.get_nonce(address, block_id).await,
@@ -170,9 +172,9 @@ impl EthereumClient {
         tx_hash: alloy::primitives::B256,
     ) -> anyhow::Result<Option<alloy::rpc::types::Transaction>> {
         retry_rpc!(
-            "get_transaction_by_hash",
             ETH_RPC_TIMEOUT,
-            &self.retry_strategy,
+            self.retry_strategy,
+            "get_transaction_by_hash",
             {
                 match &self.inner {
                     #[cfg(feature = "helios")]
@@ -192,9 +194,9 @@ impl EthereumClient {
         tx_hash: alloy::primitives::B256,
     ) -> anyhow::Result<alloy::primitives::Bytes> {
         retry_rpc!(
-            "trace_transaction_output",
             ETH_RPC_TIMEOUT,
-            &self.retry_strategy,
+            self.retry_strategy,
+            "trace_transaction_output",
             {
                 match &self.inner {
                     #[cfg(feature = "helios")]
@@ -216,7 +218,7 @@ impl EthereumClient {
         data: Bytes,
         block_number: u64,
     ) -> anyhow::Result<Bytes> {
-        retry_rpc!("call", ETH_RPC_TIMEOUT, &self.retry_strategy, {
+        retry_rpc!(ETH_RPC_TIMEOUT, self.retry_strategy, "call", {
             match &self.inner {
                 #[cfg(feature = "helios")]
                 EthereumClientInner::Helios(client) => {
@@ -275,6 +277,8 @@ mod tests {
     use crate::indexer_eth::test_utils;
 
     use super::*;
+
+    // TODO: add more tests for non HTTP-related functionality, e.g. clamp_oldest_supported_with
 
     #[tokio::test]
     async fn get_block_returns_block_on_200() {

--- a/chain-signatures/node/src/indexer_eth/client.rs
+++ b/chain-signatures/node/src/indexer_eth/client.rs
@@ -82,13 +82,24 @@ impl EthereumClient {
     }
 
     pub async fn get_block(&self, block_id: BlockId) -> Option<Block> {
-        let res = retry_rpc!(ETH_RPC_TIMEOUT, self.retry_strategy, "get_block", {
-            match &self.inner {
-                #[cfg(feature = "helios")]
-                EthereumClientInner::Helios(client) => client.get_block(block_id).await,
-                EthereumClientInner::DirectRpc(client) => client.get_block(block_id).await,
+        let max_attempts = self.retry_strategy.max_times;
+        let res = retry_rpc!(
+            ETH_RPC_TIMEOUT,
+            self.retry_strategy,
+            |attempt, err, sleep| {
+                tracing::warn!(
+                    client = self.client_name(),
+                    "get_block failed (attempt {attempt}/{max_attempts}) for {block_id:?}: {err:#}; retrying in {sleep:?}"
+                );
+            },
+            {
+                match &self.inner {
+                    #[cfg(feature = "helios")]
+                    EthereumClientInner::Helios(client) => client.get_block(block_id).await,
+                    EthereumClientInner::DirectRpc(client) => client.get_block(block_id).await,
+                }
             }
-        });
+        );
 
         match res {
             Ok(Some(block)) => Some(block),
@@ -97,7 +108,10 @@ impl EthereumClient {
                 None
             }
             Err(err) => {
-                tracing::warn!(client = self.client_name(), "{err}");
+                tracing::warn!(
+                    client = self.client_name(),
+                    "get_block failed for {block_id:?}: {err:#}"
+                );
                 None
             }
         }
@@ -108,18 +122,36 @@ impl EthereumClient {
             return Vec::new();
         }
 
-        let res = retry_rpc!(ETH_RPC_BATCH_TIMEOUT, self.retry_strategy, "get_blocks", {
-            match &self.inner {
-                #[cfg(feature = "helios")]
-                EthereumClientInner::Helios(client) => client.get_blocks(block_ids).await,
-                EthereumClientInner::DirectRpc(client) => client.get_blocks(block_ids).await,
+        let max_attempts = self.retry_strategy.max_times;
+        let num_blocks = block_ids.len();
+
+        let res = retry_rpc!(
+            ETH_RPC_BATCH_TIMEOUT,
+            self.retry_strategy,
+            |attempt, err, sleep| {
+                tracing::warn!(
+                    client = self.client_name(),
+                    num_blocks,
+                    "get_blocks failed (attempt {attempt}/{max_attempts}): {err:#}; retrying in {sleep:?}"
+                );
+            },
+            {
+                match &self.inner {
+                    #[cfg(feature = "helios")]
+                    EthereumClientInner::Helios(client) => client.get_blocks(block_ids).await,
+                    EthereumClientInner::DirectRpc(client) => client.get_blocks(block_ids).await,
+                }
             }
-        });
+        );
 
         match res {
             Ok(blocks) => blocks,
             Err(err) => {
-                tracing::warn!(client = self.client_name(), "{err}");
+                tracing::warn!(
+                    client = self.client_name(),
+                    num_blocks,
+                    "get_blocks failed: {err:#}"
+                );
                 block_ids.iter().copied().map(MaybeBlock::Missing).collect()
             }
         }
@@ -191,6 +223,7 @@ impl EthereumClient {
         &self,
         tx_hash: alloy::primitives::B256,
     ) -> anyhow::Result<alloy::primitives::Bytes> {
+        // TODO: trace_transaction_output can be slow, consider a longer timeout than ETH_RPC_TIMEOUT if necessary
         retry_rpc!(
             ETH_RPC_TIMEOUT,
             self.retry_strategy,

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -4,6 +4,8 @@ mod config;
 pub mod indexer_eth_direct_rpc;
 #[cfg(feature = "helios")]
 pub mod indexer_eth_helios;
+#[cfg(test)]
+pub mod test_utils;
 
 use crate::indexer_eth::abi::{ChainSignatures, SignatureRequestedEncoding};
 use crate::metrics::requests::{record_request_latency_since, SignRequestStep};
@@ -1069,7 +1071,7 @@ impl<S: StateManager, T: ChainTelemetry> ChainStream for EthereumStream<S, T> {
 }
 #[cfg(test)]
 mod tests {
-    use super::{CatchupIter, EthConfig, EthereumClient, EthereumIndexer, MaybeBlock};
+    use super::{test_utils, CatchupIter, EthConfig, EthereumClient, EthereumIndexer, MaybeBlock};
     use crate::backlog::Backlog;
     #[cfg(feature = "helios")]
     use crate::indexer_eth::indexer_eth_helios;
@@ -1086,36 +1088,6 @@ mod tests {
     use serde_json::json;
     use std::sync::Arc;
     use tokio::sync::{mpsc, Notify};
-
-    fn block_response(request_id: u64, number: u64) -> serde_json::Value {
-        json!({
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "result": {
-                "number": format!("0x{number:x}"),
-                "hash": format!("0x{:064x}", number),
-                "parentHash": format!("0x{:064x}", number.saturating_sub(1)),
-                "sha3Uncles": format!("0x{:064x}", 1),
-                "logsBloom": format!("0x{}", "0".repeat(512)),
-                "transactionsRoot": format!("0x{:064x}", 2),
-                "stateRoot": format!("0x{:064x}", 3),
-                "receiptsRoot": format!("0x{:064x}", 4),
-                "miner": format!("0x{:040x}", 5),
-                "difficulty": "0x0",
-                "totalDifficulty": "0x0",
-                "extraData": "0x",
-                "size": "0x1",
-                "gasLimit": "0x1c9c380",
-                "gasUsed": "0x0",
-                "timestamp": "0x1",
-                "uncles": [],
-                "nonce": "0x0000000000000000",
-                "mixHash": format!("0x{:064x}", 9),
-                "baseFeePerGas": "0x1",
-                "transactions": []
-            }
-        })
-    }
 
     fn missing_block_response(request_id: u64) -> serde_json::Value {
         json!({
@@ -1152,7 +1124,7 @@ mod tests {
             })))
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(block_response(1, 12).to_string())
+            .with_body(test_utils::block_response(1, 12).to_string())
             .create_async()
             .await;
 
@@ -1182,9 +1154,7 @@ mod tests {
             },
             state_manager,
             telemetry: NoopChainTelemetry,
-            client: Arc::new(EthereumClient::DirectRpc(
-                super::indexer_eth_direct_rpc::RpcEthereumClient::new(&server.url()),
-            )),
+            client: Arc::new(test_utils::create_test_ethereum_client(&server.url()).await),
             events_tx,
             contract_address: Address::ZERO,
             catchup_complete: Arc::new(Notify::new()),
@@ -1222,9 +1192,7 @@ mod tests {
             },
             state_manager,
             telemetry: NoopChainTelemetry,
-            client: Arc::new(EthereumClient::DirectRpc(
-                super::indexer_eth_direct_rpc::RpcEthereumClient::new("http://127.0.0.1:1"),
-            )),
+            client: Arc::new(test_utils::create_test_ethereum_client("http://127.0.0.1:1").await),
             events_tx,
             contract_address: Address::ZERO,
             catchup_complete: Arc::new(Notify::new()),
@@ -1254,8 +1222,8 @@ mod tests {
             .with_header("content-type", "application/json")
             .with_body(
                 json!([
-                    block_response(3, 9),
-                    block_response(1, 7),
+                    test_utils::block_response(3, 9),
+                    test_utils::block_response(1, 7),
                     missing_block_response(2),
                 ])
                 .to_string(),
@@ -1263,9 +1231,7 @@ mod tests {
             .create_async()
             .await;
 
-        let client = EthereumClient::DirectRpc(
-            super::indexer_eth_direct_rpc::RpcEthereumClient::new(&server.url()),
-        );
+        let client = test_utils::create_test_ethereum_client(&server.url()).await;
         let block_ids = vec![
             BlockId::Number(BlockNumberOrTag::Number(7)),
             BlockId::Number(BlockNumberOrTag::Number(8)),
@@ -1305,18 +1271,16 @@ mod tests {
             .with_header("content-type", "application/json")
             .with_body(
                 json!([
-                    block_response(4, 20),
+                    test_utils::block_response(4, 20),
                     missing_block_response(5),
-                    block_response(6, 22),
+                    test_utils::block_response(6, 22),
                 ])
                 .to_string(),
             )
             .create_async()
             .await;
 
-        let client = EthereumClient::DirectRpc(
-            super::indexer_eth_direct_rpc::RpcEthereumClient::new(&server.url()),
-        );
+        let client = test_utils::create_test_ethereum_client(&server.url()).await;
         let block_ids = vec![
             BlockId::Number(BlockNumberOrTag::Number(20)),
             BlockId::Number(BlockNumberOrTag::Number(21)),
@@ -1340,9 +1304,9 @@ mod tests {
 
         let first_batch = (10..42)
             .enumerate()
-            .map(|(index, block_number)| block_response(index as u64 + 1, block_number))
+            .map(|(index, block_number)| test_utils::block_response(index as u64 + 1, block_number))
             .collect::<Vec<_>>();
-        let second_batch = vec![block_response(33, 42)];
+        let second_batch = vec![test_utils::block_response(33, 42)];
 
         let second_batch_mock = server
             .mock("POST", "/")
@@ -1364,9 +1328,7 @@ mod tests {
             .create_async()
             .await;
 
-        let client = Arc::new(EthereumClient::DirectRpc(
-            super::indexer_eth_direct_rpc::RpcEthereumClient::new(&server.url()),
-        ));
+        let client = Arc::new(test_utils::create_test_ethereum_client(&server.url()).await);
         let mut iter = CatchupIter::new(client, 10, 43);
 
         for expected_number in 10..42 {
@@ -1392,13 +1354,13 @@ mod tests {
 
         let first_batch = (0..32)
             .enumerate()
-            .map(|(idx, block_number)| block_response(idx as u64 + 1, block_number))
+            .map(|(idx, block_number)| test_utils::block_response(idx as u64 + 1, block_number))
             .collect::<Vec<_>>();
         let second_batch = (32..64)
             .enumerate()
-            .map(|(idx, block_number)| block_response((idx + 33) as u64, block_number))
+            .map(|(idx, block_number)| test_utils::block_response((idx + 33) as u64, block_number))
             .collect::<Vec<_>>();
-        let third_batch = vec![block_response(65, 64)];
+        let third_batch = vec![test_utils::block_response(65, 64)];
 
         let first_batch_mock = server
             .mock("POST", "/")
@@ -1430,9 +1392,7 @@ mod tests {
             .create_async()
             .await;
 
-        let client = Arc::new(EthereumClient::DirectRpc(
-            super::indexer_eth_direct_rpc::RpcEthereumClient::new(&server.url()),
-        ));
+        let client = Arc::new(test_utils::create_test_ethereum_client(&server.url()).await);
         let mut iter = CatchupIter::new(client, 0, 65);
 
         for expected_number in 0..65 {
@@ -1576,9 +1536,7 @@ mod tests {
             },
             state_manager,
             telemetry: NoopChainTelemetry,
-            client: Arc::new(EthereumClient::DirectRpc(
-                super::indexer_eth_direct_rpc::RpcEthereumClient::new(&server.url()),
-            )),
+            client: Arc::new(test_utils::create_test_ethereum_client(&server.url()).await),
             events_tx,
             contract_address: Address::ZERO,
             catchup_complete: Arc::new(Notify::new()),

--- a/chain-signatures/node/src/indexer_eth/test_utils.rs
+++ b/chain-signatures/node/src/indexer_eth/test_utils.rs
@@ -1,14 +1,16 @@
 use super::{EthConfig, EthereumClient};
-use backon::ExponentialBuilder;
+use crate::util::retry::RetryConfig;
 use std::time::Duration;
 
 /// Creates a test Ethereum client with a small retry strategy for testing purposes.
 pub async fn create_test_ethereum_client(url: &str) -> EthereumClient {
     // Use a small retry strategy for testing to avoid long delays
-    let retry_strategy = ExponentialBuilder::default()
-        .with_min_delay(Duration::from_millis(1))
-        .with_max_delay(Duration::from_millis(10))
-        .with_max_times(2);
+    let retry_strategy = RetryConfig {
+        min_delay: Duration::from_millis(1),
+        max_delay: Duration::from_millis(10),
+        max_times: 2,
+        jitter: false,
+    };
 
     let eth = EthConfig {
         execution_rpc_http_url: url.to_string(),

--- a/chain-signatures/node/src/indexer_eth/test_utils.rs
+++ b/chain-signatures/node/src/indexer_eth/test_utils.rs
@@ -1,0 +1,58 @@
+use super::{EthConfig, EthereumClient};
+use backon::ExponentialBuilder;
+use std::time::Duration;
+
+/// Creates a test Ethereum client with a small retry strategy for testing purposes.
+pub async fn create_test_ethereum_client(url: &str) -> EthereumClient {
+    // Use a small retry strategy for testing to avoid long delays
+    let retry_strategy = ExponentialBuilder::default()
+        .with_min_delay(Duration::from_millis(1))
+        .with_max_delay(Duration::from_millis(10))
+        .with_max_times(2);
+
+    let eth = EthConfig {
+        execution_rpc_http_url: url.to_string(),
+        light_client: false,
+        account_sk: "".to_string(),
+        consensus_rpc_http_url: "".to_string(),
+        contract_address: "".to_string(),
+        network: "".to_string(),
+        helios_data_path: "".to_string(),
+        refresh_finalized_interval: 0,
+        optimistic_requests: false,
+    };
+
+    EthereumClient::new_with_strategy(eth, retry_strategy)
+        .await
+        .unwrap()
+}
+
+pub fn block_response(request_id: u64, number: u64) -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": {
+            "number": format!("0x{number:x}"),
+            "hash": format!("0x{:064x}", number),
+            "parentHash": format!("0x{:064x}", number.saturating_sub(1)),
+            "sha3Uncles": format!("0x{:064x}", 1),
+            "logsBloom": format!("0x{}", "0".repeat(512)),
+            "transactionsRoot": format!("0x{:064x}", 2),
+            "stateRoot": format!("0x{:064x}", 3),
+            "receiptsRoot": format!("0x{:064x}", 4),
+            "miner": format!("0x{:040x}", 5),
+            "difficulty": "0x0",
+            "totalDifficulty": "0x0",
+            "extraData": "0x",
+            "size": "0x1",
+            "gasLimit": "0x1c9c380",
+            "gasUsed": "0x0",
+            "timestamp": "0x1",
+            "uncles": [],
+            "nonce": "0x0000000000000000",
+            "mixHash": format!("0x{:064x}", 9),
+            "baseFeePerGas": "0x1",
+            "transactions": []
+        }
+    })
+}

--- a/chain-signatures/node/src/indexer_sol/client.rs
+++ b/chain-signatures/node/src/indexer_sol/client.rs
@@ -422,4 +422,297 @@ impl SolanaClient {
     }
 }
 
-// TODO: add unit tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_sdk::pubkey::Pubkey;
+    use solana_sdk::signature::Signature;
+
+    /// Helper to create a SolanaClient for testing with mockito
+    fn test_client(url: &str) -> SolanaClient {
+        SolanaClient::for_indexer(
+            url.to_string(),
+            url.replace("http", "ws"),
+            Pubkey::new_unique(),
+        )
+        .with_fast_retry()
+    }
+
+    /// Helper to create a mock JSON-RPC response for getSlot
+    fn slot_response(slot: u64) -> String {
+        format!(r#"{{"jsonrpc":"2.0","id":1,"result":{slot}}}"#)
+    }
+
+    /// Helper to create a mock JSON-RPC response for getBlock
+    fn make_block_response(id: usize, slot: u64) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "result": {
+                "blockHeight": slot,
+                "blockTime": null,
+                "blockhash": "11111111111111111111111111111111",
+                "parentSlot": slot.saturating_sub(1),
+                "previousBlockhash": "11111111111111111111111111111111",
+                "transactions": [],
+                "rewards": []
+            }
+        })
+    }
+
+    /// Helper to create a mock JSON-RPC response for getSignaturesForAddress
+    fn signature_entry(slot: u64, sig: &str) -> serde_json::Value {
+        serde_json::json!({
+            "signature": sig,
+            "slot": slot,
+            "err": null,
+            "memo": null,
+            "blockTime": null,
+            "confirmationStatus": "confirmed"
+        })
+    }
+
+    /// Helper to create a mock JSON-RPC response for getSignaturesForAddress
+    fn signatures_response(entries: &[serde_json::Value]) -> String {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": entries
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn block_fetch_config_fields() {
+        let config = SolanaClient::block_fetch_config();
+        assert_eq!(config.encoding, Some(UiTransactionEncoding::Json));
+        assert_eq!(config.transaction_details, Some(TransactionDetails::Full));
+        assert_eq!(config.rewards, Some(false));
+        assert_eq!(
+            config.commitment.map(|c| c.commitment),
+            Some(solana_sdk::commitment_config::CommitmentLevel::Confirmed)
+        );
+        assert_eq!(config.max_supported_transaction_version, Some(0));
+    }
+
+    #[tokio::test]
+    async fn get_slot_returns_slot_on_200() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(slot_response(42))
+            .create_async()
+            .await;
+
+        let client = test_client(&server.url());
+        assert_eq!(client.get_slot().await.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn get_slot_retries_on_500_then_succeeds() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _fail = server
+            .mock("POST", "/")
+            .with_status(500)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let _ok = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(slot_response(7))
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = test_client(&server.url());
+        assert_eq!(client.get_slot().await.unwrap(), 7);
+    }
+
+    #[tokio::test]
+    async fn get_slot_exhausts_retries_on_persistent_500() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(500)
+            .expect(3) // 1 attempt + 2 retries
+            .create_async()
+            .await;
+
+        let client = test_client(&server.url());
+        assert!(client.get_slot().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn fetch_blocks_returns_blocks_on_200() {
+        let mut server = mockito::Server::new_async().await;
+        let body = serde_json::json!([make_block_response(0, 100), make_block_response(1, 101),])
+            .to_string();
+
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .create_async()
+            .await;
+
+        let client = test_client(&server.url());
+        let result = client.fetch_blocks(&[100, 101]).await;
+
+        assert_eq!(result.len(), 2);
+        assert!(result.contains_key(&100));
+        assert!(result.contains_key(&101));
+    }
+
+    #[tokio::test]
+    async fn fetch_blocks_returns_empty_for_empty_input() {
+        let server = mockito::Server::new_async().await;
+        let client = test_client(&server.url());
+        // Should short-circuit without any HTTP call
+        let result = client.fetch_blocks(&[]).await;
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fetch_blocks_skips_skipped_slots() {
+        let mut server = mockito::Server::new_async().await;
+
+        // Slot 101 is skipped (error code -32007), slot 100 is present
+        let body = serde_json::json!([
+            make_block_response(0, 100),
+            { "id": 1, "result": null, "error": { "code": -32007, "message": "Slot was skipped" } }
+        ])
+        .to_string();
+
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .create_async()
+            .await;
+
+        let client = test_client(&server.url());
+        let result = client.fetch_blocks(&[100, 101]).await;
+
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key(&100));
+        assert!(!result.contains_key(&101));
+    }
+
+    #[tokio::test]
+    async fn fetch_blocks_returns_empty_on_persistent_failure() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(500)
+            .expect(3) // 1 attempt + 2 retries
+            .create_async()
+            .await;
+
+        let client = test_client(&server.url());
+
+        // fetch_blocks swallows errors and returns empty map
+        let result = client.fetch_blocks(&[100, 101]).await;
+
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fetch_slots_filters_to_range() {
+        let mut server = mockito::Server::new_async().await;
+
+        // First page: slots 105, 103, 101, 98
+        // Second page: empty → stop
+        let sig_a = Signature::new_unique().to_string();
+        let sig_b = Signature::new_unique().to_string();
+        let sig_c = Signature::new_unique().to_string();
+        let sig_d = Signature::new_unique().to_string();
+
+        let page1 = signatures_response(&[
+            signature_entry(105, &sig_a),
+            signature_entry(103, &sig_b),
+            signature_entry(101, &sig_c),
+            signature_entry(98, &sig_d), // below start_slot=100, triggers stop
+        ]);
+
+        let _mock1 = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(page1)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = test_client(&server.url());
+
+        // Range [100, 104]: should include 103, 101 but not 105 (above end) or 98 (below start)
+        let slots = client.fetch_slots(100, 104).await.unwrap();
+
+        assert_eq!(slots, BTreeSet::from([101, 103]));
+    }
+
+    #[tokio::test]
+    async fn fetch_slots_returns_empty_when_no_signatures() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(signatures_response(&[]))
+            .create_async()
+            .await;
+
+        let client = test_client(&server.url());
+        let slots = client.fetch_slots(100, 200).await.unwrap();
+        assert!(slots.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fetch_signatures_paginates_until_start_slot() {
+        let mut server = mockito::Server::new_async().await;
+
+        let sig_a = Signature::new_unique().to_string();
+        let sig_b = Signature::new_unique().to_string();
+        let sig_c = Signature::new_unique().to_string();
+
+        // Page 1: slots 200, 150 — both in range [100, 200]
+        let page1 =
+            signatures_response(&[signature_entry(200, &sig_a), signature_entry(150, &sig_b)]);
+        // Page 2: slot 90 — below start_slot, stops pagination
+        let page2 = signatures_response(&[signature_entry(90, &sig_c)]);
+
+        let _mock1 = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(page1)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let _mock2 = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(page2)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = test_client(&server.url());
+        let sigs = client.fetch_signatures(100, 200).await.unwrap();
+
+        assert_eq!(sigs.len(), 2);
+        assert_eq!(sigs[0].slot, 200);
+        assert_eq!(sigs[1].slot, 150);
+    }
+}

--- a/chain-signatures/node/src/indexer_sol/client.rs
+++ b/chain-signatures/node/src/indexer_sol/client.rs
@@ -164,6 +164,7 @@ impl SolanaClient {
         &self,
         signature: &Signature,
     ) -> anyhow::Result<EncodedConfirmedTransactionWithStatusMeta> {
+        let max_attempts = self.retry_strategy.max_times;
         retry_rpc!(
             SOL_RPC_TIMEOUT,
             self.retry_strategy,
@@ -171,6 +172,7 @@ impl SolanaClient {
                 tracing::warn!(
                     operation = %signature,
                     attempt,
+                    max_attempts,
                     error = %err,
                     retry_in = ?sleep,
                     "get_tx failed, retrying"
@@ -193,15 +195,17 @@ impl SolanaClient {
     }
 
     pub async fn get_block(&self, slot: u64) -> anyhow::Result<UiConfirmedBlock> {
+        let max_attempts = self.retry_strategy.max_times;
         retry_rpc!(
             SOL_RPC_TIMEOUT,
             self.retry_strategy,
             // Notify on retry with structured logging
-            |attempts, err, delay| {
+            |attempt, err, delay| {
                 tracing::warn!(
                     ?err,
-                    attempts,
-                    slot,
+                    attempt,
+                    max_attempts,
+                    ?slot,
                     "failed to fetch Solana block; retrying in {:?}",
                     delay
                 );
@@ -220,14 +224,16 @@ impl SolanaClient {
             return HashMap::new();
         }
 
+        let max_attempts = self.retry_strategy.max_times;
         let res = retry_rpc!(
             SOL_BATCH_TIMEOUT,
             self.retry_strategy,
             // Notify on retry with structured logging
-            |attempts, err, delay| {
+            |attempt, err, delay| {
                 tracing::warn!(
                     ?err,
-                    attempts,
+                    attempt,
+                    max_attempts,
                     "failed to send batch request or deserialize response; retrying in {:?}",
                     delay
                 );

--- a/chain-signatures/node/src/indexer_sol/client.rs
+++ b/chain-signatures/node/src/indexer_sol/client.rs
@@ -167,7 +167,15 @@ impl SolanaClient {
         retry_rpc!(
             SOL_RPC_TIMEOUT,
             self.retry_strategy,
-            format!("get_tx({})", signature),
+            |attempt, err, sleep| {
+                tracing::warn!(
+                    operation = %signature,
+                    attempt,
+                    error = %err,
+                    retry_in = ?sleep,
+                    "get_tx failed, retrying"
+                );
+            },
             {
                 self.rpc_client
                     .get_transaction_with_config(
@@ -188,7 +196,6 @@ impl SolanaClient {
         retry_rpc!(
             SOL_RPC_TIMEOUT,
             self.retry_strategy,
-            format!("get_block({})", slot),
             // Notify on retry with structured logging
             |attempts, err, delay| {
                 tracing::warn!(
@@ -216,7 +223,6 @@ impl SolanaClient {
         let res = retry_rpc!(
             SOL_BATCH_TIMEOUT,
             self.retry_strategy,
-            "fetch_blocks",
             // Notify on retry with structured logging
             |attempts, err, delay| {
                 tracing::warn!(
@@ -285,7 +291,6 @@ impl SolanaClient {
         retry_rpc!(
             SOL_RPC_TIMEOUT,
             self.retry_strategy,
-            format!("fetch_signatures_from_latest({})", address),
             // Notify on retry with structured logging
             |attempts, err, delay| {
                 tracing::warn!(

--- a/chain-signatures/node/src/indexer_sol/client.rs
+++ b/chain-signatures/node/src/indexer_sol/client.rs
@@ -36,12 +36,22 @@ const SOL_RPC_MIN_DELAY: Duration = Duration::from_millis(500);
 const SOL_RPC_MAX_DELAY: Duration = Duration::from_secs(10);
 const SOL_RPC_MAX_RETRIES: usize = 5;
 
-/// Helper for consistent config
-fn default_sol_retry_strategy() -> RetryConfig {
+/// Default retry strategy
+fn default_retry_strategy() -> RetryConfig {
     RetryConfig {
         min_delay: SOL_RPC_MIN_DELAY,
         max_delay: SOL_RPC_MAX_DELAY,
         max_times: SOL_RPC_MAX_RETRIES,
+        jitter: true,
+    }
+}
+
+/// Retry strategy with infinite retries, used for get_block, fetch_blocks and fetch_signatures_from_latest (catchup path).
+fn catchup_retry_strategy() -> RetryConfig {
+    RetryConfig {
+        min_delay: SOL_RPC_MIN_DELAY,
+        max_delay: SOL_RPC_MAX_DELAY,
+        max_times: usize::MAX,
         jitter: true,
     }
 }
@@ -70,7 +80,10 @@ struct JsonRpcResponse<T> {
 #[derive(Clone)]
 pub struct SolanaClient {
     pub client: Arc<anchor_client::Client<Arc<Keypair>>>,
-    retry_strategy: RetryConfig,
+    /// Retry strategy for RPC calls that are not part of catchup (e.g. get_slot, get_tx)
+    rpc_retry: RetryConfig,
+    /// Retry strategy for RPC calls that are part of catchup (e.g. get_block, fetch_blocks, fetch_signatures_from_latest)
+    catchup_retry: RetryConfig,
     pub rpc_client: Arc<RpcClient>,
     pub rpc_http_url: String,
     pub rpc_ws_url: String,
@@ -95,7 +108,8 @@ impl SolanaClient {
             .expect("Invalid Solana program address provided in configuration");
         Self {
             client: Arc::new(client),
-            retry_strategy: default_sol_retry_strategy(),
+            rpc_retry: default_retry_strategy(),
+            catchup_retry: catchup_retry_strategy(),
             rpc_client,
             rpc_http_url: sol.rpc_http_url.clone(),
             rpc_ws_url: sol.rpc_ws_url.clone(),
@@ -119,7 +133,8 @@ impl SolanaClient {
         let rpc_client = Arc::new(RpcClient::new(rpc_http_url.clone()));
         Self {
             client: Arc::new(client),
-            retry_strategy: default_sol_retry_strategy(),
+            rpc_retry: default_retry_strategy(),
+            catchup_retry: catchup_retry_strategy(),
             rpc_client,
             rpc_http_url,
             rpc_ws_url,
@@ -132,12 +147,15 @@ impl SolanaClient {
     /// A helper function to create a SolanaClient with a custom retry strategy for testing purposes.
     #[cfg(test)]
     pub(crate) fn with_fast_retry(mut self) -> Self {
-        self.retry_strategy = RetryConfig {
+        let retry_config = RetryConfig {
             min_delay: Duration::from_millis(1),
             max_delay: Duration::from_millis(10),
             max_times: 2,
             jitter: true,
         };
+
+        self.rpc_retry = retry_config;
+        self.catchup_retry = retry_config;
         self
     }
 
@@ -152,7 +170,7 @@ impl SolanaClient {
     }
 
     pub async fn get_slot(&self) -> anyhow::Result<u64> {
-        retry_rpc!(SOL_RPC_TIMEOUT, self.retry_strategy, "get_slot", {
+        retry_rpc!(SOL_RPC_TIMEOUT, self.rpc_retry, "get_slot", {
             self.rpc_client
                 .get_slot()
                 .await
@@ -164,10 +182,10 @@ impl SolanaClient {
         &self,
         signature: &Signature,
     ) -> anyhow::Result<EncodedConfirmedTransactionWithStatusMeta> {
-        let max_attempts = self.retry_strategy.max_times;
+        let max_attempts = self.rpc_retry.max_times;
         retry_rpc!(
             SOL_RPC_TIMEOUT,
-            self.retry_strategy,
+            self.rpc_retry,
             |attempt, err, sleep| {
                 tracing::warn!(
                     operation = %signature,
@@ -195,10 +213,10 @@ impl SolanaClient {
     }
 
     pub async fn get_block(&self, slot: u64) -> anyhow::Result<UiConfirmedBlock> {
-        let max_attempts = self.retry_strategy.max_times;
+        let max_attempts = self.catchup_retry.max_times;
         retry_rpc!(
             SOL_RPC_TIMEOUT,
-            self.retry_strategy,
+            self.catchup_retry,
             // Notify on retry with structured logging
             |attempt, err, delay| {
                 tracing::warn!(
@@ -224,10 +242,10 @@ impl SolanaClient {
             return HashMap::new();
         }
 
-        let max_attempts = self.retry_strategy.max_times;
+        let max_attempts = self.catchup_retry.max_times;
         let res = retry_rpc!(
             SOL_BATCH_TIMEOUT,
-            self.retry_strategy,
+            self.catchup_retry,
             // Notify on retry with structured logging
             |attempt, err, delay| {
                 tracing::warn!(
@@ -296,7 +314,7 @@ impl SolanaClient {
     ) -> anyhow::Result<Vec<RpcConfirmedTransactionStatusWithSignature>> {
         retry_rpc!(
             SOL_RPC_TIMEOUT,
-            self.retry_strategy,
+            self.catchup_retry,
             // Notify on retry with structured logging
             |attempts, err, delay| {
                 tracing::warn!(

--- a/chain-signatures/node/src/indexer_sol/client.rs
+++ b/chain-signatures/node/src/indexer_sol/client.rs
@@ -1,4 +1,4 @@
-use backon::{ExponentialBuilder, Retryable};
+use super::SolConfig;
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -8,13 +8,16 @@ use solana_client::rpc_config::RpcBlockConfig;
 use solana_client::rpc_response::RpcConfirmedTransactionStatusWithSignature;
 use solana_sdk::signer::keypair::Keypair;
 use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey, signature::Signature};
-use solana_transaction_status::{TransactionDetails, UiConfirmedBlock, UiTransactionEncoding};
+use solana_transaction_status::{
+    EncodedConfirmedTransactionWithStatusMeta, TransactionDetails, UiConfirmedBlock,
+    UiTransactionEncoding,
+};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use super::SolConfig;
+use crate::util::retry::{retry_rpc, RetryConfig};
 
 const MAX_SIGNATURES_FOR_FAST_CATCHUP: usize = 1000;
 
@@ -26,6 +29,22 @@ const MAX_CHUNK_SIZE: usize = 50;
 
 /// The max chunk size allowed for fetching concurrently.
 pub const MAX_CONCURRENT_CHUNK_SIZE: usize = MAX_CONCURRENT_FETCH * MAX_CHUNK_SIZE;
+
+const SOL_RPC_TIMEOUT: Duration = Duration::from_secs(2);
+const SOL_BATCH_TIMEOUT: Duration = Duration::from_secs(30);
+const SOL_RPC_MIN_DELAY: Duration = Duration::from_millis(500);
+const SOL_RPC_MAX_DELAY: Duration = Duration::from_secs(10);
+const SOL_RPC_MAX_RETRIES: usize = 5;
+
+/// Helper for consistent config
+fn default_sol_retry_strategy() -> RetryConfig {
+    RetryConfig {
+        min_delay: SOL_RPC_MIN_DELAY,
+        max_delay: SOL_RPC_MAX_DELAY,
+        max_times: SOL_RPC_MAX_RETRIES,
+        jitter: true,
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum SolanaCatchupBlock {
@@ -51,6 +70,7 @@ struct JsonRpcResponse<T> {
 #[derive(Clone)]
 pub struct SolanaClient {
     pub client: Arc<anchor_client::Client<Arc<Keypair>>>,
+    retry_strategy: RetryConfig,
     pub rpc_client: Arc<RpcClient>,
     pub rpc_http_url: String,
     pub rpc_ws_url: String,
@@ -75,6 +95,7 @@ impl SolanaClient {
             .expect("Invalid Solana program address provided in configuration");
         Self {
             client: Arc::new(client),
+            retry_strategy: default_sol_retry_strategy(),
             rpc_client,
             rpc_http_url: sol.rpc_http_url.clone(),
             rpc_ws_url: sol.rpc_ws_url.clone(),
@@ -98,6 +119,7 @@ impl SolanaClient {
         let rpc_client = Arc::new(RpcClient::new(rpc_http_url.clone()));
         Self {
             client: Arc::new(client),
+            retry_strategy: default_sol_retry_strategy(),
             rpc_client,
             rpc_http_url,
             rpc_ws_url,
@@ -105,6 +127,18 @@ impl SolanaClient {
             program_id: program_address,
             payer,
         }
+    }
+
+    /// A helper function to create a SolanaClient with a custom retry strategy for testing purposes.
+    #[cfg(test)]
+    pub(crate) fn with_fast_retry(mut self) -> Self {
+        self.retry_strategy = RetryConfig {
+            min_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(10),
+            max_times: 2,
+            jitter: true,
+        };
+        self
     }
 
     pub fn block_fetch_config() -> RpcBlockConfig {
@@ -117,21 +151,46 @@ impl SolanaClient {
         }
     }
 
-    pub async fn get_block(&self, slot: u64) -> UiConfirmedBlock {
-        let mut attempts = 1;
-        let fetch = || async {
+    pub async fn get_slot(&self) -> anyhow::Result<u64> {
+        retry_rpc!(SOL_RPC_TIMEOUT, self.retry_strategy, "get_slot", {
             self.rpc_client
-                .get_block_with_config(slot, Self::block_fetch_config())
+                .get_slot()
                 .await
-        };
-        fetch
-            .retry(
-                &ExponentialBuilder::default()
-                    .with_min_delay(Duration::from_millis(500))
-                    .with_max_delay(Duration::from_secs(10))
-                    .with_max_times(usize::MAX),
-            )
-            .notify(|err, delay| {
+                .map_err(|e| anyhow::anyhow!(e))
+        })
+    }
+
+    pub async fn get_tx(
+        &self,
+        signature: &Signature,
+    ) -> anyhow::Result<EncodedConfirmedTransactionWithStatusMeta> {
+        retry_rpc!(
+            SOL_RPC_TIMEOUT,
+            self.retry_strategy,
+            format!("get_tx({})", signature),
+            {
+                self.rpc_client
+                    .get_transaction_with_config(
+                        signature,
+                        solana_client::rpc_config::RpcTransactionConfig {
+                            encoding: Some(UiTransactionEncoding::JsonParsed),
+                            commitment: Some(CommitmentConfig::confirmed()),
+                            max_supported_transaction_version: Some(0),
+                        },
+                    )
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+        )
+    }
+
+    pub async fn get_block(&self, slot: u64) -> anyhow::Result<UiConfirmedBlock> {
+        retry_rpc!(
+            SOL_RPC_TIMEOUT,
+            self.retry_strategy,
+            format!("get_block({})", slot),
+            // Notify on retry with structured logging
+            |attempts, err, delay| {
                 tracing::warn!(
                     ?err,
                     attempts,
@@ -139,10 +198,14 @@ impl SolanaClient {
                     "failed to fetch Solana block; retrying in {:?}",
                     delay
                 );
-                attempts += 1;
-            })
-            .await
-            .expect("Solana get_block eventually succeeded")
+            },
+            {
+                self.rpc_client
+                    .get_block_with_config(slot, Self::block_fetch_config())
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+        )
     }
 
     pub async fn fetch_blocks(&self, slots: &[u64]) -> HashMap<u64, UiConfirmedBlock> {
@@ -150,108 +213,101 @@ impl SolanaClient {
             return HashMap::new();
         }
 
-        let mut attempts = 1;
-        let fetch = || async {
-            let mut requests = Vec::new();
-            for (i, &slot) in slots.iter().enumerate() {
-                let config = Self::block_fetch_config();
-                let config_val = serde_json::to_value(config)
-                    .map_err(|e| anyhow::anyhow!("serialization error: {e}"))?;
-                requests.push(JsonRpcRequest {
-                    jsonrpc: "2.0",
-                    id: i,
-                    method: "getBlock",
-                    params: json!([slot, config_val]),
-                });
-            }
-
-            let resp = self
-                .http_client
-                .post(&self.rpc_http_url)
-                .json(&requests)
-                .send()
-                .await?;
-            let responses = resp
-                .json::<Vec<JsonRpcResponse<UiConfirmedBlock>>>()
-                .await?;
-
-            let mut results = HashMap::new();
-            for resp_obj in responses {
-                if let Some(block) = resp_obj.result {
-                    if resp_obj.id < slots.len() {
-                        let slot = slots[resp_obj.id];
-                        results.insert(slot, block);
-                    }
-                } else if let Some(err) = resp_obj.error {
-                    let is_skipped = err
-                        .get("code")
-                        .and_then(|c| c.as_i64())
-                        .map(|c| c == -32007)
-                        .unwrap_or(false);
-                    let slot = slots.get(resp_obj.id);
-                    if !is_skipped {
-                        tracing::warn!(?err, ?slot, "JSON-RPC batch response error");
-                    }
-                }
-            }
-            Ok(results)
-        };
-
-        fetch
-            .retry(
-                &ExponentialBuilder::default()
-                    .with_min_delay(Duration::from_millis(500))
-                    .with_max_delay(Duration::from_secs(10))
-                    .with_max_times(usize::MAX),
-            )
-            .notify(|err: &anyhow::Error, delay| {
+        let res = retry_rpc!(
+            SOL_BATCH_TIMEOUT,
+            self.retry_strategy,
+            "fetch_blocks",
+            // Notify on retry with structured logging
+            |attempts, err, delay| {
                 tracing::warn!(
                     ?err,
                     attempts,
                     "failed to send batch request or deserialize response; retrying in {:?}",
                     delay
                 );
-                attempts += 1;
-            })
-            .await
-            .unwrap_or_default()
+            },
+            {
+                let mut requests = Vec::new();
+                for (i, &slot) in slots.iter().enumerate() {
+                    let config = Self::block_fetch_config();
+                    let config_val = serde_json::to_value(config)
+                        .map_err(|e| anyhow::anyhow!("serialization error: {e}"))?;
+                    requests.push(JsonRpcRequest {
+                        jsonrpc: "2.0",
+                        id: i,
+                        method: "getBlock",
+                        params: json!([slot, config_val]),
+                    });
+                }
+
+                let resp = self
+                    .http_client
+                    .post(&self.rpc_http_url)
+                    .json(&requests)
+                    .send()
+                    .await?;
+                let responses = resp
+                    .json::<Vec<JsonRpcResponse<UiConfirmedBlock>>>()
+                    .await?;
+
+                let mut results = HashMap::new();
+                for resp_obj in responses {
+                    if let Some(block) = resp_obj.result {
+                        if resp_obj.id < slots.len() {
+                            let slot = slots[resp_obj.id];
+                            results.insert(slot, block);
+                        }
+                    } else if let Some(err) = resp_obj.error {
+                        let is_skipped = err
+                            .get("code")
+                            .and_then(|c| c.as_i64())
+                            .map(|c| c == -32007)
+                            .unwrap_or(false);
+                        let slot = slots.get(resp_obj.id);
+                        if !is_skipped {
+                            tracing::warn!(?err, ?slot, "JSON-RPC batch response error");
+                        }
+                    }
+                }
+                Ok::<HashMap<u64, UiConfirmedBlock>, anyhow::Error>(results)
+            }
+        );
+
+        // If batch fails entirely, return an empty map
+        res.unwrap_or_default()
     }
 
     pub async fn fetch_signatures_from_latest(
         &self,
         address: &Pubkey,
         before: Option<Signature>,
-    ) -> Vec<RpcConfirmedTransactionStatusWithSignature> {
-        let mut attempts = 1;
-        let fetch = || async {
-            let config = GetConfirmedSignaturesForAddress2Config {
-                before,
-                until: None,
-                limit: Some(MAX_SIGNATURES_FOR_FAST_CATCHUP),
-                commitment: Some(CommitmentConfig::confirmed()),
-            };
-            self.rpc_client
-                .get_signatures_for_address_with_config(address, config)
-                .await
-        };
-        fetch
-            .retry(
-                &ExponentialBuilder::default()
-                    .with_min_delay(Duration::from_millis(500))
-                    .with_max_delay(Duration::from_secs(10))
-                    .with_max_times(usize::MAX),
-            )
-            .notify(|err, delay| {
+    ) -> anyhow::Result<Vec<RpcConfirmedTransactionStatusWithSignature>> {
+        retry_rpc!(
+            SOL_RPC_TIMEOUT,
+            self.retry_strategy,
+            format!("fetch_signatures_from_latest({})", address),
+            // Notify on retry with structured logging
+            |attempts, err, delay| {
                 tracing::warn!(
                     ?err,
                     attempts,
                     "failed to fetch signatures for address; retrying in {:?}",
                     delay
                 );
-                attempts += 1;
-            })
-            .await
-            .expect("Solana fetch_signatures_from_latest eventually succeeded")
+            },
+            {
+                let config = GetConfirmedSignaturesForAddress2Config {
+                    before,
+                    until: None,
+                    limit: Some(MAX_SIGNATURES_FOR_FAST_CATCHUP),
+                    commitment: Some(CommitmentConfig::confirmed()),
+                };
+                self.rpc_client
+                    .get_signatures_for_address_with_config(address, config)
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+        )
     }
 
     /// Fetch signatures within the range provided [start_slot, end_slot]
@@ -259,7 +315,7 @@ impl SolanaClient {
         &self,
         start_slot: u64,
         end_slot: u64,
-    ) -> Vec<RpcConfirmedTransactionStatusWithSignature> {
+    ) -> anyhow::Result<Vec<RpcConfirmedTransactionStatusWithSignature>> {
         let mut signatures = Vec::new();
         let mut before = None;
         tracing::trace!(start_slot, end_slot, "fetching signatures in range");
@@ -272,7 +328,8 @@ impl SolanaClient {
         loop {
             let batch = self
                 .fetch_signatures_from_latest(&self.program_id, before)
-                .await;
+                .await?;
+
             if batch.is_empty() {
                 tracing::trace!(
                     ?before,
@@ -311,16 +368,17 @@ impl SolanaClient {
             }
             before = last_sig;
         }
-        signatures
+        Ok(signatures)
     }
 
     /// Fetch slots covered by signatures in the range provided [start_slot, end_slot]
-    pub async fn fetch_slots(&self, start_slot: u64, end_slot: u64) -> BTreeSet<u64> {
-        self.fetch_signatures(start_slot, end_slot)
-            .await
-            .into_iter()
-            .map(|sig| sig.slot)
-            .collect()
+    pub async fn fetch_slots(
+        &self,
+        start_slot: u64,
+        end_slot: u64,
+    ) -> anyhow::Result<BTreeSet<u64>> {
+        let sigs = self.fetch_signatures(start_slot, end_slot).await?;
+        Ok(sigs.into_iter().map(|sig| sig.slot).collect())
     }
 
     pub async fn fetch_blocks_for_slots(
@@ -358,3 +416,5 @@ impl SolanaClient {
         blocks_by_height
     }
 }
+
+// TODO: add unit tests

--- a/chain-signatures/node/src/indexer_sol/mod.rs
+++ b/chain-signatures/node/src/indexer_sol/mod.rs
@@ -5,7 +5,8 @@ use crate::protocol::Chain;
 use crate::sign_bidirectional::hash_rlp_data;
 use crate::stream::{ChainIndexer, ChainStream};
 use crate::util::ethabi_request_id;
-use crate::util::retry::{retry_async, RetryConfig, RetryError, RetryReason};
+// TODO: import from mpc-indexer-core later
+use crate::retry_rpc;
 pub use client::{SolanaCatchupBlock, SolanaClient, MAX_CONCURRENT_CHUNK_SIZE};
 pub use config::SolConfig;
 
@@ -20,6 +21,7 @@ use anchor_lang::solana_program::keccak;
 use anchor_lang::Discriminator;
 use anyhow::Context;
 use async_trait::async_trait;
+use backon::ExponentialBuilder;
 use futures_util::stream::StreamExt;
 use futures_util::Stream;
 use k256::elliptic_curve::sec1::FromEncodedPoint;
@@ -58,6 +60,19 @@ const CPI_RESPOND_EVENT_HINTS: &[&str] = &[
     "Program log: Instruction: RespondBidirectional",
 ];
 
+const SOL_RPC_TIMEOUT: Duration = Duration::from_secs(2);
+const SOL_RPC_MIN_DELAY: Duration = Duration::from_millis(500);
+const SOL_RPC_MAX_DELAY: Duration = Duration::from_secs(10);
+const SOL_RPC_MAX_RETRIES: usize = 5;
+
+/// Helper for consistent config
+fn sol_retry_strategy() -> ExponentialBuilder {
+    ExponentialBuilder::default()
+        .with_jitter()
+        .with_min_delay(SOL_RPC_MIN_DELAY)
+        .with_max_delay(SOL_RPC_MAX_DELAY)
+        .with_max_times(SOL_RPC_MAX_RETRIES)
+}
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct SolSignRequest {
     pub payload: [u8; 32],
@@ -590,21 +605,13 @@ async fn subscribe_to_program_events<T: ChainTelemetry>(
     // with no gaps. We do not wait for the first WS event because that could deadlock if
     // no program-mentioning transactions arrive (e.g. in tests after a single sign call).
     if let Some(anchor_tx) = anchor_tx.take() {
-        match rpc_client
-            .get_slot_with_commitment(CommitmentConfig::confirmed())
-            .await
-        {
-            Ok(slot) => {
-                let _ = anchor_tx.send(slot);
-            }
-            Err(err) => {
-                tracing::warn!(
-                    ?err,
-                    "failed to fetch anchor slot after WS subscribe; retry on reconnect"
-                );
-                // Drop anchor_tx — livestream() will receive a RecvError and propagate the failure.
-            }
-        }
+        let slot = retry_rpc!(
+            "get_slot",
+            SOL_RPC_TIMEOUT,
+            &sol_retry_strategy(),
+            rpc_client.get_slot_with_commitment(CommitmentConfig::confirmed()).await
+        )?;
+        let _ = anchor_tx.send(slot);
     }
 
     // stall watchdog
@@ -651,7 +658,7 @@ async fn subscribe_to_program_events<T: ChainTelemetry>(
                             continue;
                         }
 
-                        let tx_res = match get_tx(rpc_client, &signature, RetryConfig::default()).await {
+                        let tx_res = match get_tx(rpc_client, &signature).await {
                             Ok(tx) => tx,
                             Err(e) => {
                                 tracing::warn!("Failed to fetch transaction {}: {}", signature, e);
@@ -948,68 +955,27 @@ pub fn to_mpc_signature(
     })
 }
 
-/// Fetch transaction with timeout + retry.
+/// Fetch transaction with timeout + retry using `backon`.
 /// Returns the same type as `RpcClient::get_transaction_with_config`.
 async fn get_tx(
     rpc_client: &RpcClient,
     signature: &Signature,
-    retry_cfg: RetryConfig,
 ) -> anyhow::Result<EncodedConfirmedTransactionWithStatusMeta> {
-    let max_attempts = retry_cfg.max_attempts;
-
-    let res = retry_async(
-        retry_cfg,
-        |attempt| async move {
-            rpc_client
-                .get_transaction_with_config(
-                    signature,
-                    solana_client::rpc_config::RpcTransactionConfig {
-                        encoding: Some(UiTransactionEncoding::JsonParsed),
-                        commitment: Some(CommitmentConfig::confirmed()),
-                        max_supported_transaction_version: Some(0),
-                    },
-                )
-                .await
-                .map_err(|e| {
-                    anyhow::anyhow!(e).context(format!(
-                        "getTransaction failed (attempt {attempt}/{}) for {}",
-                        max_attempts, signature
-                    ))
-                })
-        },
-        |_attempt, _reason| true,
-        |attempt, reason, sleep| match reason {
-            RetryReason::Error(e) => {
-                tracing::warn!(
-                    "getTransaction failed (attempt {attempt}/{}) for {}: {e:#}; retrying in {sleep:?}",
-                    max_attempts,
-                    signature
-                );
-            }
-            RetryReason::Timeout(t) => {
-                tracing::warn!(
-                    "getTransaction timed out after {t:?} (attempt {attempt}/{}) for {}; retrying in {sleep:?}",
-                    max_attempts,
-                    signature
-                );
-            }
-        },
+    retry_rpc!(
+        format!("get_tx({})", signature),
+        SOL_RPC_TIMEOUT,
+        &sol_retry_strategy(),
+        rpc_client
+            .get_transaction_with_config(
+                signature,
+                solana_client::rpc_config::RpcTransactionConfig {
+                    encoding: Some(UiTransactionEncoding::JsonParsed),
+                    commitment: Some(CommitmentConfig::confirmed()),
+                    max_supported_transaction_version: Some(0),
+                },
+            )
+            .await
     )
-    .await;
-
-    match res {
-        Ok(tx) => Ok(tx),
-        Err(RetryError::Exhausted { last_error, .. }) => Err(last_error),
-        Err(RetryError::TimeoutExhausted {
-            attempts,
-            last_timeout,
-        }) => Err(anyhow::anyhow!(
-            "getTransaction timed out after {:?} (attempt {attempts}/{}) for {}",
-            last_timeout,
-            max_attempts,
-            signature
-        )),
-    }
 }
 
 #[cfg(test)]

--- a/chain-signatures/node/src/indexer_sol/mod.rs
+++ b/chain-signatures/node/src/indexer_sol/mod.rs
@@ -609,7 +609,9 @@ async fn subscribe_to_program_events<T: ChainTelemetry>(
             "get_slot",
             SOL_RPC_TIMEOUT,
             &sol_retry_strategy(),
-            rpc_client.get_slot_with_commitment(CommitmentConfig::confirmed()).await
+            rpc_client
+                .get_slot_with_commitment(CommitmentConfig::confirmed())
+                .await
         )?;
         let _ = anchor_tx.send(slot);
     }

--- a/chain-signatures/node/src/indexer_sol/mod.rs
+++ b/chain-signatures/node/src/indexer_sol/mod.rs
@@ -604,6 +604,7 @@ async fn subscribe_to_program_events<T: ChainTelemetry>(
                     ?err,
                     "failed to fetch anchor slot after WS subscribe; retry on reconnect"
                 );
+                // Drop anchor_tx — livestream() will receive a RecvError and propagate the failure.
             }
         }
     }

--- a/chain-signatures/node/src/indexer_sol/mod.rs
+++ b/chain-signatures/node/src/indexer_sol/mod.rs
@@ -959,7 +959,9 @@ mod tests {
     use mpc_primitives::NoopChainTelemetry;
     use solana_sdk::commitment_config::CommitmentLevel;
     use solana_sdk::pubkey::Pubkey;
-    use solana_transaction_status::{TransactionDetails, UiTransactionEncoding, UiTransactionStatusMeta};
+    use solana_transaction_status::{
+        TransactionDetails, UiTransactionEncoding, UiTransactionStatusMeta,
+    };
 
     #[test]
     fn request_id_matches_ethabi() {

--- a/chain-signatures/node/src/indexer_sol/mod.rs
+++ b/chain-signatures/node/src/indexer_sol/mod.rs
@@ -5,8 +5,6 @@ use crate::protocol::Chain;
 use crate::sign_bidirectional::hash_rlp_data;
 use crate::stream::{ChainIndexer, ChainStream};
 use crate::util::ethabi_request_id;
-// TODO: import from mpc-indexer-core later
-use crate::retry_rpc;
 pub use client::{SolanaCatchupBlock, SolanaClient, MAX_CONCURRENT_CHUNK_SIZE};
 pub use config::SolConfig;
 
@@ -21,7 +19,6 @@ use anchor_lang::solana_program::keccak;
 use anchor_lang::Discriminator;
 use anyhow::Context;
 use async_trait::async_trait;
-use backon::ExponentialBuilder;
 use futures_util::stream::StreamExt;
 use futures_util::Stream;
 use k256::elliptic_curve::sec1::FromEncodedPoint;
@@ -38,15 +35,14 @@ use signet_program::{
     SignatureRespondedEvent,
 };
 use solana_client::{
-    nonblocking::{pubsub_client::PubsubClient, rpc_client::RpcClient},
+    nonblocking::pubsub_client::PubsubClient,
     rpc_config::{RpcTransactionLogsConfig, RpcTransactionLogsFilter},
 };
 use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey, signature::Signature};
 use solana_transaction_status::option_serializer::OptionSerializer;
 use solana_transaction_status::{
-    EncodedConfirmedTransactionWithStatusMeta, EncodedTransaction,
-    EncodedTransactionWithStatusMeta, UiConfirmedBlock, UiInstruction, UiParsedInstruction,
-    UiTransactionEncoding,
+    EncodedTransaction, EncodedTransactionWithStatusMeta, UiConfirmedBlock, UiInstruction,
+    UiParsedInstruction,
 };
 use tokio::sync::{mpsc, oneshot};
 
@@ -60,19 +56,6 @@ const CPI_RESPOND_EVENT_HINTS: &[&str] = &[
     "Program log: Instruction: RespondBidirectional",
 ];
 
-const SOL_RPC_TIMEOUT: Duration = Duration::from_secs(2);
-const SOL_RPC_MIN_DELAY: Duration = Duration::from_millis(500);
-const SOL_RPC_MAX_DELAY: Duration = Duration::from_secs(10);
-const SOL_RPC_MAX_RETRIES: usize = 5;
-
-/// Helper for consistent config
-fn sol_retry_strategy() -> ExponentialBuilder {
-    ExponentialBuilder::default()
-        .with_jitter()
-        .with_min_delay(SOL_RPC_MIN_DELAY)
-        .with_max_delay(SOL_RPC_MAX_DELAY)
-        .with_max_times(SOL_RPC_MAX_RETRIES)
-}
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct SolSignRequest {
     pub payload: [u8; 32],
@@ -188,16 +171,13 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for SolanaIndexer<S, T> {
         self.live_rx = Some(live_rx);
 
         let program_id = self.program_id;
-        let rpc_http_url = self.client.rpc_http_url.clone();
-        let rpc_ws_url = self.client.rpc_ws_url.clone();
 
         // Oneshot to receive the first observed slot from the live subscription.
         let (anchor_tx, anchor_rx) = oneshot::channel::<u64>();
 
         tokio::spawn(subscribe_and_buffer_live_events(
             program_id,
-            rpc_http_url,
-            rpc_ws_url,
+            self.client.clone(),
             live_tx,
             anchor_tx,
             self.telemetry.clone(),
@@ -221,7 +201,17 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for SolanaIndexer<S, T> {
             return Box::pin(futures_util::stream::empty());
         }
 
-        let slots = self.client.fetch_slots(start_slot, end_slot).await;
+        // TODO: should probably propagate the error, but it would require updating the ChainIndexer trait
+        let slots = match self.client.fetch_slots(start_slot, end_slot).await {
+            Ok(slots) => slots,
+            Err(err) => {
+                tracing::warn!(
+                    ?err,
+                    "failed to fetch slots for catchup, returning empty stream"
+                );
+                return Box::pin(futures_util::stream::empty());
+            }
+        };
         let remaining_slots: VecDeque<u64> = slots.into_iter().collect();
 
         let client = self.client.clone();
@@ -254,7 +244,7 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for SolanaIndexer<S, T> {
         match block {
             SolanaCatchupBlock::Block(block) => self.process_block(*slot, block).await,
             SolanaCatchupBlock::Missing => {
-                let block = self.client.get_block(*slot).await;
+                let block = self.client.get_block(*slot).await?;
                 self.process_block(*slot, &block).await
             }
         }
@@ -461,13 +451,11 @@ impl SolanaSignEvent {
 /// catchup covers `[persisted_block, anchor)` with no gaps.
 async fn subscribe_and_buffer_live_events<T: ChainTelemetry>(
     program_id: Pubkey,
-    rpc_url: String,
-    ws_url: String,
+    client: SolanaClient,
     live_tx: mpsc::Sender<ChainEvent>,
     anchor_tx: oneshot::Sender<u64>,
     telemetry: T,
 ) {
-    let rpc = RpcClient::new(rpc_url);
     let mut anchor_tx = Some(anchor_tx);
     loop {
         // TODO: if solana ever fails and needs to retry, we actually need to do catchup
@@ -475,8 +463,7 @@ async fn subscribe_and_buffer_live_events<T: ChainTelemetry>(
         // high level of run_stream. Issue: https://github.com/sig-net/mpc/issues/811
         let result = subscribe_to_program_events(
             program_id,
-            &rpc,
-            &ws_url,
+            &client,
             live_tx.clone(),
             &mut anchor_tx,
             telemetry.clone(),
@@ -584,13 +571,12 @@ fn parse_cpi_events(
 
 async fn subscribe_to_program_events<T: ChainTelemetry>(
     program_id: Pubkey,
-    rpc_client: &RpcClient,
-    ws_url: &str,
+    client: &SolanaClient,
     events_tx: mpsc::Sender<ChainEvent>,
     anchor_tx: &mut Option<oneshot::Sender<u64>>,
     telemetry: T,
 ) -> anyhow::Result<()> {
-    let pubsub_client = PubsubClient::new(ws_url).await?;
+    let pubsub_client = PubsubClient::new(&client.rpc_ws_url).await?;
 
     let filter = RpcTransactionLogsFilter::Mentions(vec![program_id.to_string()]);
     let config = RpcTransactionLogsConfig {
@@ -605,15 +591,21 @@ async fn subscribe_to_program_events<T: ChainTelemetry>(
     // with no gaps. We do not wait for the first WS event because that could deadlock if
     // no program-mentioning transactions arrive (e.g. in tests after a single sign call).
     if let Some(anchor_tx) = anchor_tx.take() {
-        let slot = retry_rpc!(
-            "get_slot",
-            SOL_RPC_TIMEOUT,
-            &sol_retry_strategy(),
-            rpc_client
-                .get_slot_with_commitment(CommitmentConfig::confirmed())
-                .await
-        )?;
-        let _ = anchor_tx.send(slot);
+        match client
+            .rpc_client
+            .get_slot_with_commitment(CommitmentConfig::confirmed())
+            .await
+        {
+            Ok(slot) => {
+                let _ = anchor_tx.send(slot);
+            }
+            Err(err) => {
+                tracing::warn!(
+                    ?err,
+                    "failed to fetch anchor slot after WS subscribe; retry on reconnect"
+                );
+            }
+        }
     }
 
     // stall watchdog
@@ -660,7 +652,7 @@ async fn subscribe_to_program_events<T: ChainTelemetry>(
                             continue;
                         }
 
-                        let tx_res = match get_tx(rpc_client, &signature).await {
+                        let tx_res = match client.get_tx(&signature).await {
                             Ok(tx) => tx,
                             Err(e) => {
                                 tracing::warn!("Failed to fetch transaction {}: {}", signature, e);
@@ -957,29 +949,6 @@ pub fn to_mpc_signature(
     })
 }
 
-/// Fetch transaction with timeout + retry using `backon`.
-/// Returns the same type as `RpcClient::get_transaction_with_config`.
-async fn get_tx(
-    rpc_client: &RpcClient,
-    signature: &Signature,
-) -> anyhow::Result<EncodedConfirmedTransactionWithStatusMeta> {
-    retry_rpc!(
-        format!("get_tx({})", signature),
-        SOL_RPC_TIMEOUT,
-        &sol_retry_strategy(),
-        rpc_client
-            .get_transaction_with_config(
-                signature,
-                solana_client::rpc_config::RpcTransactionConfig {
-                    encoding: Some(UiTransactionEncoding::JsonParsed),
-                    commitment: Some(CommitmentConfig::confirmed()),
-                    max_supported_transaction_version: Some(0),
-                },
-            )
-            .await
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -990,7 +959,7 @@ mod tests {
     use mpc_primitives::NoopChainTelemetry;
     use solana_sdk::commitment_config::CommitmentLevel;
     use solana_sdk::pubkey::Pubkey;
-    use solana_transaction_status::{TransactionDetails, UiTransactionStatusMeta};
+    use solana_transaction_status::{TransactionDetails, UiTransactionEncoding, UiTransactionStatusMeta};
 
     #[test]
     fn request_id_matches_ethabi() {

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -17,6 +17,7 @@ use alloy::primitives::Address;
 use alloy::providers::fillers::{FillProvider, JoinFill, WalletFiller};
 use alloy::providers::{Provider, RootProvider, WalletProvider};
 use alloy::rpc::types::{Transaction, TransactionReceipt};
+use backon::{ConstantBuilder, ExponentialBuilder, Retryable};
 use cait_sith::protocol::Participant;
 use cait_sith::FullSignature;
 use k256::{AffinePoint, Secp256k1};
@@ -31,7 +32,7 @@ use crate::indexer_canton::ledger_api::{
 use crate::indexer_canton::{CantonAuthProvider, CantonConfig};
 use crate::indexer_hydration::HydrationConfig;
 use crate::indexer_sol::SolanaClient;
-use crate::util::retry::{retry_async, Backoff, RetryConfig, RetryError, RetryReason};
+// use crate::util::retry::{retry_async, Backoff, RetryConfig, RetryError, RetryReason};
 use alloy::contract::{ContractInstance, Interface};
 use alloy::dyn_abi::DynSolValue;
 use alloy::network::EthereumWallet;
@@ -1270,72 +1271,70 @@ async fn execute_publish(client: ChainClient, action: PublishAction) {
         "trying to publish signature",
     );
 
-    let retry_cfg = RetryConfig {
-        max_attempts: MAX_PUBLISH_RETRY,
-        per_attempt_timeout: Duration::from_secs(120),
-        backoff: Backoff::Fixed(Duration::from_secs(5)),
-    };
+    // TODO: consider adding jitter
+    let backoff = ConstantBuilder::default()
+        .with_delay(Duration::from_secs(5)) // TODO: use constant
+        .with_max_times(MAX_PUBLISH_RETRY);
 
-    let publish_res: Result<(), RetryError<()>> = retry_async(
-        retry_cfg,
-        |_attempt| async {
+    let mut attempt = 0;
+
+    let publish_op = || async {
+        let fut = async {
             match &client {
                 ChainClient::Near(near) => {
                     try_publish_near(near, &action, &action.timestamp, &action.signature)
                         .await
-                        .map_err(|_| ())
+                        .map_err(|_| anyhow::anyhow!("Near publish failed"))
                 }
                 ChainClient::Ethereum(eth) => {
-                    try_publish_eth(eth, &action, &action.timestamp, &action.signature).await
+                    try_publish_eth(eth, &action, &action.timestamp, &action.signature)
+                        .await
+                        .map_err(|_| anyhow::anyhow!("Ethereum publish failed"))
                 }
                 ChainClient::Solana(sol) => {
                     try_publish_sol(sol, &action, &action.timestamp, &action.signature)
                         .await
-                        .map_err(|_| ())
+                        .map_err(|_| anyhow::anyhow!("Solana publish failed"))
                 }
                 ChainClient::Hydration(hyd) => {
                     try_publish_hydration(hyd, &action, &action.timestamp, &action.signature)
                         .await
-                        .map_err(|_| ())
+                        .map_err(|_| anyhow::anyhow!("Hydration publish failed"))
                 }
                 ChainClient::Canton(canton) => {
                     try_publish_canton(canton, &action, &action.timestamp, &action.signature)
                         .await
-                        .map_err(|_| ())
+                        .map_err(|_| anyhow::anyhow!("Canton publish failed"))
                 }
                 ChainClient::Err(msg) => {
                     tracing::error!(msg, "no client for chain");
                     Ok(())
                 }
             }
-        },
-        |_attempt, _reason| true,
-        |attempt, reason, sleep| match reason {
-            RetryReason::Error(_) => {
-                tracing::warn!(
-                    ?sign_id,
-                    retry_count = attempt.saturating_sub(1),
-                    elapsed = ?action.timestamp.elapsed(),
-                    chain = ?action.indexed.chain,
-                    "failed to publish, retrying in {sleep:?}"
-                );
-            }
-            RetryReason::Timeout(t) => {
-                tracing::warn!(
-                    ?sign_id,
-                    retry_count = attempt.saturating_sub(1),
-                    elapsed = ?action.timestamp.elapsed(),
-                    chain = ?action.indexed.chain,
-                    "publish timed out after {t:?}, retrying in {sleep:?}"
-                );
-            }
-        },
-    )
-    .await;
+        };
 
-    let publish_ok = publish_res.is_ok();
+        match tokio::time::timeout(Duration::from_secs(120), fut).await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(e),
+            Err(_) => Err(anyhow::anyhow!("Publish attempt timed out")),
+        }
+    };
 
-    if publish_ok {
+    let publish_res = publish_op
+        .retry(&backoff)
+        .notify(|err: &anyhow::Error, sleep: Duration| {
+            attempt += 1;
+            tracing::warn!(
+                ?sign_id,
+                retry_count = attempt,
+                elapsed = ?action.timestamp.elapsed(),
+                ?chain,
+                "failed to publish ({err}), retrying in {sleep:?}"
+            );
+        })
+        .await;
+
+    if publish_res.is_ok() {
         let elapsed_secs =
             crate::util::unix_elapsed(action.indexed.unix_timestamp_indexed).as_secs();
         if elapsed_secs <= chain.expected_response_time_secs() {
@@ -1429,12 +1428,6 @@ async fn try_publish_near(
     Ok(())
 }
 
-#[derive(Debug)]
-enum PollErr {
-    NotReady,
-    Rpc(anyhow::Error),
-}
-
 // wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
 async fn wait_for_pending_tx(
     provider: &EthContractFillProvider,
@@ -1442,61 +1435,38 @@ async fn wait_for_pending_tx(
     sign_ids: Vec<SignId>,
     max_attempts: usize,
 ) -> Result<Transaction, ()> {
-    let sign_ids_ref = &sign_ids;
+    // TODO: use constants, consider adding jitter
+    let backoff = ExponentialBuilder::default()
+        .with_min_delay(Duration::from_secs(1))
+        .with_max_delay(Duration::from_secs(10))
+        .with_max_times(max_attempts);
 
-    let cfg = RetryConfig {
-        max_attempts,
-        per_attempt_timeout: Duration::from_secs(5),
-        backoff: Backoff::ExponentialJitter {
-            base: Duration::from_secs(1),
-            cap: Duration::from_secs(10),
-            jitter_max_ms: 0,
-        },
+    let mut attempt = 0;
+    let poll_op = || async {
+        let fut = provider.get_transaction_by_hash(tx_hash);
+        match tokio::time::timeout(Duration::from_secs(5), fut).await {
+            Ok(Ok(Some(tx))) => {
+                tracing::info!(?sign_ids, "eth signature respond pending transaction found");
+                Ok(tx)
+            }
+            Ok(Ok(None)) => Err(anyhow::anyhow!("Transaction not in mempool yet")),
+            Ok(Err(e)) => Err(anyhow::anyhow!("RPC Error: {e}")),
+            Err(_) => Err(anyhow::anyhow!("RPC Request Timed Out")),
+        }
     };
 
-    let res: Result<Transaction, RetryError<PollErr>> = retry_async(
-        cfg,
-        |_attempt| async {
-            match provider.get_transaction_by_hash(tx_hash).await {
-                Ok(Some(tx)) => {
-                    tracing::info!(?sign_ids_ref, "eth signature respond pending transaction found");
-                    Ok(tx)
-                }
-                Ok(None) => Err(PollErr::NotReady),
-                Err(e) => Err(PollErr::Rpc(anyhow::anyhow!(e))),
-            }
-        },
-        |_attempt, _reason| true,
-        |attempt, reason, sleep| match reason {
-            RetryReason::Error(PollErr::NotReady) => {
-                tracing::error!(
-                    ?sign_ids_ref,
-                    attempt,
-                    "eth signature respond pending transaction not found, retrying in {sleep:?}"
-                );
-            }
-            RetryReason::Error(PollErr::Rpc(e)) => {
-                tracing::error!(
-                    ?sign_ids_ref,
-                    attempt,
-                    "failed to get eth signature respond pending transaction, retrying in {sleep:?}: {e:?}"
-                );
-            }
-            RetryReason::Timeout(_t) => {
-                tracing::error!(
-                    ?sign_ids_ref,
-                    attempt,
-                    "timeout while getting eth signature respond pending transaction, retrying in {sleep:?}"
-                );
-            }
-        },
-    )
-    .await;
-
-    match res {
-        Ok(tx) => Ok(tx),
-        Err(_) => Err(()),
-    }
+    poll_op
+        .retry(&backoff)
+        .notify(|err: &anyhow::Error, sleep: Duration| {
+            attempt += 1;
+            tracing::error!(
+                ?sign_ids,
+                attempt,
+                "failed to get eth signature respond pending transaction: {err}, retrying in {sleep:?}"
+            );
+        })
+        .await
+        .map_err(|_| ()) // TODO: double check if this is the right way
 }
 
 // wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
@@ -1506,88 +1476,38 @@ async fn wait_for_transaction_receipt(
     sign_ids: Vec<SignId>,
     max_attempts: usize,
 ) -> Result<TransactionReceipt, ()> {
-    let sign_ids_ref = &sign_ids;
+    // TODO: use constants, consider adding jitter
+    let backoff = ExponentialBuilder::default()
+        .with_min_delay(Duration::from_secs(1))
+        .with_max_delay(Duration::from_secs(20))
+        .with_max_times(max_attempts);
 
-    let retry_config = RetryConfig {
-        max_attempts,
-        per_attempt_timeout: Duration::from_secs(2),
-        backoff: Backoff::ExponentialJitter {
-            base: Duration::from_secs(1),
-            cap: Duration::from_secs(20),
-            jitter_max_ms: 0,
-        },
+    let mut attempt = 0;
+    let poll_op = || async {
+        let fut = provider.get_transaction_receipt(tx_hash);
+        match tokio::time::timeout(Duration::from_secs(2), fut).await {
+            Ok(Ok(Some(receipt))) => {
+                tracing::info!(?sign_ids, "eth signature respond transaction receipt found");
+                Ok(receipt)
+            }
+            Ok(Ok(None)) => Err(anyhow::anyhow!("Receipt not ready yet")),
+            Ok(Err(e)) => Err(anyhow::anyhow!("RPC Error: {e}")),
+            Err(_) => Err(anyhow::anyhow!("RPC Request Timed Out")),
+        }
     };
 
-    let res: Result<TransactionReceipt, RetryError<PollErr>> = retry_async(
-        retry_config,
-        |_attempt| async {
-            match provider.get_transaction_receipt(tx_hash).await {
-                Ok(Some(receipt)) => {
-                    tracing::info!(?sign_ids_ref, "eth signature respond transaction receipt found");
-                    Ok(receipt)
-                }
-                Ok(None) => Err(PollErr::NotReady),
-                Err(e) => Err(PollErr::Rpc(anyhow::anyhow!(e))),
-            }
-        },
-        |_attempt, _reason| true,
-        |attempt, reason, sleep| match reason {
-            RetryReason::Error(PollErr::NotReady) => {
-                tracing::error!(
-                    ?sign_ids_ref,
-                    attempt,
-                    "eth signature respond transaction receipt not found, retrying in {sleep:?}"
-                );
-            }
-            RetryReason::Error(PollErr::Rpc(e)) => {
-                tracing::error!(
-                    ?sign_ids_ref,
-                    attempt,
-                    "failed to get eth signature respond transaction receipt, retrying in {sleep:?}: {e:?}"
-                );
-            }
-            RetryReason::Timeout(_t) => {
-                tracing::error!(
-                    ?sign_ids_ref,
-                    attempt,
-                    "timeout while getting eth signature respond transaction receipt, retrying in {sleep:?}"
-                );
-            }
-        },
-    )
-    .await;
-
-    match res {
-        Ok(r) => Ok(r),
-        Err(_) => Err(()),
-    }
-}
-
-fn log_retry_err(ctx: &str, sign_ids: &[SignId], err: RetryError<anyhow::Error>) {
-    match err {
-        RetryError::Exhausted {
-            attempts,
-            last_error,
-        } => {
+    poll_op
+        .retry(&backoff)
+        .notify(|err: &anyhow::Error, sleep: Duration| {
+            attempt += 1;
             tracing::error!(
                 ?sign_ids,
-                attempts,
-                ?last_error,
-                "{ctx}: retry attempts exhausted"
+                attempt,
+                "failed to get eth signature respond transaction receipt: {err}, retrying in {sleep:?}"
             );
-        }
-        RetryError::TimeoutExhausted {
-            attempts,
-            last_timeout,
-        } => {
-            tracing::error!(
-                ?sign_ids,
-                attempts,
-                ?last_timeout,
-                "{ctx}: timeout exhausted"
-            );
-        }
-    }
+        })
+        .await
+        .map_err(|_| ()) // TODO: double check if this is the right way
 }
 
 async fn send_eth_transaction(
@@ -1596,114 +1516,95 @@ async fn send_eth_transaction(
     gas: u64,
     sign_ids: &[SignId],
 ) -> Result<alloy::primitives::B256, ()> {
-    let cfg_nonce = RetryConfig {
-        max_attempts: 3,
-        per_attempt_timeout: Duration::from_secs(2),
-        backoff: Backoff::ExponentialJitter {
-            base: Duration::from_millis(500),
-            cap: Duration::from_secs(5),
-            jitter_max_ms: 200,
-        },
+    // 1. Fetch Nonce
+    // TODO: constants + jitter
+    let nonce_backoff = ExponentialBuilder::default()
+        .with_min_delay(Duration::from_millis(500))
+        .with_max_delay(Duration::from_secs(5))
+        .with_max_times(3);
+
+    let mut nonce_attempt = 0;
+    let nonce_op = || async {
+        let fut = contract
+            .provider()
+            .get_transaction_count(contract.provider().default_signer_address())
+            .pending();
+
+        match tokio::time::timeout(Duration::from_secs(2), fut).await {
+            Ok(Ok(n)) => Ok(n),
+            Ok(Err(e)) => Err(anyhow::anyhow!("RPC Error: {e}")),
+            Err(_) => Err(anyhow::anyhow!("Timeout getting nonce")),
+        }
     };
 
-    let nonce_res: Result<u64, RetryError<anyhow::Error>> = retry_async(
-        cfg_nonce,
-        |_attempt| async {
-            contract
-                .provider()
-                .get_transaction_count(contract.provider().default_signer_address())
-                .pending()
-                .await
-                .map_err(|e| anyhow::anyhow!(e))
-        },
-        |_attempt, _reason| true,
-        |attempt, reason, sleep| match reason {
-            RetryReason::Error(e) => {
-                tracing::warn!(
-                    ?sign_ids,
-                    attempt,
-                    ?e,
-                    "get_nonce failed, retrying in {sleep:?}"
-                );
-            }
-            RetryReason::Timeout(t) => {
-                tracing::warn!(
-                    ?sign_ids,
-                    attempt,
-                    "get_nonce timed out after {t:?}, retrying in {sleep:?}"
-                );
-            }
-        },
-    )
-    .await;
-
-    let nonce = match nonce_res {
-        Ok(nonce) => {
-            tracing::info!(nonce, "will send eth tx with nonce");
-            nonce
+    let nonce = match nonce_op
+        .retry(&nonce_backoff)
+        .notify(|err: &anyhow::Error, sleep: Duration| {
+            nonce_attempt += 1;
+            tracing::warn!(
+                ?sign_ids,
+                attempt = nonce_attempt,
+                "get_nonce failed: {err}, retrying in {sleep:?}"
+            );
+        })
+        .await
+    {
+        Ok(n) => {
+            tracing::info!(nonce = n, "will send eth tx with nonce");
+            n
         }
         Err(err) => {
-            log_retry_err("failed to get nonce", sign_ids, err);
+            tracing::error!(
+                ?sign_ids,
+                ?err,
+                "failed to get nonce: retry attempts exhausted"
+            );
             return Err(());
         }
     };
 
-    let cfg_send = RetryConfig {
-        max_attempts: 3,
-        per_attempt_timeout: Duration::from_secs(5),
-        backoff: Backoff::ExponentialJitter {
-            base: Duration::from_millis(500),
-            cap: Duration::from_secs(10),
-            jitter_max_ms: 200,
-        },
+    // 2. Send Tx
+    // TODO: constants + jitter
+    let send_backoff = ExponentialBuilder::default()
+        .with_min_delay(Duration::from_millis(500))
+        .with_max_delay(Duration::from_secs(10))
+        .with_max_times(3);
+
+    let mut send_attempt = 0;
+    let send_op = || async {
+        let respond_call = contract
+            .function("respond", params)
+            .unwrap()
+            .gas(gas)
+            .nonce(nonce);
+        let fut = respond_call.send();
+
+        match tokio::time::timeout(Duration::from_secs(5), fut).await {
+            Ok(Ok(pending)) => Ok(*pending.tx_hash()),
+            Ok(Err(e)) => Err(anyhow::anyhow!("RPC Error: {e}")),
+            Err(_) => Err(anyhow::anyhow!("Timeout sending tx")),
+        }
     };
 
-    let send_res: Result<alloy::primitives::B256, RetryError<anyhow::Error>> = retry_async(
-        cfg_send,
-        |_attempt| async {
-            let pending = contract
-                .function("respond", params)
-                .unwrap()
-                .gas(gas)
-                .nonce(nonce)
-                .send()
-                .await
-                .map_err(|e| anyhow::anyhow!(e))?;
-
-            Ok(*pending.tx_hash())
-        },
-        |_attempt, _reason| true,
-        |attempt, reason, sleep| match reason {
-            RetryReason::Error(e) => {
-                tracing::warn!(
-                    ?sign_ids,
-                    attempt,
-                    ?e,
-                    "send eth tx failed, retrying in {sleep:?}"
-                );
-            }
-            RetryReason::Timeout(t) => {
-                tracing::warn!(
-                    ?sign_ids,
-                    attempt,
-                    "send eth tx timed out after {t:?}, retrying in {sleep:?}"
-                );
-            }
-        },
-    )
-    .await;
-
-    match send_res {
-        Ok(tx_hash) => Ok(tx_hash),
-        Err(err) => {
-            log_retry_err(
-                "failed to send ethereum signature transaction",
-                sign_ids,
-                err,
+    send_op
+        .retry(&send_backoff)
+        .notify(|err: &anyhow::Error, sleep: Duration| {
+            send_attempt += 1;
+            tracing::warn!(
+                ?sign_ids,
+                attempt = send_attempt,
+                "send eth tx failed: {err}, retrying in {sleep:?}"
             );
-            Err(())
-        }
-    }
+        })
+        .await
+        .inspect_err(|err| {
+            tracing::error!(
+                ?sign_ids,
+                ?err,
+                "failed to send ethereum signature transaction: retry attempts exhausted"
+            );
+        })
+        .map_err(|_| ())
 }
 
 async fn try_publish_eth(
@@ -1847,58 +1748,47 @@ async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAc
         .map(|action| (action.indexed.id, action.signature))
         .collect();
 
-    let cfg = RetryConfig {
-        max_attempts: MAX_PUBLISH_RETRY,
-        per_attempt_timeout: Duration::from_secs(120),
-        backoff: Backoff::ExponentialJitter {
-            base: Duration::from_secs(1),
-            cap: Duration::from_secs(10),
-            jitter_max_ms: 0,
-        },
-    };
+    // TODO: use constants, consider adding jitter
+    let backoff = ExponentialBuilder::default()
+        .with_min_delay(Duration::from_secs(1))
+        .with_max_delay(Duration::from_secs(10))
+        .with_max_times(MAX_PUBLISH_RETRY);
 
-    let res: Result<(), RetryError<()>> = retry_async(
-        cfg,
-        |_attempt| async {
+    let mut attempt = 0;
+
+    let publish_op = || async {
+        let fut = async {
             match client {
-                ChainClient::Near(_) => {
-                    tracing::error!("near has no batch publish");
-                    Ok(())
-                }
-                ChainClient::Solana(_) => {
-                    tracing::error!("Solana has no batch publish");
-                    Ok(())
-                }
-                ChainClient::Ethereum(eth) => {
-                    try_batch_publish_eth(eth, actions, &signatures).await
-                }
-                ChainClient::Hydration(_) => {
-                    tracing::error!("Hydration has no batch publish");
-                    Ok(())
-                }
-                ChainClient::Canton(_) => {
-                    tracing::error!("Canton does not support batch publish");
-                    Ok(())
-                }
+                ChainClient::Ethereum(eth) => try_batch_publish_eth(eth, actions, &signatures)
+                    .await
+                    .map_err(|_| anyhow::anyhow!("Eth batch publish failed")),
+                ChainClient::Near(_) => Err(anyhow::anyhow!("Near has no batch publish")),
+                ChainClient::Solana(_) => Err(anyhow::anyhow!("Solana has no batch publish")),
+                ChainClient::Hydration(_) => Err(anyhow::anyhow!("Hydration has no batch publish")),
+                ChainClient::Canton(_) => Err(anyhow::anyhow!("Canton has no batch publish")),
                 ChainClient::Err(msg) => {
                     tracing::error!(msg, "no client for chain");
                     Ok(())
                 }
             }
-        },
-        |_attempt, _reason| true,
-        |attempt, reason, sleep| match reason {
-            RetryReason::Error(_e) => {
-                tracing::warn!("batch publish failed (attempt {attempt}), retrying in {sleep:?}");
-            }
-            RetryReason::Timeout(t) => {
-                tracing::warn!(
-                    "batch publish timed out after {t:?} (attempt {attempt}), retrying in {sleep:?}"
-                );
-            }
-        },
-    )
-    .await;
+        };
+
+        match tokio::time::timeout(Duration::from_secs(120), fut).await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(e),
+            Err(_) => Err(anyhow::anyhow!("Batch publish attempt timed out")),
+        }
+    };
+
+    let res = publish_op
+        .retry(&backoff)
+        .notify(|err: &anyhow::Error, sleep: Duration| {
+            attempt += 1;
+            tracing::warn!(
+                "batch publish failed (attempt {attempt}): {err}, retrying in {sleep:?}"
+            );
+        })
+        .await;
 
     if res.is_ok() {
         for action in actions.iter() {
@@ -1926,11 +1816,10 @@ async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAc
                 action.timestamp,
             );
         }
-        actions.clear();
-        return;
+    } else {
+        tracing::info!("exceeded max retries, trashing publish request");
     }
 
-    tracing::info!("exceeded max retries, trashing publish request");
     actions.clear();
 }
 

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -32,7 +32,6 @@ use crate::indexer_canton::ledger_api::{
 use crate::indexer_canton::{CantonAuthProvider, CantonConfig};
 use crate::indexer_hydration::HydrationConfig;
 use crate::indexer_sol::SolanaClient;
-// use crate::util::retry::{retry_async, Backoff, RetryConfig, RetryError, RetryReason};
 use alloy::contract::{ContractInstance, Interface};
 use alloy::dyn_abi::DynSolValue;
 use alloy::network::EthereumWallet;
@@ -95,6 +94,38 @@ type EthContractFillProvider = FillProvider<
     >,
     RootProvider,
 >;
+
+// Publish retry constants
+const PUBLISH_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(120);
+const PUBLISH_FIXED_DELAY: Duration = Duration::from_secs(5);
+const BATCH_PUBLISH_MIN_DELAY: Duration = Duration::from_secs(1);
+const BATCH_PUBLISH_MAX_DELAY: Duration = Duration::from_secs(10);
+
+// Get nonce retry constants
+const ETH_NONCE_MAX_ATTEMPTS: usize = 3;
+const ETH_NONCE_TIMEOUT: Duration = Duration::from_secs(2);
+const ETH_NONCE_MIN_DELAY: Duration = Duration::from_millis(500);
+const ETH_NONCE_MAX_DELAY: Duration = Duration::from_secs(5);
+
+// Send Ethereum tx retry constants
+const ETH_SEND_MAX_ATTEMPTS: usize = 3;
+const ETH_SEND_TIMEOUT: Duration = Duration::from_secs(5);
+const ETH_SEND_MIN_DELAY: Duration = Duration::from_millis(500);
+const ETH_SEND_MAX_DELAY: Duration = Duration::from_secs(10);
+
+// Polling Mempool
+const ETH_MEMPOOL_TIMEOUT: Duration = Duration::from_secs(5);
+const ETH_MEMPOOL_MIN_DELAY: Duration = Duration::from_secs(1);
+const ETH_MEMPOOL_MAX_DELAY: Duration = Duration::from_secs(10);
+
+// Polling Receipt
+const ETH_RECEIPT_TIMEOUT: Duration = Duration::from_secs(2);
+const ETH_RECEIPT_MIN_DELAY: Duration = Duration::from_secs(1);
+const ETH_RECEIPT_MAX_DELAY: Duration = Duration::from_secs(20);
+
+// Ethereum gas limits
+const ETH_BASE_GAS_LIMIT: u64 = 40_000;
+const ETH_BATCH_GAS_PER_REQUEST: u64 = 20_000;
 
 type EthContractInstance = ContractInstance<EthContractFillProvider>;
 
@@ -1271,9 +1302,9 @@ async fn execute_publish(client: ChainClient, action: PublishAction) {
         "trying to publish signature",
     );
 
-    // TODO: consider adding jitter
     let backoff = ConstantBuilder::default()
-        .with_delay(Duration::from_secs(5)) // TODO: use constant
+        .with_jitter()
+        .with_delay(PUBLISH_FIXED_DELAY)
         .with_max_times(MAX_PUBLISH_RETRY);
 
     let mut attempt = 0;
@@ -1313,7 +1344,7 @@ async fn execute_publish(client: ChainClient, action: PublishAction) {
             }
         };
 
-        match tokio::time::timeout(Duration::from_secs(120), fut).await {
+        match tokio::time::timeout(PUBLISH_ATTEMPT_TIMEOUT, fut).await {
             Ok(Ok(())) => Ok(()),
             Ok(Err(e)) => Err(e),
             Err(_) => Err(anyhow::anyhow!("Publish attempt timed out")),
@@ -1435,17 +1466,16 @@ async fn wait_for_pending_tx(
     sign_ids: Vec<SignId>,
     max_attempts: usize,
 ) -> Result<Transaction, ()> {
-    // TODO: use constants
     let backoff = ExponentialBuilder::default()
         .with_jitter()
-        .with_min_delay(Duration::from_secs(1))
-        .with_max_delay(Duration::from_secs(10))
+        .with_min_delay(ETH_MEMPOOL_MIN_DELAY)
+        .with_max_delay(ETH_MEMPOOL_MAX_DELAY)
         .with_max_times(max_attempts);
 
     let mut attempt = 0;
     let poll_op = || async {
         let fut = provider.get_transaction_by_hash(tx_hash);
-        match tokio::time::timeout(Duration::from_secs(5), fut).await {
+        match tokio::time::timeout(ETH_MEMPOOL_TIMEOUT, fut).await {
             Ok(Ok(Some(tx))) => {
                 tracing::info!(?sign_ids, "eth signature respond pending transaction found");
                 Ok(tx)
@@ -1480,14 +1510,14 @@ async fn wait_for_transaction_receipt(
     // TODO: use constants
     let backoff = ExponentialBuilder::default()
         .with_jitter()
-        .with_min_delay(Duration::from_secs(1))
-        .with_max_delay(Duration::from_secs(20))
+        .with_min_delay(ETH_RECEIPT_MIN_DELAY)
+        .with_max_delay(ETH_RECEIPT_MAX_DELAY)
         .with_max_times(max_attempts);
 
     let mut attempt = 0;
     let poll_op = || async {
         let fut = provider.get_transaction_receipt(tx_hash);
-        match tokio::time::timeout(Duration::from_secs(2), fut).await {
+        match tokio::time::timeout(ETH_RECEIPT_TIMEOUT, fut).await {
             Ok(Ok(Some(receipt))) => {
                 tracing::info!(?sign_ids, "eth signature respond transaction receipt found");
                 Ok(receipt)
@@ -1519,12 +1549,11 @@ async fn send_eth_transaction(
     sign_ids: &[SignId],
 ) -> Result<alloy::primitives::B256, ()> {
     // 1. Fetch Nonce
-    // TODO: constants
     let nonce_backoff = ExponentialBuilder::default()
         .with_jitter()
-        .with_min_delay(Duration::from_millis(500))
-        .with_max_delay(Duration::from_secs(5))
-        .with_max_times(3);
+        .with_min_delay(ETH_NONCE_MIN_DELAY)
+        .with_max_delay(ETH_NONCE_MAX_DELAY)
+        .with_max_times(ETH_NONCE_MAX_ATTEMPTS);
 
     let mut nonce_attempt = 0;
     let nonce_op = || async {
@@ -1533,7 +1562,7 @@ async fn send_eth_transaction(
             .get_transaction_count(contract.provider().default_signer_address())
             .pending();
 
-        match tokio::time::timeout(Duration::from_secs(2), fut).await {
+        match tokio::time::timeout(ETH_NONCE_TIMEOUT, fut).await {
             Ok(Ok(n)) => Ok(n),
             Ok(Err(e)) => Err(anyhow::anyhow!("RPC Error: {e}")),
             Err(_) => Err(anyhow::anyhow!("Timeout getting nonce")),
@@ -1567,12 +1596,11 @@ async fn send_eth_transaction(
     };
 
     // 2. Send Tx
-    // TODO: constants
     let send_backoff = ExponentialBuilder::default()
         .with_jitter()
-        .with_min_delay(Duration::from_millis(500))
-        .with_max_delay(Duration::from_secs(10))
-        .with_max_times(3);
+        .with_min_delay(ETH_SEND_MIN_DELAY)
+        .with_max_delay(ETH_SEND_MAX_DELAY)
+        .with_max_times(ETH_SEND_MAX_ATTEMPTS);
 
     let mut send_attempt = 0;
     let send_op = || async {
@@ -1583,7 +1611,7 @@ async fn send_eth_transaction(
             .nonce(nonce);
         let fut = respond_call.send();
 
-        match tokio::time::timeout(Duration::from_secs(5), fut).await {
+        match tokio::time::timeout(ETH_SEND_TIMEOUT, fut).await {
             Ok(Ok(pending)) => Ok(*pending.tx_hash()),
             Ok(Err(e)) => Err(anyhow::anyhow!("RPC Error: {e}")),
             Err(_) => Err(anyhow::anyhow!("Timeout sending tx")),
@@ -1635,7 +1663,7 @@ async fn try_publish_eth(
     let tx_hash = send_eth_transaction(
         &eth.contract,
         &params,
-        40000,
+        ETH_BASE_GAS_LIMIT,
         std::slice::from_ref(&action.indexed.id),
     )
     .await?;
@@ -1701,7 +1729,10 @@ async fn try_batch_publish_eth(
     }
 
     let params = [DynSolValue::Array(params_vec.clone())];
-    let gas = std::cmp::max(40000, 20000 * num_requests as u64);
+    let gas = std::cmp::max(
+        ETH_BASE_GAS_LIMIT,
+        ETH_BATCH_GAS_PER_REQUEST * num_requests as u64,
+    );
 
     let tx_hash = send_eth_transaction(&eth.contract, &params, gas, &sign_ids).await?;
 
@@ -1752,11 +1783,11 @@ async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAc
         .map(|action| (action.indexed.id, action.signature))
         .collect();
 
-    // TODO: use constants, consider adding jitter
     let backoff = ExponentialBuilder::default()
-        .with_min_delay(Duration::from_secs(1))
-        .with_max_delay(Duration::from_secs(10))
-        .with_max_times(MAX_PUBLISH_RETRY);
+        .with_min_delay(BATCH_PUBLISH_MIN_DELAY)
+        .with_max_delay(BATCH_PUBLISH_MAX_DELAY)
+        .with_max_times(MAX_PUBLISH_RETRY)
+        .with_jitter();
 
     let mut attempt = 0;
 

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -1435,8 +1435,9 @@ async fn wait_for_pending_tx(
     sign_ids: Vec<SignId>,
     max_attempts: usize,
 ) -> Result<Transaction, ()> {
-    // TODO: use constants, consider adding jitter
+    // TODO: use constants
     let backoff = ExponentialBuilder::default()
+        .with_jitter()
         .with_min_delay(Duration::from_secs(1))
         .with_max_delay(Duration::from_secs(10))
         .with_max_times(max_attempts);
@@ -1476,8 +1477,9 @@ async fn wait_for_transaction_receipt(
     sign_ids: Vec<SignId>,
     max_attempts: usize,
 ) -> Result<TransactionReceipt, ()> {
-    // TODO: use constants, consider adding jitter
+    // TODO: use constants
     let backoff = ExponentialBuilder::default()
+        .with_jitter()
         .with_min_delay(Duration::from_secs(1))
         .with_max_delay(Duration::from_secs(20))
         .with_max_times(max_attempts);
@@ -1517,8 +1519,9 @@ async fn send_eth_transaction(
     sign_ids: &[SignId],
 ) -> Result<alloy::primitives::B256, ()> {
     // 1. Fetch Nonce
-    // TODO: constants + jitter
+    // TODO: constants
     let nonce_backoff = ExponentialBuilder::default()
+        .with_jitter()
         .with_min_delay(Duration::from_millis(500))
         .with_max_delay(Duration::from_secs(5))
         .with_max_times(3);
@@ -1564,8 +1567,9 @@ async fn send_eth_transaction(
     };
 
     // 2. Send Tx
-    // TODO: constants + jitter
+    // TODO: constants
     let send_backoff = ExponentialBuilder::default()
+        .with_jitter()
         .with_min_delay(Duration::from_millis(500))
         .with_max_delay(Duration::from_secs(10))
         .with_max_times(3);

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -17,7 +17,7 @@ use alloy::primitives::Address;
 use alloy::providers::fillers::{FillProvider, JoinFill, WalletFiller};
 use alloy::providers::{Provider, RootProvider, WalletProvider};
 use alloy::rpc::types::{Transaction, TransactionReceipt};
-use backon::{ConstantBuilder, ExponentialBuilder, Retryable};
+use backon::{ConstantBuilder, ExponentialBuilder};
 use cait_sith::protocol::Participant;
 use cait_sith::FullSignature;
 use k256::{AffinePoint, Secp256k1};
@@ -126,6 +126,29 @@ const ETH_RECEIPT_MAX_DELAY: Duration = Duration::from_secs(20);
 // Ethereum gas limits
 const ETH_BASE_GAS_LIMIT: u64 = 40_000;
 const ETH_BATCH_GAS_PER_REQUEST: u64 = 20_000;
+
+/// A macro to wrap async closures for backon retries with a timeout and notification.
+macro_rules! retry_action {
+    ($timeout:expr, $strategy:expr, |$attempt:ident, $err:ident, $sleep:ident| $notify:block, $code:block) => {{
+        let mut $attempt = 0;
+        let op = || async {
+            let fut = async $code;
+            match tokio::time::timeout($timeout, fut).await {
+                Ok(Ok(res)) => Ok(res),
+                Ok(Err(e)) => Err(e),
+                Err(_) => Err(anyhow::anyhow!("Operation timed out")),
+            }
+        };
+
+        use backon::Retryable;
+        op.retry($strategy)
+            .notify(|$err: &anyhow::Error, $sleep: std::time::Duration| {
+                $attempt += 1;
+                $notify
+            })
+            .await
+    }};
+}
 
 type EthContractInstance = ContractInstance<EthContractFillProvider>;
 
@@ -1307,10 +1330,21 @@ async fn execute_publish(client: ChainClient, action: PublishAction) {
         .with_delay(PUBLISH_FIXED_DELAY)
         .with_max_times(MAX_PUBLISH_RETRY);
 
-    let mut attempt = 0;
-
-    let publish_op = || async {
-        let fut = async {
+    let publish_res = retry_action!(
+        PUBLISH_ATTEMPT_TIMEOUT,
+        &backoff,
+        // Log the error and retry attempt
+        |attempt, err, sleep| {
+            tracing::warn!(
+                ?sign_id,
+                retry_count = attempt,
+                elapsed = ?action.timestamp.elapsed(),
+                ?chain,
+                "failed to publish ({err}), retrying in {sleep:?}"
+            );
+        },
+        // Try to publish the signature
+        {
             match &client {
                 ChainClient::Near(near) => {
                     try_publish_near(near, &action, &action.timestamp, &action.signature)
@@ -1342,28 +1376,8 @@ async fn execute_publish(client: ChainClient, action: PublishAction) {
                     Ok(())
                 }
             }
-        };
-
-        match tokio::time::timeout(PUBLISH_ATTEMPT_TIMEOUT, fut).await {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(e)) => Err(e),
-            Err(_) => Err(anyhow::anyhow!("Publish attempt timed out")),
         }
-    };
-
-    let publish_res = publish_op
-        .retry(&backoff)
-        .notify(|err: &anyhow::Error, sleep: Duration| {
-            attempt += 1;
-            tracing::warn!(
-                ?sign_id,
-                retry_count = attempt,
-                elapsed = ?action.timestamp.elapsed(),
-                ?chain,
-                "failed to publish ({err}), retrying in {sleep:?}"
-            );
-        })
-        .await;
+    );
 
     if publish_res.is_ok() {
         let elapsed_secs =
@@ -1472,32 +1486,29 @@ async fn wait_for_pending_tx(
         .with_max_delay(ETH_MEMPOOL_MAX_DELAY)
         .with_max_times(max_attempts);
 
-    let mut attempt = 0;
-    let poll_op = || async {
-        let fut = provider.get_transaction_by_hash(tx_hash);
-        match tokio::time::timeout(ETH_MEMPOOL_TIMEOUT, fut).await {
-            Ok(Ok(Some(tx))) => {
-                tracing::info!(?sign_ids, "eth signature respond pending transaction found");
-                Ok(tx)
-            }
-            Ok(Ok(None)) => Err(anyhow::anyhow!("Transaction not in mempool yet")),
-            Ok(Err(e)) => Err(anyhow::anyhow!("RPC Error: {e}")),
-            Err(_) => Err(anyhow::anyhow!("RPC Request Timed Out")),
-        }
-    };
-
-    poll_op
-        .retry(&backoff)
-        .notify(|err: &anyhow::Error, sleep: Duration| {
-            attempt += 1;
+    retry_action!(
+        ETH_MEMPOOL_TIMEOUT,
+        &backoff,
+        // Log the error and retry attempt
+        |attempt, err, sleep| {
             tracing::error!(
                 ?sign_ids,
                 attempt,
                 "failed to get eth signature respond pending transaction: {err}, retrying in {sleep:?}"
             );
-        })
-        .await
-        .map_err(|_| ()) // TODO: double check if this is the right way
+        },
+        // Try to get the pending transaction
+        {
+            match provider.get_transaction_by_hash(tx_hash).await {
+                Ok(Some(tx)) => {
+                    tracing::info!(?sign_ids, "eth signature respond pending transaction found");
+                    Ok(tx)
+                }
+                Ok(None) => Err(anyhow::anyhow!("Transaction not in mempool yet")),
+                Err(e) => Err(anyhow::anyhow!("RPC Error: {e}")),
+            }
+        }
+    ).map_err(|_| ())
 }
 
 // wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
@@ -1514,32 +1525,29 @@ async fn wait_for_transaction_receipt(
         .with_max_delay(ETH_RECEIPT_MAX_DELAY)
         .with_max_times(max_attempts);
 
-    let mut attempt = 0;
-    let poll_op = || async {
-        let fut = provider.get_transaction_receipt(tx_hash);
-        match tokio::time::timeout(ETH_RECEIPT_TIMEOUT, fut).await {
-            Ok(Ok(Some(receipt))) => {
-                tracing::info!(?sign_ids, "eth signature respond transaction receipt found");
-                Ok(receipt)
-            }
-            Ok(Ok(None)) => Err(anyhow::anyhow!("Receipt not ready yet")),
-            Ok(Err(e)) => Err(anyhow::anyhow!("RPC Error: {e}")),
-            Err(_) => Err(anyhow::anyhow!("RPC Request Timed Out")),
-        }
-    };
-
-    poll_op
-        .retry(&backoff)
-        .notify(|err: &anyhow::Error, sleep: Duration| {
-            attempt += 1;
+    retry_action!(
+        ETH_RECEIPT_TIMEOUT,
+        &backoff,
+        // Log the error and retry attempt
+        |attempt, err, sleep| {
             tracing::error!(
                 ?sign_ids,
                 attempt,
                 "failed to get eth signature respond transaction receipt: {err}, retrying in {sleep:?}"
             );
-        })
-        .await
-        .map_err(|_| ()) // TODO: double check if this is the right way
+        },
+        // Try to get the transaction receipt
+        {
+            match provider.get_transaction_receipt(tx_hash).await {
+                Ok(Some(receipt)) => {
+                    tracing::info!(?sign_ids, "eth signature respond transaction receipt found");
+                    Ok(receipt)
+                }
+                Ok(None) => Err(anyhow::anyhow!("Receipt not ready yet")),
+                Err(e) => Err(anyhow::anyhow!("RPC Error: {e}")),
+            }
+        }
+    ).map_err(|_| ())
 }
 
 async fn send_eth_transaction(
@@ -1548,6 +1556,7 @@ async fn send_eth_transaction(
     gas: u64,
     sign_ids: &[SignId],
 ) -> Result<alloy::primitives::B256, ()> {
+    // TODO: fetching nonce from RPC is slow and expensive, consider better approach (fetch once, increment locally, etc.)
     // 1. Fetch Nonce
     let nonce_backoff = ExponentialBuilder::default()
         .with_jitter()
@@ -1555,36 +1564,28 @@ async fn send_eth_transaction(
         .with_max_delay(ETH_NONCE_MAX_DELAY)
         .with_max_times(ETH_NONCE_MAX_ATTEMPTS);
 
-    let mut nonce_attempt = 0;
-    let nonce_op = || async {
-        let fut = contract
-            .provider()
-            .get_transaction_count(contract.provider().default_signer_address())
-            .pending();
-
-        match tokio::time::timeout(ETH_NONCE_TIMEOUT, fut).await {
-            Ok(Ok(n)) => Ok(n),
-            Ok(Err(e)) => Err(anyhow::anyhow!("RPC Error: {e}")),
-            Err(_) => Err(anyhow::anyhow!("Timeout getting nonce")),
-        }
-    };
-
-    let nonce = match nonce_op
-        .retry(&nonce_backoff)
-        .notify(|err: &anyhow::Error, sleep: Duration| {
-            nonce_attempt += 1;
+    let nonce = match retry_action!(
+        ETH_NONCE_TIMEOUT,
+        &nonce_backoff,
+        // Log the error and retry attempt
+        |attempt, err, sleep| {
             tracing::warn!(
                 ?sign_ids,
-                attempt = nonce_attempt,
+                attempt,
                 "get_nonce failed: {err}, retrying in {sleep:?}"
             );
-        })
-        .await
-    {
-        Ok(n) => {
-            tracing::info!(nonce = n, "will send eth tx with nonce");
-            n
+        },
+        // Try to get the nonce
+        {
+            contract
+                .provider()
+                .get_transaction_count(contract.provider().default_signer_address())
+                .pending()
+                .await
+                .map_err(|e| anyhow::anyhow!("RPC Error: {e}"))
         }
+    ) {
+        Ok(n) => n,
         Err(err) => {
             tracing::error!(
                 ?sign_ids,
@@ -1595,6 +1596,8 @@ async fn send_eth_transaction(
         }
     };
 
+    tracing::info!(nonce, "will send eth tx with nonce");
+
     // 2. Send Tx
     let send_backoff = ExponentialBuilder::default()
         .with_jitter()
@@ -1602,41 +1605,35 @@ async fn send_eth_transaction(
         .with_max_delay(ETH_SEND_MAX_DELAY)
         .with_max_times(ETH_SEND_MAX_ATTEMPTS);
 
-    let mut send_attempt = 0;
-    let send_op = || async {
-        let respond_call = contract
-            .function("respond", params)
-            .unwrap()
-            .gas(gas)
-            .nonce(nonce);
-        let fut = respond_call.send();
-
-        match tokio::time::timeout(ETH_SEND_TIMEOUT, fut).await {
-            Ok(Ok(pending)) => Ok(*pending.tx_hash()),
-            Ok(Err(e)) => Err(anyhow::anyhow!("RPC Error: {e}")),
-            Err(_) => Err(anyhow::anyhow!("Timeout sending tx")),
-        }
-    };
-
-    send_op
-        .retry(&send_backoff)
-        .notify(|err: &anyhow::Error, sleep: Duration| {
-            send_attempt += 1;
+    retry_action!(
+        ETH_SEND_TIMEOUT,
+        &send_backoff,
+        |attempt, err, sleep| {
             tracing::warn!(
                 ?sign_ids,
-                attempt = send_attempt,
+                attempt,
                 "send eth tx failed: {err}, retrying in {sleep:?}"
             );
-        })
-        .await
-        .inspect_err(|err| {
-            tracing::error!(
-                ?sign_ids,
-                ?err,
-                "failed to send ethereum signature transaction: retry attempts exhausted"
-            );
-        })
-        .map_err(|_| ())
+        },
+        {
+            contract
+                .function("respond", params)
+                .unwrap()
+                .gas(gas)
+                .nonce(nonce)
+                .send()
+                .await
+                .map(|pending| *pending.tx_hash())
+                .map_err(|e| anyhow::anyhow!("RPC Error: {e}"))
+        }
+    )
+    .map_err(|err| {
+        tracing::error!(
+            ?sign_ids,
+            ?err,
+            "failed to send ethereum signature transaction: retry attempts exhausted"
+        );
+    })
 }
 
 async fn try_publish_eth(
@@ -1789,10 +1786,17 @@ async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAc
         .with_max_times(MAX_PUBLISH_RETRY)
         .with_jitter();
 
-    let mut attempt = 0;
-
-    let publish_op = || async {
-        let fut = async {
+    let res = retry_action!(
+        Duration::from_secs(120),
+        &backoff,
+        // Log the error and retry attempt
+        |attempt, err, sleep| {
+            tracing::warn!(
+                "batch publish failed (attempt {attempt}): {err}, retrying in {sleep:?}"
+            );
+        },
+        // Try to publish the signatures in batch
+        {
             match client {
                 ChainClient::Ethereum(eth) => try_batch_publish_eth(eth, actions, &signatures)
                     .await
@@ -1806,24 +1810,8 @@ async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAc
                     Ok(())
                 }
             }
-        };
-
-        match tokio::time::timeout(Duration::from_secs(120), fut).await {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(e)) => Err(e),
-            Err(_) => Err(anyhow::anyhow!("Batch publish attempt timed out")),
         }
-    };
-
-    let res = publish_op
-        .retry(&backoff)
-        .notify(|err: &anyhow::Error, sleep: Duration| {
-            attempt += 1;
-            tracing::warn!(
-                "batch publish failed (attempt {attempt}): {err}, retrying in {sleep:?}"
-            );
-        })
-        .await;
+    );
 
     if res.is_ok() {
         for action in actions.iter() {

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -5,6 +5,7 @@ use crate::metrics::requests::{record_request_latency_since, SignRequestStep};
 use crate::protocol::contract::primitives::{ParticipantMap, Participants};
 use crate::protocol::contract::RunningContractState;
 use crate::protocol::{Chain, Governance, IndexedSignRequest, ProtocolState};
+use crate::util::retry::{retry_rpc, RetryConfig};
 use crate::util::AffinePointExt as _;
 use std::collections::BTreeSet;
 
@@ -17,7 +18,6 @@ use alloy::primitives::Address;
 use alloy::providers::fillers::{FillProvider, JoinFill, WalletFiller};
 use alloy::providers::{Provider, RootProvider, WalletProvider};
 use alloy::rpc::types::{Transaction, TransactionReceipt};
-use backon::{ConstantBuilder, ExponentialBuilder};
 use cait_sith::protocol::Participant;
 use cait_sith::FullSignature;
 use k256::{AffinePoint, Secp256k1};
@@ -126,29 +126,6 @@ const ETH_RECEIPT_MAX_DELAY: Duration = Duration::from_secs(20);
 // Ethereum gas limits
 const ETH_BASE_GAS_LIMIT: u64 = 40_000;
 const ETH_BATCH_GAS_PER_REQUEST: u64 = 20_000;
-
-/// A macro to wrap async closures for backon retries with a timeout and notification.
-macro_rules! retry_action {
-    ($timeout:expr, $strategy:expr, |$attempt:ident, $err:ident, $sleep:ident| $notify:block, $code:block) => {{
-        let mut $attempt = 0;
-        let op = || async {
-            let fut = async $code;
-            match tokio::time::timeout($timeout, fut).await {
-                Ok(Ok(res)) => Ok(res),
-                Ok(Err(e)) => Err(e),
-                Err(_) => Err(anyhow::anyhow!("Operation timed out")),
-            }
-        };
-
-        use backon::Retryable;
-        op.retry($strategy)
-            .notify(|$err: &anyhow::Error, $sleep: std::time::Duration| {
-                $attempt += 1;
-                $notify
-            })
-            .await
-    }};
-}
 
 type EthContractInstance = ContractInstance<EthContractFillProvider>;
 
@@ -1325,14 +1302,16 @@ async fn execute_publish(client: ChainClient, action: PublishAction) {
         "trying to publish signature",
     );
 
-    let backoff = ConstantBuilder::default()
-        .with_jitter()
-        .with_delay(PUBLISH_FIXED_DELAY)
-        .with_max_times(MAX_PUBLISH_RETRY);
+    let retry_config = RetryConfig {
+        max_times: MAX_PUBLISH_RETRY,
+        min_delay: PUBLISH_FIXED_DELAY,
+        max_delay: PUBLISH_FIXED_DELAY,
+        jitter: true,
+    };
 
-    let publish_res = retry_action!(
+    let publish_res = retry_rpc!(
         PUBLISH_ATTEMPT_TIMEOUT,
-        &backoff,
+        retry_config,
         // Log the error and retry attempt
         |attempt, err, sleep| {
             tracing::warn!(
@@ -1480,15 +1459,16 @@ async fn wait_for_pending_tx(
     sign_ids: Vec<SignId>,
     max_attempts: usize,
 ) -> Result<Transaction, ()> {
-    let backoff = ExponentialBuilder::default()
-        .with_jitter()
-        .with_min_delay(ETH_MEMPOOL_MIN_DELAY)
-        .with_max_delay(ETH_MEMPOOL_MAX_DELAY)
-        .with_max_times(max_attempts);
+    let retry_config = RetryConfig {
+        max_times: max_attempts,
+        min_delay: ETH_MEMPOOL_MIN_DELAY,
+        max_delay: ETH_MEMPOOL_MAX_DELAY,
+        jitter: true,
+    };
 
-    retry_action!(
+    retry_rpc!(
         ETH_MEMPOOL_TIMEOUT,
-        &backoff,
+        retry_config,
         // Log the error and retry attempt
         |attempt, err, sleep| {
             tracing::error!(
@@ -1518,16 +1498,16 @@ async fn wait_for_transaction_receipt(
     sign_ids: Vec<SignId>,
     max_attempts: usize,
 ) -> Result<TransactionReceipt, ()> {
-    // TODO: use constants
-    let backoff = ExponentialBuilder::default()
-        .with_jitter()
-        .with_min_delay(ETH_RECEIPT_MIN_DELAY)
-        .with_max_delay(ETH_RECEIPT_MAX_DELAY)
-        .with_max_times(max_attempts);
+    let retry_config = RetryConfig {
+        max_times: max_attempts,
+        min_delay: ETH_RECEIPT_MIN_DELAY,
+        max_delay: ETH_RECEIPT_MAX_DELAY,
+        jitter: true,
+    };
 
-    retry_action!(
+    retry_rpc!(
         ETH_RECEIPT_TIMEOUT,
-        &backoff,
+        retry_config,
         // Log the error and retry attempt
         |attempt, err, sleep| {
             tracing::error!(
@@ -1558,15 +1538,16 @@ async fn send_eth_transaction(
 ) -> Result<alloy::primitives::B256, ()> {
     // TODO: fetching nonce from RPC is slow and expensive, consider better approach (fetch once, increment locally, etc.)
     // 1. Fetch Nonce
-    let nonce_backoff = ExponentialBuilder::default()
-        .with_jitter()
-        .with_min_delay(ETH_NONCE_MIN_DELAY)
-        .with_max_delay(ETH_NONCE_MAX_DELAY)
-        .with_max_times(ETH_NONCE_MAX_ATTEMPTS);
+    let nonce_retry = RetryConfig {
+        max_times: ETH_NONCE_MAX_ATTEMPTS,
+        min_delay: ETH_NONCE_MIN_DELAY,
+        max_delay: ETH_NONCE_MAX_DELAY,
+        jitter: true,
+    };
 
-    let nonce = match retry_action!(
+    let nonce = match retry_rpc!(
         ETH_NONCE_TIMEOUT,
-        &nonce_backoff,
+        nonce_retry,
         // Log the error and retry attempt
         |attempt, err, sleep| {
             tracing::warn!(
@@ -1599,15 +1580,16 @@ async fn send_eth_transaction(
     tracing::info!(nonce, "will send eth tx with nonce");
 
     // 2. Send Tx
-    let send_backoff = ExponentialBuilder::default()
-        .with_jitter()
-        .with_min_delay(ETH_SEND_MIN_DELAY)
-        .with_max_delay(ETH_SEND_MAX_DELAY)
-        .with_max_times(ETH_SEND_MAX_ATTEMPTS);
+    let send_retry = RetryConfig {
+        max_times: ETH_SEND_MAX_ATTEMPTS,
+        min_delay: ETH_SEND_MIN_DELAY,
+        max_delay: ETH_SEND_MAX_DELAY,
+        jitter: true,
+    };
 
-    retry_action!(
+    retry_rpc!(
         ETH_SEND_TIMEOUT,
-        &send_backoff,
+        &send_retry,
         |attempt, err, sleep| {
             tracing::warn!(
                 ?sign_ids,
@@ -1633,6 +1615,7 @@ async fn send_eth_transaction(
             ?err,
             "failed to send ethereum signature transaction: retry attempts exhausted"
         );
+        ()
     })
 }
 
@@ -1780,15 +1763,16 @@ async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAc
         .map(|action| (action.indexed.id, action.signature))
         .collect();
 
-    let backoff = ExponentialBuilder::default()
-        .with_min_delay(BATCH_PUBLISH_MIN_DELAY)
-        .with_max_delay(BATCH_PUBLISH_MAX_DELAY)
-        .with_max_times(MAX_PUBLISH_RETRY)
-        .with_jitter();
+    let retry_config = RetryConfig {
+        max_times: MAX_PUBLISH_RETRY,
+        min_delay: BATCH_PUBLISH_MIN_DELAY,
+        max_delay: BATCH_PUBLISH_MAX_DELAY,
+        jitter: true,
+    };
 
-    let res = retry_action!(
-        Duration::from_secs(120),
-        &backoff,
+    let res = retry_rpc!(
+        PUBLISH_ATTEMPT_TIMEOUT,
+        retry_config,
         // Log the error and retry attempt
         |attempt, err, sleep| {
             tracing::warn!(

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -1615,7 +1615,6 @@ async fn send_eth_transaction(
             ?err,
             "failed to send ethereum signature transaction: retry attempts exhausted"
         );
-        ()
     })
 }
 

--- a/chain-signatures/node/src/rpc.rs
+++ b/chain-signatures/node/src/rpc.rs
@@ -1589,7 +1589,7 @@ async fn send_eth_transaction(
 
     retry_rpc!(
         ETH_SEND_TIMEOUT,
-        &send_retry,
+        send_retry,
         |attempt, err, sleep| {
             tracing::warn!(
                 ?sign_ids,
@@ -1784,10 +1784,22 @@ async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAc
                 ChainClient::Ethereum(eth) => try_batch_publish_eth(eth, actions, &signatures)
                     .await
                     .map_err(|_| anyhow::anyhow!("Eth batch publish failed")),
-                ChainClient::Near(_) => Err(anyhow::anyhow!("Near has no batch publish")),
-                ChainClient::Solana(_) => Err(anyhow::anyhow!("Solana has no batch publish")),
-                ChainClient::Hydration(_) => Err(anyhow::anyhow!("Hydration has no batch publish")),
-                ChainClient::Canton(_) => Err(anyhow::anyhow!("Canton has no batch publish")),
+                ChainClient::Near(_) => {
+                    tracing::error!("Near has no batch publish");
+                    Ok(())
+                }
+                ChainClient::Solana(_) => {
+                    tracing::error!("Solana has no batch publish");
+                    Ok(())
+                }
+                ChainClient::Hydration(_) => {
+                    tracing::error!("Hydration has no batch publish");
+                    Ok(())
+                }
+                ChainClient::Canton(_) => {
+                    tracing::error!("Canton has no batch publish");
+                    Ok(())
+                }
                 ChainClient::Err(msg) => {
                     tracing::error!(msg, "no client for chain");
                     Ok(())

--- a/chain-signatures/node/src/util/retry.rs
+++ b/chain-signatures/node/src/util/retry.rs
@@ -1,169 +1,29 @@
-use rand::Rng;
-use std::future::Future;
-use std::sync::Arc;
-use std::time::Duration;
-
-#[derive(Clone)]
-pub enum Backoff {
-    /// Sleep a fixed duration between retries.
-    Fixed(Duration),
-
-    /// Exponential backoff with jitter:
-    /// delay = min(cap, base * 2^(attempt-1)) + rand(0..=jitter_max_ms)
-    ExponentialJitter {
-        base: Duration,
-        cap: Duration,
-        jitter_max_ms: u64,
-    },
-
-    /// Provide a custom function: attempt (1-based) -> delay
-    Custom(Arc<dyn Fn(usize) -> Duration + Send + Sync>),
-}
-
-impl Backoff {
-    pub fn delay(&self, attempt: usize) -> Duration {
-        match self {
-            Backoff::Fixed(d) => *d,
-            Backoff::ExponentialJitter {
-                base,
-                cap,
-                jitter_max_ms,
-            } => compute_backoff_with_jitter(*base, *cap, attempt, *jitter_max_ms),
-            Backoff::Custom(f) => (f)(attempt),
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct RetryConfig {
-    /// Total attempts including the first one. Must be >= 1.
-    pub max_attempts: usize,
-    /// timeout applied per attempt.
-    pub per_attempt_timeout: Duration,
-    /// Backoff strategy (default: exponential + 0 jitter).
-    pub backoff: Backoff,
-}
-
-impl RetryConfig {
-    pub fn new(max_attempts: usize, per_attempt_timeout: Duration, backoff: Backoff) -> Self {
-        assert!(max_attempts >= 1, "max_attempts must be at least 1");
-        Self {
-            max_attempts,
-            per_attempt_timeout,
-            backoff,
-        }
-    }
-}
-
-impl Default for RetryConfig {
-    fn default() -> Self {
-        Self {
-            max_attempts: 5,
-            per_attempt_timeout: Duration::from_secs(2),
-            backoff: Backoff::ExponentialJitter {
-                base: Duration::from_millis(500),
-                cap: Duration::from_secs(10),
-                jitter_max_ms: 0,
-            },
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum RetryError<E> {
-    Exhausted {
-        attempts: usize,
-        last_error: E,
-    },
-    TimeoutExhausted {
-        attempts: usize,
-        last_timeout: Duration,
-    },
-}
-
-/// Reason for a retry attempt (passed to hooks).
-#[derive(Debug)]
-pub enum RetryReason<'a, E> {
-    Error(&'a E),
-    Timeout(Duration),
-}
-
-pub fn compute_backoff_with_jitter(
-    base: Duration,
-    cap: Duration,
-    attempt: usize,
-    jitter_max_ms: u64,
-) -> Duration {
-    // Exponential: base * 2^(attempt-1)
-    let pow = (attempt.saturating_sub(1)).min(16) as u32;
-    let exp_ms = base.as_millis().saturating_mul(1u128 << pow);
-
-    let bounded_ms = exp_ms.min(cap.as_millis());
-    let mut delay = match u64::try_from(bounded_ms) {
-        Ok(ms) => Duration::from_millis(ms),
-        Err(_) => cap.min(Duration::from_millis(u64::MAX)),
-    };
-
-    if jitter_max_ms > 0 {
-        let jitter = rand::thread_rng().gen_range(0..=jitter_max_ms);
-        delay += Duration::from_millis(jitter);
-    }
-    delay
-}
-
-/// Generic retry for async ops returning Result<T, E>.
-///
-/// - attempt is 1..=max_attempts
-/// - should_retry decides whether to continue retrying
-/// - on_retry is invoked before sleeping (log/metrics/tracing)
-pub async fn retry_async<T, E, Fut, Op, ShouldRetry, OnRetry>(
-    cfg: RetryConfig,
-    mut op: Op,
-    mut should_retry: ShouldRetry,
-    mut on_retry: OnRetry,
-) -> Result<T, RetryError<E>>
-where
-    Fut: Future<Output = Result<T, E>>,
-    Op: FnMut(usize) -> Fut,
-    ShouldRetry: FnMut(usize, RetryReason<'_, E>) -> bool,
-    OnRetry: FnMut(usize, RetryReason<'_, E>, Duration),
-{
-    assert!(cfg.max_attempts >= 1, "max_attempts must be at least 1");
-
-    for attempt in 1..=cfg.max_attempts {
-        match tokio::time::timeout(cfg.per_attempt_timeout, op(attempt)).await {
-            Ok(Ok(v)) => return Ok(v),
-            Ok(Err(e)) => {
-                let is_last = attempt == cfg.max_attempts;
-                if is_last || !should_retry(attempt, RetryReason::Error(&e)) {
-                    return Err(RetryError::Exhausted {
-                        attempts: attempt,
-                        last_error: e,
-                    });
-                }
-                let sleep_duration = cfg.backoff.delay(attempt);
-                on_retry(attempt, RetryReason::Error(&e), sleep_duration);
-                tokio::time::sleep(sleep_duration).await;
+// TODO: move to mpc-indexer-core
+/// A universal macro to wrap any asynchronous RPC call with a timeout and a `backon` retry strategy.
+#[macro_export]
+macro_rules! retry_rpc {
+    ($op_name:expr, $timeout:expr, $strategy:expr, $code:expr) => {{
+        let fetch_op = || async {
+            // Wrap the code block in an async block to evaluate the Future lazily
+            let fut = async { $code };
+            match tokio::time::timeout($timeout, fut).await {
+                Ok(Ok(res)) => Ok(res),
+                Ok(Err(e)) => Err(anyhow::anyhow!("RPC Error: {e}")),
+                Err(_) => Err(anyhow::anyhow!("Request timed out")),
             }
-            Err(_elapsed) => {
-                let is_last = attempt == cfg.max_attempts;
-                if is_last || !should_retry(attempt, RetryReason::Timeout(cfg.per_attempt_timeout))
-                {
-                    return Err(RetryError::TimeoutExhausted {
-                        attempts: attempt,
-                        last_timeout: cfg.per_attempt_timeout,
-                    });
-                }
-                let sleep_duration = cfg.backoff.delay(attempt);
-                on_retry(
-                    attempt,
-                    RetryReason::Timeout(cfg.per_attempt_timeout),
-                    sleep_duration,
+        };
+
+        use backon::Retryable;
+        use anyhow::Context;
+        fetch_op
+            .retry($strategy)
+            .notify(|err: &anyhow::Error, dur: std::time::Duration| {
+                tracing::warn!(
+                    operation = %$op_name,
+                    "RPC call failed: {err}; retrying in {dur:?}"
                 );
-                tokio::time::sleep(sleep_duration).await;
-            }
-        }
-    }
-
-    unreachable!("loop returns on success or exhausted");
+            })
+            .await
+            .context(format!("{} exhausted", $op_name))
+    }};
 }

--- a/chain-signatures/node/src/util/retry.rs
+++ b/chain-signatures/node/src/util/retry.rs
@@ -1,29 +1,146 @@
-// TODO: move to mpc-indexer-core
-/// A universal macro to wrap any asynchronous RPC call with a timeout and a `backon` retry strategy.
+use backon::ExponentialBuilder;
+
+/// Configuration for retrying RPC calls with exponential backoff.
+#[derive(Clone, Copy)]
+pub struct RetryConfig {
+    min_delay: Duration,
+    max_delay: Duration,
+    max_times: usize,
+    jitter: bool,
+}
+
+impl RetryConfig {
+    /// Builds an [`ExponentialBuilder`] from this configuration.
+    pub fn build(self) -> ExponentialBuilder {
+        let mut b = ExponentialBuilder::default()
+            .with_min_delay(self.min_delay)
+            .with_max_delay(self.max_delay)
+            .with_max_times(self.max_times);
+        if self.jitter {
+            b = b.with_jitter();
+        }
+        b
+    }
+}
+
+/// Wraps an async RPC call with a timeout and [`backon`] exponential-backoff retry strategy.
+///
+/// # Forms
+///
+/// ## 1. Bare — no operation name, silent on retry
+/// ```ignore
+/// retry_rpc!(timeout, strategy, { code })
+/// ```
+///
+/// ## 2. Standard — named operation, structured [`tracing::warn`] on every retry
+/// ```ignore
+/// retry_rpc!(timeout, strategy, "op_name", { code })
+/// ```
+///
+/// ## 3. Full — named operation, custom notify closure
+/// ```ignore
+/// retry_rpc!(timeout, strategy, "op_name", |attempt, err, sleep| { notify }, { code })
+/// ```
+///
+/// # Parameters
+///
+/// | Parameter  | Type                  | Description                                              |
+/// |------------|-----------------------|----------------------------------------------------------|
+/// | `timeout`  | [`Duration`]          | Per-attempt deadline. Timeout counts as a retryable error|
+/// | `strategy` | [`RetryConfig`]       | Retry policy |
+/// | `op_name`  | `&str`                | Logged as `operation=` in tracing spans                  |
+/// | `attempt`  | injected `u32`        | 1-indexed retry count, available inside `notify`         |
+/// | `err`      | injected `&anyhow::Error` | The error that triggered this retry                  |
+/// | `sleep`    | injected [`Duration`] | How long backon will sleep before the next attempt       |
+/// | `code`     | `{ async block }`     | The fallible async operation. Must return `anyhow::Result<T>` |
+///
+/// # Return value
+///
+/// Returns `anyhow::Result<T>` — either the first successful value or the last
+/// error after all retries are exhausted.
+///
+/// # Examples
+///
+/// ## Standard form (most common)
+/// ```ignore
+/// // Retries up to strategy.max_times, logs each failure via tracing::warn!
+/// let slot: u64 = retry_rpc!(SOL_RPC_TIMEOUT, self.retry_strategy, "get_slot", {
+///     self.rpc_client.get_slot().await.map_err(anyhow::Error::from)
+/// })?;
+/// ```
+///
+/// ## Bare form (fire-and-forget, no logging)
+/// ```ignore
+/// let slot: u64 = retry_rpc!(SOL_RPC_TIMEOUT, self.retry_strategy, {
+///     self.rpc_client.get_slot().await.map_err(anyhow::Error::from)
+/// })?;
+/// ```
+///
+/// ## Full form (custom retry logging)
+/// ```ignore
+/// let block = retry_rpc!(
+///     ETH_RPC_TIMEOUT,
+///     self.retry_strategy,
+///     "get_block",
+///     |attempt, err, sleep| {
+///         tracing::error!(attempt, error = %err, retry_in = ?sleep, "get_block failed");
+///     },
+///     {
+///         client.get_block(block_id).await
+///     }
+/// )?;
+/// ```
 #[macro_export]
 macro_rules! retry_rpc {
-    ($op_name:expr, $timeout:expr, $strategy:expr, $code:expr) => {{
-        let fetch_op = || async {
-            // Wrap the code block in an async block to evaluate the Future lazily
-            let fut = async { $code };
+    // Bare form: no op_name
+    ($timeout:expr, $strategy:expr, { $($code:tt)* }) => {
+        $crate::retry_rpc!($timeout, $strategy, "rpc", { $($code)* })
+    };
+
+    // Standard form: op_name with default structured logging
+    ($timeout:expr, $strategy:expr, $op_name:expr, { $($code:tt)* }) => {{
+        let mut attempt_counter: u32 = 0;
+        let op = || async {
+            let fut = async { $($code)* };
             match tokio::time::timeout($timeout, fut).await {
                 Ok(Ok(res)) => Ok(res),
-                Ok(Err(e)) => Err(anyhow::anyhow!("RPC Error: {e}")),
-                Err(_) => Err(anyhow::anyhow!("Request timed out")),
+                Ok(Err(e)) => Err(e),
+                Err(_) => Err(anyhow::anyhow!("Operation timed out after {:?}", $timeout)),
             }
         };
-
         use backon::Retryable;
-        use anyhow::Context;
-        fetch_op
-            .retry($strategy)
-            .notify(|err: &anyhow::Error, dur: std::time::Duration| {
+        op.retry($strategy.build())
+            .notify(|err: &anyhow::Error, sleep: std::time::Duration| {
+                attempt_counter += 1;
                 tracing::warn!(
-                    operation = %$op_name,
-                    "RPC call failed: {err}; retrying in {dur:?}"
+                    operation = $op_name,
+                    attempt = attempt_counter,
+                    error = %err,
+                    retry_in = ?sleep,
+                    "RPC call failed, retrying"
                 );
             })
             .await
-            .context(format!("{} exhausted", $op_name))
+    }};
+
+    // Full form: custom notify
+    ($timeout:expr, $strategy:expr, $op_name:expr, |$attempt:ident, $err:ident, $sleep:ident| $notify:block, { $($code:tt)* }) => {{
+        let mut attempt_counter: u32 = 0;
+        let op = || async {
+            let fut = async { $($code)* };
+            match tokio::time::timeout($timeout, fut).await {
+                Ok(Ok(res)) => Ok(res),
+                Ok(Err(e)) => Err(e),
+                Err(_) => Err(anyhow::anyhow!("Operation timed out after {:?}", $timeout)),
+            }
+        };
+        use backon::Retryable;
+        op.retry($strategy.build())
+            .notify(|$err: &anyhow::Error, $sleep: std::time::Duration| {
+                attempt_counter += 1;
+                let $attempt = attempt_counter;
+                $notify
+            })
+            .await
     }};
 }

--- a/chain-signatures/node/src/util/retry.rs
+++ b/chain-signatures/node/src/util/retry.rs
@@ -31,17 +31,12 @@ impl RetryConfig {
 ///
 /// # Forms
 ///
-/// ## 1. Bare — no operation name, silent on retry
-/// ```ignore
-/// retry_rpc!(timeout, strategy, { code })
-/// ```
-///
-/// ## 2. Standard — named operation, structured [`tracing::warn`] on every retry
+/// ## 1. Standard — named operation, structured [`tracing::warn`] on every retry
 /// ```ignore
 /// retry_rpc!(timeout, strategy, "op_name", { code })
 /// ```
 ///
-/// ## 3. Full — named operation, custom notify closure
+/// ## 2. Full — named operation, custom notify closure
 /// ```ignore
 /// retry_rpc!(timeout, strategy, "op_name", |attempt, err, sleep| { notify }, { code })
 /// ```
@@ -73,13 +68,6 @@ impl RetryConfig {
 /// })?;
 /// ```
 ///
-/// ## Bare form (fire-and-forget, no logging)
-/// ```ignore
-/// let slot: u64 = retry_rpc!(SOL_RPC_TIMEOUT, self.retry_strategy, {
-///     self.rpc_client.get_slot().await.map_err(anyhow::Error::from)
-/// })?;
-/// ```
-///
 /// ## Full form (custom retry logging)
 /// ```ignore
 /// let block = retry_rpc!(
@@ -95,13 +83,8 @@ impl RetryConfig {
 /// )?;
 /// ```
 macro_rules! retry_rpc {
-    // Bare form: no op_name
-    ($timeout:expr, $strategy:expr, { $($code:tt)* }) => {
-        $crate::retry_rpc!($timeout, $strategy, "rpc", { $($code)* })
-    };
-
-    // Standard form: op_name with default structured logging
-    ($timeout:expr, $strategy:expr, $op_name:expr, { $($code:tt)* }) => {{
+    // Standard form: op_name string, default structured logging
+    ($timeout:expr, $strategy:expr, $op_name:literal, { $($code:tt)* }) => {{
         let mut attempt_counter: u32 = 0;
         let op = || async {
             let fut = async { $($code)* };
@@ -126,8 +109,8 @@ macro_rules! retry_rpc {
             .await
     }};
 
-    // Full form: custom notify
-    ($timeout:expr, $strategy:expr, $op_name:expr, |$attempt:ident, $err:ident, $sleep:ident| $notify:block, { $($code:tt)* }) => {{
+    // Full form: custom notify closure, no op_name
+    ($timeout:expr, $strategy:expr, |$attempt:ident, $err:ident, $sleep:ident| $notify:block, { $($code:tt)* }) => {{
         let mut attempt_counter: u32 = 0;
         let op = || async {
             let fut = async { $($code)* };

--- a/chain-signatures/node/src/util/retry.rs
+++ b/chain-signatures/node/src/util/retry.rs
@@ -1,3 +1,5 @@
+// TODO: this should be moved somewhere so that it can be re-used by both indexer crates and the node crate
+
 use std::time::Duration;
 
 use backon::ExponentialBuilder;

--- a/chain-signatures/node/src/util/retry.rs
+++ b/chain-signatures/node/src/util/retry.rs
@@ -27,6 +27,26 @@ impl RetryConfig {
     }
 }
 
+/// Helper to identify whether an RPC error should be retried.
+/// Protects against endlessly retrying terminal client errors (4xx).
+pub fn is_retryable(e: &anyhow::Error) -> bool {
+    let s = e.to_string();
+    // 408 Request Timeout and 429 Too Many Requests are retryable.
+    if s.contains("408") || s.contains("429") {
+        return true;
+    }
+    // Other 4xx errors are generally client errors and should not be retried.
+    if s.contains("400")
+        || s.contains("401")
+        || s.contains("403")
+        || s.contains("404")
+        || s.contains("405")
+    {
+        return false;
+    }
+    true
+}
+
 /// Wraps an async RPC call with a timeout and [`backon`] exponential-backoff retry strategy.
 ///
 /// # Forms
@@ -96,6 +116,9 @@ macro_rules! retry_rpc {
         };
         use backon::Retryable;
         op.retry(&$strategy.build())
+            // Retry only if the error is retryable (e.g., not a 4xx client error)
+            .when(|e: &anyhow::Error| crate::util::retry::is_retryable(e))
+            // Log each retry attempt with structured tracing
             .notify(|err: &anyhow::Error, sleep: std::time::Duration| {
                 attempt_counter += 1;
                 tracing::warn!(
@@ -107,6 +130,7 @@ macro_rules! retry_rpc {
                 );
             })
             .await
+            .map_err(|e| anyhow::anyhow!("{e} (exhausted after {} attempts)", attempt_counter + 1))
     }};
 
     // Full form: custom notify closure, no op_name
@@ -122,12 +146,16 @@ macro_rules! retry_rpc {
         };
         use backon::Retryable;
         op.retry(&$strategy.build())
+            // Retry only if the error is retryable (e.g., not a 4xx client error)
+            .when(|e: &anyhow::Error| crate::util::retry::is_retryable(e))
+            // Log each retry attempt with the user-provided notify closure
             .notify(|$err: &anyhow::Error, $sleep: std::time::Duration| {
                 attempt_counter += 1;
                 let $attempt = attempt_counter;
                 $notify
             })
             .await
+            .map_err(|e| anyhow::anyhow!("{e} (exhausted after {} attempts)", attempt_counter + 1))
     }};
 }
 

--- a/chain-signatures/node/src/util/retry.rs
+++ b/chain-signatures/node/src/util/retry.rs
@@ -1,12 +1,14 @@
+use std::time::Duration;
+
 use backon::ExponentialBuilder;
 
 /// Configuration for retrying RPC calls with exponential backoff.
 #[derive(Clone, Copy)]
 pub struct RetryConfig {
-    min_delay: Duration,
-    max_delay: Duration,
-    max_times: usize,
-    jitter: bool,
+    pub min_delay: Duration,
+    pub max_delay: Duration,
+    pub max_times: usize,
+    pub jitter: bool,
 }
 
 impl RetryConfig {
@@ -90,7 +92,6 @@ impl RetryConfig {
 ///     }
 /// )?;
 /// ```
-#[macro_export]
 macro_rules! retry_rpc {
     // Bare form: no op_name
     ($timeout:expr, $strategy:expr, { $($code:tt)* }) => {
@@ -109,7 +110,7 @@ macro_rules! retry_rpc {
             }
         };
         use backon::Retryable;
-        op.retry($strategy.build())
+        op.retry(&$strategy.build())
             .notify(|err: &anyhow::Error, sleep: std::time::Duration| {
                 attempt_counter += 1;
                 tracing::warn!(
@@ -135,7 +136,7 @@ macro_rules! retry_rpc {
             }
         };
         use backon::Retryable;
-        op.retry($strategy.build())
+        op.retry(&$strategy.build())
             .notify(|$err: &anyhow::Error, $sleep: std::time::Duration| {
                 attempt_counter += 1;
                 let $attempt = attempt_counter;
@@ -144,3 +145,5 @@ macro_rules! retry_rpc {
             .await
     }};
 }
+
+pub(crate) use retry_rpc;


### PR DESCRIPTION
This PR standardizes the retry logic for RPC and publishing operations across the Ethereum, Solana, and cross-chain publisher components. It replaces custom, ad-hoc retry loops with a centralized `retry_rpc!` macro built on top of the `backon` crate (we were already using it in some places).

**Core retry infra:**

- Replaced custom retry logic in `util/retry.rs` with `retry_rpc!` macro, which provides both a standard form (auto-logging) and a custom closure form (for detailed context). Distinction between timeout and all attempts exhausted preserved: the macro unifies both errors into standard `anyhow` errors seamlessly (no need to do explicit match)
- Add HTTP 4xx Suppression using `is_retryable` utility. This ensures we immediately fail on terminal client errors (HTTP 400-405) while correctly retrying rate limits (429) or timeouts (408) (previously we were retrying all)
- Introduce `RetryConfig` struct which maps to `backon::ExponentialBuilder`, so we can use different retry strategies for different use-cases 

**Update Ethereum client:**

- Update methods to use `retry_rpc!`
- Add `retry_strategy` field, which holds `RetryConfig` (we have default and faster version for unit tests)
- Add some unit tests, introduce `test_utils` and implemented `create_test_ethereum_client()` helper (with fast retries), used for both client and indexer tests

**Update Solana client:**

- Update methods to use `retry_rpc!`
- Add `retry_strategy` field, which holds `RetryConfig`
- `subscribe_and_buffer_live_events` now accepts fully configured `SolanaClient` (with retries)

**Update RPC and publishing:**

- Replace magic numbers with constants for different operations (Publishing, Nonce Fetching, Tx Sending, Mempool Polling, Receipt Polling, etc.)
- Update methods to utilize `retry_rpc!`

I only covered places where we already had some retry logic (`rpc.rs`, Solana and Ethereum clients), it does not include Canton and Hydration. These should be addressed separately.