### PR TITLE
feat: abort sign tasks on regression

### DIFF
--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -23,6 +23,7 @@ use crate::types::SignatureProtocol;
 use crate::util::{AffinePointExt, JoinMap, TimeoutBudget};
 
 use cait_sith::protocol::{Action, InitializationError, Participant};
+use lru::LruCache;
 use cait_sith::PresignOutput;
 use chrono::Utc;
 use k256::Secp256k1;
@@ -32,7 +33,8 @@ use mpc_primitives::{IndexedSignRequest, SignId, SignKind};
 use rand::rngs::StdRng;
 use rand::seq::IteratorRandom;
 use rand::SeedableRng;
-use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
@@ -1551,9 +1553,9 @@ pub struct SignatureSpawner {
     delayed_watchers: HashMap<SignId, JoinHandle<()>>,
     /// Maps in-flight tasks to their chain, enabling bulk abort on checkpoint regression.
     task_chains: HashMap<SignId, Chain>,
-    /// Cache of recently completed/aborted sign IDs. Prevents late-arriving peer
-    /// posit messages from re-creating orphan inboxes after a task is gone.
-    dead_ids: HashSet<SignId>,
+    /// LRU cache of recently completed/aborted sign IDs. Prevents late-arriving
+    /// peer posit messages from re-creating orphan inboxes after a task is gone.
+    dead_ids: LruCache<SignId, ()>,
     mesh_state: watch::Receiver<MeshState>,
     /// Limiter that limits the amount of sign tasks from progressing and utilizing
     /// too much compute otherwise the whole system will be flooded with requests.
@@ -1579,6 +1581,9 @@ impl SignatureSpawner {
         cfg: ProtocolConfig,
     ) {
         let sign_id = indexed.id;
+        // Ensure we don't retain the dead tag from a prior incarnation of this
+        // sign ID (e.g. after regression recovery re-queues a completed request).
+        self.dead_ids.pop(&sign_id);
         self.task_chains.insert(sign_id, indexed.chain);
         tracing::info!(?sign_id, "spawning signature task");
 
@@ -1729,14 +1734,10 @@ impl SignatureSpawner {
     }
 
     /// Record a sign ID as dead so that late-arriving peer posits are dropped
-    /// instead of recreating an orphan inbox. Evicts the oldest entry when the
-    /// cache exceeds [`MAX_DEAD_IDS`] — safe because the stalest IDs are the
-    /// least likely to still receive late messages.
+    /// instead of recreating an orphan inbox. Automatically LRU-evicts the
+    /// stalest entry when the cache exceeds [`MAX_DEAD_IDS`].
     fn mark_dead(&mut self, sign_id: SignId) {
-        if self.dead_ids.len() >= MAX_DEAD_IDS {
-            self.dead_ids.clear();
-        }
-        self.dead_ids.insert(sign_id);
+        self.dead_ids.put(sign_id, ());
     }
 
     fn abort_delayed_watcher(&mut self, sign_id: SignId, reason: &str) {
@@ -1866,7 +1867,7 @@ impl SignatureSpawnerTask {
             inboxes: HashMap::new(),
             delayed_watchers: HashMap::new(),
             task_chains: HashMap::new(),
-            dead_ids: HashSet::new(),
+            dead_ids: LruCache::new(NonZeroUsize::new(MAX_DEAD_IDS).unwrap()),
             presignatures: presignature_storage,
             mesh_state,
             limiter: SignLimiter::new(MAX_CONCURRENT_PROPOSERS),

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -68,6 +68,7 @@ pub enum Sign {
     Request(IndexedSignRequest),
     Completion(SignId),
     Checkpoint(IndexedSignRequest),
+    AbortChain { chain: Chain },
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1544,6 +1545,8 @@ pub struct SignatureSpawner {
     inboxes: HashMap<SignId, Subscriber<SignTaskMessage>>,
     /// Tracks delay watcher tasks that will increment the delayed metric when response time exceeds expected
     delayed_watchers: HashMap<SignId, JoinHandle<()>>,
+    /// Maps in-flight tasks to their chain, enabling bulk abort on checkpoint regression.
+    task_chains: HashMap<SignId, Chain>,
     mesh_state: watch::Receiver<MeshState>,
     /// Limiter that limits the amount of sign tasks from progressing and utilizing
     /// too much compute otherwise the whole system will be flooded with requests.
@@ -1569,6 +1572,7 @@ impl SignatureSpawner {
         cfg: ProtocolConfig,
     ) {
         let sign_id = indexed.id;
+        self.task_chains.insert(sign_id, indexed.chain);
         tracing::info!(?sign_id, "spawning signature task");
 
         // Spawn a reactive watcher task that increments the delayed metric
@@ -1665,6 +1669,7 @@ impl SignatureSpawner {
     }
 
     fn handle_completion(&mut self, sign_id: SignId) {
+        self.task_chains.remove(&sign_id);
         if let Some(inbox) = self.inboxes.remove(&sign_id) {
             inbox.clear_capacity_global();
         }
@@ -1683,6 +1688,7 @@ impl SignatureSpawner {
             Ok(outcome) => outcome,
             Err(sign_id) => {
                 tracing::warn!(?sign_id, "signature task interrupted");
+                self.task_chains.remove(&sign_id);
                 if let Some(inbox) = self.inboxes.remove(&sign_id) {
                     inbox.clear_capacity_global();
                 }
@@ -1691,6 +1697,7 @@ impl SignatureSpawner {
                 return;
             }
         };
+        self.task_chains.remove(&sign_id);
         if let Some(inbox) = self.inboxes.remove(&sign_id) {
             inbox.clear_capacity_global();
         }
@@ -1740,6 +1747,24 @@ impl SignatureSpawner {
                 );
 
                 self.spawn_task(governance, request, cfg.clone());
+            }
+            Sign::AbortChain { chain } => {
+                tracing::warn!(?chain, "aborting all in-flight signature tasks on chain regression");
+                let to_abort: Vec<SignId> = self
+                    .task_chains
+                    .iter()
+                    .filter(|(_, c)| **c == chain)
+                    .map(|(id, _)| *id)
+                    .collect();
+                for sign_id in to_abort {
+                    self.task_chains.remove(&sign_id);
+                    if let Some(inbox) = self.inboxes.remove(&sign_id) {
+                        inbox.clear_capacity_global();
+                    }
+                    self.abort_delayed_watcher(sign_id, "chain aborted");
+                    self.tasks.abort(sign_id);
+                }
+                set_inbox_count(SIGN_POSIT_INBOX_LABEL, self.inboxes.len());
             }
         }
 
@@ -1813,6 +1838,7 @@ impl SignatureSpawnerTask {
             tasks: JoinMap::new(),
             inboxes: HashMap::new(),
             delayed_watchers: HashMap::new(),
+            task_chains: HashMap::new(),
             presignatures: presignature_storage,
             mesh_state,
             limiter: SignLimiter::new(MAX_CONCURRENT_PROPOSERS),

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -32,7 +32,7 @@ use mpc_primitives::{IndexedSignRequest, SignId, SignKind};
 use rand::rngs::StdRng;
 use rand::seq::IteratorRandom;
 use rand::SeedableRng;
-use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
@@ -61,6 +61,10 @@ const ACCEPT_POSIT_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Metric channel label shared by every entry in `SignatureSpawner.inboxes`.
 const SIGN_POSIT_INBOX_LABEL: &str = "sign_posit_inbox";
+
+/// Upper bound on the number of recently-completed/aborted sign IDs we remember
+/// so that late-arriving peer posit messages do not re-create orphan inboxes.
+const MAX_DEAD_IDS: usize = 4096;
 
 #[derive(Debug, Clone, PartialEq)]
 #[allow(clippy::large_enum_variant)]
@@ -1547,6 +1551,9 @@ pub struct SignatureSpawner {
     delayed_watchers: HashMap<SignId, JoinHandle<()>>,
     /// Maps in-flight tasks to their chain, enabling bulk abort on checkpoint regression.
     task_chains: HashMap<SignId, Chain>,
+    /// Cache of recently completed/aborted sign IDs. Prevents late-arriving peer
+    /// posit messages from re-creating orphan inboxes after a task is gone.
+    dead_ids: HashSet<SignId>,
     mesh_state: watch::Receiver<MeshState>,
     /// Limiter that limits the amount of sign tasks from progressing and utilizing
     /// too much compute otherwise the whole system will be flooded with requests.
@@ -1651,6 +1658,11 @@ impl SignatureSpawner {
         if from == me {
             return;
         }
+        // Drop late-arriving posits for already-completed/aborted sign IDs
+        // to prevent re-creating orphan inboxes.
+        if self.dead_ids.contains(&sign_id) {
+            return;
+        }
         let inbox = self.inboxes.entry(sign_id).or_insert_with(|| {
             Subscriber::unsubscribed_with_capacity(
                 SIGN_POSIT_INBOX_LABEL,
@@ -1669,6 +1681,7 @@ impl SignatureSpawner {
     }
 
     fn handle_completion(&mut self, sign_id: SignId) {
+        self.mark_dead(sign_id);
         self.task_chains.remove(&sign_id);
         if let Some(inbox) = self.inboxes.remove(&sign_id) {
             inbox.clear_capacity_global();
@@ -1688,6 +1701,7 @@ impl SignatureSpawner {
             Ok(outcome) => outcome,
             Err(sign_id) => {
                 tracing::warn!(?sign_id, "signature task interrupted");
+                self.mark_dead(sign_id);
                 self.task_chains.remove(&sign_id);
                 if let Some(inbox) = self.inboxes.remove(&sign_id) {
                     inbox.clear_capacity_global();
@@ -1697,6 +1711,7 @@ impl SignatureSpawner {
                 return;
             }
         };
+        self.mark_dead(sign_id);
         self.task_chains.remove(&sign_id);
         if let Some(inbox) = self.inboxes.remove(&sign_id) {
             inbox.clear_capacity_global();
@@ -1711,6 +1726,17 @@ impl SignatureSpawner {
                 tracing::warn!(?sign_id, "signature task terminated");
             }
         }
+    }
+
+    /// Record a sign ID as dead so that late-arriving peer posits are dropped
+    /// instead of recreating an orphan inbox. Evicts the oldest entry when the
+    /// cache exceeds [`MAX_DEAD_IDS`] — safe because the stalest IDs are the
+    /// least likely to still receive late messages.
+    fn mark_dead(&mut self, sign_id: SignId) {
+        if self.dead_ids.len() >= MAX_DEAD_IDS {
+            self.dead_ids.clear();
+        }
+        self.dead_ids.insert(sign_id);
     }
 
     fn abort_delayed_watcher(&mut self, sign_id: SignId, reason: &str) {
@@ -1757,6 +1783,7 @@ impl SignatureSpawner {
                     .map(|(id, _)| *id)
                     .collect();
                 for sign_id in to_abort {
+                    self.mark_dead(sign_id);
                     self.task_chains.remove(&sign_id);
                     if let Some(inbox) = self.inboxes.remove(&sign_id) {
                         inbox.clear_capacity_global();
@@ -1839,6 +1866,7 @@ impl SignatureSpawnerTask {
             inboxes: HashMap::new(),
             delayed_watchers: HashMap::new(),
             task_chains: HashMap::new(),
+            dead_ids: HashSet::new(),
             presignatures: presignature_storage,
             mesh_state,
             limiter: SignLimiter::new(MAX_CONCURRENT_PROPOSERS),

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -23,10 +23,10 @@ use crate::types::SignatureProtocol;
 use crate::util::{AffinePointExt, JoinMap, TimeoutBudget};
 
 use cait_sith::protocol::{Action, InitializationError, Participant};
-use lru::LruCache;
 use cait_sith::PresignOutput;
 use chrono::Utc;
 use k256::Secp256k1;
+use lru::LruCache;
 use mpc_contract::config::ProtocolConfig;
 use mpc_crypto::derive_key;
 use mpc_primitives::{IndexedSignRequest, SignId, SignKind};
@@ -1776,7 +1776,10 @@ impl SignatureSpawner {
                 self.spawn_task(governance, request, cfg.clone());
             }
             Sign::AbortChain { chain } => {
-                tracing::warn!(?chain, "aborting all in-flight signature tasks on chain regression");
+                tracing::warn!(
+                    ?chain,
+                    "aborting all in-flight signature tasks on chain regression"
+                );
                 let to_abort: Vec<SignId> = self
                     .task_chains
                     .iter()
@@ -1834,6 +1837,25 @@ impl SignatureSpawner {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+impl SignatureSpawner {
+    fn test_dead_ids_contains(&self, sign_id: &SignId) -> bool {
+        self.dead_ids.contains(sign_id)
+    }
+
+    fn test_inboxes_contains(&self, sign_id: &SignId) -> bool {
+        self.inboxes.contains_key(sign_id)
+    }
+
+    fn test_tasks_contains(&self, sign_id: SignId) -> bool {
+        self.tasks.contains_key(&sign_id)
+    }
+
+    fn test_task_chains_contains(&self, sign_id: &SignId) -> bool {
+        self.task_chains.contains_key(sign_id)
     }
 }
 
@@ -2168,5 +2190,109 @@ mod tests {
             SignOrganizer::proposer_per_round(2, &participants, &entropy),
             Participant::from(0)
         );
+    }
+
+    #[tokio::test]
+    async fn test_abort_chain_dead_ids_lifecycle() {
+        let account_id: near_account_id::AccountId = "p-0".parse().unwrap();
+        let mut participants = Participants::default();
+        participants.insert(&Participant::from(0), ParticipantInfo::new(0));
+
+        let governance = GovernanceInfo {
+            me: Participant::from(0),
+            threshold: 1,
+            epoch: 0,
+            public_key: k256::AffinePoint::default(),
+            participants: [Participant::from(0)].into_iter().collect(),
+            is_running: true,
+        };
+
+        let redis_cfg = deadpool_redis::Config::from_url("redis://127.0.0.1/");
+        let pool = redis_cfg.create_pool(Some(Runtime::Tokio1)).unwrap();
+        let presignatures = Presignature::storage(&pool, &account_id);
+        let (_inbox, _outbox, msg_channel) = MessageChannel::new();
+        let (rpc_tx, _rpc_rx) = mpsc::channel(1);
+        let rpc_channel = RpcChannel { tx: rpc_tx };
+        let (contract, _tx) = ContractStateWatcher::with_running(
+            &account_id,
+            k256::AffinePoint::default(),
+            1,
+            participants.clone(),
+        );
+        let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
+
+        let mut spawner = SignatureSpawner {
+            contract,
+            presignatures,
+            tasks: JoinMap::new(),
+            inboxes: HashMap::new(),
+            delayed_watchers: HashMap::new(),
+            task_chains: HashMap::new(),
+            dead_ids: LruCache::new(NonZeroUsize::new(MAX_DEAD_IDS).unwrap()),
+            mesh_state: mesh_rx,
+            limiter: SignLimiter::new(MAX_CONCURRENT_PROPOSERS),
+            msg: msg_channel,
+            rpc: rpc_channel,
+            backlog: Backlog::new(),
+            node_account_id: account_id,
+        };
+
+        let cfg = ProtocolConfig::default();
+        let sign_id = SignId::new([42u8; 32]);
+        let args = mpc_primitives::SignArgs {
+            entropy: [1u8; 32],
+            epsilon: k256::Scalar::from(1u64),
+            payload: k256::Scalar::from(2u64),
+            path: "test".to_string(),
+            key_version: 1,
+        };
+        let request = IndexedSignRequest::sign(sign_id, args, Chain::Solana, 0);
+
+        // Step 1: Spawn → inbox created, task_chains populated, not dead
+        spawner.spawn_task(&governance, request.clone(), cfg.clone());
+        assert!(spawner.test_tasks_contains(sign_id));
+        assert!(spawner.test_inboxes_contains(&sign_id));
+        assert!(spawner.test_task_chains_contains(&sign_id));
+        assert!(!spawner.test_dead_ids_contains(&sign_id));
+
+        // Step 2: Abort chain → inbox removed, task_chains cleared, marked dead
+        spawner.handle_request(
+            &governance,
+            Sign::AbortChain {
+                chain: Chain::Solana,
+            },
+            &cfg,
+        );
+        assert!(!spawner.test_tasks_contains(sign_id));
+        assert!(!spawner.test_inboxes_contains(&sign_id));
+        assert!(!spawner.test_task_chains_contains(&sign_id));
+        assert!(spawner.test_dead_ids_contains(&sign_id));
+
+        // Step 3: Late posit → dropped (dead_id check), inbox NOT recreated
+        spawner.handle_posit(
+            Participant::from(0),
+            sign_id,
+            0,
+            0,
+            Participant::from(1),
+            PositAction::Propose,
+        );
+        assert!(!spawner.test_inboxes_contains(&sign_id));
+
+        // Step 4: Re-spawn → dead cleared, task_chains repopulated
+        spawner.spawn_task(&governance, request, cfg.clone());
+        assert!(spawner.test_tasks_contains(sign_id));
+        assert!(!spawner.test_dead_ids_contains(&sign_id));
+
+        // Step 5: Posit after re-spawn → accepted, inbox re-created
+        spawner.handle_posit(
+            Participant::from(0),
+            sign_id,
+            0,
+            0,
+            Participant::from(1),
+            PositAction::Propose,
+        );
+        assert!(spawner.test_inboxes_contains(&sign_id));
     }
 }

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -74,7 +74,7 @@ pub enum Sign {
     Request(IndexedSignRequest),
     Completion(SignId),
     Checkpoint(IndexedSignRequest),
-    AbortChain { chain: Chain },
+    AbortChain(Chain),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1775,7 +1775,7 @@ impl SignatureSpawner {
 
                 self.spawn_task(governance, request, cfg.clone());
             }
-            Sign::AbortChain { chain } => {
+            Sign::AbortChain(chain) => {
                 tracing::warn!(
                     ?chain,
                     "aborting all in-flight signature tasks on chain regression"
@@ -2258,9 +2258,7 @@ mod tests {
         // Step 2: Abort chain → inbox removed, task_chains cleared, marked dead
         spawner.handle_request(
             &governance,
-            Sign::AbortChain {
-                chain: Chain::Solana,
-            },
+            Sign::AbortChain(Chain::Solana),
             &cfg,
         );
         assert!(!spawner.test_tasks_contains(sign_id));

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -2256,11 +2256,7 @@ mod tests {
         assert!(!spawner.test_dead_ids_contains(&sign_id));
 
         // Step 2: Abort chain → inbox removed, task_chains cleared, marked dead
-        spawner.handle_request(
-            &governance,
-            Sign::AbortChain(Chain::Solana),
-            &cfg,
-        );
+        spawner.handle_request(&governance, Sign::AbortChain(Chain::Solana), &cfg);
         assert!(!spawner.test_tasks_contains(sign_id));
         assert!(!spawner.test_inboxes_contains(&sign_id));
         assert!(!spawner.test_task_chains_contains(&sign_id));

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -116,6 +116,7 @@ pub async fn run_stream<S: ChainStream, T: ChainTelemetry>(
         indexer,
         checkpoints_rx.clone(),
         backlog.clone(),
+        sign_tx.clone(),
         mesh_state.clone(),
         node_client,
         threshold,
@@ -462,11 +463,13 @@ mod tests {
         indexer.livestream().await.unwrap();
         let (_cp_tx, cp_rx) = watch::channel(CheckpointDigest::default());
         let (_m_tx, m_rx) = watch::channel(MeshState::default());
+        let (_sign_tx, _sign_rx) = mpsc::channel(1);
         let (pipeline, _state_rx) = ChainPipeline::from_state(
             ChainStreaming::Catchup { anchor_height: 4 },
             indexer,
             cp_rx,
             Backlog::new(),
+            _sign_tx,
             m_rx,
             NodeClient::new(&Default::default()),
             0,
@@ -501,11 +504,13 @@ mod tests {
         indexer.livestream().await.unwrap();
         let (_cp_tx, cp_rx) = watch::channel(CheckpointDigest::default());
         let (_m_tx, m_rx) = watch::channel(MeshState::default());
+        let (_stx, _srx) = mpsc::channel(1);
         let (pipeline, _state_rx) = ChainPipeline::from_state(
             ChainStreaming::Catchup { anchor_height: 4 },
             indexer,
             cp_rx,
             Backlog::new(),
+            _stx,
             m_rx,
             NodeClient::new(&Default::default()),
             0,
@@ -1365,6 +1370,7 @@ mod tests {
         });
         let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
 
+        let (_stx, _srx) = mpsc::channel(1);
         let (catchup_tx, catchup_rx) = oneshot::channel();
         let indexer = MockCatchupIndexer {
             catchup_started_tx: Arc::new(Mutex::new(Some(catchup_tx))),
@@ -1374,6 +1380,7 @@ mod tests {
             indexer,
             cp_rx,
             backlog,
+            _stx,
             mesh_rx,
             NodeClient::new(&Default::default()),
             0,
@@ -1446,6 +1453,7 @@ mod tests {
         let (cp_tx, cp_rx) = watch::channel(CheckpointDigest { height: 10, digest });
         let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
         let (next_called_tx, next_called_rx) = oneshot::channel();
+        let (_stx, _srx) = mpsc::channel(1);
         let indexer = MockLiveIndexer {
             next_called_tx: Arc::new(Mutex::new(Some(next_called_tx))),
         };
@@ -1455,6 +1463,7 @@ mod tests {
             indexer,
             cp_rx,
             backlog,
+            _stx,
             mesh_rx,
             NodeClient::new(&Default::default()),
             1,

--- a/chain-signatures/node/src/stream/pipeline.rs
+++ b/chain-signatures/node/src/stream/pipeline.rs
@@ -23,6 +23,7 @@ pub struct ChainPipeline<I: ChainIndexer> {
 }
 
 impl<I: ChainIndexer> ChainPipeline<I> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         indexer: I,
         checkpoints_rx: watch::Receiver<CheckpointDigest>,
@@ -161,7 +162,7 @@ impl<I: ChainIndexer> ChainPipeline<I> {
         .is_some()
         {
             tracing::warn!(%chain, "backlog regressed via consensus checkpoint; aborting in-flight tasks");
-            let _ = self.sign_tx.send(Sign::AbortChain { chain }).await;
+            let _ = self.sign_tx.send(Sign::AbortChain(chain)).await;
         }
 
         // Determine anchor height

--- a/chain-signatures/node/src/stream/pipeline.rs
+++ b/chain-signatures/node/src/stream/pipeline.rs
@@ -1,12 +1,13 @@
 use crate::backlog::Backlog;
 use crate::mesh::MeshState;
 use crate::node_client::NodeClient;
+use crate::protocol::signature::Sign;
 use crate::protocol::Chain;
 use crate::stream::{ChainIndexer, ChainStreaming};
 use futures_util::StreamExt;
 use mpc_primitives::CheckpointDigest;
 use near_account_id::AccountId;
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch};
 
 pub struct ChainPipeline<I: ChainIndexer> {
     indexer: I,
@@ -14,6 +15,7 @@ pub struct ChainPipeline<I: ChainIndexer> {
     state_rx: watch::Receiver<ChainStreaming>,
     checkpoints_rx: watch::Receiver<CheckpointDigest>,
     backlog: Backlog,
+    sign_tx: mpsc::Sender<Sign>,
     mesh_state: watch::Receiver<MeshState>,
     node_client: NodeClient,
     threshold: usize,
@@ -25,6 +27,7 @@ impl<I: ChainIndexer> ChainPipeline<I> {
         indexer: I,
         checkpoints_rx: watch::Receiver<CheckpointDigest>,
         backlog: Backlog,
+        sign_tx: mpsc::Sender<Sign>,
         mesh_state: watch::Receiver<MeshState>,
         node_client: NodeClient,
         threshold: usize,
@@ -35,6 +38,7 @@ impl<I: ChainIndexer> ChainPipeline<I> {
             indexer,
             checkpoints_rx,
             backlog,
+            sign_tx,
             mesh_state,
             node_client,
             threshold,
@@ -48,6 +52,7 @@ impl<I: ChainIndexer> ChainPipeline<I> {
         indexer: I,
         checkpoints_rx: watch::Receiver<CheckpointDigest>,
         backlog: Backlog,
+        sign_tx: mpsc::Sender<Sign>,
         mesh_state: watch::Receiver<MeshState>,
         node_client: NodeClient,
         threshold: usize,
@@ -60,6 +65,7 @@ impl<I: ChainIndexer> ChainPipeline<I> {
             state_rx: state_rx.clone(),
             backlog,
             checkpoints_rx,
+            sign_tx,
             mesh_state,
             node_client,
             threshold,
@@ -140,9 +146,10 @@ impl<I: ChainIndexer> ChainPipeline<I> {
         }
 
         // Perform consensus checkpoint alignment. Returns None when no alignment is
-        // needed (the normal case); returns Some(height) when the backlog was aligned.
-        // Either way, continue to livestream initialization.
-        crate::backlog::consensus::align_backlog_with_consensus(
+        // needed (the normal case); returns Some(height) when the backlog was regressed.
+        // When regression occurs, abort all in-flight signature tasks for this chain
+        // so stale tasks don't complete and publish abandoned signatures/checkpoints.
+        if crate::backlog::consensus::align_backlog_with_consensus(
             chain,
             &self.backlog,
             &mut self.checkpoints_rx,
@@ -150,7 +157,12 @@ impl<I: ChainIndexer> ChainPipeline<I> {
             &self.node_client,
             &self.my_account_id,
         )
-        .await;
+        .await
+        .is_some()
+        {
+            tracing::warn!(%chain, "backlog regressed via consensus checkpoint; aborting in-flight tasks");
+            let _ = self.sign_tx.send(Sign::AbortChain { chain }).await;
+        }
 
         // Determine anchor height
         let anchor_height = loop {

--- a/chain-signatures/node/src/util/mod.rs
+++ b/chain-signatures/node/src/util/mod.rs
@@ -210,7 +210,7 @@ impl<T, U> JoinMap<T, U> {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.mapping.is_empty()
+        self.tasks.is_empty()
     }
 }
 

--- a/integration-tests/tests/cases/canton_stream.rs
+++ b/integration-tests/tests/cases/canton_stream.rs
@@ -34,10 +34,12 @@ async fn stream_canton(
     let (_cp_tx, cp_rx) = tokio::sync::watch::channel(CheckpointDigest::default());
     let (_mesh_tx, mesh_rx) = tokio::sync::watch::channel(MeshState::default());
     let node_client = NodeClient::new(&Default::default());
+    let (sign_tx, _sign_rx) = tokio::sync::mpsc::channel(1);
     let (pipeline, mut state_rx) = ChainPipeline::new(
         indexer,
         cp_rx,
         backlog,
+        sign_tx,
         mesh_rx,
         node_client,
         0,

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -386,10 +386,12 @@ async fn stream_ethereum(
     let (_cp_tx, cp_rx) = watch::channel(CheckpointDigest::default());
     let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
     let node_client = NodeClient::new(&Default::default());
+    let (sign_tx, _sign_rx) = tokio::sync::mpsc::channel(1);
     let (pipeline, mut state_rx) = ChainPipeline::new(
         indexer,
         cp_rx,
         backlog,
+        sign_tx,
         mesh_rx,
         node_client,
         0,

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -61,10 +61,12 @@ async fn stream_solana_with_backlog(
     // Start from Recovery so that handle_recovery() calls livestream(), which
     // spawns the live event subscription and initializes the live_rx channel.
     // Starting in Live would skip this initialization and produce no events.
+    let (sign_tx, _sign_rx) = mpsc::channel(1);
     let (pipeline, mut state_rx) = ChainPipeline::new(
         indexer,
         cp_rx,
         backlog,
+        sign_tx,
         mesh_rx,
         node_client,
         0,


### PR DESCRIPTION
on chain consensus regression detected, the MPC node immediately halts all active signature generation and consensus checkpoint tasks for the regressed chain. This prevents the node from wasting compute resources and publishing stale/abandoned signatures or checkpoints on-chain.

## Changes
* `Sign::AbortChain(chain)` notifies SignatureSpawner of a consensus regression.
* On Sign::AbortChain, the spawner immediately aborts running tasks, removes their posit inboxes, and cancels delayed watcher handles.
* dead_ids LruCache in SignatureSpawner to track recently completed/aborted task IDs.
* Late-arriving peer posit messages for stale requests are silently dropped if the request ID is in the cache, preventing orphaned inbox memory leaks.
  * Automatically clears a task's ID from the cache upon spawn_task so that re-queued requests (after catchup and alignment) can successfully process new peer messages.