### PR TITLE
refactor: centralize `IndexedSignRequest` metrics update and decouple Eth indexer from telemetry

### DIFF
--- a/chain-signatures/node/src/indexer_canton/stream.rs
+++ b/chain-signatures/node/src/indexer_canton/stream.rs
@@ -444,9 +444,12 @@ async fn process_canton_event(
                 let request_id = canton_event.generate_request_id();
                 let entropy: [u8; 32] = keccak256(request_id).into();
                 match canton_event.generate_sign_request(entropy) {
-                    Ok(indexed) => {
+                    Ok(request) => {
                         if events_tx
-                            .send(ChainEvent::SignRequest(indexed))
+                            .send(ChainEvent::SignRequest {
+                                request,
+                                block_timestamp: None, // Canton does not provide block timestamps in the event
+                            })
                             .await
                             .is_err()
                         {

--- a/chain-signatures/node/src/indexer_canton/stream.rs
+++ b/chain-signatures/node/src/indexer_canton/stream.rs
@@ -448,7 +448,7 @@ async fn process_canton_event(
                         if events_tx
                             .send(ChainEvent::SignRequest {
                                 request,
-                                block_timestamp: None, // Canton does not provide block timestamps in the event
+                                block_timestamp: None,
                             })
                             .await
                             .is_err()

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -533,10 +533,6 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             .collect_execution_confirmations(block_number, block_receipts)
             .await?;
 
-        for _request in &sign_requests {
-            self.telemetry.request_indexed(Some(block_timestamp));
-        }
-
         // Always forward the processed block to the "finalization" stage so it can emit
         // `ChainEvent::Block` even when there are no relevant contract logs.
         Ok(BlockAndRequests::new(
@@ -830,9 +826,12 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
                 .context("failed to emit ExecutionConfirmed event")?;
         }
 
-        for req in indexed_requests {
+        for request in indexed_requests {
             self.events_tx
-                .send(ChainEvent::SignRequest(req))
+                .send(ChainEvent::SignRequest {
+                    request,
+                    block_timestamp: Some(block.header.timestamp),
+                })
                 .await
                 .context("failed to emit SignRequest event")?;
         }

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -6,7 +6,6 @@ pub mod indexer_eth_direct_rpc;
 pub mod indexer_eth_helios;
 
 use crate::indexer_eth::abi::{ChainSignatures, SignatureRequestedEncoding};
-use crate::metrics::requests::{record_request_latency_since, SignRequestStep};
 use crate::protocol::Chain;
 use crate::respond_bidirectional::CompletedTx;
 use crate::stream::{ChainIndexer, ChainStream};
@@ -535,12 +534,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             .await?;
 
         for _request in &sign_requests {
-            record_request_latency_since(
-                Chain::Ethereum,
-                SignRequestStep::Indexing,
-                "ok",
-                block_timestamp,
-            );
+            self.telemetry.request_indexed(Some(block_timestamp));
         }
 
         // Always forward the processed block to the "finalization" stage so it can emit

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -469,7 +469,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     async fn parse_block(&self, block: &Block) -> anyhow::Result<BlockAndRequests> {
         let block_number = block.header.number;
         let block_hash = block.header.hash;
-        let block_timestamp = block.header.timestamp;
+
         tracing::info!(
             "Processing block number {} with hash {:?}",
             block_number,

--- a/chain-signatures/node/src/indexer_sol/mod.rs
+++ b/chain-signatures/node/src/indexer_sol/mod.rs
@@ -862,7 +862,7 @@ async fn emit_events(
                     events_tx
                         .send(ChainEvent::SignRequest {
                             request,
-                            block_timestamp: None, // Solana does not provide block timestamps in the event
+                            block_timestamp: None,
                         })
                         .await?;
                 }

--- a/chain-signatures/node/src/indexer_sol/mod.rs
+++ b/chain-signatures/node/src/indexer_sol/mod.rs
@@ -858,8 +858,13 @@ async fn emit_events(
         SolanaEvents::Sign(events) => {
             let signature = signature.as_ref().to_vec();
             for ev in events {
-                if let Some(req) = ev.build_sign_request(&signature) {
-                    events_tx.send(ChainEvent::SignRequest(req)).await?;
+                if let Some(request) = ev.build_sign_request(&signature) {
+                    events_tx
+                        .send(ChainEvent::SignRequest {
+                            request,
+                            block_timestamp: None, // Solana does not provide block timestamps in the event
+                        })
+                        .await?;
                 }
             }
         }

--- a/chain-signatures/node/src/metrics/indexers.rs
+++ b/chain-signatures/node/src/metrics/indexers.rs
@@ -50,13 +50,11 @@ impl ChainTelemetry for PrometheusChainTelemetry {
             .set(block_number as i64);
     }
 
-    fn request_indexed(&self, block_timestamp: Option<u64>) {
-        if let Some(ts) = block_timestamp {
-            // Ethereum path
-            record_request_latency_since(self.chain, SignRequestStep::Indexing, "ok", ts);
-        } else {
-            // Solana, Hydration, Canton path
-            record_indexing_step_reached(self.chain);
-        }
+    fn request_indexed_at(&self, block_timestamp: u64) {
+        record_request_latency_since(self.chain, SignRequestStep::Indexing, "ok", block_timestamp);
+    }
+
+    fn request_indexed(&self) {
+        record_indexing_step_reached(self.chain);
     }
 }

--- a/chain-signatures/node/src/metrics/indexers.rs
+++ b/chain-signatures/node/src/metrics/indexers.rs
@@ -2,7 +2,10 @@ use mpc_primitives::{Chain, ChainTelemetry};
 use prometheus::IntGaugeVec;
 use std::sync::LazyLock;
 
-use super::try_create_int_gauge_vec_with_node_account_id;
+use super::{
+    requests::{record_indexing_step_reached, record_request_latency_since, SignRequestStep},
+    try_create_int_gauge_vec_with_node_account_id,
+};
 
 /// Possible status options:
 ///     - "indexed" - latest block number seen by the indexer
@@ -45,5 +48,15 @@ impl ChainTelemetry for PrometheusChainTelemetry {
         LATEST_BLOCK_NUMBER
             .with_label_values(&[self.chain.as_str(), "checkpoint"])
             .set(block_number as i64);
+    }
+
+    fn request_indexed(&self, block_timestamp: Option<u64>) {
+        if let Some(ts) = block_timestamp {
+            // Ethereum path
+            record_request_latency_since(self.chain, SignRequestStep::Indexing, "ok", ts);
+        } else {
+            // Solana, Hydration, Canton path
+            record_indexing_step_reached(self.chain);
+        }
     }
 }

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -142,9 +142,16 @@ pub async fn run_stream<S: ChainStream, T: ChainTelemetry>(
                         requeue_pending_sign_requests(&backlog, chain, sign_tx.clone()).await;
                         resume_pending_publish_requests(&backlog, chain, &contract_watcher, &rpc).await;
                     }
-                    ChainEvent::SignRequest(req) => {
+                    ChainEvent::SignRequest { request, block_timestamp } => {
+                        // Handle metrics reporting for the sign request event
+                        if let Some(ts) = block_timestamp {
+                            telemetry.request_indexed_at(ts);
+                        } else {
+                            telemetry.request_indexed();
+                        }
+
                         if let Err(err) =
-                            process_sign_request(req, sign_tx.clone(), backlog.clone(), caught_up).await
+                            process_sign_request(request, sign_tx.clone(), backlog.clone(), caught_up).await
                         {
                             tracing::error!(?err, %chain, "failed to process sign request");
                         }

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -145,8 +145,10 @@ pub async fn run_stream<S: ChainStream, T: ChainTelemetry>(
                     ChainEvent::SignRequest { request, block_timestamp } => {
                         // Handle metrics reporting for the sign request event
                         if let Some(ts) = block_timestamp {
+                            // Report the request was indexed at the given block timestamp is currently used for Ethereum due to ~15 min finality delay
                             telemetry.request_indexed_at(ts);
                         } else {
+                            // Other faster chains (e.g. for Solana, Canton, or Hydration) report that a request was indexed without a block timestamp
                             telemetry.request_indexed();
                         }
 

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -1084,7 +1084,7 @@ mod tests {
         let client = EthereumTestStream::new(vec![
             Some(ChainEvent::SignRequest {
                 request: replacement,
-                block_timestamp: None
+                block_timestamp: None,
             }),
             Some(ChainEvent::CatchupCompleted),
             None,

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -568,7 +568,10 @@ mod tests {
         };
         let client = SolanaTestStream::new(vec![
             Some(ChainEvent::CatchupCompleted),
-            Some(ChainEvent::SignRequest(indexed.clone())),
+            Some(ChainEvent::SignRequest {
+                request: indexed.clone(),
+                block_timestamp: None,
+            }),
             Some(ChainEvent::Respond(sig_responded)),
             None,
         ]);
@@ -768,7 +771,10 @@ mod tests {
 
         // push SignRequest
         events_tx
-            .send(ChainEvent::SignRequest(indexed.clone()))
+            .send(ChainEvent::SignRequest {
+                request: indexed.clone(),
+                block_timestamp: None,
+            })
             .await
             .unwrap();
 
@@ -1076,7 +1082,10 @@ mod tests {
         let replacement =
             IndexedSignRequest::sign(sign_id, args.clone(), Chain::Ethereum, replayed_timestamp);
         let client = EthereumTestStream::new(vec![
-            Some(ChainEvent::SignRequest(replacement)),
+            Some(ChainEvent::SignRequest {
+                request: replacement,
+                block_timestamp: None
+            }),
             Some(ChainEvent::CatchupCompleted),
             None,
         ]);

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -1,5 +1,4 @@
 use crate::backlog::Backlog;
-use crate::metrics::requests::record_indexing_step_reached;
 use crate::protocol::{Chain, IndexedSignRequest, Sign};
 use crate::respond_bidirectional::CompletedTx;
 use crate::rpc::{ContractStateWatcher, RpcChannel};
@@ -17,11 +16,6 @@ pub(crate) async fn process_sign_request(
     backlog: Backlog,
     caught_up: bool,
 ) -> anyhow::Result<()> {
-    // Ethereum records its own indexing latency (includes finality delay) from the block timestamp in `parse_block`.
-    if sign_request.chain != Chain::Ethereum {
-        record_indexing_step_reached(sign_request.chain);
-    }
-
     if matches!(sign_request.kind, SignKind::RespondBidirectional(_)) {
         anyhow::bail!("Unexpected sign request kind");
     }

--- a/chain-signatures/primitives/src/events.rs
+++ b/chain-signatures/primitives/src/events.rs
@@ -7,7 +7,12 @@ use crate::{
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 pub enum ChainEvent {
-    SignRequest(IndexedSignRequest),
+    SignRequest {
+        /// The sign request that was observed on the chain.
+        request: IndexedSignRequest,
+        /// Optional block timestamp of the request, if available. This is used for metrics reporting.
+        block_timestamp: Option<u64>,
+    },
     Respond(SignatureRespondedEvent),
     RespondBidirectional(RespondBidirectionalEvent),
 
@@ -32,10 +37,14 @@ pub enum ChainEvent {
 impl std::fmt::Debug for ChainEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ChainEvent::SignRequest(r) => f
-                .debug_tuple("SignRequest")
-                .field(&r.id)
-                .field(&r.chain.as_str())
+            ChainEvent::SignRequest {
+                request,
+                block_timestamp,
+            } => f
+                .debug_struct("SignRequest")
+                .field("id", &request.id)
+                .field("chain", &request.chain.as_str())
+                .field("block_timestamp", block_timestamp)
                 .finish(),
             ChainEvent::Respond(ev) => f
                 .debug_tuple("Respond")

--- a/chain-signatures/primitives/src/traits.rs
+++ b/chain-signatures/primitives/src/traits.rs
@@ -30,9 +30,11 @@ pub trait ChainTelemetry: Send + Sync + Clone + 'static {
     /// Records that a checkpoint was created
     fn checkpoint_created(&self, block_number: u64);
 
-    /// Report that a request was indexed.
-    /// Pass `Some(timestamp)` if the chain supports block timestamps (Ethereum), otherwise `None`.
-    fn request_indexed(&self, block_timestamp: Option<u64>);
+    /// Report that a request was indexed at the given block timestamp (e.g. for Ethereum)
+    fn request_indexed_at(&self, block_timestamp: u64);
+
+    /// Report that a request was indexed without a block timestamp (e.g. for Solana, Canton, or Hydration)
+    fn request_indexed(&self);
 }
 
 /// No-op implementation for tests
@@ -43,5 +45,6 @@ impl ChainTelemetry for NoopChainTelemetry {
     fn block_indexed(&self, _block_number: u64) {}
     fn block_finalized(&self, _block_number: u64) {}
     fn checkpoint_created(&self, _block_number: u64) {}
-    fn request_indexed(&self, _block_timestamp: Option<u64>) {}
+    fn request_indexed_at(&self, _block_timestamp: u64) {}
+    fn request_indexed(&self) {}
 }

--- a/chain-signatures/primitives/src/traits.rs
+++ b/chain-signatures/primitives/src/traits.rs
@@ -30,10 +30,10 @@ pub trait ChainTelemetry: Send + Sync + Clone + 'static {
     /// Records that a checkpoint was created
     fn checkpoint_created(&self, block_number: u64);
 
-    /// Report that a request was indexed at the given block timestamp (e.g. for Ethereum)
+    /// Report that a request was indexed at the given block timestamp (currently used for Ethereum due to ~15 min finality delay)
     fn request_indexed_at(&self, block_timestamp: u64);
 
-    /// Report that a request was indexed without a block timestamp (e.g. for Solana, Canton, or Hydration)
+    /// Report that a request was indexed without a block timestamp (faster chains, e.g. for Solana, Canton, or Hydration)
     fn request_indexed(&self);
 }
 

--- a/chain-signatures/primitives/src/traits.rs
+++ b/chain-signatures/primitives/src/traits.rs
@@ -29,6 +29,10 @@ pub trait ChainTelemetry: Send + Sync + Clone + 'static {
 
     /// Records that a checkpoint was created
     fn checkpoint_created(&self, block_number: u64);
+
+    /// Report that a request was indexed.
+    /// Pass `Some(timestamp)` if the chain supports block timestamps (Ethereum), otherwise `None`.
+    fn request_indexed(&self, block_timestamp: Option<u64>);
 }
 
 /// No-op implementation for tests
@@ -39,4 +43,5 @@ impl ChainTelemetry for NoopChainTelemetry {
     fn block_indexed(&self, _block_number: u64) {}
     fn block_finalized(&self, _block_number: u64) {}
     fn checkpoint_created(&self, _block_number: u64) {}
+    fn request_indexed(&self, _block_timestamp: Option<u64>) {}
 }

--- a/integration-tests/src/mpc_fixture/mock_chain.rs
+++ b/integration-tests/src/mpc_fixture/mock_chain.rs
@@ -44,7 +44,10 @@ impl MockChain {
         let mut inner = self.inner.lock().await;
         let events: Vec<ChainEvent> = requests
             .iter()
-            .map(|r| ChainEvent::SignRequest(r.clone()))
+            .map(|r| ChainEvent::SignRequest {
+                request: r.clone(),
+                block_timestamp: None,
+            })
             .collect();
         inner.distribute_events(&events).await;
     }

--- a/integration-tests/src/mpc_fixture/mock_stream.rs
+++ b/integration-tests/src/mpc_fixture/mock_stream.rs
@@ -136,7 +136,10 @@ impl InnerMockStream {
                 continue;
             }
 
-            block.push(ChainEvent::SignRequest(request.clone()))
+            block.push(ChainEvent::SignRequest {
+                request: request.clone(),
+                block_timestamp: None,
+            });
         }
 
         self.future_blocks.push(block);

--- a/integration-tests/tests/cases/canton_stream.rs
+++ b/integration-tests/tests/cases/canton_stream.rs
@@ -70,7 +70,7 @@ async fn wait_for_sign_request(
     timeout(Duration::from_secs(timeout_secs), async {
         loop {
             match stream.next_event().await {
-                Some(ChainEvent::SignRequest(req)) => return Ok(req),
+                Some(ChainEvent::SignRequest { request, .. }) => return Ok(request),
                 Some(ChainEvent::Block(_)) => continue,
                 Some(_) => continue,
                 None => tokio::time::sleep(Duration::from_millis(100)).await,
@@ -179,10 +179,10 @@ async fn test_canton_stream_concurrent_events() -> Result<()> {
     let mut received_ids = HashSet::new();
     for _ in 0..20 {
         match timeout(Duration::from_secs(5), stream.next_event()).await {
-            Ok(Some(ChainEvent::SignRequest(req))) => {
-                assert_eq!(req.chain, Chain::Canton);
-                assert_eq!(req.args.path, sandbox.requester_party);
-                received_ids.insert(req.id.request_id);
+            Ok(Some(ChainEvent::SignRequest { request, .. })) => {
+                assert_eq!(request.chain, Chain::Canton);
+                assert_eq!(request.args.path, sandbox.requester_party);
+                received_ids.insert(request.id.request_id);
                 if received_ids.len() >= 3 {
                     break;
                 }
@@ -213,7 +213,7 @@ async fn test_canton_stream_catchup_linear() -> Result<()> {
     let mut last_block_stream1: u64 = 0;
     for _ in 0..10 {
         match timeout(Duration::from_millis(500), stream1.next_event()).await {
-            Ok(Some(ChainEvent::SignRequest(_))) => seen_by_stream1 += 1,
+            Ok(Some(ChainEvent::SignRequest { .. })) => seen_by_stream1 += 1,
             Ok(Some(ChainEvent::Block(b))) => {
                 if b > last_block_stream1 {
                     last_block_stream1 = b;
@@ -240,7 +240,7 @@ async fn test_canton_stream_catchup_linear() -> Result<()> {
     for _ in 0..20 {
         match timeout(Duration::from_secs(1), stream2.next_event()).await {
             Ok(Some(ChainEvent::Block(b))) if b >= last_block_stream1 => caught_up = true,
-            Ok(Some(ChainEvent::SignRequest(_))) => seen_sign_events = true,
+            Ok(Some(ChainEvent::SignRequest { .. })) => seen_sign_events = true,
             Ok(Some(_)) => {}
             _ => break,
         }
@@ -279,9 +279,9 @@ async fn test_canton_stream_checkpoint_persistence() -> Result<()> {
                 break None;
             };
             match event {
-                ChainEvent::SignRequest(req) => {
+                ChainEvent::SignRequest { request, .. } => {
                     saw_sign_request = true;
-                    backlog.insert(req).await;
+                    backlog.insert(request).await;
                 }
                 ChainEvent::Block(height) => {
                     if let Some(persisted_checkpoint) = backlog
@@ -332,9 +332,9 @@ async fn test_canton_stream_checkpoint_persistence() -> Result<()> {
     let mut saw_new_checkpoint = false;
     for _ in 0..20 {
         match timeout(Duration::from_secs(5), stream2.next_event()).await {
-            Ok(Some(ChainEvent::SignRequest(req))) => {
-                sign_request_ids.push(req.id.request_id);
-                backlog.insert(req).await;
+            Ok(Some(ChainEvent::SignRequest { request, .. })) => {
+                sign_request_ids.push(request.id.request_id);
+                backlog.insert(request).await;
                 if saw_new_checkpoint {
                     break;
                 }

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -716,7 +716,7 @@ async fn test_ethereum_stream_parse_sign_event() -> Result<()> {
 
     let req = loop {
         match next_event_within(&mut stream, Duration::from_secs(10)).await? {
-            ChainEvent::SignRequest(req) => break req,
+            ChainEvent::SignRequest { request, .. } => break request,
             _ => continue,
         }
     };
@@ -984,10 +984,10 @@ async fn test_ethereum_stream_concurrent_events() -> Result<()> {
 
     let mut received: Vec<[u8; 32]> = Vec::new();
     while received.len() < payloads.len() {
-        if let ChainEvent::SignRequest(req) =
+        if let ChainEvent::SignRequest { request, .. } =
             next_event_within(&mut stream, Duration::from_secs(10)).await?
         {
-            let bytes: [u8; 32] = req.args.payload.to_bytes().into();
+            let bytes: [u8; 32] = request.args.payload.to_bytes().into();
             received.push(bytes);
         }
     }
@@ -1015,16 +1015,16 @@ async fn test_ethereum_stream_checkpointing() -> Result<()> {
                 break None;
             };
             match event {
-                ChainEvent::SignRequest(req) => {
+                ChainEvent::SignRequest { request, .. } => {
                     saw_sign_request = true;
 
                     // The production indexer loop inserts sign requests into the backlog.
                     // These integration tests consume `ChainEvent`s directly, so replicate
                     // that behavior here so checkpoints capture pending requests.
-                    if matches!(req.kind, SignKind::RespondBidirectional(_)) {
+                    if matches!(request.kind, SignKind::RespondBidirectional(_)) {
                         continue;
                     }
-                    backlog.insert(req.clone()).await;
+                    backlog.insert(request.clone()).await;
                 }
                 ChainEvent::Block(height) => {
                     tracing::info!(height, "observed block event");
@@ -1063,13 +1063,13 @@ async fn test_ethereum_stream_checkpointing() -> Result<()> {
     let mut saw_new_checkpoint = false;
     for _ in 0..12 {
         match next_event_within(&mut stream, Duration::from_secs(10)).await? {
-            ChainEvent::SignRequest(req) => {
+            ChainEvent::SignRequest { request, .. } => {
                 saw_new_event = true;
 
-                if matches!(req.kind, SignKind::RespondBidirectional(_)) {
+                if matches!(request.kind, SignKind::RespondBidirectional(_)) {
                     continue;
                 }
-                backlog.insert(req.clone()).await;
+                backlog.insert(request.clone()).await;
 
                 if saw_new_checkpoint {
                     break;
@@ -1113,7 +1113,7 @@ async fn test_ethereum_stream_sign_and_respond_flow() -> Result<()> {
 
     let sign_req = loop {
         match next_event_within(&mut stream, Duration::from_secs(30)).await? {
-            ChainEvent::SignRequest(req) => break req,
+            ChainEvent::SignRequest { request, .. } => break request,
             _ => continue,
         }
     };

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -96,7 +96,7 @@ async fn wait_for_sign_request<S: StateManager, T: ChainTelemetry>(
 ) -> Result<IndexedSignRequest> {
     loop {
         match timeout(Duration::from_secs(6), stream.next_event()).await {
-            Ok(Some(ChainEvent::SignRequest(req))) => return Ok(req),
+            Ok(Some(ChainEvent::SignRequest { request, .. })) => return Ok(request),
             Ok(Some(ChainEvent::Block(_))) => continue,
             Ok(Some(ChainEvent::CatchupCompleted)) => {
                 tracing::info!("received CatchupCompleted event while waiting for SignRequest");
@@ -197,7 +197,7 @@ async fn test_solana_stream_catchup_linear() -> Result<()> {
     for _ in 0..10 {
         if let Ok(Some(event)) = timeout(Duration::from_millis(500), stream1.next_event()).await {
             match event {
-                ChainEvent::SignRequest(_) => seen_by_client1 += 1,
+                ChainEvent::SignRequest { .. } => seen_by_client1 += 1,
                 ChainEvent::Block(block) => last_block_client1 = last_block_client1.max(block),
                 _ => {}
             }
@@ -226,8 +226,8 @@ async fn test_solana_stream_catchup_linear() -> Result<()> {
     for _ in 0..20 {
         if let Ok(Some(event)) = timeout(Duration::from_secs(1), stream2.next_event()).await {
             match event {
-                ChainEvent::SignRequest(req) => {
-                    sign_events.push(req);
+                ChainEvent::SignRequest { request, .. } => {
+                    sign_events.push(request);
                 }
                 ChainEvent::Block(block) if block >= last_block_client1 => {
                     caught_up = true;
@@ -319,10 +319,10 @@ async fn test_solana_stream_concurrent_events() -> Result<()> {
             break;
         }
 
-        if let Ok(Some(ChainEvent::SignRequest(req))) =
+        if let Ok(Some(ChainEvent::SignRequest { request, .. })) =
             timeout(remaining, stream.next_event()).await
         {
-            sign_events.push(req);
+            sign_events.push(request);
         }
     }
 
@@ -417,7 +417,7 @@ async fn test_solana_stream_checkpoint_persistence() -> Result<()> {
     timeout(Duration::from_secs(5), async {
         loop {
             match stream2.next_event().await {
-                Some(ChainEvent::SignRequest(req)) => break Ok(req),
+                Some(ChainEvent::SignRequest { request, .. }) => break Ok(request),
                 Some(other) => {
                     tracing::info!(?other, "received non-sign/block event");
                     continue;


### PR DESCRIPTION
This PR focuses on final decoupling of indexers from Node's Prometheus metrics and centralization of telemetry updates for `IndexedSignRequest`:

- `ChainEvent::SignRequest` - add optional `block_timestamp` field. Currently only Ethereum provides `Some(block_timestamp)`, the rest are just `None`
- Remove `metrics::requests::record_request_latency_since` from Ethereum indexer. Request metrics are now being updated in one place - `run_stream` using either `request_indexed_at` or `request_indexed` methods from `ChainTelemetry`