### PR TITLE
refactor: Ethereum RPC publisher client

### DIFF
--- a/chain-signatures/node/src/rpc/canton.rs
+++ b/chain-signatures/node/src/rpc/canton.rs
@@ -1,0 +1,269 @@
+use super::PublishAction;
+use crate::indexer_canton::ledger_api::{
+    ActiveContractEntry, CumulativeFilter, EventFormat, GetActiveContractsRequest,
+    IdentifierFilter, JsCommands, LedgerEndResponse, PartyFilter,
+    SubmitAndWaitForTransactionRequest, SubmitAndWaitForTransactionResponse, TemplateFilterValue,
+};
+use crate::indexer_canton::{
+    contracts::{CantonSignature, EcdsaSigData},
+    CantonAuthProvider, CantonConfig,
+};
+use crate::indexer_canton::{der_encode_signature, CantonChainCtx};
+use mpc_primitives::{Chain, SignKind, Signature};
+use std::time::{Duration, Instant};
+
+#[derive(Clone)]
+pub struct CantonClient {
+    pub(crate) config: CantonConfig,
+    http_client: reqwest::Client,
+    auth_provider: CantonAuthProvider,
+}
+
+impl std::fmt::Debug for CantonClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CantonClient")
+            .field("config", &self.config)
+            .field("auth_provider", &"<hidden>")
+            .finish()
+    }
+}
+
+impl CantonClient {
+    pub async fn new(config: &CantonConfig) -> anyhow::Result<Self> {
+        let http_client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()?;
+
+        let auth_provider = CantonAuthProvider::new(config.auth.clone())?;
+
+        if !config.signer_contract_id.is_empty() || !config.signer_template_id.is_empty() {
+            tracing::info!(
+                signer_cid = %config.signer_contract_id,
+                signer_template_id = %config.signer_template_id,
+                "canton Signer contract configured"
+            );
+        }
+
+        Ok(Self {
+            config: config.clone(),
+            http_client,
+            auth_provider,
+        })
+    }
+
+    pub fn ledger_api_user(&self) -> &str {
+        &self.config.ledger_api_user
+    }
+
+    pub async fn bearer_token(&self) -> anyhow::Result<String> {
+        self.auth_provider.bearer_token().await
+    }
+
+    fn json_api_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.config.json_api_url, path)
+    }
+
+    pub async fn auth_post(&self, path: &str) -> anyhow::Result<reqwest::RequestBuilder> {
+        let token = self.bearer_token().await?;
+        Ok(self
+            .http_client
+            .post(self.json_api_endpoint(path))
+            .bearer_auth(token))
+    }
+
+    pub async fn auth_get(&self, path: &str) -> anyhow::Result<reqwest::RequestBuilder> {
+        let token = self.bearer_token().await?;
+        Ok(self
+            .http_client
+            .get(self.json_api_endpoint(path))
+            .bearer_auth(token))
+    }
+
+    pub async fn fetch_ledger_end(&self) -> anyhow::Result<u64> {
+        let resp = self.auth_get("/v2/state/ledger-end").await?.send().await?;
+        let resp = check_response(resp, "ledger-end").await?;
+        let body: LedgerEndResponse = resp.json().await?;
+        Ok(body.offset)
+    }
+
+    pub async fn fetch_active_contracts(
+        &self,
+        parties: &[&str],
+        template_id: Option<&str>,
+        include_blob: bool,
+    ) -> anyhow::Result<Vec<ActiveContractEntry>> {
+        let offset = self.fetch_ledger_end().await?;
+
+        let mut filters = serde_json::Map::new();
+        for party in parties {
+            let value = match template_id {
+                Some(tid) => serde_json::to_value(PartyFilter {
+                    cumulative: vec![CumulativeFilter {
+                        identifier_filter: IdentifierFilter::TemplateFilter {
+                            value: TemplateFilterValue {
+                                template_id: tid.to_string(),
+                                include_created_event_blob: include_blob,
+                            },
+                        },
+                    }],
+                })?,
+                None => serde_json::json!({}),
+            };
+            filters.insert(party.to_string(), value);
+        }
+
+        let req = GetActiveContractsRequest {
+            active_at_offset: offset,
+            event_format: EventFormat {
+                filters_by_party: filters,
+                verbose: true,
+            },
+        };
+
+        let resp = self
+            .auth_post("/v2/state/active-contracts")
+            .await?
+            .json(&req)
+            .send()
+            .await?;
+
+        let resp = check_response(resp, "active-contracts query").await?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn submit_and_wait(
+        &self,
+        commands: JsCommands,
+        context: &str,
+    ) -> anyhow::Result<SubmitAndWaitForTransactionResponse> {
+        let resp = self
+            .auth_post("/v2/commands/submit-and-wait-for-transaction")
+            .await?
+            .json(&SubmitAndWaitForTransactionRequest { commands })
+            .send()
+            .await?;
+        let resp = check_response(resp, context).await?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn exercise_choice(
+        &self,
+        command_id: &str,
+        choice: &str,
+        choice_argument: serde_json::Value,
+    ) -> anyhow::Result<()> {
+        use crate::indexer_canton::ledger_api::{Command, JsCommands};
+        let commands = JsCommands {
+            command_id: command_id.to_string(),
+            user_id: self.config.ledger_api_user.clone(),
+            act_as: vec![self.config.party_id.clone()],
+            read_as: vec![self.config.party_id.clone()],
+            commands: vec![Command::ExerciseCommand {
+                template_id: self.config.signer_template_id.clone(),
+                contract_id: self.config.signer_contract_id.clone(),
+                choice: choice.to_string(),
+                choice_argument,
+            }],
+            disclosed_contracts: vec![],
+        };
+        self.submit_and_wait(commands, &format!("canton {choice}"))
+            .await?;
+        Ok(())
+    }
+}
+
+async fn check_response(
+    resp: reqwest::Response,
+    context: &str,
+) -> anyhow::Result<reqwest::Response> {
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("{context} failed: {status} {text}");
+    }
+    Ok(resp)
+}
+
+pub async fn try_publish_canton(
+    canton: &CantonClient,
+    action: &PublishAction,
+    timestamp: &Instant,
+    signature: &Signature,
+) -> anyhow::Result<()> {
+    let sign_id = action.indexed.id;
+    let request_id_hex = hex::encode(action.indexed.id.request_id);
+
+    tracing::info!(
+        ?sign_id,
+        chain = ?action.indexed.chain,
+        elapsed = ?timestamp.elapsed(),
+        request_id = %request_id_hex,
+        "canton: publishing signature"
+    );
+
+    let der_sig = hex::encode(der_encode_signature(signature)?);
+    let canton_signature = serde_json::to_value(CantonSignature::EcdsaSig(EcdsaSigData {
+        der: der_sig,
+        recovery_id: signature.recovery_id,
+    }))?;
+    let (choice, command_id, choice_argument) = match &action.indexed.kind {
+        SignKind::SignBidirectional(event) if event.chain == Chain::Canton => {
+            let chain_ctx_bytes = event
+                .chain_ctx
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("missing chain_ctx on Canton sign request"))?;
+            let ctx: CantonChainCtx = borsh::from_slice(chain_ctx_bytes)
+                .map_err(|e| anyhow::anyhow!("failed to deserialize CantonChainCtx: {e}"))?;
+            (
+                "Respond",
+                format!("mpc-respond-{request_id_hex}"),
+                serde_json::json!({
+                    "signEventCid": ctx.sign_event_contract_id,
+                    "requestId": request_id_hex,
+                    "signature": canton_signature,
+                }),
+            )
+        }
+        SignKind::RespondBidirectional(respond_tx) => {
+            let chain_ctx_bytes = respond_tx
+                .chain_ctx
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("missing chain_ctx on Canton response"))?;
+            let ctx: CantonChainCtx = borsh::from_slice(chain_ctx_bytes)
+                .map_err(|e| anyhow::anyhow!("failed to deserialize CantonChainCtx: {e}"))?;
+            (
+                "RespondBidirectional",
+                format!("mpc-respond-bidir-{request_id_hex}"),
+                serde_json::json!({
+                    "signEventCid": ctx.sign_event_contract_id,
+                    "requestId": request_id_hex,
+                    "serializedOutput": hex::encode(&respond_tx.output),
+                    "signature": canton_signature,
+                }),
+            )
+        }
+        _ => anyhow::bail!("Canton supports only Canton SignBidirectional or RespondBidirectional"),
+    };
+
+    canton
+        .exercise_choice(&command_id, choice, choice_argument)
+        .await
+        .inspect_err(|err| {
+            tracing::error!(
+                ?sign_id,
+                choice,
+                request_id = %request_id_hex,
+                error = %err,
+                "canton: failed to publish signature"
+            );
+        })?;
+
+    tracing::info!(
+        ?sign_id,
+        choice,
+        elapsed = ?timestamp.elapsed(),
+        "published canton {choice} successfully"
+    );
+
+    Ok(())
+}

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -37,12 +37,6 @@ type EthContractFillProvider = FillProvider<
     RootProvider,
 >;
 
-// Get nonce retry constants
-const ETH_NONCE_MAX_ATTEMPTS: usize = 3;
-const ETH_NONCE_TIMEOUT: Duration = Duration::from_secs(2);
-const ETH_NONCE_MIN_DELAY: Duration = Duration::from_millis(500);
-const ETH_NONCE_MAX_DELAY: Duration = Duration::from_secs(5);
-
 // Send Ethereum tx retry constants
 const ETH_SEND_MAX_ATTEMPTS: usize = 3;
 const ETH_SEND_TIMEOUT: Duration = Duration::from_secs(5);
@@ -188,50 +182,6 @@ async fn send_eth_responses(
     gas: u64,
     sign_ids: &[SignId],
 ) -> Result<alloy::primitives::B256, ()> {
-    // TODO: fetching nonce from RPC is slow and expensive, consider better approach (fetch once, increment locally, etc.)
-    // 1. Fetch Nonce
-    let nonce_retry = RetryConfig {
-        max_times: ETH_NONCE_MAX_ATTEMPTS,
-        min_delay: ETH_NONCE_MIN_DELAY,
-        max_delay: ETH_NONCE_MAX_DELAY,
-        jitter: true,
-    };
-
-    let nonce = match retry_rpc!(
-        ETH_NONCE_TIMEOUT,
-        nonce_retry,
-        // Log the error and retry attempt
-        |attempt, err, sleep| {
-            tracing::warn!(
-                ?sign_ids,
-                attempt,
-                "get_nonce failed: {err}, retrying in {sleep:?}"
-            );
-        },
-        // Try to get the nonce
-        {
-            contract
-                .provider()
-                .get_transaction_count(contract.provider().default_signer_address())
-                .pending()
-                .await
-                .map_err(|e| anyhow::anyhow!("RPC Error: {e}"))
-        }
-    ) {
-        Ok(n) => n,
-        Err(err) => {
-            tracing::error!(
-                ?sign_ids,
-                ?err,
-                "failed to get nonce: retry attempts exhausted"
-            );
-            return Err(());
-        }
-    };
-
-    tracing::info!(nonce, "will send eth tx with nonce");
-
-    // 2. Send Tx
     let send_retry = RetryConfig {
         max_times: ETH_SEND_MAX_ATTEMPTS,
         min_delay: ETH_SEND_MIN_DELAY,
@@ -250,6 +200,21 @@ async fn send_eth_responses(
             );
         },
         {
+            // TODO: fetching nonce from RPC is slow and expensive, consider better approach (fetch once, increment locally, etc.)
+            // Fetch nonce here in the retry loop, otherwise we may get the same nonce on retry
+            let nonce = contract
+                .provider()
+                .get_transaction_count(contract.provider().default_signer_address())
+                .pending()
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to fetch nonce: {e}"))?;
+
+            tracing::info!(
+                nonce,
+                "will send eth tx with nonce {nonce} for sign_ids: {:?}",
+                sign_ids
+            );
+
             contract
                 .respond(responses.clone()) // Need to clone because closure has to implement `FnMut` (otherwise it's `FnOnce`)
                 .gas(gas)
@@ -320,7 +285,7 @@ pub async fn try_publish_eth(
 
 pub async fn try_batch_publish_eth(
     eth: &EthClient,
-    actions: &Vec<PublishAction>,
+    actions: &[PublishAction],
     signatures: &HashMap<SignId, Signature>,
 ) -> Result<(), ()> {
     let chain = Chain::Ethereum;

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -1,0 +1,407 @@
+use super::PublishAction;
+use crate::indexer_eth::EthConfig;
+use crate::util::retry::{retry_rpc, RetryConfig};
+use alloy::contract::{ContractInstance, Interface};
+use alloy::dyn_abi::DynSolValue;
+use alloy::network::EthereumWallet;
+use alloy::primitives::Address;
+use alloy::primitives::U256;
+use alloy::providers::fillers::{FillProvider, JoinFill, WalletFiller};
+use alloy::providers::ProviderBuilder;
+use alloy::providers::{Provider, RootProvider, WalletProvider};
+use alloy::rpc::types::{Transaction, TransactionReceipt};
+use alloy_signer_local::PrivateKeySigner;
+use k256::elliptic_curve::point::AffineCoordinates;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use mpc_primitives::{Chain, SignId, Signature};
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::time::{Duration, Instant};
+
+type EthContractFillProvider = FillProvider<
+    JoinFill<
+        JoinFill<
+            alloy::providers::Identity,
+            JoinFill<
+                alloy::providers::fillers::GasFiller,
+                JoinFill<
+                    alloy::providers::fillers::BlobGasFiller,
+                    JoinFill<
+                        alloy::providers::fillers::NonceFiller,
+                        alloy::providers::fillers::ChainIdFiller,
+                    >,
+                >,
+            >,
+        >,
+        WalletFiller<EthereumWallet>,
+    >,
+    RootProvider,
+>;
+type EthContractInstance = ContractInstance<EthContractFillProvider>;
+
+// Get nonce retry constants
+const ETH_NONCE_MAX_ATTEMPTS: usize = 3;
+const ETH_NONCE_TIMEOUT: Duration = Duration::from_secs(2);
+const ETH_NONCE_MIN_DELAY: Duration = Duration::from_millis(500);
+const ETH_NONCE_MAX_DELAY: Duration = Duration::from_secs(5);
+
+// Send Ethereum tx retry constants
+const ETH_SEND_MAX_ATTEMPTS: usize = 3;
+const ETH_SEND_TIMEOUT: Duration = Duration::from_secs(5);
+const ETH_SEND_MIN_DELAY: Duration = Duration::from_millis(500);
+const ETH_SEND_MAX_DELAY: Duration = Duration::from_secs(10);
+
+// Polling Mempool
+const ETH_MEMPOOL_TIMEOUT: Duration = Duration::from_secs(5);
+const ETH_MEMPOOL_MIN_DELAY: Duration = Duration::from_secs(1);
+const ETH_MEMPOOL_MAX_DELAY: Duration = Duration::from_secs(10);
+
+// Polling Receipt
+const ETH_RECEIPT_TIMEOUT: Duration = Duration::from_secs(2);
+const ETH_RECEIPT_MIN_DELAY: Duration = Duration::from_secs(1);
+const ETH_RECEIPT_MAX_DELAY: Duration = Duration::from_secs(20);
+
+// Ethereum gas limits
+const ETH_BASE_GAS_LIMIT: u64 = 40_000;
+const ETH_BATCH_GAS_PER_REQUEST: u64 = 20_000;
+
+/// The maximum number of attempts to fetch eth tx and its receipt
+const ETH_TX_RECEIPT_MAX_ATTEMPTS: usize = 6;
+
+#[derive(Clone)]
+pub struct EthClient {
+    contract: EthContractInstance,
+}
+
+impl EthClient {
+    pub fn new(eth: &EthConfig) -> Self {
+        let signer: PrivateKeySigner = eth
+            .account_sk
+            .parse()
+            .expect("cannot parse Eth account sk into PrivateKeySigner");
+        let wallet = EthereumWallet::from(signer.clone());
+        let provider = ProviderBuilder::new()
+            .wallet(wallet)
+            .connect_http(eth.execution_rpc_http_url.parse().unwrap());
+        // Create a contract instance.
+        let json: serde_json::Value = serde_json::from_slice(include_bytes!(
+            "../../../contract-eth/artifacts/contracts/ChainSignatures.sol/ChainSignatures.json"
+        ))
+        .unwrap();
+
+        // Get `abi` from the artifact.
+        let abi_value = json.get("abi").expect("Failed to get ABI from artifact");
+        let abi = serde_json::from_str(&abi_value.to_string()).unwrap();
+
+        let contract = ContractInstance::new(
+            Address::from_str(&format!("0x{}", eth.contract_address)).unwrap(),
+            provider.clone(),
+            Interface::new(abi),
+        );
+        Self { contract }
+    }
+}
+
+// wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
+async fn wait_for_pending_tx(
+    provider: &EthContractFillProvider,
+    tx_hash: alloy::primitives::B256,
+    sign_ids: Vec<SignId>,
+    max_attempts: usize,
+) -> Result<Transaction, ()> {
+    let retry_config = RetryConfig {
+        max_times: max_attempts,
+        min_delay: ETH_MEMPOOL_MIN_DELAY,
+        max_delay: ETH_MEMPOOL_MAX_DELAY,
+        jitter: true,
+    };
+
+    retry_rpc!(
+        ETH_MEMPOOL_TIMEOUT,
+        retry_config,
+        // Log the error and retry attempt
+        |attempt, err, sleep| {
+            tracing::error!(
+                ?sign_ids,
+                attempt,
+                "failed to get eth signature respond pending transaction: {err}, retrying in {sleep:?}"
+            );
+        },
+        // Try to get the pending transaction
+        {
+            match provider.get_transaction_by_hash(tx_hash).await {
+                Ok(Some(tx)) => {
+                    tracing::info!(?sign_ids, "eth signature respond pending transaction found");
+                    Ok(tx)
+                }
+                Ok(None) => Err(anyhow::anyhow!("Transaction not in mempool yet")),
+                Err(e) => Err(anyhow::anyhow!("RPC Error: {e}")),
+            }
+        }
+    ).map_err(|_| ())
+}
+
+// wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
+async fn wait_for_transaction_receipt(
+    provider: &EthContractFillProvider,
+    tx_hash: alloy::primitives::B256,
+    sign_ids: Vec<SignId>,
+    max_attempts: usize,
+) -> Result<TransactionReceipt, ()> {
+    let retry_config = RetryConfig {
+        max_times: max_attempts,
+        min_delay: ETH_RECEIPT_MIN_DELAY,
+        max_delay: ETH_RECEIPT_MAX_DELAY,
+        jitter: true,
+    };
+
+    retry_rpc!(
+        ETH_RECEIPT_TIMEOUT,
+        retry_config,
+        // Log the error and retry attempt
+        |attempt, err, sleep| {
+            tracing::error!(
+                ?sign_ids,
+                attempt,
+                "failed to get eth signature respond transaction receipt: {err}, retrying in {sleep:?}"
+            );
+        },
+        // Try to get the transaction receipt
+        {
+            match provider.get_transaction_receipt(tx_hash).await {
+                Ok(Some(receipt)) => {
+                    tracing::info!(?sign_ids, "eth signature respond transaction receipt found");
+                    Ok(receipt)
+                }
+                Ok(None) => Err(anyhow::anyhow!("Receipt not ready yet")),
+                Err(e) => Err(anyhow::anyhow!("RPC Error: {e}")),
+            }
+        }
+    ).map_err(|_| ())
+}
+
+async fn send_eth_transaction(
+    contract: &EthContractInstance,
+    params: &[DynSolValue],
+    gas: u64,
+    sign_ids: &[SignId],
+) -> Result<alloy::primitives::B256, ()> {
+    // TODO: fetching nonce from RPC is slow and expensive, consider better approach (fetch once, increment locally, etc.)
+    // 1. Fetch Nonce
+    let nonce_retry = RetryConfig {
+        max_times: ETH_NONCE_MAX_ATTEMPTS,
+        min_delay: ETH_NONCE_MIN_DELAY,
+        max_delay: ETH_NONCE_MAX_DELAY,
+        jitter: true,
+    };
+
+    let nonce = match retry_rpc!(
+        ETH_NONCE_TIMEOUT,
+        nonce_retry,
+        // Log the error and retry attempt
+        |attempt, err, sleep| {
+            tracing::warn!(
+                ?sign_ids,
+                attempt,
+                "get_nonce failed: {err}, retrying in {sleep:?}"
+            );
+        },
+        // Try to get the nonce
+        {
+            contract
+                .provider()
+                .get_transaction_count(contract.provider().default_signer_address())
+                .pending()
+                .await
+                .map_err(|e| anyhow::anyhow!("RPC Error: {e}"))
+        }
+    ) {
+        Ok(n) => n,
+        Err(err) => {
+            tracing::error!(
+                ?sign_ids,
+                ?err,
+                "failed to get nonce: retry attempts exhausted"
+            );
+            return Err(());
+        }
+    };
+
+    tracing::info!(nonce, "will send eth tx with nonce");
+
+    // 2. Send Tx
+    let send_retry = RetryConfig {
+        max_times: ETH_SEND_MAX_ATTEMPTS,
+        min_delay: ETH_SEND_MIN_DELAY,
+        max_delay: ETH_SEND_MAX_DELAY,
+        jitter: true,
+    };
+
+    retry_rpc!(
+        ETH_SEND_TIMEOUT,
+        send_retry,
+        |attempt, err, sleep| {
+            tracing::warn!(
+                ?sign_ids,
+                attempt,
+                "send eth tx failed: {err}, retrying in {sleep:?}"
+            );
+        },
+        {
+            contract
+                .function("respond", params)
+                .unwrap()
+                .gas(gas)
+                .nonce(nonce)
+                .send()
+                .await
+                .map(|pending| *pending.tx_hash())
+                .map_err(|e| anyhow::anyhow!("RPC Error: {e}"))
+        }
+    )
+    .map_err(|err| {
+        tracing::error!(
+            ?sign_ids,
+            ?err,
+            "failed to send ethereum signature transaction: retry attempts exhausted"
+        );
+    })
+}
+
+pub async fn try_publish_eth(
+    eth: &EthClient,
+    action: &PublishAction,
+    timestamp: &Instant,
+    signature: &Signature,
+) -> Result<(), ()> {
+    let sign_id = action.indexed.id;
+    let params = [DynSolValue::Array(vec![DynSolValue::Tuple(vec![
+        DynSolValue::FixedBytes(action.indexed.id.request_id.into(), 32),
+        DynSolValue::Tuple(vec![
+            DynSolValue::Tuple(vec![
+                DynSolValue::from(U256::from_be_slice(&signature.big_r.x())),
+                DynSolValue::from(U256::from_be_slice(
+                    signature.big_r.to_encoded_point(false).y().unwrap(),
+                )),
+            ]),
+            DynSolValue::from(U256::from_be_slice(&signature.s.to_bytes())),
+            DynSolValue::from(signature.recovery_id),
+        ]),
+    ])])];
+
+    let tx_hash = send_eth_transaction(
+        &eth.contract,
+        &params,
+        ETH_BASE_GAS_LIMIT,
+        std::slice::from_ref(&action.indexed.id),
+    )
+    .await?;
+
+    let receipt = wait_for_transaction_receipt(
+        eth.contract.provider(),
+        tx_hash,
+        vec![action.indexed.id],
+        ETH_TX_RECEIPT_MAX_ATTEMPTS,
+    )
+    .await?;
+
+    // Check if transaction was successful
+    if !receipt.status() {
+        tracing::error!(
+            ?sign_id,
+            tx_hash = ?receipt.transaction_hash,
+            "transaction failed"
+        );
+        return Err(());
+    }
+
+    let tx_hash = receipt.transaction_hash;
+    tracing::info!(
+        ?sign_id,
+        tx_hash = ?tx_hash,
+        elapsed = ?timestamp.elapsed(),
+        "published ethereum signature successfully"
+    );
+    Ok(())
+}
+
+pub async fn try_batch_publish_eth(
+    eth: &EthClient,
+    actions: &Vec<PublishAction>,
+    signatures: &HashMap<SignId, Signature>,
+) -> Result<(), ()> {
+    let chain = Chain::Ethereum;
+    let mut params_vec = vec![];
+    let num_requests = actions.len();
+    let sign_ids = actions
+        .iter()
+        .map(|action| action.indexed.id)
+        .collect::<Vec<_>>();
+    tracing::info!(?sign_ids, "will send eth batch tx");
+    for action in actions {
+        let signature = signatures
+            .get(&action.indexed.id)
+            .expect("signature not found in map");
+        params_vec.push(DynSolValue::Tuple(vec![
+            DynSolValue::FixedBytes(action.indexed.id.request_id.into(), 32),
+            DynSolValue::Tuple(vec![
+                DynSolValue::Tuple(vec![
+                    DynSolValue::from(U256::from_be_slice(&signature.big_r.x())),
+                    DynSolValue::from(U256::from_be_slice(
+                        signature.big_r.to_encoded_point(false).y().unwrap(),
+                    )),
+                ]),
+                DynSolValue::from(U256::from_be_slice(&signature.s.to_bytes())),
+                DynSolValue::from(signature.recovery_id),
+            ]),
+        ]));
+    }
+
+    let params = [DynSolValue::Array(params_vec.clone())];
+    let gas = std::cmp::max(
+        ETH_BASE_GAS_LIMIT,
+        ETH_BATCH_GAS_PER_REQUEST * num_requests as u64,
+    );
+
+    let tx_hash = send_eth_transaction(&eth.contract, &params, gas, &sign_ids).await?;
+
+    tracing::info!(?tx_hash, "sent eth tx");
+
+    let tx = wait_for_pending_tx(
+        eth.contract.provider(),
+        tx_hash,
+        sign_ids.clone(),
+        ETH_TX_RECEIPT_MAX_ATTEMPTS,
+    )
+    .await?;
+
+    tracing::info!(?tx, "tx found in mempool");
+
+    let receipt = wait_for_transaction_receipt(
+        eth.contract.provider(),
+        tx_hash,
+        sign_ids.clone(),
+        ETH_TX_RECEIPT_MAX_ATTEMPTS,
+    )
+    .await?;
+
+    // Check if transaction was successful
+    if !receipt.status() {
+        tracing::error!(
+            ?sign_ids,
+            tx_hash = ?receipt.transaction_hash,
+            "eth batch transaction failed"
+        );
+        return Err(());
+    }
+
+    let tx_hash = receipt.transaction_hash;
+    tracing::info!(
+        ?chain,
+        ?sign_ids,
+        ?tx_hash,
+        num_requests,
+        "eth batch published ethereum signatures successfully"
+    );
+    Ok(())
+}

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -96,270 +96,256 @@ impl EthClient {
 
         Self { contract }
     }
-}
 
-// wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
-async fn wait_for_pending_tx(
-    provider: &EthContractFillProvider,
-    tx_hash: alloy::primitives::B256,
-    sign_ids: Vec<SignId>,
-    max_attempts: usize,
-) -> Result<Transaction, ()> {
-    let retry_config = RetryConfig {
-        max_times: max_attempts,
-        min_delay: ETH_MEMPOOL_MIN_DELAY,
-        max_delay: ETH_MEMPOOL_MAX_DELAY,
-        jitter: true,
-    };
+    // Wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
+    async fn wait_for_transaction_receipt(
+        &self,
+        tx_hash: alloy::primitives::B256,
+        sign_ids: Vec<SignId>,
+    ) -> Result<TransactionReceipt, ()> {
+        let retry_config = RetryConfig {
+            max_times: ETH_TX_RECEIPT_MAX_ATTEMPTS,
+            min_delay: ETH_RECEIPT_MIN_DELAY,
+            max_delay: ETH_RECEIPT_MAX_DELAY,
+            jitter: true,
+        };
 
-    retry_rpc!(
-        ETH_MEMPOOL_TIMEOUT,
-        retry_config,
-        // Log the error and retry attempt
-        |attempt, err, sleep| {
-            tracing::error!(
-                ?sign_ids,
-                attempt,
-                "failed to get eth signature respond pending transaction: {err}, retrying in {sleep:?}"
-            );
-        },
-        // Try to get the pending transaction
-        {
-            match provider.get_transaction_by_hash(tx_hash).await {
-                Ok(Some(tx)) => {
-                    tracing::info!(?sign_ids, "eth signature respond pending transaction found");
-                    Ok(tx)
+        retry_rpc!(
+            ETH_RECEIPT_TIMEOUT,
+            retry_config,
+            // Log the error and retry attempt
+            |attempt, err, sleep| {
+                tracing::error!(
+                    ?sign_ids,
+                    attempt,
+                    "failed to get eth signature respond transaction receipt: {err}, retrying in {sleep:?}"
+                );
+            },
+            // Try to get the transaction receipt
+            {
+                match self.contract.provider().get_transaction_receipt(tx_hash).await {
+                    Ok(Some(receipt)) => {
+                        tracing::info!(?sign_ids, "eth signature respond transaction receipt found");
+                        Ok(receipt)
+                    }
+                    Ok(None) => Err(anyhow::anyhow!("Receipt not ready yet")),
+                    Err(e) => Err(anyhow::anyhow!("RPC Error: {e}")),
                 }
-                Ok(None) => Err(anyhow::anyhow!("Transaction not in mempool yet")),
-                Err(e) => Err(anyhow::anyhow!("RPC Error: {e}")),
             }
-        }
-    ).map_err(|_| ())
-}
-
-// wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
-async fn wait_for_transaction_receipt(
-    provider: &EthContractFillProvider,
-    tx_hash: alloy::primitives::B256,
-    sign_ids: Vec<SignId>,
-    max_attempts: usize,
-) -> Result<TransactionReceipt, ()> {
-    let retry_config = RetryConfig {
-        max_times: max_attempts,
-        min_delay: ETH_RECEIPT_MIN_DELAY,
-        max_delay: ETH_RECEIPT_MAX_DELAY,
-        jitter: true,
-    };
-
-    retry_rpc!(
-        ETH_RECEIPT_TIMEOUT,
-        retry_config,
-        // Log the error and retry attempt
-        |attempt, err, sleep| {
-            tracing::error!(
-                ?sign_ids,
-                attempt,
-                "failed to get eth signature respond transaction receipt: {err}, retrying in {sleep:?}"
-            );
-        },
-        // Try to get the transaction receipt
-        {
-            match provider.get_transaction_receipt(tx_hash).await {
-                Ok(Some(receipt)) => {
-                    tracing::info!(?sign_ids, "eth signature respond transaction receipt found");
-                    Ok(receipt)
-                }
-                Ok(None) => Err(anyhow::anyhow!("Receipt not ready yet")),
-                Err(e) => Err(anyhow::anyhow!("RPC Error: {e}")),
-            }
-        }
-    ).map_err(|_| ())
-}
-
-async fn send_eth_responses(
-    contract: &ChainSignatures::ChainSignaturesInstance<EthContractFillProvider>,
-    responses: Vec<ChainSignatures::Response>,
-    gas: u64,
-    sign_ids: &[SignId],
-) -> Result<alloy::primitives::B256, ()> {
-    let send_retry = RetryConfig {
-        max_times: ETH_SEND_MAX_ATTEMPTS,
-        min_delay: ETH_SEND_MIN_DELAY,
-        max_delay: ETH_SEND_MAX_DELAY,
-        jitter: true,
-    };
-
-    retry_rpc!(
-        ETH_SEND_TIMEOUT,
-        send_retry,
-        |attempt, err, sleep| {
-            tracing::warn!(
-                ?sign_ids,
-                attempt,
-                "send eth tx failed: {err}, retrying in {sleep:?}"
-            );
-        },
-        {
-            // TODO: fetching nonce from RPC is slow and expensive, consider better approach (fetch once, increment locally, etc.)
-            // Fetch nonce here in the retry loop, otherwise we may get the same nonce on retry
-            let nonce = contract
-                .provider()
-                .get_transaction_count(contract.provider().default_signer_address())
-                .pending()
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to fetch nonce: {e}"))?;
-
-            tracing::info!(
-                nonce,
-                "will send eth tx with nonce {nonce} for sign_ids: {:?}",
-                sign_ids
-            );
-
-            contract
-                .respond(responses.clone()) // Need to clone because closure has to implement `FnMut` (otherwise it's `FnOnce`)
-                .gas(gas)
-                .nonce(nonce)
-                .send()
-                .await
-                .map(|pending| *pending.tx_hash())
-                .map_err(|e| anyhow::anyhow!("RPC Error: {e}"))
-        }
-    )
-    .map_err(|err| {
-        tracing::error!(
-            ?sign_ids,
-            ?err,
-            "failed to send ethereum signature transaction: retry attempts exhausted"
-        );
-    })
-}
-
-pub async fn try_publish_eth(
-    eth: &EthClient,
-    action: &PublishAction,
-    timestamp: &Instant,
-    mpc_sig: &mpc_primitives::Signature,
-) -> Result<(), ()> {
-    let sign_id = action.indexed.id;
-
-    let response = ChainSignatures::Response {
-        requestId: action.indexed.id.request_id.into(),
-        signature: mpc_sig.into(),
-    };
-
-    let tx_hash = send_eth_responses(
-        &eth.contract,
-        vec![response],
-        ETH_BASE_GAS_LIMIT,
-        std::slice::from_ref(&action.indexed.id),
-    )
-    .await?;
-
-    let receipt = wait_for_transaction_receipt(
-        eth.contract.provider(),
-        tx_hash,
-        vec![action.indexed.id],
-        ETH_TX_RECEIPT_MAX_ATTEMPTS,
-    )
-    .await?;
-
-    // Check if transaction was successful
-    if !receipt.status() {
-        tracing::error!(
-            ?sign_id,
-            tx_hash = ?receipt.transaction_hash,
-            "transaction failed"
-        );
-        return Err(());
+        ).map_err(|_| ())
     }
 
-    let tx_hash = receipt.transaction_hash;
-    tracing::info!(
-        ?sign_id,
-        tx_hash = ?tx_hash,
-        elapsed = ?timestamp.elapsed(),
-        "published ethereum signature successfully"
-    );
-    Ok(())
-}
+    // TODO: This is probably redundant since `wait_for_transaction_receipt` already waits for the transaction to be mined.
+    // Wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
+    async fn wait_for_pending_tx(
+        &self,
+        tx_hash: alloy::primitives::B256,
+        sign_ids: Vec<SignId>,
+    ) -> Result<Transaction, ()> {
+        let retry_config = RetryConfig {
+            max_times: ETH_TX_RECEIPT_MAX_ATTEMPTS,
+            min_delay: ETH_MEMPOOL_MIN_DELAY,
+            max_delay: ETH_MEMPOOL_MAX_DELAY,
+            jitter: true,
+        };
 
-pub async fn try_batch_publish_eth(
-    eth: &EthClient,
-    actions: &[PublishAction],
-    signatures: &HashMap<SignId, Signature>,
-) -> Result<(), ()> {
-    let chain = Chain::Ethereum;
-    let num_requests = actions.len();
-    let sign_ids = actions
-        .iter()
-        .map(|action| action.indexed.id)
-        .collect::<Vec<_>>();
-
-    tracing::info!(?sign_ids, "will send eth batch tx");
-
-    // Map to typed ABI structs
-    let responses: Vec<ChainSignatures::Response> = actions
-        .iter()
-        .map(|action| {
-            let mpc_sig = signatures
-                .get(&action.indexed.id)
-                .expect("signature not found in map");
-
-            ChainSignatures::Response {
-                requestId: action.indexed.id.request_id.into(),
-                signature: mpc_sig.into(),
+        retry_rpc!(
+            ETH_MEMPOOL_TIMEOUT,
+            retry_config,
+            // Log the error and retry attempt
+            |attempt, err, sleep| {
+                tracing::error!(
+                    ?sign_ids,
+                    attempt,
+                    "failed to get eth signature respond pending transaction: {err}, retrying in {sleep:?}"
+                );
+            },
+            // Try to get the pending transaction
+            {
+                match self.contract.provider().get_transaction_by_hash(tx_hash).await {
+                    Ok(Some(tx)) => {
+                        tracing::info!(?sign_ids, "eth signature respond pending transaction found");
+                        Ok(tx)
+                    }
+                    Ok(None) => Err(anyhow::anyhow!("Transaction not in mempool yet")),
+                    Err(e) => Err(anyhow::anyhow!("RPC Error: {e}")),
+                }
             }
+        ).map_err(|_| ())
+    }
+
+    async fn send_responses(
+        &self,
+        responses: Vec<ChainSignatures::Response>,
+        gas: u64,
+        sign_ids: &[SignId],
+    ) -> Result<alloy::primitives::B256, ()> {
+        let send_retry = RetryConfig {
+            max_times: ETH_SEND_MAX_ATTEMPTS,
+            min_delay: ETH_SEND_MIN_DELAY,
+            max_delay: ETH_SEND_MAX_DELAY,
+            jitter: true,
+        };
+
+        retry_rpc!(
+            ETH_SEND_TIMEOUT,
+            send_retry,
+            |attempt, err, sleep| {
+                tracing::warn!(
+                    ?sign_ids,
+                    attempt,
+                    "send eth tx failed: {err}, retrying in {sleep:?}"
+                );
+            },
+            {
+                // TODO: fetching nonce from RPC is slow and expensive, consider better approach (fetch once, increment locally, etc.)
+                // Fetch nonce here in the retry loop, otherwise we may get the same nonce on retry
+                let nonce = self
+                    .contract
+                    .provider()
+                    .get_transaction_count(self.contract.provider().default_signer_address())
+                    .pending()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to fetch nonce: {e}"))?;
+
+                tracing::info!(
+                    nonce,
+                    "will send eth tx with nonce {nonce} for sign_ids: {:?}",
+                    sign_ids
+                );
+
+                self.contract
+                    .respond(responses.clone()) // Need to clone because closure has to implement `FnMut` (otherwise it's `FnOnce`)
+                    .gas(gas)
+                    .nonce(nonce)
+                    .send()
+                    .await
+                    .map(|pending| *pending.tx_hash())
+                    .map_err(|e| anyhow::anyhow!("RPC Error: {e}"))
+            }
+        )
+        .map_err(|err| {
+            tracing::error!(
+                ?sign_ids,
+                ?err,
+                "failed to send ethereum signature transaction: retry attempts exhausted"
+            );
         })
-        .collect();
-
-    // Calculate Gas
-    let gas = std::cmp::max(
-        ETH_BASE_GAS_LIMIT,
-        ETH_BATCH_GAS_PER_REQUEST * num_requests as u64,
-    );
-
-    // Send Transaction with typed ABI Call
-    let tx_hash = send_eth_responses(&eth.contract, responses, gas, &sign_ids).await?;
-
-    tracing::info!(?tx_hash, "sent eth tx");
-
-    // Wait for mempool
-    let tx = wait_for_pending_tx(
-        eth.contract.provider(),
-        tx_hash,
-        sign_ids.clone(),
-        ETH_TX_RECEIPT_MAX_ATTEMPTS,
-    )
-    .await?;
-
-    tracing::info!(?tx, "tx found in mempool");
-
-    // Wait for receipt
-    let receipt = wait_for_transaction_receipt(
-        eth.contract.provider(),
-        tx_hash,
-        sign_ids.clone(),
-        ETH_TX_RECEIPT_MAX_ATTEMPTS,
-    )
-    .await?;
-
-    // Check status
-    if !receipt.status() {
-        tracing::error!(
-            ?sign_ids,
-            tx_hash = ?receipt.transaction_hash,
-            "eth batch transaction failed"
-        );
-        return Err(());
     }
 
-    let tx_hash = receipt.transaction_hash;
-    tracing::info!(
-        ?chain,
-        ?sign_ids,
-        ?tx_hash,
-        num_requests,
-        "eth batch published ethereum signatures successfully"
-    );
-    Ok(())
+    pub async fn publish_signature(
+        &self,
+        action: &PublishAction,
+        timestamp: &Instant,
+        mpc_sig: &mpc_primitives::Signature,
+    ) -> Result<(), ()> {
+        let sign_id = action.indexed.id;
+
+        let response = ChainSignatures::Response {
+            requestId: action.indexed.id.request_id.into(),
+            signature: mpc_sig.into(),
+        };
+
+        let tx_hash = self
+            .send_responses(
+                vec![response],
+                ETH_BASE_GAS_LIMIT,
+                std::slice::from_ref(&action.indexed.id),
+            )
+            .await?;
+
+        let receipt = self
+            .wait_for_transaction_receipt(tx_hash, vec![action.indexed.id])
+            .await?;
+
+        // Check if transaction was successful
+        if !receipt.status() {
+            tracing::error!(
+                ?sign_id,
+                tx_hash = ?receipt.transaction_hash,
+                "transaction failed"
+            );
+            return Err(());
+        }
+
+        let tx_hash = receipt.transaction_hash;
+        tracing::info!(
+            ?sign_id,
+            tx_hash = ?tx_hash,
+            elapsed = ?timestamp.elapsed(),
+            "published ethereum signature successfully"
+        );
+        Ok(())
+    }
+
+    pub async fn batch_publish_signature(
+        &self,
+        actions: &[PublishAction],
+        signatures: &HashMap<SignId, Signature>,
+    ) -> Result<(), ()> {
+        let chain = Chain::Ethereum;
+        let num_requests = actions.len();
+        let sign_ids = actions
+            .iter()
+            .map(|action| action.indexed.id)
+            .collect::<Vec<_>>();
+
+        tracing::info!(?sign_ids, "will send eth batch tx");
+
+        // Map to typed ABI structs
+        let responses: Vec<ChainSignatures::Response> = actions
+            .iter()
+            .map(|action| {
+                let mpc_sig = signatures
+                    .get(&action.indexed.id)
+                    .expect("signature not found in map");
+
+                ChainSignatures::Response {
+                    requestId: action.indexed.id.request_id.into(),
+                    signature: mpc_sig.into(),
+                }
+            })
+            .collect();
+
+        // Calculate Gas
+        let gas = std::cmp::max(
+            ETH_BASE_GAS_LIMIT,
+            ETH_BATCH_GAS_PER_REQUEST * num_requests as u64,
+        );
+
+        // Send Transaction with typed ABI Call
+        let tx_hash = self.send_responses(responses, gas, &sign_ids).await?;
+
+        tracing::info!(?tx_hash, "sent eth tx");
+
+        // Wait for mempool
+        let tx = self.wait_for_pending_tx(tx_hash, sign_ids.clone()).await?;
+
+        tracing::info!(?tx, "tx found in mempool");
+
+        // Wait for receipt
+        let receipt = self
+            .wait_for_transaction_receipt(tx_hash, sign_ids.clone())
+            .await?;
+
+        // Check status
+        if !receipt.status() {
+            tracing::error!(
+                ?sign_ids,
+                tx_hash = ?receipt.transaction_hash,
+                "eth batch transaction failed"
+            );
+            return Err(());
+        }
+
+        let tx_hash = receipt.transaction_hash;
+        tracing::info!(
+            ?chain,
+            ?sign_ids,
+            ?tx_hash,
+            num_requests,
+            "eth batch published ethereum signatures successfully"
+        );
+        Ok(())
+    }
 }

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -258,3 +258,339 @@ impl EthClient {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::{B256, U256};
+    use k256::{AffinePoint, Scalar};
+    use mockito::{Matcher, Server};
+    use serde_json::json;
+
+    fn create_test_signature() -> mpc_primitives::Signature {
+        mpc_primitives::Signature::new(AffinePoint::GENERATOR, Scalar::from(42u64), 1)
+    }
+
+    fn mock_config(url: &str) -> EthConfig {
+        EthConfig {
+            account_sk: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                .to_string(),
+            execution_rpc_http_url: url.to_string(),
+            contract_address: "1234567890123456789012345678901234567890".to_string(),
+            consensus_rpc_http_url: "".to_string(),
+            network: "sepolia".to_string(),
+            helios_data_path: "".to_string(),
+            refresh_finalized_interval: 1000,
+            optimistic_requests: false,
+            light_client: false,
+        }
+    }
+
+    fn mock_receipt_json(tx_hash: B256, status: &str) -> serde_json::Value {
+        json!({
+            "transactionHash": format!("{tx_hash:#x}"),
+            "status": status,
+            "blockHash": format!("{:#x}", B256::repeat_byte(0xbb)),
+            "blockNumber": "0x2",
+            "transactionIndex": "0x0",
+            "from": format!("{:#x}", Address::ZERO),
+            "to": format!("{:#x}", Address::ZERO),
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x3a29f0f8",
+            "contractAddress": null,
+            "logsBloom": format!("0x{}", "0".repeat(512)),
+            "cumulativeGasUsed": "0x5208",
+            "type": "0x2",
+            "logs": []
+        })
+    }
+
+    /// Alloy's FillProvider automatically queries the network to estimate gas and fees
+    /// before submitting a transaction. We must mock these to prevent mockito from panicking.
+    async fn mock_alloy_background_rpcs(server: &mut Server) {
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({"method": "eth_chainId"})))
+            .with_status(200)
+            .with_body(json!({"jsonrpc": "2.0", "id": 1, "result": "0x1"}).to_string())
+            .expect_at_least(0)
+            .create_async()
+            .await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({"method": "eth_feeHistory"})))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0", "id": 1,
+                    "result": {
+                        "oldestBlock": "0x1",
+                        "reward": [["0x1"]],
+                        "baseFeePerGas": ["0x1", "0x1"],
+                        "gasUsedRatio": [0.5]
+                    }
+                })
+                .to_string(),
+            )
+            .expect_at_least(0)
+            .create_async()
+            .await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_getBlockByNumber"}),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0", "id": 1,
+                    "result": {
+                        "number": "0x1",
+                        "baseFeePerGas": "0x1",
+                        "timestamp": "0x1"
+                    }
+                })
+                .to_string(),
+            )
+            .expect_at_least(0)
+            .create_async()
+            .await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({"method": "eth_estimateGas"})))
+            .with_status(200)
+            .with_body(json!({"jsonrpc": "2.0", "id": 1, "result": "0x5208"}).to_string())
+            .expect_at_least(0)
+            .create_async()
+            .await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_maxPriorityFeePerGas"}),
+            ))
+            .with_status(200)
+            .with_body(json!({"jsonrpc": "2.0", "id": 1, "result": "0x1"}).to_string())
+            .expect_at_least(0)
+            .create_async()
+            .await;
+    }
+
+    #[test]
+    fn test_signature_to_abi_conversion() {
+        let mpc_sig = create_test_signature();
+        let abi_sig: ChainSignatures::Signature = (&mpc_sig).into();
+
+        assert_eq!(abi_sig.recoveryId, 1);
+        assert_eq!(abi_sig.s, U256::from(42));
+        assert_eq!(abi_sig.bigR.x, U256::from_be_slice(&mpc_sig.big_r.x()));
+        assert_eq!(
+            abi_sig.bigR.y,
+            U256::from_be_slice(mpc_sig.big_r.to_encoded_point(false).y().unwrap())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_transaction_receipt_retries_on_null() {
+        let mut server = Server::new_async().await;
+        let tx_hash = B256::repeat_byte(0xcc);
+
+        // First call returns null (pending in mempool)
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_getTransactionReceipt"}),
+            ))
+            .with_status(200)
+            .with_body(json!({"jsonrpc": "2.0", "id": 1, "result": null}).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        // Second call returns reverted receipt
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_getTransactionReceipt"}),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0", "id": 2,
+                    "result": mock_receipt_json(tx_hash, "0x0")
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = EthClient::new(&mock_config(&server.url()));
+        let receipt = client
+            .wait_for_transaction_receipt(tx_hash, &[SignId::new([2u8; 32])])
+            .await
+            .unwrap();
+
+        // Assert it fetched successfully and caught the reverted status
+        assert!(!receipt.status());
+    }
+
+    #[tokio::test]
+    async fn test_send_eth_responses_refetches_nonce_on_retry() {
+        let mut server = Server::new_async().await;
+        mock_alloy_background_rpcs(&mut server).await;
+
+        // Mock the nonce fetch.
+        // We use expect_at_least(2) to prove the retry mechanism successfully fires and refetches.
+        let nonce_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_getTransactionCount"}),
+            ))
+            .with_status(200)
+            .with_body(json!({"jsonrpc": "2.0", "id": 1, "result": "0x1"}).to_string())
+            .expect_at_least(2)
+            .create_async()
+            .await;
+
+        // Mock the transaction send failing every time
+        let send_mock = server.mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({"method": "eth_sendRawTransaction"})))
+            .with_status(200)
+            .with_body(json!({"jsonrpc": "2.0", "id": 1, "error": {"code": -32000, "message": "mock error"}}).to_string())
+            .expect_at_least(2)
+            .create_async().await;
+
+        let client = EthClient::new(&mock_config(&server.url()));
+
+        // Attempt to send
+        let result = client
+            .send_responses(vec![], 21000, &[SignId::new([3u8; 32])])
+            .await;
+
+        // Verify it failed completely
+        assert!(result.is_err());
+
+        // Assert that `eth_getTransactionCount` was called multiple times.
+        nonce_mock.assert_async().await;
+        send_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_execute_publish_fails_on_reverted_tx() {
+        let mut server = Server::new_async().await;
+        let tx_hash = B256::repeat_byte(0xaa);
+        mock_alloy_background_rpcs(&mut server).await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_getTransactionCount"}),
+            ))
+            .with_status(200)
+            .with_body(json!({"jsonrpc": "2.0", "id": 1, "result": "0x1"}).to_string())
+            .create_async()
+            .await;
+
+        // Mock send succeeding
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_sendRawTransaction"}),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({"jsonrpc": "2.0", "id": 1, "result": format!("{tx_hash:#x}")}).to_string(),
+            )
+            .create_async()
+            .await;
+
+        // Mock receipt showing a reverted transaction (status: "0x0")
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_getTransactionReceipt"}),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0", "id": 1,
+                    "result": mock_receipt_json(tx_hash, "0x0")
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let client = EthClient::new(&mock_config(&server.url()));
+
+        // Execute the full publish pipeline
+        let result = client
+            .execute_publish(vec![], 21000, &[SignId::new([4u8; 32])])
+            .await;
+
+        // It should return Err(()) because the receipt status was 0x0
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_execute_publish_success() {
+        let mut server = Server::new_async().await;
+        let tx_hash = B256::repeat_byte(0x77);
+        mock_alloy_background_rpcs(&mut server).await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_getTransactionCount"}),
+            ))
+            .with_status(200)
+            .with_body(json!({"jsonrpc": "2.0", "id": 1, "result": "0x1"}).to_string())
+            .create_async()
+            .await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_sendRawTransaction"}),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({"jsonrpc": "2.0", "id": 1, "result": format!("{tx_hash:#x}")}).to_string(),
+            )
+            .create_async()
+            .await;
+
+        // Mock the receipt confirming the transaction was mined successfully (status: "0x1")
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_getTransactionReceipt"}),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0", "id": 1,
+                    "result": mock_receipt_json(tx_hash, "0x1")
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let client = EthClient::new(&mock_config(&server.url()));
+
+        let result = client
+            .execute_publish(vec![], 21000, &[SignId::new([5u8; 32])])
+            .await;
+
+        // Assert the happy path returns Ok
+        assert!(
+            result.is_ok(),
+            "The happy path should complete successfully"
+        );
+    }
+}

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -1,8 +1,7 @@
 use super::PublishAction;
+use crate::indexer_eth::abi::ChainSignatures;
 use crate::indexer_eth::EthConfig;
 use crate::util::retry::{retry_rpc, RetryConfig};
-use alloy::contract::{ContractInstance, Interface};
-use alloy::dyn_abi::DynSolValue;
 use alloy::network::EthereumWallet;
 use alloy::primitives::Address;
 use alloy::primitives::U256;
@@ -37,7 +36,6 @@ type EthContractFillProvider = FillProvider<
     >,
     RootProvider,
 >;
-type EthContractInstance = ContractInstance<EthContractFillProvider>;
 
 // Get nonce retry constants
 const ETH_NONCE_MAX_ATTEMPTS: usize = 3;
@@ -70,7 +68,7 @@ const ETH_TX_RECEIPT_MAX_ATTEMPTS: usize = 6;
 
 #[derive(Clone)]
 pub struct EthClient {
-    contract: EthContractInstance,
+    contract: ChainSignatures::ChainSignaturesInstance<EthContractFillProvider>,
 }
 
 impl EthClient {
@@ -83,21 +81,11 @@ impl EthClient {
         let provider = ProviderBuilder::new()
             .wallet(wallet)
             .connect_http(eth.execution_rpc_http_url.parse().unwrap());
-        // Create a contract instance.
-        let json: serde_json::Value = serde_json::from_slice(include_bytes!(
-            "../../../contract-eth/artifacts/contracts/ChainSignatures.sol/ChainSignatures.json"
-        ))
-        .unwrap();
 
-        // Get `abi` from the artifact.
-        let abi_value = json.get("abi").expect("Failed to get ABI from artifact");
-        let abi = serde_json::from_str(&abi_value.to_string()).unwrap();
+        // Build the contract instance
+        let address = Address::from_str(&format!("0x{}", eth.contract_address)).unwrap();
+        let contract = ChainSignatures::new(address, provider);
 
-        let contract = ContractInstance::new(
-            Address::from_str(&format!("0x{}", eth.contract_address)).unwrap(),
-            provider.clone(),
-            Interface::new(abi),
-        );
         Self { contract }
     }
 }
@@ -180,9 +168,9 @@ async fn wait_for_transaction_receipt(
     ).map_err(|_| ())
 }
 
-async fn send_eth_transaction(
-    contract: &EthContractInstance,
-    params: &[DynSolValue],
+async fn send_eth_responses(
+    contract: &ChainSignatures::ChainSignaturesInstance<EthContractFillProvider>,
+    responses: Vec<ChainSignatures::Response>,
     gas: u64,
     sign_ids: &[SignId],
 ) -> Result<alloy::primitives::B256, ()> {
@@ -249,8 +237,7 @@ async fn send_eth_transaction(
         },
         {
             contract
-                .function("respond", params)
-                .unwrap()
+                .respond(responses)
                 .gas(gas)
                 .nonce(nonce)
                 .send()
@@ -272,26 +259,25 @@ pub async fn try_publish_eth(
     eth: &EthClient,
     action: &PublishAction,
     timestamp: &Instant,
-    signature: &Signature,
+    mpc_sig: &mpc_primitives::Signature,
 ) -> Result<(), ()> {
     let sign_id = action.indexed.id;
-    let params = [DynSolValue::Array(vec![DynSolValue::Tuple(vec![
-        DynSolValue::FixedBytes(action.indexed.id.request_id.into(), 32),
-        DynSolValue::Tuple(vec![
-            DynSolValue::Tuple(vec![
-                DynSolValue::from(U256::from_be_slice(&signature.big_r.x())),
-                DynSolValue::from(U256::from_be_slice(
-                    signature.big_r.to_encoded_point(false).y().unwrap(),
-                )),
-            ]),
-            DynSolValue::from(U256::from_be_slice(&signature.s.to_bytes())),
-            DynSolValue::from(signature.recovery_id),
-        ]),
-    ])])];
 
-    let tx_hash = send_eth_transaction(
+    let response = ChainSignatures::Response {
+        requestId: action.indexed.id.request_id.into(),
+        signature: ChainSignatures::Signature {
+            bigR: ChainSignatures::AffinePoint {
+                x: U256::from_be_slice(&mpc_sig.big_r.x()),
+                y: U256::from_be_slice(mpc_sig.big_r.to_encoded_point(false).y().unwrap()),
+            },
+            s: U256::from_be_slice(&mpc_sig.s.to_bytes()),
+            recoveryId: mpc_sig.recovery_id,
+        },
+    };
+
+    let tx_hash = send_eth_responses(
         &eth.contract,
-        &params,
+        vec![response],
         ETH_BASE_GAS_LIMIT,
         std::slice::from_ref(&action.indexed.id),
     )
@@ -331,42 +317,47 @@ pub async fn try_batch_publish_eth(
     signatures: &HashMap<SignId, Signature>,
 ) -> Result<(), ()> {
     let chain = Chain::Ethereum;
-    let mut params_vec = vec![];
     let num_requests = actions.len();
     let sign_ids = actions
         .iter()
         .map(|action| action.indexed.id)
         .collect::<Vec<_>>();
+
     tracing::info!(?sign_ids, "will send eth batch tx");
+
+    // Map to typed ABI structs
+    let mut responses = Vec::with_capacity(num_requests);
     for action in actions {
-        let signature = signatures
+        let mpc_sig = signatures
             .get(&action.indexed.id)
             .expect("signature not found in map");
-        params_vec.push(DynSolValue::Tuple(vec![
-            DynSolValue::FixedBytes(action.indexed.id.request_id.into(), 32),
-            DynSolValue::Tuple(vec![
-                DynSolValue::Tuple(vec![
-                    DynSolValue::from(U256::from_be_slice(&signature.big_r.x())),
-                    DynSolValue::from(U256::from_be_slice(
-                        signature.big_r.to_encoded_point(false).y().unwrap(),
-                    )),
-                ]),
-                DynSolValue::from(U256::from_be_slice(&signature.s.to_bytes())),
-                DynSolValue::from(signature.recovery_id),
-            ]),
-        ]));
+
+        let response = ChainSignatures::Response {
+            requestId: action.indexed.id.request_id.into(),
+            signature: ChainSignatures::Signature {
+                bigR: ChainSignatures::AffinePoint {
+                    x: U256::from_be_slice(&mpc_sig.big_r.x()),
+                    y: U256::from_be_slice(mpc_sig.big_r.to_encoded_point(false).y().unwrap()),
+                },
+                s: U256::from_be_slice(&mpc_sig.s.to_bytes()),
+                recoveryId: mpc_sig.recovery_id,
+            },
+        };
+        responses.push(response);
     }
 
-    let params = [DynSolValue::Array(params_vec.clone())];
+    // Calculate Gas
     let gas = std::cmp::max(
         ETH_BASE_GAS_LIMIT,
         ETH_BATCH_GAS_PER_REQUEST * num_requests as u64,
     );
 
-    let tx_hash = send_eth_transaction(&eth.contract, &params, gas, &sign_ids).await?;
+    // Send Transaction with typed ABI Call
+    let tx_hash = send_eth_responses(&eth.contract, responses, gas, &sign_ids).await?;
 
     tracing::info!(?tx_hash, "sent eth tx");
 
+    // Wait for mempool
     let tx = wait_for_pending_tx(
         eth.contract.provider(),
         tx_hash,
@@ -377,6 +368,7 @@ pub async fn try_batch_publish_eth(
 
     tracing::info!(?tx, "tx found in mempool");
 
+    // Wait for receipt
     let receipt = wait_for_transaction_receipt(
         eth.contract.provider(),
         tx_hash,
@@ -385,7 +377,7 @@ pub async fn try_batch_publish_eth(
     )
     .await?;
 
-    // Check if transaction was successful
+    // Check status
     if !receipt.status() {
         tracing::error!(
             ?sign_ids,

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -66,6 +66,20 @@ const ETH_BATCH_GAS_PER_REQUEST: u64 = 20_000;
 /// The maximum number of attempts to fetch eth tx and its receipt
 const ETH_TX_RECEIPT_MAX_ATTEMPTS: usize = 6;
 
+/// Convert MPC Signature to ChainSignatures::Signature
+impl From<&Signature> for ChainSignatures::Signature {
+    fn from(mpc_sig: &Signature) -> Self {
+        ChainSignatures::Signature {
+            bigR: ChainSignatures::AffinePoint {
+                x: U256::from_be_slice(&mpc_sig.big_r.x()),
+                y: U256::from_be_slice(mpc_sig.big_r.to_encoded_point(false).y().unwrap()),
+            },
+            s: U256::from_be_slice(&mpc_sig.s.to_bytes()),
+            recoveryId: mpc_sig.recovery_id,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct EthClient {
     contract: ChainSignatures::ChainSignaturesInstance<EthContractFillProvider>,
@@ -237,7 +251,7 @@ async fn send_eth_responses(
         },
         {
             contract
-                .respond(responses)
+                .respond(responses.clone()) // Need to clone because closure has to implement `FnMut` (otherwise it's `FnOnce`)
                 .gas(gas)
                 .nonce(nonce)
                 .send()
@@ -265,14 +279,7 @@ pub async fn try_publish_eth(
 
     let response = ChainSignatures::Response {
         requestId: action.indexed.id.request_id.into(),
-        signature: ChainSignatures::Signature {
-            bigR: ChainSignatures::AffinePoint {
-                x: U256::from_be_slice(&mpc_sig.big_r.x()),
-                y: U256::from_be_slice(mpc_sig.big_r.to_encoded_point(false).y().unwrap()),
-            },
-            s: U256::from_be_slice(&mpc_sig.s.to_bytes()),
-            recoveryId: mpc_sig.recovery_id,
-        },
+        signature: mpc_sig.into(),
     };
 
     let tx_hash = send_eth_responses(
@@ -326,25 +333,19 @@ pub async fn try_batch_publish_eth(
     tracing::info!(?sign_ids, "will send eth batch tx");
 
     // Map to typed ABI structs
-    let mut responses = Vec::with_capacity(num_requests);
-    for action in actions {
-        let mpc_sig = signatures
-            .get(&action.indexed.id)
-            .expect("signature not found in map");
+    let responses: Vec<ChainSignatures::Response> = actions
+        .iter()
+        .map(|action| {
+            let mpc_sig = signatures
+                .get(&action.indexed.id)
+                .expect("signature not found in map");
 
-        let response = ChainSignatures::Response {
-            requestId: action.indexed.id.request_id.into(),
-            signature: ChainSignatures::Signature {
-                bigR: ChainSignatures::AffinePoint {
-                    x: U256::from_be_slice(&mpc_sig.big_r.x()),
-                    y: U256::from_be_slice(mpc_sig.big_r.to_encoded_point(false).y().unwrap()),
-                },
-                s: U256::from_be_slice(&mpc_sig.s.to_bytes()),
-                recoveryId: mpc_sig.recovery_id,
-            },
-        };
-        responses.push(response);
-    }
+            ChainSignatures::Response {
+                requestId: action.indexed.id.request_id.into(),
+                signature: mpc_sig.into(),
+            }
+        })
+        .collect();
 
     // Calculate Gas
     let gas = std::cmp::max(

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -3,16 +3,17 @@ use crate::indexer_eth::abi::ChainSignatures;
 use crate::indexer_eth::EthConfig;
 use crate::util::retry::{retry_rpc, RetryConfig};
 use alloy::network::EthereumWallet;
-use alloy::primitives::Address;
-use alloy::primitives::U256;
-use alloy::providers::fillers::{FillProvider, JoinFill, WalletFiller};
-use alloy::providers::ProviderBuilder;
-use alloy::providers::{Provider, RootProvider, WalletProvider};
-use alloy::rpc::types::{Transaction, TransactionReceipt};
+use alloy::primitives::{Address, B256, U256};
+use alloy::providers::{
+    fillers::{
+        BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller, WalletFiller,
+    },
+    Provider, ProviderBuilder, RootProvider, WalletProvider,
+};
+use alloy::rpc::types::TransactionReceipt;
 use alloy_signer_local::PrivateKeySigner;
-use k256::elliptic_curve::point::AffineCoordinates;
-use k256::elliptic_curve::sec1::ToEncodedPoint;
-use mpc_primitives::{Chain, SignId, Signature};
+use k256::elliptic_curve::{point::AffineCoordinates, sec1::ToEncodedPoint};
+use mpc_primitives::{SignId, Signature};
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::time::{Duration, Instant};
@@ -21,16 +22,7 @@ type EthContractFillProvider = FillProvider<
     JoinFill<
         JoinFill<
             alloy::providers::Identity,
-            JoinFill<
-                alloy::providers::fillers::GasFiller,
-                JoinFill<
-                    alloy::providers::fillers::BlobGasFiller,
-                    JoinFill<
-                        alloy::providers::fillers::NonceFiller,
-                        alloy::providers::fillers::ChainIdFiller,
-                    >,
-                >,
-            >,
+            JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
         >,
         WalletFiller<EthereumWallet>,
     >,
@@ -42,11 +34,6 @@ const ETH_SEND_MAX_ATTEMPTS: usize = 3;
 const ETH_SEND_TIMEOUT: Duration = Duration::from_secs(5);
 const ETH_SEND_MIN_DELAY: Duration = Duration::from_millis(500);
 const ETH_SEND_MAX_DELAY: Duration = Duration::from_secs(10);
-
-// Polling Mempool
-const ETH_MEMPOOL_TIMEOUT: Duration = Duration::from_secs(5);
-const ETH_MEMPOOL_MIN_DELAY: Duration = Duration::from_secs(1);
-const ETH_MEMPOOL_MAX_DELAY: Duration = Duration::from_secs(10);
 
 // Polling Receipt
 const ETH_RECEIPT_TIMEOUT: Duration = Duration::from_secs(2);
@@ -100,8 +87,8 @@ impl EthClient {
     // Wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
     async fn wait_for_transaction_receipt(
         &self,
-        tx_hash: alloy::primitives::B256,
-        sign_ids: Vec<SignId>,
+        tx_hash: B256,
+        sign_ids: &[SignId],
     ) -> Result<TransactionReceipt, ()> {
         let retry_config = RetryConfig {
             max_times: ETH_TX_RECEIPT_MAX_ATTEMPTS,
@@ -129,45 +116,6 @@ impl EthClient {
                         Ok(receipt)
                     }
                     Ok(None) => Err(anyhow::anyhow!("Receipt not ready yet")),
-                    Err(e) => Err(anyhow::anyhow!("RPC Error: {e}")),
-                }
-            }
-        ).map_err(|_| ())
-    }
-
-    // TODO: This is probably redundant since `wait_for_transaction_receipt` already waits for the transaction to be mined.
-    // Wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
-    async fn wait_for_pending_tx(
-        &self,
-        tx_hash: alloy::primitives::B256,
-        sign_ids: Vec<SignId>,
-    ) -> Result<Transaction, ()> {
-        let retry_config = RetryConfig {
-            max_times: ETH_TX_RECEIPT_MAX_ATTEMPTS,
-            min_delay: ETH_MEMPOOL_MIN_DELAY,
-            max_delay: ETH_MEMPOOL_MAX_DELAY,
-            jitter: true,
-        };
-
-        retry_rpc!(
-            ETH_MEMPOOL_TIMEOUT,
-            retry_config,
-            // Log the error and retry attempt
-            |attempt, err, sleep| {
-                tracing::error!(
-                    ?sign_ids,
-                    attempt,
-                    "failed to get eth signature respond pending transaction: {err}, retrying in {sleep:?}"
-                );
-            },
-            // Try to get the pending transaction
-            {
-                match self.contract.provider().get_transaction_by_hash(tx_hash).await {
-                    Ok(Some(tx)) => {
-                        tracing::info!(?sign_ids, "eth signature respond pending transaction found");
-                        Ok(tx)
-                    }
-                    Ok(None) => Err(anyhow::anyhow!("Transaction not in mempool yet")),
                     Err(e) => Err(anyhow::anyhow!("RPC Error: {e}")),
                 }
             }
@@ -233,73 +181,65 @@ impl EthClient {
         })
     }
 
+    /// Shared logic to send the transaction, wait for the receipt, and verify success.
+    async fn execute_publish(
+        &self,
+        responses: Vec<ChainSignatures::Response>,
+        gas: u64,
+        sign_ids: &[SignId],
+    ) -> Result<(), ()> {
+        let tx_hash = self.send_responses(responses, gas, sign_ids).await?;
+        let receipt = self.wait_for_transaction_receipt(tx_hash, sign_ids).await?;
+
+        if !receipt.status() {
+            tracing::error!(?sign_ids, ?tx_hash, "ethereum transaction failed");
+            return Err(());
+        }
+
+        tracing::info!(
+            ?sign_ids,
+            ?tx_hash,
+            "ethereum transaction published successfully"
+        );
+        Ok(())
+    }
+
     pub async fn publish_signature(
         &self,
         action: &PublishAction,
         timestamp: &Instant,
         mpc_sig: &mpc_primitives::Signature,
     ) -> Result<(), ()> {
-        let sign_id = action.indexed.id;
-
         let response = ChainSignatures::Response {
             requestId: action.indexed.id.request_id.into(),
             signature: mpc_sig.into(),
         };
 
-        let tx_hash = self
-            .send_responses(
-                vec![response],
-                ETH_BASE_GAS_LIMIT,
-                std::slice::from_ref(&action.indexed.id),
-            )
-            .await?;
+        self.execute_publish(
+            vec![response],
+            ETH_BASE_GAS_LIMIT,
+            std::slice::from_ref(&action.indexed.id),
+        )
+        .await?;
 
-        let receipt = self
-            .wait_for_transaction_receipt(tx_hash, vec![action.indexed.id])
-            .await?;
-
-        // Check if transaction was successful
-        if !receipt.status() {
-            tracing::error!(
-                ?sign_id,
-                tx_hash = ?receipt.transaction_hash,
-                "transaction failed"
-            );
-            return Err(());
-        }
-
-        let tx_hash = receipt.transaction_hash;
-        tracing::info!(
-            ?sign_id,
-            tx_hash = ?tx_hash,
-            elapsed = ?timestamp.elapsed(),
-            "published ethereum signature successfully"
-        );
+        tracing::info!(elapsed = ?timestamp.elapsed(), "single publish complete");
         Ok(())
     }
 
-    pub async fn batch_publish_signature(
+    pub async fn batch_publish_signatures(
         &self,
         actions: &[PublishAction],
         signatures: &HashMap<SignId, Signature>,
     ) -> Result<(), ()> {
-        let chain = Chain::Ethereum;
         let num_requests = actions.len();
-        let sign_ids = actions
-            .iter()
-            .map(|action| action.indexed.id)
-            .collect::<Vec<_>>();
+        let sign_ids: Vec<_> = actions.iter().map(|a| a.indexed.id).collect();
 
-        tracing::info!(?sign_ids, "will send eth batch tx");
-
-        // Map to typed ABI structs
         let responses: Vec<ChainSignatures::Response> = actions
             .iter()
             .map(|action| {
                 let mpc_sig = signatures
                     .get(&action.indexed.id)
-                    .expect("signature not found in map");
-
+                    .expect("signature not found");
                 ChainSignatures::Response {
                     requestId: action.indexed.id.request_id.into(),
                     signature: mpc_sig.into(),
@@ -307,45 +247,14 @@ impl EthClient {
             })
             .collect();
 
-        // Calculate Gas
         let gas = std::cmp::max(
             ETH_BASE_GAS_LIMIT,
             ETH_BATCH_GAS_PER_REQUEST * num_requests as u64,
         );
 
-        // Send Transaction with typed ABI Call
-        let tx_hash = self.send_responses(responses, gas, &sign_ids).await?;
+        self.execute_publish(responses, gas, &sign_ids).await?;
 
-        tracing::info!(?tx_hash, "sent eth tx");
-
-        // Wait for mempool
-        let tx = self.wait_for_pending_tx(tx_hash, sign_ids.clone()).await?;
-
-        tracing::info!(?tx, "tx found in mempool");
-
-        // Wait for receipt
-        let receipt = self
-            .wait_for_transaction_receipt(tx_hash, sign_ids.clone())
-            .await?;
-
-        // Check status
-        if !receipt.status() {
-            tracing::error!(
-                ?sign_ids,
-                tx_hash = ?receipt.transaction_hash,
-                "eth batch transaction failed"
-            );
-            return Err(());
-        }
-
-        let tx_hash = receipt.transaction_hash;
-        tracing::info!(
-            ?chain,
-            ?sign_ids,
-            ?tx_hash,
-            num_requests,
-            "eth batch published ethereum signatures successfully"
-        );
+        tracing::info!(num_requests, "batch publish complete");
         Ok(())
     }
 }

--- a/chain-signatures/node/src/rpc/hydration.rs
+++ b/chain-signatures/node/src/rpc/hydration.rs
@@ -1,0 +1,309 @@
+use super::PublishAction;
+use crate::indexer_hydration::HydrationConfig;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use mpc_primitives::{SignId, SignKind, Signature};
+use parity_scale_codec::{Decode, Encode};
+use sp_core::{sr25519, Pair as _};
+use sp_runtime::{
+    traits::{IdentifyAccount, Verify},
+    MultiSignature as SpMultiSignature,
+};
+use std::time::Instant;
+use subxt::config::substrate::{
+    AccountId32, BlakeTwo256, MultiSignature, SubstrateConfig, SubstrateExtrinsicParams,
+    SubstrateHeader,
+};
+use subxt::tx::Payload;
+use subxt::Config as SubxtConfig;
+use subxt::OnlineClient;
+
+enum HydradxConfig {}
+
+impl SubxtConfig for HydradxConfig {
+    type AccountId = <SubstrateConfig as SubxtConfig>::AccountId;
+    type Address = <SubstrateConfig as SubxtConfig>::AccountId;
+    type Signature = <SubstrateConfig as SubxtConfig>::Signature;
+    type Hasher = BlakeTwo256;
+    type Header = SubstrateHeader<u32, BlakeTwo256>;
+    type ExtrinsicParams = SubstrateExtrinsicParams<Self>;
+    type AssetId = <SubstrateConfig as SubxtConfig>::AssetId;
+}
+
+#[derive(Clone)]
+struct HydrationSigner {
+    account_id: AccountId32,
+    signer: sr25519::Pair,
+}
+
+impl HydrationSigner {
+    fn from_uri(uri: &str) -> anyhow::Result<Self> {
+        let signer = sr25519::Pair::from_string(uri, None)?;
+        let account_id = <SpMultiSignature as Verify>::Signer::from(signer.public()).into_account();
+
+        Ok(Self {
+            account_id: AccountId32(account_id.into()),
+            signer,
+        })
+    }
+}
+
+impl subxt::tx::Signer<HydradxConfig> for HydrationSigner {
+    fn account_id(&self) -> <HydradxConfig as SubxtConfig>::AccountId {
+        self.account_id.clone()
+    }
+
+    fn sign(&self, signer_payload: &[u8]) -> <HydradxConfig as SubxtConfig>::Signature {
+        MultiSignature::Sr25519(self.signer.sign(signer_payload).0)
+    }
+}
+
+#[derive(Clone)]
+pub struct HydrationClient {
+    api: OnlineClient<HydradxConfig>,
+    signer: HydrationSigner,
+}
+
+const PALLET_SIGNET: &str = "Signet";
+
+/// This type mirrors the on-chain representation of an affine point
+#[derive(Clone, Debug, Encode, Decode)]
+struct HydrationAffinePoint {
+    pub x: [u8; 32],
+    pub y: [u8; 32],
+}
+
+/// This type mirrors the on-chain signature format
+#[derive(Clone, Debug, Encode, Decode)]
+struct HydrationSignature {
+    pub big_r: HydrationAffinePoint,
+    pub s: [u8; 32],
+    pub recovery_id: u8,
+}
+
+/// A thin wrapper used to mirror the on-chain `BoundedVec` type for SCALE
+/// encoding/decoding. This type does **not** enforce any length bounds; it
+/// is effectively just a `Vec<T>` on the client side.
+///
+/// Callers are responsible for ensuring that the inner `Vec` length respects
+/// the maximum length enforced by the on-chain pallet, otherwise the
+/// resulting transaction may be rejected on-chain.
+#[derive(Clone, Debug, Encode, Decode)]
+struct BoundedVec<T>(pub Vec<T>);
+
+/// this type is used to construct tx to call respond() on pallet
+struct HydrationRespondTx {
+    pub request_ids: BoundedVec<[u8; 32]>,
+    pub signatures: BoundedVec<HydrationSignature>,
+}
+
+impl Payload for HydrationRespondTx {
+    fn encode_call_data_to(
+        &self,
+        metadata: &subxt::Metadata,
+        out: &mut Vec<u8>,
+    ) -> std::result::Result<(), subxt::ext::subxt_core::Error> {
+        let pallet = metadata.pallet_by_name(PALLET_SIGNET).ok_or_else(|| {
+            subxt::ext::subxt_core::Error::Metadata(
+                subxt::error::MetadataError::PalletNameNotFound(PALLET_SIGNET.to_string()),
+            )
+        })?;
+
+        let respond_call_index = pallet
+            .call_variant_by_name("respond")
+            .ok_or_else(|| {
+                subxt::ext::subxt_core::Error::Metadata(
+                    subxt::error::MetadataError::CallNameNotFound("respond".to_string()),
+                )
+            })?
+            .index;
+
+        let pallet_index: u8 = pallet.index();
+
+        out.push(pallet_index);
+        out.push(respond_call_index);
+
+        (&self.request_ids, &self.signatures).encode_to(out);
+        Ok(())
+    }
+}
+
+/// this type is used to construct tx to call respond_bidirectional() on pallet
+struct HydrationRespondBidirectionalTx {
+    pub request_id: [u8; 32],
+    pub serialized_output: BoundedVec<u8>,
+    pub signature: HydrationSignature,
+}
+
+impl Payload for HydrationRespondBidirectionalTx {
+    fn encode_call_data_to(
+        &self,
+        metadata: &subxt::Metadata,
+        out: &mut Vec<u8>,
+    ) -> std::result::Result<(), subxt::ext::subxt_core::Error> {
+        let pallet = metadata.pallet_by_name(PALLET_SIGNET).ok_or_else(|| {
+            subxt::ext::subxt_core::Error::Metadata(
+                subxt::error::MetadataError::PalletNameNotFound(PALLET_SIGNET.to_string()),
+            )
+        })?;
+
+        let pallet_index: u8 = pallet.index();
+
+        let respond_bidirectional_call_index = pallet
+            .call_variant_by_name("respond_bidirectional")
+            .ok_or_else(|| {
+                subxt::ext::subxt_core::Error::Metadata(
+                    subxt::error::MetadataError::CallNameNotFound(
+                        "respond_bidirectional".to_string(),
+                    ),
+                )
+            })?
+            .index;
+
+        out.push(pallet_index);
+        out.push(respond_bidirectional_call_index);
+
+        // respond_bidirectional(origin, request_id, serialized_output, signature)
+        (&self.request_id, &self.serialized_output, &self.signature).encode_to(out);
+        Ok(())
+    }
+}
+
+impl HydrationClient {
+    pub async fn new(config: &HydrationConfig) -> anyhow::Result<Self> {
+        let api = OnlineClient::<HydradxConfig>::from_url(&config.rpc_ws_url).await?;
+        let signer = HydrationSigner::from_uri(&config.signer_uri)?;
+        Ok(Self { api, signer })
+    }
+
+    fn to_hydration_signature(sig: &Signature) -> anyhow::Result<HydrationSignature> {
+        let enc = sig.big_r.to_encoded_point(false);
+
+        let x: [u8; 32] = enc
+            .x()
+            .ok_or_else(|| anyhow::anyhow!("missing x"))?
+            .as_slice()
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("x must be 32 bytes"))?;
+
+        let y: [u8; 32] = enc
+            .y()
+            .ok_or_else(|| anyhow::anyhow!("missing y"))?
+            .as_slice()
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("y must be 32 bytes"))?;
+
+        let s: [u8; 32] = sig.s.to_bytes().into();
+
+        Ok(HydrationSignature {
+            big_r: HydrationAffinePoint { x, y },
+            s,
+            recovery_id: sig.recovery_id,
+        })
+    }
+
+    async fn call_respond(&self, id: &SignId, response: &Signature) -> anyhow::Result<()> {
+        let tx = HydrationRespondTx {
+            request_ids: BoundedVec(vec![id.request_id]),
+            signatures: BoundedVec(vec![Self::to_hydration_signature(response)?]),
+        };
+
+        let progress = self
+            .api
+            .tx()
+            .sign_and_submit_then_watch_default(&tx, &self.signer)
+            .await?;
+
+        progress.wait_for_finalized_success().await?;
+        Ok(())
+    }
+
+    async fn call_respond_bidirectional(
+        &self,
+        id: &SignId,
+        serialized_output: Vec<u8>,
+        response: &Signature,
+    ) -> anyhow::Result<subxt::config::HashFor<HydradxConfig>> {
+        let tx = HydrationRespondBidirectionalTx {
+            request_id: id.request_id,
+            serialized_output: BoundedVec(serialized_output),
+            signature: Self::to_hydration_signature(response)?,
+        };
+
+        let progress = self
+            .api
+            .tx()
+            .sign_and_submit_then_watch_default(&tx, &self.signer)
+            .await?;
+
+        let events = progress.wait_for_finalized_success().await?;
+        Ok(events.extrinsic_hash())
+    }
+}
+
+pub async fn try_publish_hydration(
+    hyd: &HydrationClient,
+    action: &PublishAction,
+    timestamp: &Instant,
+    signature: &Signature,
+) -> Result<(), ()> {
+    let chain = action.indexed.chain;
+    let sign_id = action.indexed.id;
+    let request_ids = [action.indexed.id.request_id];
+
+    tracing::info!(
+        ?sign_id,
+        ?chain,
+        elapsed = ?timestamp.elapsed(),
+        request_id = ?request_ids[0],
+        "Hydration: publishing signature"
+    );
+
+    match &action.indexed.kind {
+        SignKind::Sign | SignKind::SignBidirectional(_) => {
+            hyd.call_respond(&action.indexed.id, signature)
+                .await
+                .map_err(|e| {
+                    tracing::error!(?sign_id, ?e, "Hydration: failed to publish signature");
+                })?;
+            tracing::info!(
+                ?sign_id,
+                elapsed = ?timestamp.elapsed(),
+                "published hydration signature successfully"
+            );
+        }
+        SignKind::RespondBidirectional(respond_bidirectional_tx) => {
+            let serialized_output = respond_bidirectional_tx.output.clone();
+            tracing::debug!(
+                ?sign_id,
+                request_id = ?request_ids[0],
+                serialized_output_len = serialized_output.len(),
+                "try_publish_hydration: entering RespondBidirectional arm"
+            );
+            let tx_hash = hyd
+                .call_respond_bidirectional(&action.indexed.id, serialized_output, signature)
+                .await
+                .map_err(|e| {
+                    tracing::error!(
+                        ?sign_id,
+                        ?e,
+                        "Hydration: failed to publish respond bidirectional signature"
+                    );
+                })?;
+            tracing::info!(
+                ?sign_id,
+                tx_hash = ?tx_hash,
+                elapsed = ?timestamp.elapsed(),
+                "published respond bidirectional hydration signature successfully"
+            );
+        }
+        SignKind::Checkpoint(_) => {
+            tracing::error!(
+                ?sign_id,
+                "try_publish_hydration: checkpoint signature publishing not supported on Hydration"
+            );
+            return Err(());
+        }
+    }
+
+    Ok(())
+}

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -1,4 +1,5 @@
 mod ethereum;
+mod hydration;
 mod near;
 
 use crate::config::Config;
@@ -12,6 +13,7 @@ use crate::util::retry::{retry_rpc, RetryConfig};
 use std::collections::BTreeSet;
 
 pub use ethereum::{try_batch_publish_eth, try_publish_eth, EthClient};
+pub use hydration::{try_publish_hydration, HydrationClient};
 pub use mpc_contract::primitives::{Read, View};
 pub use near::{try_publish_near, NearClient};
 
@@ -34,21 +36,8 @@ use crate::indexer_sol::SolanaClient;
 
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use near_account_id::AccountId;
-use parity_scale_codec::{Decode, Encode};
-use sp_core::{sr25519, Pair as _};
-use sp_runtime::{
-    traits::{IdentifyAccount, Verify},
-    MultiSignature as SpMultiSignature,
-};
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
-use subxt::config::substrate::{
-    AccountId32, BlakeTwo256, MultiSignature, SubstrateConfig, SubstrateExtrinsicParams,
-    SubstrateHeader,
-};
-use subxt::tx::Payload;
-use subxt::Config as SubxtConfig;
-use subxt::OnlineClient;
 use tokio::sync::{mpsc, watch};
 
 /// The maximum amount of times to retry publishing a signature.
@@ -537,229 +526,6 @@ impl RpcExecutor {
             }
             Chain::Bitcoin => ChainClient::Err("no bitcoin client available for node"),
         }
-    }
-}
-
-enum HydradxConfig {}
-
-impl SubxtConfig for HydradxConfig {
-    type AccountId = <SubstrateConfig as SubxtConfig>::AccountId;
-    type Address = <SubstrateConfig as SubxtConfig>::AccountId;
-    type Signature = <SubstrateConfig as SubxtConfig>::Signature;
-    type Hasher = BlakeTwo256;
-    type Header = SubstrateHeader<u32, BlakeTwo256>;
-    type ExtrinsicParams = SubstrateExtrinsicParams<Self>;
-    type AssetId = <SubstrateConfig as SubxtConfig>::AssetId;
-}
-
-#[derive(Clone)]
-struct HydrationSigner {
-    account_id: AccountId32,
-    signer: sr25519::Pair,
-}
-
-impl HydrationSigner {
-    fn from_uri(uri: &str) -> anyhow::Result<Self> {
-        let signer = sr25519::Pair::from_string(uri, None)?;
-        let account_id = <SpMultiSignature as Verify>::Signer::from(signer.public()).into_account();
-
-        Ok(Self {
-            account_id: AccountId32(account_id.into()),
-            signer,
-        })
-    }
-}
-
-impl subxt::tx::Signer<HydradxConfig> for HydrationSigner {
-    fn account_id(&self) -> <HydradxConfig as SubxtConfig>::AccountId {
-        self.account_id.clone()
-    }
-
-    fn sign(&self, signer_payload: &[u8]) -> <HydradxConfig as SubxtConfig>::Signature {
-        MultiSignature::Sr25519(self.signer.sign(signer_payload).0)
-    }
-}
-
-#[derive(Clone)]
-pub struct HydrationClient {
-    api: OnlineClient<HydradxConfig>,
-    signer: HydrationSigner,
-}
-
-const PALLET_SIGNET: &str = "Signet";
-
-/// This type mirrors the on-chain representation of an affine point
-#[derive(Clone, Debug, Encode, Decode)]
-struct HydrationAffinePoint {
-    pub x: [u8; 32],
-    pub y: [u8; 32],
-}
-
-/// This type mirrors the on-chain signature format
-#[derive(Clone, Debug, Encode, Decode)]
-struct HydrationSignature {
-    pub big_r: HydrationAffinePoint,
-    pub s: [u8; 32],
-    pub recovery_id: u8,
-}
-
-/// A thin wrapper used to mirror the on-chain `BoundedVec` type for SCALE
-/// encoding/decoding. This type does **not** enforce any length bounds; it
-/// is effectively just a `Vec<T>` on the client side.
-///
-/// Callers are responsible for ensuring that the inner `Vec` length respects
-/// the maximum length enforced by the on-chain pallet, otherwise the
-/// resulting transaction may be rejected on-chain.
-#[derive(Clone, Debug, Encode, Decode)]
-struct BoundedVec<T>(pub Vec<T>);
-
-/// this type is used to construct tx to call respond() on pallet
-struct HydrationRespondTx {
-    pub request_ids: BoundedVec<[u8; 32]>,
-    pub signatures: BoundedVec<HydrationSignature>,
-}
-
-impl Payload for HydrationRespondTx {
-    fn encode_call_data_to(
-        &self,
-        metadata: &subxt::Metadata,
-        out: &mut Vec<u8>,
-    ) -> std::result::Result<(), subxt::ext::subxt_core::Error> {
-        let pallet = metadata.pallet_by_name(PALLET_SIGNET).ok_or_else(|| {
-            subxt::ext::subxt_core::Error::Metadata(
-                subxt::error::MetadataError::PalletNameNotFound(PALLET_SIGNET.to_string()),
-            )
-        })?;
-
-        let respond_call_index = pallet
-            .call_variant_by_name("respond")
-            .ok_or_else(|| {
-                subxt::ext::subxt_core::Error::Metadata(
-                    subxt::error::MetadataError::CallNameNotFound("respond".to_string()),
-                )
-            })?
-            .index;
-
-        let pallet_index: u8 = pallet.index();
-
-        out.push(pallet_index);
-        out.push(respond_call_index);
-
-        (&self.request_ids, &self.signatures).encode_to(out);
-        Ok(())
-    }
-}
-
-/// this type is used to construct tx to call respond_bidirectional() on pallet
-struct HydrationRespondBidirectionalTx {
-    pub request_id: [u8; 32],
-    pub serialized_output: BoundedVec<u8>,
-    pub signature: HydrationSignature,
-}
-
-impl Payload for HydrationRespondBidirectionalTx {
-    fn encode_call_data_to(
-        &self,
-        metadata: &subxt::Metadata,
-        out: &mut Vec<u8>,
-    ) -> std::result::Result<(), subxt::ext::subxt_core::Error> {
-        let pallet = metadata.pallet_by_name(PALLET_SIGNET).ok_or_else(|| {
-            subxt::ext::subxt_core::Error::Metadata(
-                subxt::error::MetadataError::PalletNameNotFound(PALLET_SIGNET.to_string()),
-            )
-        })?;
-
-        let pallet_index: u8 = pallet.index();
-
-        let respond_bidirectional_call_index = pallet
-            .call_variant_by_name("respond_bidirectional")
-            .ok_or_else(|| {
-                subxt::ext::subxt_core::Error::Metadata(
-                    subxt::error::MetadataError::CallNameNotFound(
-                        "respond_bidirectional".to_string(),
-                    ),
-                )
-            })?
-            .index;
-
-        out.push(pallet_index);
-        out.push(respond_bidirectional_call_index);
-
-        // respond_bidirectional(origin, request_id, serialized_output, signature)
-        (&self.request_id, &self.serialized_output, &self.signature).encode_to(out);
-        Ok(())
-    }
-}
-
-impl HydrationClient {
-    pub async fn new(config: &HydrationConfig) -> anyhow::Result<Self> {
-        let api = OnlineClient::<HydradxConfig>::from_url(&config.rpc_ws_url).await?;
-        let signer = HydrationSigner::from_uri(&config.signer_uri)?;
-        Ok(Self { api, signer })
-    }
-
-    fn to_hydration_signature(sig: &Signature) -> anyhow::Result<HydrationSignature> {
-        let enc = sig.big_r.to_encoded_point(false);
-
-        let x: [u8; 32] = enc
-            .x()
-            .ok_or_else(|| anyhow::anyhow!("missing x"))?
-            .as_slice()
-            .try_into()
-            .map_err(|_| anyhow::anyhow!("x must be 32 bytes"))?;
-
-        let y: [u8; 32] = enc
-            .y()
-            .ok_or_else(|| anyhow::anyhow!("missing y"))?
-            .as_slice()
-            .try_into()
-            .map_err(|_| anyhow::anyhow!("y must be 32 bytes"))?;
-
-        let s: [u8; 32] = sig.s.to_bytes().into();
-
-        Ok(HydrationSignature {
-            big_r: HydrationAffinePoint { x, y },
-            s,
-            recovery_id: sig.recovery_id,
-        })
-    }
-
-    async fn call_respond(&self, id: &SignId, response: &Signature) -> anyhow::Result<()> {
-        let tx = HydrationRespondTx {
-            request_ids: BoundedVec(vec![id.request_id]),
-            signatures: BoundedVec(vec![Self::to_hydration_signature(response)?]),
-        };
-
-        let progress = self
-            .api
-            .tx()
-            .sign_and_submit_then_watch_default(&tx, &self.signer)
-            .await?;
-
-        progress.wait_for_finalized_success().await?;
-        Ok(())
-    }
-
-    async fn call_respond_bidirectional(
-        &self,
-        id: &SignId,
-        serialized_output: Vec<u8>,
-        response: &Signature,
-    ) -> anyhow::Result<subxt::config::HashFor<HydradxConfig>> {
-        let tx = HydrationRespondBidirectionalTx {
-            request_id: id.request_id,
-            serialized_output: BoundedVec(serialized_output),
-            signature: Self::to_hydration_signature(response)?,
-        };
-
-        let progress = self
-            .api
-            .tx()
-            .sign_and_submit_then_watch_default(&tx, &self.signer)
-            .await?;
-
-        let events = progress.wait_for_finalized_success().await?;
-        Ok(events.extrinsic_hash())
     }
 }
 
@@ -1320,74 +1086,6 @@ async fn try_publish_sol(
             tracing::error!(
                 ?sign_id,
                 "try_publish_sol: checkpoint signature publishing not supported on Solana"
-            );
-            return Err(());
-        }
-    }
-
-    Ok(())
-}
-
-async fn try_publish_hydration(
-    hyd: &HydrationClient,
-    action: &PublishAction,
-    timestamp: &Instant,
-    signature: &Signature,
-) -> Result<(), ()> {
-    let chain = action.indexed.chain;
-    let sign_id = action.indexed.id;
-    let request_ids = [action.indexed.id.request_id];
-
-    tracing::info!(
-        ?sign_id,
-        ?chain,
-        elapsed = ?timestamp.elapsed(),
-        request_id = ?request_ids[0],
-        "Hydration: publishing signature"
-    );
-
-    match &action.indexed.kind {
-        SignKind::Sign | SignKind::SignBidirectional(_) => {
-            hyd.call_respond(&action.indexed.id, signature)
-                .await
-                .map_err(|e| {
-                    tracing::error!(?sign_id, ?e, "Hydration: failed to publish signature");
-                })?;
-            tracing::info!(
-                ?sign_id,
-                elapsed = ?timestamp.elapsed(),
-                "published hydration signature successfully"
-            );
-        }
-        SignKind::RespondBidirectional(respond_bidirectional_tx) => {
-            let serialized_output = respond_bidirectional_tx.output.clone();
-            tracing::debug!(
-                ?sign_id,
-                request_id = ?request_ids[0],
-                serialized_output_len = serialized_output.len(),
-                "try_publish_hydration: entering RespondBidirectional arm"
-            );
-            let tx_hash = hyd
-                .call_respond_bidirectional(&action.indexed.id, serialized_output, signature)
-                .await
-                .map_err(|e| {
-                    tracing::error!(
-                        ?sign_id,
-                        ?e,
-                        "Hydration: failed to publish respond bidirectional signature"
-                    );
-                })?;
-            tracing::info!(
-                ?sign_id,
-                tx_hash = ?tx_hash,
-                elapsed = ?timestamp.elapsed(),
-                "published respond bidirectional hydration signature successfully"
-            );
-        }
-        SignKind::Checkpoint(_) => {
-            tracing::error!(
-                ?sign_id,
-                "try_publish_hydration: checkpoint signature publishing not supported on Hydration"
             );
             return Err(());
         }

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -2,6 +2,7 @@ mod canton;
 mod ethereum;
 mod hydration;
 mod near;
+mod solana;
 
 use crate::config::Config;
 use crate::indexer_eth::EthConfig;
@@ -18,20 +19,19 @@ pub use ethereum::EthClient;
 pub use hydration::{try_publish_hydration, HydrationClient};
 pub use mpc_contract::primitives::{Read, View};
 pub use near::{try_publish_near, NearClient};
+pub use solana::try_publish_sol;
 
 use enum_map::EnumMap;
-use solana_sdk::pubkey::Pubkey;
 
 use cait_sith::protocol::Participant;
 use cait_sith::FullSignature;
 use k256::{AffinePoint, Secp256k1};
-use mpc_primitives::{CheckpointDigest, SignId, SignKind, Signature};
+use mpc_primitives::{CheckpointDigest, SignId, Signature};
 
 use crate::indexer_canton::CantonConfig;
 use crate::indexer_hydration::HydrationConfig;
 use crate::indexer_sol::SolanaClient;
 
-use k256::elliptic_curve::sec1::ToEncodedPoint;
 use near_account_id::AccountId;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
@@ -812,111 +812,6 @@ async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAc
     }
 
     actions.clear();
-}
-
-use signet_program::accounts::Respond as SolanaRespondAccount;
-use signet_program::accounts::RespondBidirectional as SolanaRespondBidirectionalAccount;
-use signet_program::instruction::Respond as SolanaRespond;
-use signet_program::instruction::RespondBidirectional as SolanaRespondBidirectional;
-use solana_sdk::signature::Signer as SolanaSigner;
-async fn try_publish_sol(
-    sol: &SolanaClient,
-    action: &PublishAction,
-    timestamp: &Instant,
-    signature: &Signature,
-) -> Result<(), ()> {
-    let program = sol.client.program(sol.program_id).map_err(|_| ())?;
-
-    let sign_id = action.indexed.id;
-    let request_ids = vec![action.indexed.id.request_id];
-    let big_r = signature.big_r.to_encoded_point(false);
-    let signature = crate::util::mpc_to_sol_signature(signature, big_r);
-
-    tracing::debug!(
-        ?sign_id,
-        request_type = ?action.indexed.kind,
-        "try_publish_sol: dispatching request"
-    );
-
-    match &action.indexed.kind {
-        SignKind::Sign | SignKind::SignBidirectional(_) => {
-            let (event_authority, _) =
-                Pubkey::find_program_address(&[b"__event_authority"], &sol.program_id);
-            let tx = program
-                .request()
-                .signer(sol.payer.clone())
-                .accounts(SolanaRespondAccount {
-                    responder: sol.payer.pubkey(),
-                    event_authority,
-                    program: sol.program_id,
-                })
-                .args(SolanaRespond {
-                    request_ids,
-                    signatures: vec![signature.clone()],
-                })
-                .send()
-                .await
-                .map_err(|err| {
-                    tracing::error!(
-                        sign_id = ?action.indexed.id,
-                        error = ?err,
-                        "failed to publish solana signature"
-                    );
-                })?;
-
-            tracing::info!(
-                ?sign_id,
-                tx_hash = ?tx,
-                elapsed = ?timestamp.elapsed(),
-                "published solana signature successfully"
-            );
-        }
-        SignKind::RespondBidirectional(respond_bidirectional_tx) => {
-            tracing::debug!(
-                ?sign_id,
-                request_id = ?request_ids[0],
-                serialized_output_len = respond_bidirectional_tx.output.len(),
-                "try_publish_sol: entering RespondBidirectional arm"
-            );
-            let respond_bidirectional_serialized_output = respond_bidirectional_tx.output.clone();
-            let tx = program
-                .request()
-                .signer(sol.payer.clone())
-                .accounts(SolanaRespondBidirectionalAccount {
-                    responder: sol.payer.clone().try_pubkey().unwrap(),
-                })
-                .args(SolanaRespondBidirectional {
-                    request_id: request_ids[0],
-                    serialized_output: respond_bidirectional_serialized_output.clone(),
-                    signature: signature.clone(),
-                })
-                .send()
-                .await
-                .map_err(|err| {
-                    tracing::error!(
-                        ?sign_id,
-                        error = ?err,
-                        "failed to publish respond bidirectional solana signature"
-                    );
-                })?;
-
-            tracing::info!(
-                ?sign_id,
-                tx_hash = ?tx,
-                elapsed = ?timestamp.elapsed(),
-                "published respond bidirectional solana signature successfully"
-            );
-        }
-        SignKind::Checkpoint(_) => {
-            tracing::error!(
-                ?sign_id,
-                "try_publish_sol: checkpoint signature publishing not supported on Solana"
-            );
-            return Err(());
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -1,28 +1,27 @@
-use crate::config::{Config, ContractConfig, NetworkConfig};
+mod ethereum;
+mod near;
+
+use crate::config::Config;
 use crate::indexer_eth::EthConfig;
 use crate::indexer_sol::SolConfig;
 use crate::metrics::requests::{record_request_latency_since, SignRequestStep};
 use crate::protocol::contract::primitives::{ParticipantMap, Participants};
 use crate::protocol::contract::RunningContractState;
-use crate::protocol::{Chain, Governance, IndexedSignRequest, ProtocolState};
+use crate::protocol::{Chain, IndexedSignRequest, ProtocolState};
 use crate::util::retry::{retry_rpc, RetryConfig};
-use crate::util::AffinePointExt as _;
 use std::collections::BTreeSet;
 
+pub use ethereum::{try_batch_publish_eth, try_publish_eth, EthClient};
 pub use mpc_contract::primitives::{Read, View};
+pub use near::{try_publish_near, NearClient};
 
 use enum_map::EnumMap;
 use solana_sdk::pubkey::Pubkey;
 
-use alloy::primitives::Address;
-use alloy::providers::fillers::{FillProvider, JoinFill, WalletFiller};
-use alloy::providers::{Provider, RootProvider, WalletProvider};
-use alloy::rpc::types::{Transaction, TransactionReceipt};
 use cait_sith::protocol::Participant;
 use cait_sith::FullSignature;
 use k256::{AffinePoint, Secp256k1};
-use mpc_keys::hpke;
-use mpc_primitives::{CheckpointDigest, ConsensusCheckpointDigest, SignId, SignKind, Signature};
+use mpc_primitives::{CheckpointDigest, SignId, SignKind, Signature};
 
 use crate::indexer_canton::ledger_api::{
     ActiveContractEntry, CumulativeFilter, EventFormat, GetActiveContractsRequest,
@@ -32,26 +31,16 @@ use crate::indexer_canton::ledger_api::{
 use crate::indexer_canton::{CantonAuthProvider, CantonConfig};
 use crate::indexer_hydration::HydrationConfig;
 use crate::indexer_sol::SolanaClient;
-use alloy::contract::{ContractInstance, Interface};
-use alloy::dyn_abi::DynSolValue;
-use alloy::network::EthereumWallet;
-use alloy::primitives::U256;
-use alloy::providers::ProviderBuilder;
-use alloy_signer_local::PrivateKeySigner;
-use k256::elliptic_curve::point::AffineCoordinates;
+
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use near_account_id::AccountId;
-use near_crypto::InMemorySigner;
-use near_fetch::result::ExecutionFinalResult;
 use parity_scale_codec::{Decode, Encode};
-use serde_json::json;
 use sp_core::{sr25519, Pair as _};
 use sp_runtime::{
     traits::{IdentifyAccount, Verify},
     MultiSignature as SpMultiSignature,
 };
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::time::{Duration, Instant};
 use subxt::config::substrate::{
     AccountId32, BlakeTwo256, MultiSignature, SubstrateConfig, SubstrateExtrinsicParams,
@@ -61,7 +50,6 @@ use subxt::tx::Payload;
 use subxt::Config as SubxtConfig;
 use subxt::OnlineClient;
 use tokio::sync::{mpsc, watch};
-use url::Url;
 
 /// The maximum amount of times to retry publishing a signature.
 const MAX_PUBLISH_RETRY: usize = 6;
@@ -70,64 +58,15 @@ const MAX_CONCURRENT_RPC_REQUESTS: usize = 1024;
 /// The update interval to fetch and update the contract's state
 const UPDATE_INTERVAL: Duration = Duration::from_secs(10);
 /// The interval to batch send Ethereum responses
-const ETH_RESPOND_BATCH_INTERVAL: Duration = Duration::from_millis(2000);
+pub const ETH_RESPOND_BATCH_INTERVAL: Duration = Duration::from_millis(2000);
 /// The batch size for Ethereum responses
-const ETH_RESPOND_BATCH_SIZE: usize = 10;
-/// The maximum number of attempts to fetch eth tx and its receipt
-const ETH_TX_RECEIPT_MAX_ATTEMPTS: usize = 6;
-type EthContractFillProvider = FillProvider<
-    JoinFill<
-        JoinFill<
-            alloy::providers::Identity,
-            JoinFill<
-                alloy::providers::fillers::GasFiller,
-                JoinFill<
-                    alloy::providers::fillers::BlobGasFiller,
-                    JoinFill<
-                        alloy::providers::fillers::NonceFiller,
-                        alloy::providers::fillers::ChainIdFiller,
-                    >,
-                >,
-            >,
-        >,
-        WalletFiller<EthereumWallet>,
-    >,
-    RootProvider,
->;
+pub const ETH_RESPOND_BATCH_SIZE: usize = 10;
 
 // Publish retry constants
 const PUBLISH_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(120);
 const PUBLISH_FIXED_DELAY: Duration = Duration::from_secs(5);
 const BATCH_PUBLISH_MIN_DELAY: Duration = Duration::from_secs(1);
 const BATCH_PUBLISH_MAX_DELAY: Duration = Duration::from_secs(10);
-
-// Get nonce retry constants
-const ETH_NONCE_MAX_ATTEMPTS: usize = 3;
-const ETH_NONCE_TIMEOUT: Duration = Duration::from_secs(2);
-const ETH_NONCE_MIN_DELAY: Duration = Duration::from_millis(500);
-const ETH_NONCE_MAX_DELAY: Duration = Duration::from_secs(5);
-
-// Send Ethereum tx retry constants
-const ETH_SEND_MAX_ATTEMPTS: usize = 3;
-const ETH_SEND_TIMEOUT: Duration = Duration::from_secs(5);
-const ETH_SEND_MIN_DELAY: Duration = Duration::from_millis(500);
-const ETH_SEND_MAX_DELAY: Duration = Duration::from_secs(10);
-
-// Polling Mempool
-const ETH_MEMPOOL_TIMEOUT: Duration = Duration::from_secs(5);
-const ETH_MEMPOOL_MIN_DELAY: Duration = Duration::from_secs(1);
-const ETH_MEMPOOL_MAX_DELAY: Duration = Duration::from_secs(10);
-
-// Polling Receipt
-const ETH_RECEIPT_TIMEOUT: Duration = Duration::from_secs(2);
-const ETH_RECEIPT_MIN_DELAY: Duration = Duration::from_secs(1);
-const ETH_RECEIPT_MAX_DELAY: Duration = Duration::from_secs(20);
-
-// Ethereum gas limits
-const ETH_BASE_GAS_LIMIT: u64 = 40_000;
-const ETH_BATCH_GAS_PER_REQUEST: u64 = 20_000;
-
-type EthContractInstance = ContractInstance<EthContractFillProvider>;
 
 #[derive(Clone)]
 pub struct PublishAction {
@@ -598,220 +537,6 @@ impl RpcExecutor {
             }
             Chain::Bitcoin => ChainClient::Err("no bitcoin client available for node"),
         }
-    }
-}
-
-#[derive(Clone)]
-pub struct NearClient {
-    client: near_fetch::Client,
-    contract_id: AccountId,
-    my_addr: Url,
-    signer: InMemorySigner,
-    cipher_pk: hpke::PublicKey,
-    sign_pk: near_crypto::PublicKey,
-}
-
-impl Governance for NearClient {
-    async fn propose_join(&self) -> anyhow::Result<()> {
-        self.propose_join().await
-    }
-
-    async fn vote_reshared(&self, epoch: u64) -> anyhow::Result<bool> {
-        self.vote_reshared(epoch).await
-    }
-
-    async fn vote_public_key(&self, public_key: &near_crypto::PublicKey) -> anyhow::Result<bool> {
-        self.vote_public_key(public_key).await
-    }
-}
-
-impl NearClient {
-    pub fn new(
-        near_rpc: &str,
-        my_addr: &Url,
-        network: &NetworkConfig,
-        contract_id: &AccountId,
-        signer: InMemorySigner,
-    ) -> Self {
-        Self {
-            client: near_fetch::Client::new(near_rpc),
-            contract_id: contract_id.clone(),
-            my_addr: my_addr.clone(),
-            signer,
-            cipher_pk: network.cipher_sk.public_key(),
-            sign_pk: network.sign_sk.public_key(),
-        }
-    }
-
-    pub fn rpc_addr(&self) -> String {
-        self.client.rpc_addr()
-    }
-
-    pub async fn fetch_state(&self) -> anyhow::Result<ProtocolState> {
-        let contract_state: mpc_contract::ProtocolContractState =
-            self.client.view(&self.contract_id, "state").await?.json()?;
-
-        let protocol_state: ProtocolState = contract_state.try_into().map_err(|_| {
-            anyhow::anyhow!("failed to parse protocol state, has it been initialized?")
-        })?;
-
-        tracing::debug!(?protocol_state, "protocol state");
-        Ok(protocol_state)
-    }
-
-    pub async fn fetch_config(&self) -> Option<ContractConfig> {
-        self.client
-            .view(&self.contract_id, "config")
-            .await
-            .inspect_err(|err| {
-                tracing::warn!(%err, "failed to fetch contract config");
-            })
-            .ok()?
-            .json()
-            .inspect(|configs| {
-                tracing::debug!(?configs, "contract config");
-            })
-            .inspect_err(|err| {
-                tracing::warn!(%err, "unable to parse config");
-            })
-            .ok()
-    }
-
-    pub async fn vote_public_key(
-        &self,
-        public_key: &near_crypto::PublicKey,
-    ) -> anyhow::Result<bool> {
-        tracing::info!(%public_key, signer_id = %self.signer.account_id, "voting for public key");
-        let result = self
-            .client
-            .call(&self.signer, &self.contract_id, "vote_pk")
-            .args_json(json!({
-                "public_key": public_key
-            }))
-            .max_gas()
-            .retry_exponential(10, 5)
-            .transact()
-            .await
-            .inspect_err(|err| {
-                tracing::warn!(%err, "failed to vote for public key");
-            })?
-            .json()?;
-
-        Ok(result)
-    }
-
-    pub async fn vote_reshared(&self, epoch: u64) -> anyhow::Result<bool> {
-        tracing::info!(%epoch, signer_id = %self.signer.account_id, "voting for reshared");
-        let result = self
-            .client
-            .call(&self.signer, &self.contract_id, "vote_reshared")
-            .args_json(json!({
-                "epoch": epoch
-            }))
-            .max_gas()
-            .retry_exponential(10, 5)
-            .transact()
-            .await
-            .inspect_err(|err| {
-                tracing::warn!(%err, "failed to vote for reshared");
-            })?
-            .json()?;
-
-        Ok(result)
-    }
-
-    pub async fn propose_join(&self) -> anyhow::Result<()> {
-        tracing::info!(signer_id = %self.signer.account_id, "joining the protocol");
-        self.client
-            .call(&self.signer, &self.contract_id, "join")
-            .args_json(json!({
-                "url": self.my_addr,
-                "cipher_pk": self.cipher_pk.to_bytes(),
-                "sign_pk": self.sign_pk,
-            }))
-            .max_gas()
-            .retry_exponential(10, 3)
-            .transact()
-            .await?
-            .into_result()?;
-
-        Ok(())
-    }
-
-    pub async fn call_respond(
-        &self,
-        id: &SignId,
-        response: &Signature,
-    ) -> Result<ExecutionFinalResult, near_fetch::Error> {
-        self.client
-            .call(&self.signer, &self.contract_id, "respond")
-            .args_json(json!({
-                "sign_id": id,
-                "signature": response,
-            }))
-            .max_gas()
-            .transact()
-            .await
-    }
-
-    pub async fn read(&self, reads: Vec<Read>) -> anyhow::Result<Vec<View>> {
-        let views: Vec<View> = self
-            .client
-            .view(&self.contract_id, "read")
-            .args_json(json!({ "reads": reads }))
-            .await?
-            .json()?;
-        Ok(views)
-    }
-
-    pub async fn call_respond_checkpoint(
-        &self,
-        checkpoint: &ConsensusCheckpointDigest,
-        signature: &Signature,
-    ) -> Result<ExecutionFinalResult, near_fetch::Error> {
-        self.client
-            .call(&self.signer, &self.contract_id, "respond_checkpoint")
-            .args_json(json!({
-                "checkpoint": checkpoint,
-                "signature": signature,
-            }))
-            .max_gas()
-            .transact()
-            .await
-    }
-}
-
-#[derive(Clone)]
-pub struct EthClient {
-    contract: EthContractInstance,
-}
-
-impl EthClient {
-    pub fn new(eth: &EthConfig) -> Self {
-        let signer: PrivateKeySigner = eth
-            .account_sk
-            .parse()
-            .expect("cannot parse Eth account sk into PrivateKeySigner");
-        let wallet = EthereumWallet::from(signer.clone());
-        let provider = ProviderBuilder::new()
-            .wallet(wallet)
-            .connect_http(eth.execution_rpc_http_url.parse().unwrap());
-        // Create a contract instance.
-        let json: serde_json::Value = serde_json::from_slice(include_bytes!(
-            "../../contract-eth/artifacts/contracts/ChainSignatures.sol/ChainSignatures.json"
-        ))
-        .unwrap();
-
-        // Get `abi` from the artifact.
-        let abi_value = json.get("abi").expect("Failed to get ABI from artifact");
-        let abi = serde_json::from_str(&abi_value.to_string()).unwrap();
-
-        let contract = ContractInstance::new(
-            Address::from_str(&format!("0x{}", eth.contract_address)).unwrap(),
-            provider.clone(),
-            Interface::new(abi),
-        );
-        Self { contract }
     }
 }
 
@@ -1411,349 +1136,6 @@ async fn run_batch_respond(
             actions_batch.push(action);
         }
     }
-}
-
-async fn try_publish_near(
-    near: &NearClient,
-    action: &PublishAction,
-    timestamp: &Instant,
-    signature: &Signature,
-) -> Result<(), near_fetch::Error> {
-    let outcome = match &action.indexed.kind {
-        SignKind::Checkpoint(checkpoint) => {
-            near.call_respond_checkpoint(checkpoint, signature).await
-        }
-        _ => near.call_respond(&action.indexed.id, signature).await,
-    }
-    .inspect_err(|err| {
-        tracing::error!(
-            sign_id = ?action.indexed.id,
-            ?err,
-            "failed to publish signature",
-        );
-    })?;
-
-    let _: () = outcome.json().inspect_err(|err| {
-        tracing::error!(
-            sign_id = ?action.indexed.id,
-            big_r = signature.big_r.to_base58(),
-            s = ?signature.s,
-            ?err,
-            "smart contract threw error",
-        );
-    })?;
-    tracing::info!(
-        sign_id = ?action.indexed.id,
-        big_r = signature.big_r.to_base58(),
-        s = ?signature.s,
-        elapsed = ?timestamp.elapsed(),
-        "published signature sucessfully",
-    );
-    Ok(())
-}
-
-// wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
-async fn wait_for_pending_tx(
-    provider: &EthContractFillProvider,
-    tx_hash: alloy::primitives::B256,
-    sign_ids: Vec<SignId>,
-    max_attempts: usize,
-) -> Result<Transaction, ()> {
-    let retry_config = RetryConfig {
-        max_times: max_attempts,
-        min_delay: ETH_MEMPOOL_MIN_DELAY,
-        max_delay: ETH_MEMPOOL_MAX_DELAY,
-        jitter: true,
-    };
-
-    retry_rpc!(
-        ETH_MEMPOOL_TIMEOUT,
-        retry_config,
-        // Log the error and retry attempt
-        |attempt, err, sleep| {
-            tracing::error!(
-                ?sign_ids,
-                attempt,
-                "failed to get eth signature respond pending transaction: {err}, retrying in {sleep:?}"
-            );
-        },
-        // Try to get the pending transaction
-        {
-            match provider.get_transaction_by_hash(tx_hash).await {
-                Ok(Some(tx)) => {
-                    tracing::info!(?sign_ids, "eth signature respond pending transaction found");
-                    Ok(tx)
-                }
-                Ok(None) => Err(anyhow::anyhow!("Transaction not in mempool yet")),
-                Err(e) => Err(anyhow::anyhow!("RPC Error: {e}")),
-            }
-        }
-    ).map_err(|_| ())
-}
-
-// wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
-async fn wait_for_transaction_receipt(
-    provider: &EthContractFillProvider,
-    tx_hash: alloy::primitives::B256,
-    sign_ids: Vec<SignId>,
-    max_attempts: usize,
-) -> Result<TransactionReceipt, ()> {
-    let retry_config = RetryConfig {
-        max_times: max_attempts,
-        min_delay: ETH_RECEIPT_MIN_DELAY,
-        max_delay: ETH_RECEIPT_MAX_DELAY,
-        jitter: true,
-    };
-
-    retry_rpc!(
-        ETH_RECEIPT_TIMEOUT,
-        retry_config,
-        // Log the error and retry attempt
-        |attempt, err, sleep| {
-            tracing::error!(
-                ?sign_ids,
-                attempt,
-                "failed to get eth signature respond transaction receipt: {err}, retrying in {sleep:?}"
-            );
-        },
-        // Try to get the transaction receipt
-        {
-            match provider.get_transaction_receipt(tx_hash).await {
-                Ok(Some(receipt)) => {
-                    tracing::info!(?sign_ids, "eth signature respond transaction receipt found");
-                    Ok(receipt)
-                }
-                Ok(None) => Err(anyhow::anyhow!("Receipt not ready yet")),
-                Err(e) => Err(anyhow::anyhow!("RPC Error: {e}")),
-            }
-        }
-    ).map_err(|_| ())
-}
-
-async fn send_eth_transaction(
-    contract: &EthContractInstance,
-    params: &[DynSolValue],
-    gas: u64,
-    sign_ids: &[SignId],
-) -> Result<alloy::primitives::B256, ()> {
-    // TODO: fetching nonce from RPC is slow and expensive, consider better approach (fetch once, increment locally, etc.)
-    // 1. Fetch Nonce
-    let nonce_retry = RetryConfig {
-        max_times: ETH_NONCE_MAX_ATTEMPTS,
-        min_delay: ETH_NONCE_MIN_DELAY,
-        max_delay: ETH_NONCE_MAX_DELAY,
-        jitter: true,
-    };
-
-    let nonce = match retry_rpc!(
-        ETH_NONCE_TIMEOUT,
-        nonce_retry,
-        // Log the error and retry attempt
-        |attempt, err, sleep| {
-            tracing::warn!(
-                ?sign_ids,
-                attempt,
-                "get_nonce failed: {err}, retrying in {sleep:?}"
-            );
-        },
-        // Try to get the nonce
-        {
-            contract
-                .provider()
-                .get_transaction_count(contract.provider().default_signer_address())
-                .pending()
-                .await
-                .map_err(|e| anyhow::anyhow!("RPC Error: {e}"))
-        }
-    ) {
-        Ok(n) => n,
-        Err(err) => {
-            tracing::error!(
-                ?sign_ids,
-                ?err,
-                "failed to get nonce: retry attempts exhausted"
-            );
-            return Err(());
-        }
-    };
-
-    tracing::info!(nonce, "will send eth tx with nonce");
-
-    // 2. Send Tx
-    let send_retry = RetryConfig {
-        max_times: ETH_SEND_MAX_ATTEMPTS,
-        min_delay: ETH_SEND_MIN_DELAY,
-        max_delay: ETH_SEND_MAX_DELAY,
-        jitter: true,
-    };
-
-    retry_rpc!(
-        ETH_SEND_TIMEOUT,
-        send_retry,
-        |attempt, err, sleep| {
-            tracing::warn!(
-                ?sign_ids,
-                attempt,
-                "send eth tx failed: {err}, retrying in {sleep:?}"
-            );
-        },
-        {
-            contract
-                .function("respond", params)
-                .unwrap()
-                .gas(gas)
-                .nonce(nonce)
-                .send()
-                .await
-                .map(|pending| *pending.tx_hash())
-                .map_err(|e| anyhow::anyhow!("RPC Error: {e}"))
-        }
-    )
-    .map_err(|err| {
-        tracing::error!(
-            ?sign_ids,
-            ?err,
-            "failed to send ethereum signature transaction: retry attempts exhausted"
-        );
-    })
-}
-
-async fn try_publish_eth(
-    eth: &EthClient,
-    action: &PublishAction,
-    timestamp: &Instant,
-    signature: &Signature,
-) -> Result<(), ()> {
-    let sign_id = action.indexed.id;
-    let params = [DynSolValue::Array(vec![DynSolValue::Tuple(vec![
-        DynSolValue::FixedBytes(action.indexed.id.request_id.into(), 32),
-        DynSolValue::Tuple(vec![
-            DynSolValue::Tuple(vec![
-                DynSolValue::from(U256::from_be_slice(&signature.big_r.x())),
-                DynSolValue::from(U256::from_be_slice(
-                    signature.big_r.to_encoded_point(false).y().unwrap(),
-                )),
-            ]),
-            DynSolValue::from(U256::from_be_slice(&signature.s.to_bytes())),
-            DynSolValue::from(signature.recovery_id),
-        ]),
-    ])])];
-
-    let tx_hash = send_eth_transaction(
-        &eth.contract,
-        &params,
-        ETH_BASE_GAS_LIMIT,
-        std::slice::from_ref(&action.indexed.id),
-    )
-    .await?;
-
-    let receipt = wait_for_transaction_receipt(
-        eth.contract.provider(),
-        tx_hash,
-        vec![action.indexed.id],
-        ETH_TX_RECEIPT_MAX_ATTEMPTS,
-    )
-    .await?;
-
-    // Check if transaction was successful
-    if !receipt.status() {
-        tracing::error!(
-            ?sign_id,
-            tx_hash = ?receipt.transaction_hash,
-            "transaction failed"
-        );
-        return Err(());
-    }
-
-    let tx_hash = receipt.transaction_hash;
-    tracing::info!(
-        ?sign_id,
-        tx_hash = ?tx_hash,
-        elapsed = ?timestamp.elapsed(),
-        "published ethereum signature successfully"
-    );
-    Ok(())
-}
-
-async fn try_batch_publish_eth(
-    eth: &EthClient,
-    actions: &Vec<PublishAction>,
-    signatures: &HashMap<SignId, Signature>,
-) -> Result<(), ()> {
-    let chain = Chain::Ethereum;
-    let mut params_vec = vec![];
-    let num_requests = actions.len();
-    let sign_ids = actions
-        .iter()
-        .map(|action| action.indexed.id)
-        .collect::<Vec<_>>();
-    tracing::info!(?sign_ids, "will send eth batch tx");
-    for action in actions {
-        let signature = signatures
-            .get(&action.indexed.id)
-            .expect("signature not found in map");
-        params_vec.push(DynSolValue::Tuple(vec![
-            DynSolValue::FixedBytes(action.indexed.id.request_id.into(), 32),
-            DynSolValue::Tuple(vec![
-                DynSolValue::Tuple(vec![
-                    DynSolValue::from(U256::from_be_slice(&signature.big_r.x())),
-                    DynSolValue::from(U256::from_be_slice(
-                        signature.big_r.to_encoded_point(false).y().unwrap(),
-                    )),
-                ]),
-                DynSolValue::from(U256::from_be_slice(&signature.s.to_bytes())),
-                DynSolValue::from(signature.recovery_id),
-            ]),
-        ]));
-    }
-
-    let params = [DynSolValue::Array(params_vec.clone())];
-    let gas = std::cmp::max(
-        ETH_BASE_GAS_LIMIT,
-        ETH_BATCH_GAS_PER_REQUEST * num_requests as u64,
-    );
-
-    let tx_hash = send_eth_transaction(&eth.contract, &params, gas, &sign_ids).await?;
-
-    tracing::info!(?tx_hash, "sent eth tx");
-
-    let tx = wait_for_pending_tx(
-        eth.contract.provider(),
-        tx_hash,
-        sign_ids.clone(),
-        ETH_TX_RECEIPT_MAX_ATTEMPTS,
-    )
-    .await?;
-
-    tracing::info!(?tx, "tx found in mempool");
-
-    let receipt = wait_for_transaction_receipt(
-        eth.contract.provider(),
-        tx_hash,
-        sign_ids.clone(),
-        ETH_TX_RECEIPT_MAX_ATTEMPTS,
-    )
-    .await?;
-
-    // Check if transaction was successful
-    if !receipt.status() {
-        tracing::error!(
-            ?sign_ids,
-            tx_hash = ?receipt.transaction_hash,
-            "eth batch transaction failed"
-        );
-        return Err(());
-    }
-
-    let tx_hash = receipt.transaction_hash;
-    tracing::info!(
-        ?chain,
-        ?sign_ids,
-        ?tx_hash,
-        num_requests,
-        "eth batch published ethereum signatures successfully"
-    );
-    Ok(())
 }
 
 async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAction>) {

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -1,3 +1,4 @@
+mod canton;
 mod ethereum;
 mod hydration;
 mod near;
@@ -12,6 +13,7 @@ use crate::protocol::{Chain, IndexedSignRequest, ProtocolState};
 use crate::util::retry::{retry_rpc, RetryConfig};
 use std::collections::BTreeSet;
 
+pub use canton::{try_publish_canton, CantonClient};
 pub use ethereum::{try_batch_publish_eth, try_publish_eth, EthClient};
 pub use hydration::{try_publish_hydration, HydrationClient};
 pub use mpc_contract::primitives::{Read, View};
@@ -25,12 +27,7 @@ use cait_sith::FullSignature;
 use k256::{AffinePoint, Secp256k1};
 use mpc_primitives::{CheckpointDigest, SignId, SignKind, Signature};
 
-use crate::indexer_canton::ledger_api::{
-    ActiveContractEntry, CumulativeFilter, EventFormat, GetActiveContractsRequest,
-    IdentifierFilter, JsCommands, LedgerEndResponse, PartyFilter,
-    SubmitAndWaitForTransactionRequest, SubmitAndWaitForTransactionResponse, TemplateFilterValue,
-};
-use crate::indexer_canton::{CantonAuthProvider, CantonConfig};
+use crate::indexer_canton::CantonConfig;
 use crate::indexer_hydration::HydrationConfig;
 use crate::indexer_sol::SolanaClient;
 
@@ -529,178 +526,6 @@ impl RpcExecutor {
     }
 }
 
-#[derive(Clone)]
-pub struct CantonClient {
-    pub(crate) config: CantonConfig,
-    http_client: reqwest::Client,
-    auth_provider: CantonAuthProvider,
-}
-
-impl std::fmt::Debug for CantonClient {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CantonClient")
-            .field("config", &self.config)
-            .field("auth_provider", &"<hidden>")
-            .finish()
-    }
-}
-
-impl CantonClient {
-    pub async fn new(config: &CantonConfig) -> anyhow::Result<Self> {
-        let http_client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
-            .build()?;
-
-        let auth_provider = CantonAuthProvider::new(config.auth.clone())?;
-
-        if !config.signer_contract_id.is_empty() || !config.signer_template_id.is_empty() {
-            tracing::info!(
-                signer_cid = %config.signer_contract_id,
-                signer_template_id = %config.signer_template_id,
-                "canton Signer contract configured"
-            );
-        }
-
-        Ok(Self {
-            config: config.clone(),
-            http_client,
-            auth_provider,
-        })
-    }
-
-    pub fn ledger_api_user(&self) -> &str {
-        &self.config.ledger_api_user
-    }
-
-    pub async fn bearer_token(&self) -> anyhow::Result<String> {
-        self.auth_provider.bearer_token().await
-    }
-
-    fn json_api_endpoint(&self, path: &str) -> String {
-        format!("{}{}", self.config.json_api_url, path)
-    }
-
-    pub async fn auth_post(&self, path: &str) -> anyhow::Result<reqwest::RequestBuilder> {
-        let token = self.bearer_token().await?;
-        Ok(self
-            .http_client
-            .post(self.json_api_endpoint(path))
-            .bearer_auth(token))
-    }
-
-    pub async fn auth_get(&self, path: &str) -> anyhow::Result<reqwest::RequestBuilder> {
-        let token = self.bearer_token().await?;
-        Ok(self
-            .http_client
-            .get(self.json_api_endpoint(path))
-            .bearer_auth(token))
-    }
-
-    pub async fn fetch_ledger_end(&self) -> anyhow::Result<u64> {
-        let resp = self.auth_get("/v2/state/ledger-end").await?.send().await?;
-        let resp = check_response(resp, "ledger-end").await?;
-        let body: LedgerEndResponse = resp.json().await?;
-        Ok(body.offset)
-    }
-
-    pub async fn fetch_active_contracts(
-        &self,
-        parties: &[&str],
-        template_id: Option<&str>,
-        include_blob: bool,
-    ) -> anyhow::Result<Vec<ActiveContractEntry>> {
-        let offset = self.fetch_ledger_end().await?;
-
-        let mut filters = serde_json::Map::new();
-        for party in parties {
-            let value = match template_id {
-                Some(tid) => serde_json::to_value(PartyFilter {
-                    cumulative: vec![CumulativeFilter {
-                        identifier_filter: IdentifierFilter::TemplateFilter {
-                            value: TemplateFilterValue {
-                                template_id: tid.to_string(),
-                                include_created_event_blob: include_blob,
-                            },
-                        },
-                    }],
-                })?,
-                None => serde_json::json!({}),
-            };
-            filters.insert(party.to_string(), value);
-        }
-
-        let req = GetActiveContractsRequest {
-            active_at_offset: offset,
-            event_format: EventFormat {
-                filters_by_party: filters,
-                verbose: true,
-            },
-        };
-
-        let resp = self
-            .auth_post("/v2/state/active-contracts")
-            .await?
-            .json(&req)
-            .send()
-            .await?;
-
-        let resp = check_response(resp, "active-contracts query").await?;
-        Ok(resp.json().await?)
-    }
-
-    pub async fn submit_and_wait(
-        &self,
-        commands: JsCommands,
-        context: &str,
-    ) -> anyhow::Result<SubmitAndWaitForTransactionResponse> {
-        let resp = self
-            .auth_post("/v2/commands/submit-and-wait-for-transaction")
-            .await?
-            .json(&SubmitAndWaitForTransactionRequest { commands })
-            .send()
-            .await?;
-        let resp = check_response(resp, context).await?;
-        Ok(resp.json().await?)
-    }
-
-    pub async fn exercise_choice(
-        &self,
-        command_id: &str,
-        choice: &str,
-        choice_argument: serde_json::Value,
-    ) -> anyhow::Result<()> {
-        use crate::indexer_canton::ledger_api::{Command, JsCommands};
-        let commands = JsCommands {
-            command_id: command_id.to_string(),
-            user_id: self.config.ledger_api_user.clone(),
-            act_as: vec![self.config.party_id.clone()],
-            read_as: vec![self.config.party_id.clone()],
-            commands: vec![Command::ExerciseCommand {
-                template_id: self.config.signer_template_id.clone(),
-                contract_id: self.config.signer_contract_id.clone(),
-                choice: choice.to_string(),
-                choice_argument,
-            }],
-            disclosed_contracts: vec![],
-        };
-        self.submit_and_wait(commands, &format!("canton {choice}"))
-            .await?;
-        Ok(())
-    }
-}
-
-async fn check_response(
-    resp: reqwest::Response,
-    context: &str,
-) -> anyhow::Result<reqwest::Response> {
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let text = resp.text().await.unwrap_or_default();
-        anyhow::bail!("{context} failed: {status} {text}");
-    }
-    Ok(resp)
-}
-
 /// Client related to a specific chain
 #[allow(clippy::large_enum_variant)]
 pub enum ChainClient {
@@ -1090,92 +915,6 @@ async fn try_publish_sol(
             return Err(());
         }
     }
-
-    Ok(())
-}
-
-async fn try_publish_canton(
-    canton: &CantonClient,
-    action: &PublishAction,
-    timestamp: &std::time::Instant,
-    signature: &mpc_primitives::Signature,
-) -> anyhow::Result<()> {
-    let sign_id = action.indexed.id;
-    let request_id_hex = hex::encode(action.indexed.id.request_id);
-
-    tracing::info!(
-        ?sign_id,
-        chain = ?action.indexed.chain,
-        elapsed = ?timestamp.elapsed(),
-        request_id = %request_id_hex,
-        "canton: publishing signature"
-    );
-
-    use crate::indexer_canton::contracts::{CantonSignature, EcdsaSigData};
-    let der_sig = hex::encode(crate::indexer_canton::der_encode_signature(signature)?);
-    let canton_signature = serde_json::to_value(CantonSignature::EcdsaSig(EcdsaSigData {
-        der: der_sig,
-        recovery_id: signature.recovery_id,
-    }))?;
-
-    let (choice, command_id, choice_argument) = match &action.indexed.kind {
-        SignKind::SignBidirectional(event) if event.chain == Chain::Canton => {
-            let chain_ctx_bytes = event
-                .chain_ctx
-                .as_deref()
-                .ok_or_else(|| anyhow::anyhow!("missing chain_ctx on Canton sign request"))?;
-            let ctx: crate::indexer_canton::CantonChainCtx = borsh::from_slice(chain_ctx_bytes)
-                .map_err(|e| anyhow::anyhow!("failed to deserialize CantonChainCtx: {e}"))?;
-            (
-                "Respond",
-                format!("mpc-respond-{request_id_hex}"),
-                serde_json::json!({
-                    "signEventCid": ctx.sign_event_contract_id,
-                    "requestId": request_id_hex,
-                    "signature": canton_signature,
-                }),
-            )
-        }
-        SignKind::RespondBidirectional(respond_tx) => {
-            let chain_ctx_bytes = respond_tx
-                .chain_ctx
-                .as_deref()
-                .ok_or_else(|| anyhow::anyhow!("missing chain_ctx on Canton response"))?;
-            let ctx: crate::indexer_canton::CantonChainCtx = borsh::from_slice(chain_ctx_bytes)
-                .map_err(|e| anyhow::anyhow!("failed to deserialize CantonChainCtx: {e}"))?;
-            (
-                "RespondBidirectional",
-                format!("mpc-respond-bidir-{request_id_hex}"),
-                serde_json::json!({
-                    "signEventCid": ctx.sign_event_contract_id,
-                    "requestId": request_id_hex,
-                    "serializedOutput": hex::encode(&respond_tx.output),
-                    "signature": canton_signature,
-                }),
-            )
-        }
-        _ => anyhow::bail!("Canton supports only Canton SignBidirectional or RespondBidirectional"),
-    };
-
-    canton
-        .exercise_choice(&command_id, choice, choice_argument)
-        .await
-        .inspect_err(|err| {
-            tracing::error!(
-                ?sign_id,
-                choice,
-                request_id = %request_id_hex,
-                error = %err,
-                "canton: failed to publish signature"
-            );
-        })?;
-
-    tracing::info!(
-        ?sign_id,
-        choice,
-        elapsed = ?timestamp.elapsed(),
-        "published canton {choice} successfully"
-    );
 
     Ok(())
 }

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -824,6 +824,7 @@ mod tests {
     use k256::elliptic_curve::ops::Reduce;
     use k256::elliptic_curve::point::DecompressPoint;
     use mpc_crypto::kdf::derive_secret_key;
+    use mpc_primitives::SignKind;
 
     fn scalar(bytes: &[u8; 32]) -> k256::Scalar {
         <k256::Scalar as Reduce<<Secp256k1 as k256::elliptic_curve::Curve>::Uint>>::reduce_bytes(

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -754,7 +754,7 @@ async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAc
         {
             match client {
                 ChainClient::Ethereum(eth) => eth
-                    .batch_publish_signature(actions, &signatures)
+                    .batch_publish_signatures(actions, &signatures)
                     .await
                     .map_err(|_| anyhow::anyhow!("Eth batch publish failed")),
                 ChainClient::Near(_) => {

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -14,7 +14,7 @@ use crate::util::retry::{retry_rpc, RetryConfig};
 use std::collections::BTreeSet;
 
 pub use canton::{try_publish_canton, CantonClient};
-pub use ethereum::{try_batch_publish_eth, try_publish_eth, EthClient};
+pub use ethereum::EthClient;
 pub use hydration::{try_publish_hydration, HydrationClient};
 pub use mpc_contract::primitives::{Read, View};
 pub use near::{try_publish_near, NearClient};
@@ -646,11 +646,10 @@ async fn execute_publish(client: ChainClient, action: PublishAction) {
                         .await
                         .map_err(|_| anyhow::anyhow!("Near publish failed"))
                 }
-                ChainClient::Ethereum(eth) => {
-                    try_publish_eth(eth, &action, &action.timestamp, &action.signature)
-                        .await
-                        .map_err(|_| anyhow::anyhow!("Ethereum publish failed"))
-                }
+                ChainClient::Ethereum(eth) => eth
+                    .publish_signature(&action, &action.timestamp, &action.signature)
+                    .await
+                    .map_err(|_| anyhow::anyhow!("Ethereum publish failed")),
                 ChainClient::Solana(sol) => {
                     try_publish_sol(sol, &action, &action.timestamp, &action.signature)
                         .await
@@ -754,7 +753,8 @@ async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAc
         // Try to publish the signatures in batch
         {
             match client {
-                ChainClient::Ethereum(eth) => try_batch_publish_eth(eth, actions, &signatures)
+                ChainClient::Ethereum(eth) => eth
+                    .batch_publish_signature(actions, &signatures)
                     .await
                     .map_err(|_| anyhow::anyhow!("Eth batch publish failed")),
                 ChainClient::Near(_) => {

--- a/chain-signatures/node/src/rpc/near.rs
+++ b/chain-signatures/node/src/rpc/near.rs
@@ -1,0 +1,235 @@
+use super::PublishAction;
+use crate::config::{ContractConfig, NetworkConfig};
+use crate::protocol::{Governance, ProtocolState};
+use crate::util::AffinePointExt as _;
+pub use mpc_contract::primitives::{Read, View};
+
+use mpc_keys::hpke;
+use mpc_primitives::{ConsensusCheckpointDigest, SignId, SignKind, Signature};
+
+use near_account_id::AccountId;
+use near_crypto::InMemorySigner;
+use near_fetch::result::ExecutionFinalResult;
+use serde_json::json;
+use std::time::Instant;
+use url::Url;
+
+#[derive(Clone)]
+pub struct NearClient {
+    client: near_fetch::Client,
+    contract_id: AccountId,
+    my_addr: Url,
+    signer: InMemorySigner,
+    cipher_pk: hpke::PublicKey,
+    sign_pk: near_crypto::PublicKey,
+}
+
+impl Governance for NearClient {
+    async fn propose_join(&self) -> anyhow::Result<()> {
+        self.propose_join().await
+    }
+
+    async fn vote_reshared(&self, epoch: u64) -> anyhow::Result<bool> {
+        self.vote_reshared(epoch).await
+    }
+
+    async fn vote_public_key(&self, public_key: &near_crypto::PublicKey) -> anyhow::Result<bool> {
+        self.vote_public_key(public_key).await
+    }
+}
+
+impl NearClient {
+    pub fn new(
+        near_rpc: &str,
+        my_addr: &Url,
+        network: &NetworkConfig,
+        contract_id: &AccountId,
+        signer: InMemorySigner,
+    ) -> Self {
+        Self {
+            client: near_fetch::Client::new(near_rpc),
+            contract_id: contract_id.clone(),
+            my_addr: my_addr.clone(),
+            signer,
+            cipher_pk: network.cipher_sk.public_key(),
+            sign_pk: network.sign_sk.public_key(),
+        }
+    }
+
+    pub fn rpc_addr(&self) -> String {
+        self.client.rpc_addr()
+    }
+
+    pub async fn fetch_state(&self) -> anyhow::Result<ProtocolState> {
+        let contract_state: mpc_contract::ProtocolContractState =
+            self.client.view(&self.contract_id, "state").await?.json()?;
+
+        let protocol_state: ProtocolState = contract_state.try_into().map_err(|_| {
+            anyhow::anyhow!("failed to parse protocol state, has it been initialized?")
+        })?;
+
+        tracing::debug!(?protocol_state, "protocol state");
+        Ok(protocol_state)
+    }
+
+    pub async fn fetch_config(&self) -> Option<ContractConfig> {
+        self.client
+            .view(&self.contract_id, "config")
+            .await
+            .inspect_err(|err| {
+                tracing::warn!(%err, "failed to fetch contract config");
+            })
+            .ok()?
+            .json()
+            .inspect(|configs| {
+                tracing::debug!(?configs, "contract config");
+            })
+            .inspect_err(|err| {
+                tracing::warn!(%err, "unable to parse config");
+            })
+            .ok()
+    }
+
+    pub async fn vote_public_key(
+        &self,
+        public_key: &near_crypto::PublicKey,
+    ) -> anyhow::Result<bool> {
+        tracing::info!(%public_key, signer_id = %self.signer.account_id, "voting for public key");
+        let result = self
+            .client
+            .call(&self.signer, &self.contract_id, "vote_pk")
+            .args_json(json!({
+                "public_key": public_key
+            }))
+            .max_gas()
+            .retry_exponential(10, 5)
+            .transact()
+            .await
+            .inspect_err(|err| {
+                tracing::warn!(%err, "failed to vote for public key");
+            })?
+            .json()?;
+
+        Ok(result)
+    }
+
+    pub async fn vote_reshared(&self, epoch: u64) -> anyhow::Result<bool> {
+        tracing::info!(%epoch, signer_id = %self.signer.account_id, "voting for reshared");
+        let result = self
+            .client
+            .call(&self.signer, &self.contract_id, "vote_reshared")
+            .args_json(json!({
+                "epoch": epoch
+            }))
+            .max_gas()
+            .retry_exponential(10, 5)
+            .transact()
+            .await
+            .inspect_err(|err| {
+                tracing::warn!(%err, "failed to vote for reshared");
+            })?
+            .json()?;
+
+        Ok(result)
+    }
+
+    pub async fn propose_join(&self) -> anyhow::Result<()> {
+        tracing::info!(signer_id = %self.signer.account_id, "joining the protocol");
+        self.client
+            .call(&self.signer, &self.contract_id, "join")
+            .args_json(json!({
+                "url": self.my_addr,
+                "cipher_pk": self.cipher_pk.to_bytes(),
+                "sign_pk": self.sign_pk,
+            }))
+            .max_gas()
+            .retry_exponential(10, 3)
+            .transact()
+            .await?
+            .into_result()?;
+
+        Ok(())
+    }
+
+    pub async fn call_respond(
+        &self,
+        id: &SignId,
+        response: &Signature,
+    ) -> Result<ExecutionFinalResult, near_fetch::Error> {
+        self.client
+            .call(&self.signer, &self.contract_id, "respond")
+            .args_json(json!({
+                "sign_id": id,
+                "signature": response,
+            }))
+            .max_gas()
+            .transact()
+            .await
+    }
+
+    pub async fn read(&self, reads: Vec<Read>) -> anyhow::Result<Vec<View>> {
+        let views: Vec<View> = self
+            .client
+            .view(&self.contract_id, "read")
+            .args_json(json!({ "reads": reads }))
+            .await?
+            .json()?;
+        Ok(views)
+    }
+
+    pub async fn call_respond_checkpoint(
+        &self,
+        checkpoint: &ConsensusCheckpointDigest,
+        signature: &Signature,
+    ) -> Result<ExecutionFinalResult, near_fetch::Error> {
+        self.client
+            .call(&self.signer, &self.contract_id, "respond_checkpoint")
+            .args_json(json!({
+                "checkpoint": checkpoint,
+                "signature": signature,
+            }))
+            .max_gas()
+            .transact()
+            .await
+    }
+}
+
+// TODO: make client method
+pub async fn try_publish_near(
+    near: &NearClient,
+    action: &PublishAction,
+    timestamp: &Instant,
+    signature: &Signature,
+) -> Result<(), near_fetch::Error> {
+    let outcome = match &action.indexed.kind {
+        SignKind::Checkpoint(checkpoint) => {
+            near.call_respond_checkpoint(checkpoint, signature).await
+        }
+        _ => near.call_respond(&action.indexed.id, signature).await,
+    }
+    .inspect_err(|err| {
+        tracing::error!(
+            sign_id = ?action.indexed.id,
+            ?err,
+            "failed to publish signature",
+        );
+    })?;
+
+    let _: () = outcome.json().inspect_err(|err| {
+        tracing::error!(
+            sign_id = ?action.indexed.id,
+            big_r = signature.big_r.to_base58(),
+            s = ?signature.s,
+            ?err,
+            "smart contract threw error",
+        );
+    })?;
+    tracing::info!(
+        sign_id = ?action.indexed.id,
+        big_r = signature.big_r.to_base58(),
+        s = ?signature.s,
+        elapsed = ?timestamp.elapsed(),
+        "published signature sucessfully",
+    );
+    Ok(())
+}

--- a/chain-signatures/node/src/rpc/solana.rs
+++ b/chain-signatures/node/src/rpc/solana.rs
@@ -1,0 +1,111 @@
+use super::PublishAction;
+use crate::indexer_sol::SolanaClient;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use mpc_primitives::{SignKind, Signature};
+use signet_program::accounts::Respond as SolanaRespondAccount;
+use signet_program::accounts::RespondBidirectional as SolanaRespondBidirectionalAccount;
+use signet_program::instruction::Respond as SolanaRespond;
+use signet_program::instruction::RespondBidirectional as SolanaRespondBidirectional;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Signer as SolanaSigner;
+use std::time::Instant;
+
+pub async fn try_publish_sol(
+    sol: &SolanaClient,
+    action: &PublishAction,
+    timestamp: &Instant,
+    signature: &Signature,
+) -> Result<(), ()> {
+    let program = sol.client.program(sol.program_id).map_err(|_| ())?;
+
+    let sign_id = action.indexed.id;
+    let request_ids = vec![action.indexed.id.request_id];
+    let big_r = signature.big_r.to_encoded_point(false);
+    let signature = crate::util::mpc_to_sol_signature(signature, big_r);
+
+    tracing::debug!(
+        ?sign_id,
+        request_type = ?action.indexed.kind,
+        "try_publish_sol: dispatching request"
+    );
+
+    match &action.indexed.kind {
+        SignKind::Sign | SignKind::SignBidirectional(_) => {
+            let (event_authority, _) =
+                Pubkey::find_program_address(&[b"__event_authority"], &sol.program_id);
+            let tx = program
+                .request()
+                .signer(sol.payer.clone())
+                .accounts(SolanaRespondAccount {
+                    responder: sol.payer.pubkey(),
+                    event_authority,
+                    program: sol.program_id,
+                })
+                .args(SolanaRespond {
+                    request_ids,
+                    signatures: vec![signature.clone()],
+                })
+                .send()
+                .await
+                .map_err(|err| {
+                    tracing::error!(
+                        sign_id = ?action.indexed.id,
+                        error = ?err,
+                        "failed to publish solana signature"
+                    );
+                })?;
+
+            tracing::info!(
+                ?sign_id,
+                tx_hash = ?tx,
+                elapsed = ?timestamp.elapsed(),
+                "published solana signature successfully"
+            );
+        }
+        SignKind::RespondBidirectional(respond_bidirectional_tx) => {
+            tracing::debug!(
+                ?sign_id,
+                request_id = ?request_ids[0],
+                serialized_output_len = respond_bidirectional_tx.output.len(),
+                "try_publish_sol: entering RespondBidirectional arm"
+            );
+            let respond_bidirectional_serialized_output = respond_bidirectional_tx.output.clone();
+            let tx = program
+                .request()
+                .signer(sol.payer.clone())
+                .accounts(SolanaRespondBidirectionalAccount {
+                    responder: sol.payer.clone().try_pubkey().unwrap(),
+                })
+                .args(SolanaRespondBidirectional {
+                    request_id: request_ids[0],
+                    serialized_output: respond_bidirectional_serialized_output.clone(),
+                    signature: signature.clone(),
+                })
+                .send()
+                .await
+                .map_err(|err| {
+                    tracing::error!(
+                        ?sign_id,
+                        error = ?err,
+                        "failed to publish respond bidirectional solana signature"
+                    );
+                })?;
+
+            tracing::info!(
+                ?sign_id,
+                tx_hash = ?tx,
+                elapsed = ?timestamp.elapsed(),
+                "published respond bidirectional solana signature successfully"
+            );
+        }
+        SignKind::Checkpoint(_) => {
+            tracing::error!(
+                ?sign_id,
+                "try_publish_sol: checkpoint signature publishing not supported on Solana"
+            );
+            return Err(());
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
- Break down `rpc.rs` and move chain clients into separate modules
- Refactor Ethereum client:
  - rename `try_publish_eth` and `try_batch_publish_eth` methods and move under `EthClient`, which is now fully self-contained
  - extracted repetitive logic into `execute_publish` method
  - improve type safety by removing nested `DynSolValue` arrays with structs generated by Alloy `sol!` macro
  - replaced manual JSON ABI artifact loading 
  - added `From<&mpc_primitives::Signature>` for cleaner mapping to `ChainSignatures::Signature`
  - moved nonce fetching inside retry loop so it can fetch new nonce on each retry (avoid reusing stale nonce)
  - removed `wait_for_pending_tx`, which was redundant since we poll for receipt anyway
- Add unit tests for Ethereum client

Canton, Hydration and Near clients haven't changed in this PR, just moved to separate modules as is