### PR TITLE
feat: introduce `ChainPublisher` trait

### DIFF
--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -320,13 +320,13 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let near_client =
                 NearClient::new(&near_rpc, &my_address, &network, &mpc_contract_id, signer);
 
+            // TODO: Centralize publishers and indexers creation: collect all chain args first, then create publishers and indexers in one place.
             // Build publishers registry
             let mut publishers: HashMap<Chain, Arc<dyn ChainPublisher>> = HashMap::new();
 
             // Add NEAR publisher unconditionally
             publishers.insert(Chain::NEAR, Arc::new(near_client.clone()));
 
-            // TODO: think about better way
             // Add other publishers based on the provided configurations
             if let Some(eth_cfg) = &eth {
                 publishers.insert(Chain::Ethereum, Arc::new(rpc::EthClient::new(eth_cfg)));

--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -1,10 +1,12 @@
 mod args;
 
+use std::{collections::HashMap, sync::Arc};
+
 use crate::backlog::Backlog;
 use crate::config::{Config, LocalConfig, NetworkConfig, OverrideConfig};
 use crate::gcp::GcpService;
 use crate::indexer_eth::EthereumStream;
-use crate::indexer_sol::SolanaStream;
+use crate::indexer_sol::{SolanaClient, SolanaStream};
 use crate::mesh::Mesh;
 use crate::metrics::indexers::PrometheusChainTelemetry;
 use crate::node_client::{self, NodeClient};
@@ -15,7 +17,7 @@ use crate::protocol::state::Node;
 use crate::protocol::sync::SyncTask;
 use crate::protocol::Chain;
 use crate::protocol::{spawn_system_metrics, MpcSignProtocol};
-use crate::rpc::{ContractStateWatcher, NearClient, RpcExecutor};
+use crate::rpc::{self, ChainPublisher, ContractStateWatcher, NearClient, RpcExecutor};
 use crate::storage::checkpoint_storage::CheckpointStorage;
 use crate::storage::triple_storage::TriplePair;
 use crate::stream::run_stream;
@@ -318,8 +320,38 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             let near_client =
                 NearClient::new(&near_rpc, &my_address, &network, &mpc_contract_id, signer);
 
-            let (rpc_channel, rpc) =
-                RpcExecutor::new(&near_client, &eth, &sol, &hydration, &canton).await;
+            // Build publishers registry
+            let mut publishers: HashMap<Chain, Arc<dyn ChainPublisher>> = HashMap::new();
+
+            // Add NEAR publisher unconditionally
+            publishers.insert(Chain::NEAR, Arc::new(near_client.clone()));
+
+            // TODO: think about better way
+            // Add other publishers based on the provided configurations
+            if let Some(eth_cfg) = &eth {
+                publishers.insert(Chain::Ethereum, Arc::new(rpc::EthClient::new(eth_cfg)));
+            }
+            if let Some(sol_cfg) = &sol {
+                publishers.insert(Chain::Solana, Arc::new(SolanaClient::from_config(sol_cfg)));
+            }
+            if let Some(hyd_cfg) = &hydration {
+                match rpc::HydrationClient::new(hyd_cfg).await {
+                    Ok(client) => {
+                        publishers.insert(Chain::Hydration, Arc::new(client));
+                    }
+                    Err(e) => tracing::error!(%e, "failed to create hydration client"),
+                }
+            }
+            if let Some(canton_cfg) = &canton {
+                match rpc::CantonClient::new(canton_cfg).await {
+                    Ok(client) => {
+                        publishers.insert(Chain::Canton, Arc::new(client));
+                    }
+                    Err(e) => tracing::error!(%e, "failed to create canton client"),
+                }
+            }
+
+            let (rpc_channel, rpc) = RpcExecutor::new(near_client.clone(), publishers).await;
 
             let (sync_channel, sync) = SyncTask::new(
                 &client,

--- a/chain-signatures/node/src/indexer_sol/client.rs
+++ b/chain-signatures/node/src/indexer_sol/client.rs
@@ -24,9 +24,9 @@ use solana_transaction_status::{
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use crate::rpc::{self, ChainPublisher, PublishAction};
+use crate::rpc::{ChainPublisher, PublishAction};
 use crate::util::retry::{retry_rpc, RetryConfig};
 
 const MAX_SIGNATURES_FOR_FAST_CATCHUP: usize = 1000;
@@ -103,6 +103,7 @@ pub struct SolanaClient {
 }
 
 impl SolanaClient {
+    // TODO: reduce duplication between from_config and for_indexer
     pub fn from_config(sol: &SolConfig) -> Self {
         let keypair = Keypair::from_base58_string(&sol.account_sk);
         let payer = Arc::new(keypair);
@@ -247,6 +248,7 @@ impl SolanaClient {
         )
     }
 
+    // TODO: consider returning a Result instead of swallowing errors and returning an empty map. This would allow the caller to handle errors more explicitly.
     pub async fn fetch_blocks(&self, slots: &[u64]) -> HashMap<u64, UiConfirmedBlock> {
         if slots.is_empty() {
             return HashMap::new();
@@ -454,13 +456,13 @@ impl SolanaClient {
 
         blocks_by_height
     }
+}
 
-    pub async fn publish_signature(
-        &self,
-        action: &PublishAction,
-        timestamp: &Instant,
-        mpc_sig: &mpc_primitives::Signature,
-    ) -> anyhow::Result<()> {
+#[async_trait::async_trait]
+impl ChainPublisher for SolanaClient {
+    async fn publish_signature(&self, action: &PublishAction) -> anyhow::Result<()> {
+        let timestamp = action.timestamp;
+        let mpc_sig = &action.signature;
         let program = self.client.program(self.program_id)?;
 
         let sign_id = action.indexed.id;
@@ -520,11 +522,11 @@ impl SolanaClient {
                     .request()
                     .signer(self.payer.clone())
                     .accounts(SolanaRespondBidirectionalAccount {
-                        responder: self.payer.clone().try_pubkey().unwrap(),
+                        responder: self.payer.pubkey(),
                     })
                     .args(SolanaRespondBidirectional {
                         request_id: request_ids[0],
-                        serialized_output: respond_bidirectional_serialized_output.clone(),
+                        serialized_output: respond_bidirectional_serialized_output,
                         signature: signature.clone(),
                     })
                     .send()
@@ -553,18 +555,6 @@ impl SolanaClient {
             }
         }
 
-        Ok(())
-    }
-}
-
-#[async_trait::async_trait]
-impl ChainPublisher for SolanaClient {
-    async fn publish_signature(&self, action: &PublishAction) -> anyhow::Result<()> {
-        let client = self.clone();
-        let action = action.clone();
-        tokio::spawn(async move {
-            rpc::execute_publish(Arc::new(client), action).await;
-        });
         Ok(())
     }
 }

--- a/chain-signatures/node/src/indexer_sol/client.rs
+++ b/chain-signatures/node/src/indexer_sol/client.rs
@@ -559,7 +559,7 @@ impl SolanaClient {
 
 #[async_trait::async_trait]
 impl ChainPublisher for SolanaClient {
-    async fn publish_action(&self, action: &PublishAction) -> anyhow::Result<()> {
+    async fn publish_signature(&self, action: &PublishAction) -> anyhow::Result<()> {
         let client = self.clone();
         let action = action.clone();
         tokio::spawn(async move {

--- a/chain-signatures/node/src/indexer_sol/client.rs
+++ b/chain-signatures/node/src/indexer_sol/client.rs
@@ -26,7 +26,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use crate::rpc::PublishAction;
+use crate::rpc::{self, ChainPublisher, PublishAction};
 use crate::util::retry::{retry_rpc, RetryConfig};
 
 const MAX_SIGNATURES_FOR_FAST_CATCHUP: usize = 1000;
@@ -460,8 +460,8 @@ impl SolanaClient {
         action: &PublishAction,
         timestamp: &Instant,
         mpc_sig: &mpc_primitives::Signature,
-    ) -> Result<(), ()> {
-        let program = self.client.program(self.program_id).map_err(|_| ())?;
+    ) -> anyhow::Result<()> {
+        let program = self.client.program(self.program_id)?;
 
         let sign_id = action.indexed.id;
         let request_ids = vec![action.indexed.id.request_id];
@@ -492,7 +492,7 @@ impl SolanaClient {
                     })
                     .send()
                     .await
-                    .map_err(|err| {
+                    .inspect_err(|err| {
                         tracing::error!(
                             sign_id = ?action.indexed.id,
                             error = ?err,
@@ -529,7 +529,7 @@ impl SolanaClient {
                     })
                     .send()
                     .await
-                    .map_err(|err| {
+                    .inspect_err(|err| {
                         tracing::error!(
                             ?sign_id,
                             error = ?err,
@@ -549,10 +549,22 @@ impl SolanaClient {
                     ?sign_id,
                     "Solana publish signature: checkpoint signature publishing not supported on Solana"
                 );
-                return Err(());
+                anyhow::bail!("checkpoint publishing not supported on Solana")
             }
         }
 
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ChainPublisher for SolanaClient {
+    async fn publish_action(&self, action: &PublishAction) -> anyhow::Result<()> {
+        let client = self.clone();
+        let action = action.clone();
+        tokio::spawn(async move {
+            rpc::execute_publish(Arc::new(client), action).await;
+        });
         Ok(())
     }
 }

--- a/chain-signatures/node/src/rpc/canton.rs
+++ b/chain-signatures/node/src/rpc/canton.rs
@@ -279,21 +279,12 @@ impl ChainPublisher for CantonClient {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Instant;
-
     use super::*;
     use crate::indexer_canton::{CantonAuthConfig, CantonChainCtx};
-    use k256::{AffinePoint, Scalar};
+    use crate::rpc::test_utils::make_publish_action;
     use mockito::{Matcher, Server, ServerGuard};
-    use mpc_primitives::{
-        Chain, IndexedSignRequest, RespondBidirectionalTx, SignArgs, SignBidirectionalEvent,
-        SignId, SignKind, Signature,
-    };
+    use mpc_primitives::{Chain, RespondBidirectionalTx, SignBidirectionalEvent, SignKind};
     use serde_json::json;
-
-    fn create_test_signature() -> Signature {
-        Signature::new(AffinePoint::GENERATOR, Scalar::from(42u64), 1)
-    }
 
     fn mock_canton_config(url: &str) -> CantonConfig {
         CantonConfig {
@@ -310,31 +301,6 @@ mod tests {
             party_id: "test-party".to_string(),
             signer_contract_id: "test-contract-id".to_string(),
             signer_template_id: "test-template-id".to_string(),
-        }
-    }
-
-    fn mock_publish_action(kind: SignKind) -> PublishAction {
-        let sign_id = SignId::new([8u8; 32]);
-        let indexed = IndexedSignRequest::new(
-            sign_id,
-            SignArgs {
-                entropy: [0; 32],
-                epsilon: Scalar::ONE,
-                payload: Scalar::ONE,
-                path: "test".to_string(),
-                key_version: 1,
-            },
-            Chain::Canton,
-            0,
-            kind,
-        );
-
-        PublishAction {
-            public_key: AffinePoint::GENERATOR,
-            indexed,
-            signature: create_test_signature(),
-            participants: vec![],
-            timestamp: Instant::now(),
         }
     }
 
@@ -390,7 +356,7 @@ mod tests {
             chain_ctx: Some(chain_ctx),
         };
 
-        let action = mock_publish_action(SignKind::SignBidirectional(event));
+        let action = make_publish_action(Chain::Canton, SignKind::SignBidirectional(event));
         assert!(client.publish_signature(&action).await.is_ok());
         submit_mock.assert_async().await;
     }
@@ -421,7 +387,7 @@ mod tests {
             chain_ctx: Some(chain_ctx),
         };
 
-        let action = mock_publish_action(SignKind::RespondBidirectional(tx));
+        let action = make_publish_action(Chain::Canton, SignKind::RespondBidirectional(tx));
         assert!(client.publish_signature(&action).await.is_ok());
         submit_mock.assert_async().await;
     }
@@ -439,7 +405,7 @@ mod tests {
             chain_ctx: None, // Missing
         };
 
-        let action = mock_publish_action(SignKind::RespondBidirectional(tx));
+        let action = make_publish_action(Chain::Canton, SignKind::RespondBidirectional(tx));
         let err = client.publish_signature(&action).await.unwrap_err();
         assert!(err.to_string().contains("missing chain_ctx"));
     }
@@ -467,7 +433,7 @@ mod tests {
             output: vec![],
             chain_ctx: Some(chain_ctx),
         };
-        let action = mock_publish_action(SignKind::RespondBidirectional(tx));
+        let action = make_publish_action(Chain::Canton, SignKind::RespondBidirectional(tx));
 
         let err = client.publish_signature(&action).await.unwrap_err();
         assert!(err.to_string().contains("500"));

--- a/chain-signatures/node/src/rpc/canton.rs
+++ b/chain-signatures/node/src/rpc/canton.rs
@@ -10,11 +10,8 @@ use crate::indexer_canton::{
     },
     CantonAuthProvider, CantonChainCtx, CantonConfig,
 };
-use mpc_primitives::{Chain, SignKind, Signature};
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use mpc_primitives::{Chain, SignKind};
+use std::time::Duration;
 
 #[derive(Clone)]
 pub struct CantonClient {
@@ -178,15 +175,27 @@ impl CantonClient {
             .await?;
         Ok(())
     }
+}
 
-    pub async fn publish_signature(
-        &self,
-        action: &PublishAction,
-        timestamp: &Instant,
-        signature: &Signature,
-    ) -> anyhow::Result<()> {
+async fn check_response(
+    resp: reqwest::Response,
+    context: &str,
+) -> anyhow::Result<reqwest::Response> {
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("{context} failed: {status} {text}");
+    }
+    Ok(resp)
+}
+
+#[async_trait::async_trait]
+impl ChainPublisher for CantonClient {
+    async fn publish_signature(&self, action: &PublishAction) -> anyhow::Result<()> {
         let sign_id = action.indexed.id;
         let request_id_hex = hex::encode(action.indexed.id.request_id);
+        let timestamp = action.timestamp;
+        let signature = &action.signature;
 
         tracing::info!(
             ?sign_id,
@@ -262,30 +271,6 @@ impl CantonClient {
             "published canton {choice} successfully"
         );
 
-        Ok(())
-    }
-}
-
-async fn check_response(
-    resp: reqwest::Response,
-    context: &str,
-) -> anyhow::Result<reqwest::Response> {
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let text = resp.text().await.unwrap_or_default();
-        anyhow::bail!("{context} failed: {status} {text}");
-    }
-    Ok(resp)
-}
-
-#[async_trait::async_trait]
-impl ChainPublisher for CantonClient {
-    async fn publish_action(&self, action: &PublishAction) -> anyhow::Result<()> {
-        let client = self.clone();
-        let action = action.clone();
-        tokio::spawn(async move {
-            super::execute_publish(Arc::new(client), action).await;
-        });
         Ok(())
     }
 }

--- a/chain-signatures/node/src/rpc/canton.rs
+++ b/chain-signatures/node/src/rpc/canton.rs
@@ -1,4 +1,4 @@
-use super::PublishAction;
+use super::{ChainPublisher, PublishAction};
 use crate::indexer_canton::{
     contracts::{CantonSignature, EcdsaSigData},
     der_encode_signature,
@@ -11,7 +11,10 @@ use crate::indexer_canton::{
     CantonAuthProvider, CantonChainCtx, CantonConfig,
 };
 use mpc_primitives::{Chain, SignKind, Signature};
-use std::time::{Duration, Instant};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 #[derive(Clone)]
 pub struct CantonClient {
@@ -273,6 +276,18 @@ async fn check_response(
         anyhow::bail!("{context} failed: {status} {text}");
     }
     Ok(resp)
+}
+
+#[async_trait::async_trait]
+impl ChainPublisher for CantonClient {
+    async fn publish_action(&self, action: &PublishAction) -> anyhow::Result<()> {
+        let client = self.clone();
+        let action = action.clone();
+        tokio::spawn(async move {
+            super::execute_publish(Arc::new(client), action).await;
+        });
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/chain-signatures/node/src/rpc/canton.rs
+++ b/chain-signatures/node/src/rpc/canton.rs
@@ -277,6 +277,8 @@ impl ChainPublisher for CantonClient {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
     use super::*;
     use crate::indexer_canton::{CantonAuthConfig, CantonChainCtx};
     use k256::{AffinePoint, Scalar};
@@ -387,10 +389,7 @@ mod tests {
         };
 
         let action = mock_publish_action(SignKind::SignBidirectional(event));
-        assert!(client
-            .publish_signature(&action, &Instant::now(), &action.signature)
-            .await
-            .is_ok());
+        assert!(client.publish_signature(&action).await.is_ok());
         submit_mock.assert_async().await;
     }
 
@@ -421,10 +420,7 @@ mod tests {
         };
 
         let action = mock_publish_action(SignKind::RespondBidirectional(tx));
-        assert!(client
-            .publish_signature(&action, &Instant::now(), &action.signature)
-            .await
-            .is_ok());
+        assert!(client.publish_signature(&action).await.is_ok());
         submit_mock.assert_async().await;
     }
 
@@ -442,10 +438,7 @@ mod tests {
         };
 
         let action = mock_publish_action(SignKind::RespondBidirectional(tx));
-        let err = client
-            .publish_signature(&action, &Instant::now(), &action.signature)
-            .await
-            .unwrap_err();
+        let err = client.publish_signature(&action).await.unwrap_err();
         assert!(err.to_string().contains("missing chain_ctx"));
     }
 
@@ -474,10 +467,7 @@ mod tests {
         };
         let action = mock_publish_action(SignKind::RespondBidirectional(tx));
 
-        let err = client
-            .publish_signature(&action, &Instant::now(), &action.signature)
-            .await
-            .unwrap_err();
+        let err = client.publish_signature(&action).await.unwrap_err();
         assert!(err.to_string().contains("500"));
         submit_mock.assert_async().await;
     }

--- a/chain-signatures/node/src/rpc/canton.rs
+++ b/chain-signatures/node/src/rpc/canton.rs
@@ -271,6 +271,8 @@ impl ChainPublisher for CantonClient {
             "published canton {choice} successfully"
         );
 
+        super::record_publish_metrics(action);
+
         Ok(())
     }
 }

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -307,12 +307,9 @@ impl EthClient {
         Ok(())
     }
 
-    pub async fn publish_signature(
-        &self,
-        action: &PublishAction,
-        timestamp: &Instant,
-        mpc_sig: &mpc_primitives::Signature,
-    ) -> anyhow::Result<()> {
+    pub async fn publish_signature(&self, action: &PublishAction) -> anyhow::Result<()> {
+        let timestamp = action.timestamp;
+        let mpc_sig = &action.signature;
         let response = ChainSignatures::Response {
             requestId: action.indexed.id.request_id.into(),
             signature: mpc_sig.into(),

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -1,4 +1,4 @@
-use super::PublishAction;
+use super::{ChainPublisher, PublishAction};
 use crate::indexer_eth::abi::ChainSignatures;
 use crate::indexer_eth::EthConfig;
 use crate::util::retry::{retry_rpc, RetryConfig};
@@ -17,6 +17,7 @@ use mpc_primitives::{SignId, Signature};
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
 
 type EthContractFillProvider = FillProvider<
     JoinFill<
@@ -47,6 +48,11 @@ const ETH_BATCH_GAS_PER_REQUEST: u64 = 20_000;
 /// The maximum number of attempts to fetch eth tx and its receipt
 const ETH_TX_RECEIPT_MAX_ATTEMPTS: usize = 6;
 
+/// The interval to batch send Ethereum responses
+const ETH_RESPOND_BATCH_INTERVAL: Duration = Duration::from_millis(2000);
+/// The batch size for Ethereum responses
+const ETH_RESPOND_BATCH_SIZE: usize = 10;
+
 /// Convert MPC Signature to ChainSignatures::Signature
 impl From<&Signature> for ChainSignatures::Signature {
     fn from(mpc_sig: &Signature) -> Self {
@@ -61,9 +67,13 @@ impl From<&Signature> for ChainSignatures::Signature {
     }
 }
 
+/// TODO: this should probably get merged with the client used by indexer
 #[derive(Clone)]
 pub struct EthClient {
+    // The contract instance for interacting with the ChainSignatures contract
     contract: ChainSignatures::ChainSignaturesInstance<EthContractFillProvider>,
+    // Channel used to send actions to the background batching task
+    batch_tx: mpsc::Sender<PublishAction>,
 }
 
 impl EthClient {
@@ -81,15 +91,107 @@ impl EthClient {
         let address = Address::from_str(&format!("0x{}", eth.contract_address)).unwrap();
         let contract = ChainSignatures::new(address, provider);
 
-        Self { contract }
+        let (batch_tx, batch_rx) = mpsc::channel(super::MAX_CONCURRENT_RPC_REQUESTS);
+
+        let client = Self { contract, batch_tx };
+
+        // Spawn the background batching loop
+        let client_clone = client.clone();
+        tokio::spawn(async move {
+            client_clone.run_batch_respond(batch_rx).await;
+        });
+
+        client
     }
 
-    // Wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
+    /// Run the background batching loop that collects publish actions and sends them in batches to the Ethereum contract.
+    async fn run_batch_respond(self, mut actions_rx: mpsc::Receiver<PublishAction>) {
+        let mut start = Instant::now();
+        let mut actions_batch: Vec<PublishAction> = vec![];
+        let mut interval = tokio::time::interval(Duration::from_millis(100));
+        loop {
+            interval.tick().await;
+            if (start.elapsed() > ETH_RESPOND_BATCH_INTERVAL
+                || actions_batch.len() >= ETH_RESPOND_BATCH_SIZE)
+                && !actions_batch.is_empty()
+            {
+                tracing::info!(
+                    num_requests = actions_batch.len(),
+                    "publishing batch of ethereum signatures",
+                );
+                self.execute_batch_publish(&mut actions_batch).await;
+                start = Instant::now();
+            }
+            if let Ok(action) = actions_rx.try_recv() {
+                actions_batch.push(action);
+            }
+        }
+    }
+
+    /// Execute a batch publish of signatures to the Ethereum contract, with retry logic.
+    async fn execute_batch_publish(&self, actions: &mut Vec<PublishAction>) {
+        let signatures: HashMap<SignId, Signature> = actions
+            .iter()
+            .map(|action| (action.indexed.id, action.signature))
+            .collect();
+
+        let retry_config = RetryConfig {
+            max_times: super::MAX_PUBLISH_RETRY,
+            min_delay: super::BATCH_PUBLISH_MIN_DELAY,
+            max_delay: super::BATCH_PUBLISH_MAX_DELAY,
+            jitter: true,
+        };
+
+        let res = retry_rpc!(
+            super::PUBLISH_ATTEMPT_TIMEOUT,
+            retry_config,
+            |attempt, err, sleep| {
+                tracing::warn!(
+                    "batch publish failed (attempt {attempt}): {err}, retrying in {sleep:?}"
+                );
+            },
+            { self.batch_publish_signatures(actions, &signatures).await }
+        );
+
+        if res.is_ok() {
+            for action in actions.iter() {
+                let chain = action.indexed.chain;
+                let elapsed = crate::util::unix_elapsed(action.indexed.unix_timestamp_indexed);
+                if elapsed.as_secs() <= chain.expected_response_time_secs() {
+                    crate::metrics::requests::record_request_latency_since(
+                        chain,
+                        crate::metrics::requests::SignRequestStep::Total,
+                        "in_time",
+                        action.indexed.unix_timestamp_indexed,
+                    );
+                } else {
+                    crate::metrics::requests::record_request_latency_since(
+                        chain,
+                        crate::metrics::requests::SignRequestStep::Total,
+                        "expired",
+                        action.indexed.unix_timestamp_indexed,
+                    );
+                }
+                crate::metrics::requests::record_request_latency_since(
+                    chain,
+                    crate::metrics::requests::SignRequestStep::Responding,
+                    "ok",
+                    action.timestamp,
+                );
+            }
+        } else {
+            tracing::info!("exceeded max retries, trashing publish request");
+        }
+
+        actions.clear();
+    }
+
+    /// Wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
     async fn wait_for_transaction_receipt(
         &self,
         tx_hash: B256,
         sign_ids: &[SignId],
-    ) -> Result<TransactionReceipt, ()> {
+    ) -> anyhow::Result<TransactionReceipt> {
         let retry_config = RetryConfig {
             max_times: ETH_TX_RECEIPT_MAX_ATTEMPTS,
             min_delay: ETH_RECEIPT_MIN_DELAY,
@@ -110,16 +212,24 @@ impl EthClient {
             },
             // Try to get the transaction receipt
             {
-                match self.contract.provider().get_transaction_receipt(tx_hash).await {
+                match self
+                    .contract
+                    .provider()
+                    .get_transaction_receipt(tx_hash)
+                    .await
+                {
                     Ok(Some(receipt)) => {
-                        tracing::info!(?sign_ids, "eth signature respond transaction receipt found");
+                        tracing::info!(
+                            ?sign_ids,
+                            "eth signature respond transaction receipt found"
+                        );
                         Ok(receipt)
                     }
                     Ok(None) => Err(anyhow::anyhow!("Receipt not ready yet")),
                     Err(e) => Err(anyhow::anyhow!("RPC Error: {e}")),
                 }
             }
-        ).map_err(|_| ())
+        )
     }
 
     async fn send_responses(
@@ -127,7 +237,7 @@ impl EthClient {
         responses: Vec<ChainSignatures::Response>,
         gas: u64,
         sign_ids: &[SignId],
-    ) -> Result<alloy::primitives::B256, ()> {
+    ) -> anyhow::Result<B256> {
         let send_retry = RetryConfig {
             max_times: ETH_SEND_MAX_ATTEMPTS,
             min_delay: ETH_SEND_MIN_DELAY,
@@ -172,13 +282,6 @@ impl EthClient {
                     .map_err(|e| anyhow::anyhow!("RPC Error: {e}"))
             }
         )
-        .map_err(|err| {
-            tracing::error!(
-                ?sign_ids,
-                ?err,
-                "failed to send ethereum signature transaction: retry attempts exhausted"
-            );
-        })
     }
 
     /// Shared logic to send the transaction, wait for the receipt, and verify success.
@@ -187,13 +290,13 @@ impl EthClient {
         responses: Vec<ChainSignatures::Response>,
         gas: u64,
         sign_ids: &[SignId],
-    ) -> Result<(), ()> {
+    ) -> anyhow::Result<()> {
         let tx_hash = self.send_responses(responses, gas, sign_ids).await?;
         let receipt = self.wait_for_transaction_receipt(tx_hash, sign_ids).await?;
 
         if !receipt.status() {
             tracing::error!(?sign_ids, ?tx_hash, "ethereum transaction failed");
-            return Err(());
+            anyhow::bail!("Ethereum transaction reverted");
         }
 
         tracing::info!(
@@ -209,7 +312,7 @@ impl EthClient {
         action: &PublishAction,
         timestamp: &Instant,
         mpc_sig: &mpc_primitives::Signature,
-    ) -> Result<(), ()> {
+    ) -> anyhow::Result<()> {
         let response = ChainSignatures::Response {
             requestId: action.indexed.id.request_id.into(),
             signature: mpc_sig.into(),
@@ -230,7 +333,7 @@ impl EthClient {
         &self,
         actions: &[PublishAction],
         signatures: &HashMap<SignId, Signature>,
-    ) -> Result<(), ()> {
+    ) -> anyhow::Result<()> {
         let num_requests = actions.len();
         let sign_ids: Vec<_> = actions.iter().map(|a| a.indexed.id).collect();
 
@@ -256,6 +359,17 @@ impl EthClient {
 
         tracing::info!(num_requests, "batch publish complete");
         Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ChainPublisher for EthClient {
+    async fn publish_action(&self, action: &PublishAction) -> anyhow::Result<()> {
+        // Push to internal batching queue
+        self.batch_tx
+            .send(action.clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("eth: batch channel closed: {e}"))
     }
 }
 

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -348,7 +348,7 @@ impl EthClient {
             })
             .collect();
 
-        // TODO: Consider using a more accurate dynamic gas estimation 
+        // TODO: Consider using a more accurate dynamic gas estimation
         let gas = std::cmp::max(
             ETH_BASE_GAS_LIMIT,
             ETH_BATCH_GAS_PER_REQUEST * num_requests as u64,

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -348,6 +348,7 @@ impl EthClient {
             })
             .collect();
 
+        // TODO: Consider using a more accurate dynamic gas estimation 
         let gas = std::cmp::max(
             ETH_BASE_GAS_LIMIT,
             ETH_BATCH_GAS_PER_REQUEST * num_requests as u64,

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -307,7 +307,8 @@ impl EthClient {
         Ok(())
     }
 
-    pub async fn publish_signature(&self, action: &PublishAction) -> anyhow::Result<()> {
+    // TODO: should probably remove this
+    async fn _publish_signature(&self, action: &PublishAction) -> anyhow::Result<()> {
         let timestamp = action.timestamp;
         let mpc_sig = &action.signature;
         let response = ChainSignatures::Response {

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -153,34 +153,13 @@ impl EthClient {
             { self.batch_publish_signatures(actions, &signatures).await }
         );
 
+        // Log metrics for successful publishes, or log an error if all retries failed
         if res.is_ok() {
             for action in actions.iter() {
-                let chain = action.indexed.chain;
-                let elapsed = crate::util::unix_elapsed(action.indexed.unix_timestamp_indexed);
-                if elapsed.as_secs() <= chain.expected_response_time_secs() {
-                    crate::metrics::requests::record_request_latency_since(
-                        chain,
-                        crate::metrics::requests::SignRequestStep::Total,
-                        "in_time",
-                        action.indexed.unix_timestamp_indexed,
-                    );
-                } else {
-                    crate::metrics::requests::record_request_latency_since(
-                        chain,
-                        crate::metrics::requests::SignRequestStep::Total,
-                        "expired",
-                        action.indexed.unix_timestamp_indexed,
-                    );
-                }
-                crate::metrics::requests::record_request_latency_since(
-                    chain,
-                    crate::metrics::requests::SignRequestStep::Responding,
-                    "ok",
-                    action.timestamp,
-                );
+                super::record_publish_metrics(action);
             }
         } else {
-            tracing::info!("exceeded max retries, trashing publish request");
+            tracing::error!("exceeded max retries, trashing publish request");
         }
 
         actions.clear();

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -136,14 +136,14 @@ impl EthClient {
             .collect();
 
         let retry_config = RetryConfig {
-            max_times: super::MAX_PUBLISH_RETRY,
+            max_times: usize::MAX,
             min_delay: super::BATCH_PUBLISH_MIN_DELAY,
             max_delay: super::BATCH_PUBLISH_MAX_DELAY,
             jitter: true,
         };
 
         let res = retry_rpc!(
-            super::PUBLISH_ATTEMPT_TIMEOUT,
+            Duration::MAX, // Prevent from timing out
             retry_config,
             |attempt, err, sleep| {
                 tracing::warn!(

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -307,26 +307,6 @@ impl EthClient {
         Ok(())
     }
 
-    // TODO: should probably remove this
-    async fn _publish_signature(&self, action: &PublishAction) -> anyhow::Result<()> {
-        let timestamp = action.timestamp;
-        let mpc_sig = &action.signature;
-        let response = ChainSignatures::Response {
-            requestId: action.indexed.id.request_id.into(),
-            signature: mpc_sig.into(),
-        };
-
-        self.execute_publish(
-            vec![response],
-            ETH_BASE_GAS_LIMIT,
-            std::slice::from_ref(&action.indexed.id),
-        )
-        .await?;
-
-        tracing::info!(elapsed = ?timestamp.elapsed(), "single publish complete");
-        Ok(())
-    }
-
     pub async fn batch_publish_signatures(
         &self,
         actions: &[PublishAction],

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -364,7 +364,7 @@ impl EthClient {
 
 #[async_trait::async_trait]
 impl ChainPublisher for EthClient {
-    async fn publish_action(&self, action: &PublishAction) -> anyhow::Result<()> {
+    async fn publish_signature(&self, action: &PublishAction) -> anyhow::Result<()> {
         // Push to internal batching queue
         self.batch_tx
             .send(action.clone())

--- a/chain-signatures/node/src/rpc/hydration.rs
+++ b/chain-signatures/node/src/rpc/hydration.rs
@@ -308,7 +308,7 @@ impl HydrationClient {
 
 #[async_trait::async_trait]
 impl ChainPublisher for HydrationClient {
-    async fn publish_action(&self, action: &PublishAction) -> anyhow::Result<()> {
+    async fn publish_signature(&self, action: &PublishAction) -> anyhow::Result<()> {
         let client = self.clone();
         let action = action.clone();
         tokio::spawn(async move {

--- a/chain-signatures/node/src/rpc/hydration.rs
+++ b/chain-signatures/node/src/rpc/hydration.rs
@@ -1,4 +1,4 @@
-use super::PublishAction;
+use super::{ChainPublisher, PublishAction};
 use crate::indexer_hydration::HydrationConfig;
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use mpc_primitives::{SignId, SignKind, Signature};
@@ -8,7 +8,7 @@ use sp_runtime::{
     traits::{IdentifyAccount, Verify},
     MultiSignature as SpMultiSignature,
 };
-use std::time::Instant;
+use std::{sync::Arc, time::Instant};
 use subxt::config::substrate::{
     AccountId32, BlakeTwo256, MultiSignature, SubstrateConfig, SubstrateExtrinsicParams,
     SubstrateHeader,
@@ -244,7 +244,7 @@ impl HydrationClient {
         action: &PublishAction,
         timestamp: &Instant,
         signature: &Signature,
-    ) -> Result<(), ()> {
+    ) -> anyhow::Result<()> {
         let chain = action.indexed.chain;
         let sign_id = action.indexed.id;
         let request_ids = [action.indexed.id.request_id];
@@ -261,9 +261,10 @@ impl HydrationClient {
             SignKind::Sign | SignKind::SignBidirectional(_) => {
                 self.call_respond(&action.indexed.id, signature)
                     .await
-                    .map_err(|e| {
-                        tracing::error!(?sign_id, ?e, "Hydration: failed to publish signature");
+                    .inspect_err(|e| {
+                        tracing::error!(?sign_id, ?e, "Hydration: failed to publish signature")
                     })?;
+
                 tracing::info!(
                     ?sign_id,
                     elapsed = ?timestamp.elapsed(),
@@ -281,7 +282,7 @@ impl HydrationClient {
                 let tx_hash = self
                     .call_respond_bidirectional(&action.indexed.id, serialized_output, signature)
                     .await
-                    .map_err(|e| {
+                    .inspect_err(|e| {
                         tracing::error!(
                             ?sign_id,
                             ?e,
@@ -296,14 +297,23 @@ impl HydrationClient {
                 );
             }
             SignKind::Checkpoint(_) => {
-                tracing::error!(
-                    ?sign_id,
-                    "Hydration publish signature: checkpoint signature publishing not supported on Hydration"
-                );
-                return Err(());
+                tracing::error!(?sign_id, "Hydration: checkpoint publishing not supported");
+                anyhow::bail!("checkpoint publishing not supported on Hydration");
             }
         }
 
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ChainPublisher for HydrationClient {
+    async fn publish_action(&self, action: &PublishAction) -> anyhow::Result<()> {
+        let client = self.clone();
+        let action = action.clone();
+        tokio::spawn(async move {
+            super::execute_publish(Arc::new(client), action).await;
+        });
         Ok(())
     }
 }

--- a/chain-signatures/node/src/rpc/hydration.rs
+++ b/chain-signatures/node/src/rpc/hydration.rs
@@ -8,7 +8,6 @@ use sp_runtime::{
     traits::{IdentifyAccount, Verify},
     MultiSignature as SpMultiSignature,
 };
-use std::{sync::Arc, time::Instant};
 use subxt::config::substrate::{
     AccountId32, BlakeTwo256, MultiSignature, SubstrateConfig, SubstrateExtrinsicParams,
     SubstrateHeader,
@@ -238,13 +237,13 @@ impl HydrationClient {
         let events = progress.wait_for_finalized_success().await?;
         Ok(events.extrinsic_hash())
     }
+}
 
-    pub async fn publish_signature(
-        &self,
-        action: &PublishAction,
-        timestamp: &Instant,
-        signature: &Signature,
-    ) -> anyhow::Result<()> {
+#[async_trait::async_trait]
+impl ChainPublisher for HydrationClient {
+    async fn publish_signature(&self, action: &PublishAction) -> anyhow::Result<()> {
+        let timestamp = action.timestamp;
+        let signature = &action.signature;
         let chain = action.indexed.chain;
         let sign_id = action.indexed.id;
         let request_ids = [action.indexed.id.request_id];
@@ -302,18 +301,6 @@ impl HydrationClient {
             }
         }
 
-        Ok(())
-    }
-}
-
-#[async_trait::async_trait]
-impl ChainPublisher for HydrationClient {
-    async fn publish_signature(&self, action: &PublishAction) -> anyhow::Result<()> {
-        let client = self.clone();
-        let action = action.clone();
-        tokio::spawn(async move {
-            super::execute_publish(Arc::new(client), action).await;
-        });
         Ok(())
     }
 }

--- a/chain-signatures/node/src/rpc/hydration.rs
+++ b/chain-signatures/node/src/rpc/hydration.rs
@@ -269,6 +269,8 @@ impl ChainPublisher for HydrationClient {
                     elapsed = ?timestamp.elapsed(),
                     "published hydration signature successfully"
                 );
+
+                super::record_publish_metrics(action);
             }
             SignKind::RespondBidirectional(respond_bidirectional_tx) => {
                 let serialized_output = respond_bidirectional_tx.output.clone();
@@ -288,12 +290,15 @@ impl ChainPublisher for HydrationClient {
                             "Hydration publish signature: failed to publish respond bidirectional signature"
                         );
                     })?;
+
                 tracing::info!(
                     ?sign_id,
                     tx_hash = ?tx_hash,
                     elapsed = ?timestamp.elapsed(),
                     "Hydration publish signature: published respond bidirectional signature successfully"
                 );
+
+                super::record_publish_metrics(action);
             }
             SignKind::Checkpoint(_) => {
                 tracing::error!(?sign_id, "Hydration: checkpoint publishing not supported");

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -4,31 +4,26 @@ mod hydration;
 mod near;
 
 use crate::config::Config;
-use crate::indexer_eth::EthConfig;
-use crate::indexer_sol::SolConfig;
 use crate::metrics::requests::{record_request_latency_since, SignRequestStep};
 use crate::protocol::contract::primitives::{ParticipantMap, Participants};
 use crate::protocol::contract::RunningContractState;
 use crate::protocol::{Chain, IndexedSignRequest, ProtocolState};
 use crate::util::retry::{retry_rpc, RetryConfig};
 use std::collections::BTreeSet;
+use std::sync::Arc;
+use enum_map::EnumMap;
 
+// TODO: move clients elsewhere
 pub use canton::CantonClient;
 pub use ethereum::EthClient;
 pub use hydration::HydrationClient;
-pub use mpc_contract::primitives::{Read, View};
+
 pub use near::NearClient;
-
-use enum_map::EnumMap;
-
 use cait_sith::protocol::Participant;
 use cait_sith::FullSignature;
 use k256::{AffinePoint, Secp256k1};
-use mpc_primitives::{CheckpointDigest, SignId, Signature};
-
-use crate::indexer_canton::CantonConfig;
-use crate::indexer_hydration::HydrationConfig;
-use crate::indexer_sol::SolanaClient;
+use mpc_primitives::{CheckpointDigest, Signature};
+pub use mpc_contract::primitives::{Read, View};
 
 use near_account_id::AccountId;
 use std::collections::HashMap;
@@ -41,16 +36,20 @@ const MAX_PUBLISH_RETRY: usize = 6;
 const MAX_CONCURRENT_RPC_REQUESTS: usize = 1024;
 /// The update interval to fetch and update the contract's state
 const UPDATE_INTERVAL: Duration = Duration::from_secs(10);
-/// The interval to batch send Ethereum responses
-pub const ETH_RESPOND_BATCH_INTERVAL: Duration = Duration::from_millis(2000);
-/// The batch size for Ethereum responses
-pub const ETH_RESPOND_BATCH_SIZE: usize = 10;
 
 // Publish retry constants
 const PUBLISH_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(120);
 const PUBLISH_FIXED_DELAY: Duration = Duration::from_secs(5);
 const BATCH_PUBLISH_MIN_DELAY: Duration = Duration::from_secs(1);
 const BATCH_PUBLISH_MAX_DELAY: Duration = Duration::from_secs(10);
+
+/// Trait for publishing signatures to different blockchains.
+#[async_trait::async_trait]
+pub trait ChainPublisher: Send + Sync + 'static {
+    /// Accepts a publish action. The publisher encapsulates how this is executed
+    /// (e.g., immediate spawn, or pushing to an internal batching queue).
+    async fn publish_action(&self, action: &PublishAction) -> anyhow::Result<()>;
+}
 
 #[derive(Clone)]
 pub struct PublishAction {
@@ -370,54 +369,26 @@ impl ContractStateWatcher {
 }
 
 pub struct RpcExecutor {
+    /// The NEAR client used to fetch contract state and config.
     near: NearClient,
-    eth: Option<EthClient>,
-    solana: Option<SolanaClient>,
-    hydration: Option<HydrationClient>,
-    canton: Option<CantonClient>,
+    /// The publishers for each chain.
+    publishers: HashMap<Chain, Arc<dyn ChainPublisher>>,
+    /// The receiver for incoming RPC actions.
     action_rx: mpsc::Receiver<RpcAction>,
 }
 
 impl RpcExecutor {
     pub async fn new(
-        near: &NearClient,
-        eth: &Option<EthConfig>,
-        solana: &Option<SolConfig>,
-        hydration: &Option<HydrationConfig>,
-        canton: &Option<CantonConfig>,
+        near: NearClient,
+        publishers: HashMap<Chain, Arc<dyn ChainPublisher>>,
     ) -> (RpcChannel, Self) {
-        let eth = eth.as_ref().map(EthClient::new);
-        let solana = solana.as_ref().map(SolanaClient::from_config);
-        let hydration = match hydration {
-            Some(h) => match HydrationClient::new(h).await {
-                Ok(client) => Some(client),
-                Err(e) => {
-                    tracing::error!(%e, "failed to create hydration client");
-                    None
-                }
-            },
-            None => None,
-        };
-        let canton = match canton {
-            Some(c) => match CantonClient::new(c).await {
-                Ok(client) => Some(client),
-                Err(e) => {
-                    tracing::error!(%e, "failed to create canton client");
-                    None
-                }
-            },
-            None => None,
-        };
-        let (tx, rx) = mpsc::channel(MAX_CONCURRENT_RPC_REQUESTS);
+        let (tx, action_rx) = mpsc::channel(MAX_CONCURRENT_RPC_REQUESTS);
         (
             RpcChannel { tx },
             Self {
-                near: near.clone(),
-                eth,
-                solana,
-                hydration,
-                canton,
-                action_rx: rx,
+                near,
+                publishers,
+                action_rx,
             },
         )
     }
@@ -443,18 +414,6 @@ impl RpcExecutor {
             }
         });
 
-        let eth_client = self.client(&Chain::Ethereum);
-        let (eth_rpc_tx, eth_rpc_rx) = mpsc::channel(MAX_CONCURRENT_RPC_REQUESTS);
-        // spin up update task for batch sending eth responses
-        tokio::spawn({
-            run_batch_respond(
-                eth_client,
-                eth_rpc_rx,
-                ETH_RESPOND_BATCH_INTERVAL,
-                ETH_RESPOND_BATCH_SIZE,
-            )
-        });
-
         // process incoming actions related to RPC
         loop {
             let Some(RpcAction::Publish(action)) = self.action_rx.recv().await else {
@@ -463,76 +422,15 @@ impl RpcExecutor {
             };
 
             let chain = action.indexed.chain;
-            let client = self.client(&chain);
-            let eth_rpc_tx = eth_rpc_tx.clone(); // clone for task use
 
-            tokio::spawn(async move {
-                match chain {
-                    Chain::NEAR | Chain::Solana | Chain::Hydration | Chain::Canton => {
-                        execute_publish(client, action).await;
-                    }
-                    Chain::Ethereum => {
-                        if let Err(err) = eth_rpc_tx.send(action).await {
-                            tracing::error!(%err, "eth: failed to send publish action");
-                        }
-                    }
-                    Chain::Bitcoin => {
-                        tracing::warn!(
-                            ?chain,
-                            "publish not supported for Bitcoin yet, dropping action"
-                        );
-                    }
-                }
-            });
+            let Some(publisher) = self.publishers.get(&chain) else {
+                tracing::warn!(?chain, "no publisher configured for chain");
+                continue;
+            };
+
+            let _ = publisher.publish_action(&action).await;
         }
     }
-
-    /// Get the client for the given chain
-    fn client(&self, chain: &Chain) -> ChainClient {
-        match chain {
-            Chain::NEAR => ChainClient::Near(self.near.clone()),
-            Chain::Ethereum => {
-                if let Some(eth) = &self.eth {
-                    ChainClient::Ethereum(eth.clone())
-                } else {
-                    ChainClient::Err("no eth client available for node")
-                }
-            }
-            Chain::Solana => {
-                if let Some(sol) = &self.solana {
-                    ChainClient::Solana(sol.clone())
-                } else {
-                    ChainClient::Err("no solana client available for node")
-                }
-            }
-            Chain::Hydration => {
-                if let Some(hydration) = &self.hydration {
-                    ChainClient::Hydration(hydration.clone())
-                } else {
-                    ChainClient::Err("no hydration client available for node")
-                }
-            }
-            Chain::Canton => {
-                if let Some(canton) = &self.canton {
-                    ChainClient::Canton(canton.clone())
-                } else {
-                    ChainClient::Err("no canton client available for node")
-                }
-            }
-            Chain::Bitcoin => ChainClient::Err("no bitcoin client available for node"),
-        }
-    }
-}
-
-/// Client related to a specific chain
-#[allow(clippy::large_enum_variant)]
-pub enum ChainClient {
-    Err(&'static str),
-    Near(NearClient),
-    Ethereum(EthClient),
-    Solana(SolanaClient),
-    Hydration(HydrationClient),
-    Canton(CantonClient),
 }
 
 async fn update_contract_data(
@@ -605,7 +503,7 @@ async fn update_contract_data(
 }
 
 /// Publish the signature and retry if it fails
-async fn execute_publish(client: ChainClient, action: PublishAction) {
+pub async fn execute_publish(publisher: Arc<dyn ChainPublisher>, action: PublishAction) {
     let chain = action.indexed.chain;
     let sign_id = action.indexed.id;
 
@@ -637,36 +535,10 @@ async fn execute_publish(client: ChainClient, action: PublishAction) {
             );
         },
         // Try to publish the signature
-        {
-            match &client {
-                ChainClient::Near(near) => near
-                    .publish_signature(&action, &action.timestamp, &action.signature)
-                    .await
-                    .map_err(|_| anyhow::anyhow!("Near publish failed")),
-                ChainClient::Ethereum(eth) => eth
-                    .publish_signature(&action, &action.timestamp, &action.signature)
-                    .await
-                    .map_err(|_| anyhow::anyhow!("Ethereum publish failed")),
-                ChainClient::Solana(sol) => sol
-                    .publish_signature(&action, &action.timestamp, &action.signature)
-                    .await
-                    .map_err(|_| anyhow::anyhow!("Solana publish failed")),
-                ChainClient::Hydration(hyd) => hyd
-                    .publish_signature(&action, &action.timestamp, &action.signature)
-                    .await
-                    .map_err(|_| anyhow::anyhow!("Hydration publish failed")),
-                ChainClient::Canton(canton) => canton
-                    .publish_signature(&action, &action.timestamp, &action.signature)
-                    .await
-                    .map_err(|_| anyhow::anyhow!("Canton publish failed")),
-                ChainClient::Err(msg) => {
-                    tracing::error!(msg, "no client for chain");
-                    Ok(())
-                }
-            }
-        }
+        { publisher.publish_action(&action).await }
     );
 
+    // TODO: consider decoupling publishing from metric recording
     if publish_res.is_ok() {
         let elapsed_secs =
             crate::util::unix_elapsed(action.indexed.unix_timestamp_indexed).as_secs();
@@ -695,119 +567,6 @@ async fn execute_publish(client: ChainClient, action: PublishAction) {
     }
 }
 
-async fn run_batch_respond(
-    client: ChainClient,
-    mut actions_rx: mpsc::Receiver<PublishAction>,
-    batch_interval: Duration,
-    batch_size: usize,
-) {
-    let mut start = Instant::now();
-    let mut actions_batch: Vec<PublishAction> = vec![];
-    let mut interval = tokio::time::interval(Duration::from_millis(100));
-    loop {
-        interval.tick().await;
-        if (start.elapsed() > batch_interval || actions_batch.len() >= batch_size)
-            && !actions_batch.is_empty()
-        {
-            tracing::info!(
-                num_requests = actions_batch.len(),
-                "publishing batch of signatures",
-            );
-            execute_batch_publish(&client, &mut actions_batch).await;
-            start = Instant::now();
-        }
-        if let Ok(action) = actions_rx.try_recv() {
-            actions_batch.push(action);
-        }
-    }
-}
-
-async fn execute_batch_publish(client: &ChainClient, actions: &mut Vec<PublishAction>) {
-    let signatures: HashMap<SignId, Signature> = actions
-        .iter()
-        .map(|action| (action.indexed.id, action.signature))
-        .collect();
-
-    let retry_config = RetryConfig {
-        max_times: MAX_PUBLISH_RETRY,
-        min_delay: BATCH_PUBLISH_MIN_DELAY,
-        max_delay: BATCH_PUBLISH_MAX_DELAY,
-        jitter: true,
-    };
-
-    let res = retry_rpc!(
-        PUBLISH_ATTEMPT_TIMEOUT,
-        retry_config,
-        // Log the error and retry attempt
-        |attempt, err, sleep| {
-            tracing::warn!(
-                "batch publish failed (attempt {attempt}): {err}, retrying in {sleep:?}"
-            );
-        },
-        // Try to publish the signatures in batch
-        {
-            match client {
-                ChainClient::Ethereum(eth) => eth
-                    .batch_publish_signatures(actions, &signatures)
-                    .await
-                    .map_err(|_| anyhow::anyhow!("Eth batch publish failed")),
-                ChainClient::Near(_) => {
-                    tracing::error!("Near has no batch publish");
-                    Ok(())
-                }
-                ChainClient::Solana(_) => {
-                    tracing::error!("Solana has no batch publish");
-                    Ok(())
-                }
-                ChainClient::Hydration(_) => {
-                    tracing::error!("Hydration has no batch publish");
-                    Ok(())
-                }
-                ChainClient::Canton(_) => {
-                    tracing::error!("Canton has no batch publish");
-                    Ok(())
-                }
-                ChainClient::Err(msg) => {
-                    tracing::error!(msg, "no client for chain");
-                    Ok(())
-                }
-            }
-        }
-    );
-
-    if res.is_ok() {
-        for action in actions.iter() {
-            let chain = action.indexed.chain;
-            let elapsed = crate::util::unix_elapsed(action.indexed.unix_timestamp_indexed);
-            if elapsed.as_secs() <= chain.expected_response_time_secs() {
-                record_request_latency_since(
-                    chain,
-                    SignRequestStep::Total,
-                    "in_time",
-                    action.indexed.unix_timestamp_indexed,
-                );
-            } else {
-                record_request_latency_since(
-                    chain,
-                    SignRequestStep::Total,
-                    "expired",
-                    action.indexed.unix_timestamp_indexed,
-                );
-            }
-            record_request_latency_since(
-                chain,
-                SignRequestStep::Responding,
-                "ok",
-                action.timestamp,
-            );
-        }
-    } else {
-        tracing::info!("exceeded max retries, trashing publish request");
-    }
-
-    actions.clear();
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -818,7 +577,7 @@ mod tests {
     use k256::elliptic_curve::ops::Reduce;
     use k256::elliptic_curve::point::DecompressPoint;
     use mpc_crypto::kdf::derive_secret_key;
-    use mpc_primitives::SignKind;
+    use mpc_primitives::{SignId, SignKind};
 
     fn scalar(bytes: &[u8; 32]) -> k256::Scalar {
         <k256::Scalar as Reduce<<Secp256k1 as k256::elliptic_curve::Curve>::Uint>>::reduce_bytes(

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -423,12 +423,16 @@ impl RpcExecutor {
 
             let chain = action.indexed.chain;
 
+            // Check if a publisher is configured for the chain. If not, log a warning and continue to the next action.
             let Some(publisher) = self.publishers.get(&chain) else {
                 tracing::warn!(?chain, "no publisher configured for chain");
                 continue;
             };
 
-            let _ = publisher.publish_signature(&action).await;
+            // Publish the signature and retry if it fails
+            if let Err(e) = publisher.publish_signature(&action).await {
+                tracing::error!(?chain, "failed to enqueue publish action: {e}");
+            }
         }
     }
 }

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -399,7 +399,7 @@ impl RpcExecutor {
         config: watch::Sender<Config>,
         checkpoints: EnumMap<Chain, watch::Sender<CheckpointDigest>>,
     ) {
-        // spin up update task for updating contract state, config and checkpoints
+        // Spin up update task for updating contract state, config and checkpoints
         let near = self.near.clone();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(UPDATE_INTERVAL);
@@ -414,9 +414,16 @@ impl RpcExecutor {
             }
         });
 
-        // process incoming actions related to RPC
+        Self::dispatch_loop(&self.publishers, &mut self.action_rx).await;
+    }
+
+    /// Dispatches incoming RPC actions to the appropriate chain publishers.
+    async fn dispatch_loop(
+        publishers: &HashMap<Chain, Arc<dyn ChainPublisher>>,
+        action_rx: &mut mpsc::Receiver<RpcAction>,
+    ) {
         loop {
-            let Some(RpcAction::Publish(action)) = self.action_rx.recv().await else {
+            let Some(RpcAction::Publish(action)) = action_rx.recv().await else {
                 tracing::error!("rpc channel closed unexpectedly");
                 return;
             };
@@ -424,14 +431,13 @@ impl RpcExecutor {
             let chain = action.indexed.chain;
 
             // Check if a publisher is configured for the chain. If not, log a warning and continue to the next action.
-            let Some(publisher) = self.publishers.get(&chain) else {
+            let Some(publisher) = publishers.get(&chain) else {
                 tracing::warn!(?chain, "no publisher configured for chain");
                 continue;
             };
 
             // Spawn a task to execute the publish action.
             let publisher = publisher.clone();
-            let action = action.clone();
             tokio::spawn(async move {
                 execute_publish(publisher, action).await;
             });
@@ -575,6 +581,8 @@ pub async fn execute_publish(publisher: Arc<dyn ChainPublisher>, action: Publish
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
     use crate::protocol::contract::primitives::{ParticipantInfo, Participants};
     use crate::protocol::contract::{ResharingContractState, RunningContractState};
@@ -584,6 +592,29 @@ mod tests {
     use k256::elliptic_curve::point::DecompressPoint;
     use mpc_crypto::kdf::derive_secret_key;
     use mpc_primitives::{SignId, SignKind};
+
+    /// A publisher that counts the number of times it has been called.
+    struct CountingPublisher {
+        call_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl ChainPublisher for CountingPublisher {
+        async fn publish_signature(&self, _action: &PublishAction) -> anyhow::Result<()> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    /// A publisher that always fails to publish a signature.
+    struct FailingPublisher;
+
+    #[async_trait::async_trait]
+    impl ChainPublisher for FailingPublisher {
+        async fn publish_signature(&self, _action: &PublishAction) -> anyhow::Result<()> {
+            anyhow::bail!("publisher failed")
+        }
+    }
 
     fn scalar(bytes: &[u8; 32]) -> k256::Scalar {
         <k256::Scalar as Reduce<<Secp256k1 as k256::elliptic_curve::Curve>::Uint>>::reduce_bytes(
@@ -613,7 +644,11 @@ mod tests {
         }
     }
 
-    fn make_indexed(epsilon: k256::Scalar, payload: k256::Scalar) -> IndexedSignRequest {
+    fn make_indexed(
+        chain: Chain,
+        epsilon: k256::Scalar,
+        payload: k256::Scalar,
+    ) -> IndexedSignRequest {
         IndexedSignRequest {
             id: SignId::new([0u8; 32]),
             args: mpc_primitives::SignArgs {
@@ -623,10 +658,22 @@ mod tests {
                 path: "test".into(),
                 key_version: 0,
             },
-            chain: Chain::NEAR,
+            chain,
             unix_timestamp_indexed: 0,
             kind: SignKind::Sign,
         }
+    }
+
+    /// Creates a `PublishAction` with a valid signature for the given chain.
+    fn make_publish_action(chain: Chain) -> PublishAction {
+        let sk = k256::SecretKey::random(&mut rand::thread_rng());
+        let pk: AffinePoint = sk.public_key().into();
+        let epsilon = scalar(&[1u8; 32]);
+        let payload = scalar(&[42u8; 32]);
+        let output = make_signature(&sk, epsilon, payload);
+        let indexed = make_indexed(chain, epsilon, payload);
+        PublishAction::new(pk, indexed, output, vec![])
+            .expect("valid signature should produce a publish action")
     }
 
     fn test_participants() -> Participants {
@@ -700,7 +747,7 @@ mod tests {
         let payload = scalar(&[42u8; 32]);
 
         let output = make_signature(&sk, epsilon, payload);
-        let indexed = make_indexed(epsilon, payload);
+        let indexed = make_indexed(Chain::NEAR, epsilon, payload);
 
         assert!(PublishAction::new(pk, indexed, output, vec![]).is_some());
     }
@@ -714,8 +761,146 @@ mod tests {
 
         let mut output = make_signature(&sk, epsilon, payload);
         output.s += k256::Scalar::ONE;
-        let indexed = make_indexed(epsilon, payload);
+        let indexed = make_indexed(Chain::NEAR, epsilon, payload);
 
         assert!(PublishAction::new(pk, indexed, output, vec![]).is_none());
+    }
+
+    #[tokio::test]
+    async fn executor_dispatches_to_configured_publisher() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+
+        // Create a publisher for Ethereum that counts the number of times it has been called.
+        let mut publishers: HashMap<Chain, Arc<dyn ChainPublisher>> = HashMap::new();
+        publishers.insert(
+            Chain::Ethereum,
+            Arc::new(CountingPublisher {
+                call_count: call_count.clone(),
+            }),
+        );
+
+        let (tx, mut rx) = mpsc::channel(16);
+        // Send a publish action to the executor.
+        tx.send(RpcAction::Publish(make_publish_action(Chain::Ethereum)))
+            .await
+            .unwrap();
+
+        // Closing the channel will cause dispatch_loop to return
+        drop(tx);
+
+        RpcExecutor::dispatch_loop(&publishers, &mut rx).await;
+
+        // Give spawned tasks a chance to complete
+        tokio::task::yield_now().await;
+
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn executor_ignores_action_for_unconfigured_chain() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+
+        // Create a publisher for Canton
+        let mut publishers: HashMap<Chain, Arc<dyn ChainPublisher>> = HashMap::new();
+        publishers.insert(
+            Chain::Canton,
+            Arc::new(CountingPublisher {
+                call_count: call_count.clone(),
+            }),
+        );
+
+        let (tx, mut rx) = mpsc::channel(16);
+
+        // Send a publish action for Ethereum (not configured)
+        tx.send(RpcAction::Publish(make_publish_action(Chain::Ethereum)))
+            .await
+            .unwrap();
+
+        drop(tx);
+
+        RpcExecutor::dispatch_loop(&publishers, &mut rx).await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(call_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn executor_continues_after_publisher_error() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+
+        // Create a publisher for NEAR that always fails, and a publisher for Solana that counts calls.
+        let mut publishers: HashMap<Chain, Arc<dyn ChainPublisher>> = HashMap::new();
+        publishers.insert(Chain::NEAR, Arc::new(FailingPublisher));
+        publishers.insert(
+            Chain::Solana,
+            Arc::new(CountingPublisher {
+                call_count: call_count.clone(),
+            }),
+        );
+
+        let (tx, mut rx) = mpsc::channel(16);
+
+        // Send a publish action for NEAR (which will fail) and then for Solana (which should succeed)
+        tx.send(RpcAction::Publish(make_publish_action(Chain::NEAR)))
+            .await
+            .unwrap();
+        tx.send(RpcAction::Publish(make_publish_action(Chain::Solana)))
+            .await
+            .unwrap();
+
+        drop(tx);
+
+        RpcExecutor::dispatch_loop(&publishers, &mut rx).await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn executor_dispatches_to_correct_publishers() {
+        const NEAR_ACTION_COUNT: usize = 3;
+        const SOL_ACTION_COUNT: usize = 2;
+
+        let near_count = Arc::new(AtomicUsize::new(0));
+        let sol_count = Arc::new(AtomicUsize::new(0));
+
+        // Create publishers for NEAR and Solana that count the number of times they have been called.
+        let mut publishers: HashMap<Chain, Arc<dyn ChainPublisher>> = HashMap::new();
+
+        publishers.insert(
+            Chain::NEAR,
+            Arc::new(CountingPublisher {
+                call_count: near_count.clone(),
+            }),
+        );
+        publishers.insert(
+            Chain::Solana,
+            Arc::new(CountingPublisher {
+                call_count: sol_count.clone(),
+            }),
+        );
+
+        let (tx, mut rx) = mpsc::channel(16);
+
+        // Send multiple publish actions for NEAR and Solana
+        for _ in 0..NEAR_ACTION_COUNT {
+            tx.send(RpcAction::Publish(make_publish_action(Chain::NEAR)))
+                .await
+                .unwrap();
+        }
+
+        for _ in 0..SOL_ACTION_COUNT {
+            tx.send(RpcAction::Publish(make_publish_action(Chain::Solana)))
+                .await
+                .unwrap();
+        }
+
+        drop(tx);
+
+        RpcExecutor::dispatch_loop(&publishers, &mut rx).await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(near_count.load(Ordering::SeqCst), NEAR_ACTION_COUNT);
+        assert_eq!(sol_count.load(Ordering::SeqCst), SOL_ACTION_COUNT);
     }
 }

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -429,10 +429,12 @@ impl RpcExecutor {
                 continue;
             };
 
-            // Publish the signature and retry if it fails
-            if let Err(e) = publisher.publish_signature(&action).await {
-                tracing::error!(?chain, "failed to enqueue publish action: {e}");
-            }
+            // Spawn a task to execute the publish action.
+            let publisher = publisher.clone();
+            let action = action.clone();
+            tokio::spawn(async move {
+                execute_publish(publisher, action).await;
+            });
         }
     }
 }

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -808,7 +808,12 @@ mod tests {
         drop(tx);
 
         RpcExecutor::dispatch_loop(&publishers, &mut rx).await;
-        tokio::task::yield_now().await;
+
+        // Yield enough times to let both spawned tasks complete.
+        // Each task calls publish_signature once and returns immediately.
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
 
         assert_eq!(call_count.load(Ordering::SeqCst), 1);
     }

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -41,7 +41,8 @@ const UPDATE_INTERVAL: Duration = Duration::from_secs(10);
 
 // Publish retry constants
 const PUBLISH_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(120);
-const PUBLISH_FIXED_DELAY: Duration = Duration::from_secs(5);
+const PUBLISH_MIN_DELAY: Duration = Duration::from_secs(5);
+const PUBLISH_MAX_DELAY: Duration = Duration::from_secs(60); // Cap to 1 min so backoff doesn't get too long for infinite retries
 const BATCH_PUBLISH_MIN_DELAY: Duration = Duration::from_secs(1);
 const BATCH_PUBLISH_MAX_DELAY: Duration = Duration::from_secs(10);
 
@@ -529,14 +530,14 @@ pub async fn execute_publish(publisher: Arc<dyn ChainPublisher>, action: Publish
     );
 
     let retry_config = RetryConfig {
-        max_times: MAX_PUBLISH_RETRY,
-        min_delay: PUBLISH_FIXED_DELAY,
-        max_delay: PUBLISH_FIXED_DELAY,
+        max_times: usize::MAX,
+        min_delay: PUBLISH_MIN_DELAY,
+        max_delay: PUBLISH_MAX_DELAY,
         jitter: true,
     };
 
     let publish_res = retry_rpc!(
-        PUBLISH_ATTEMPT_TIMEOUT,
+        Duration::MAX, // Prevent from timing out
         retry_config,
         // Log the error and retry attempt
         |attempt, err, sleep| {

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -32,15 +32,12 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, watch};
 
-/// The maximum amount of times to retry publishing a signature.
-const MAX_PUBLISH_RETRY: usize = 6;
 /// The maximum number of concurrent RPC requests the system can make
 const MAX_CONCURRENT_RPC_REQUESTS: usize = 1024;
 /// The update interval to fetch and update the contract's state
 const UPDATE_INTERVAL: Duration = Duration::from_secs(10);
 
 // Publish retry constants
-const PUBLISH_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(120);
 const PUBLISH_MIN_DELAY: Duration = Duration::from_secs(5);
 const PUBLISH_MAX_DELAY: Duration = Duration::from_secs(60); // Cap to 1 min so backoff doesn't get too long for infinite retries
 const BATCH_PUBLISH_MIN_DELAY: Duration = Duration::from_secs(1);

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -552,6 +552,7 @@ pub async fn execute_publish(publisher: Arc<dyn ChainPublisher>, action: Publish
         { publisher.publish_signature(&action).await }
     );
 
+    // TODO: Consider adding a metric update for failed publish attempts here, if needed.
     // Log error if the publish failed after all retries
     if publish_res.is_err() {
         tracing::error!(
@@ -691,7 +692,7 @@ mod tests {
         let payload = scalar(&[42u8; 32]);
 
         let output = make_signature(&sk, epsilon, payload);
-        let indexed = make_indexed(Chain::NEAR, epsilon, payload);
+        let indexed = make_indexed(Chain::NEAR, epsilon, payload, SignKind::Sign);
 
         assert!(PublishAction::new(pk, indexed, output, vec![]).is_some());
     }
@@ -705,7 +706,7 @@ mod tests {
 
         let mut output = make_signature(&sk, epsilon, payload);
         output.s += k256::Scalar::ONE;
-        let indexed = make_indexed(Chain::NEAR, epsilon, payload);
+        let indexed = make_indexed(Chain::NEAR, epsilon, payload, SignKind::Sign);
 
         assert!(PublishAction::new(pk, indexed, output, vec![]).is_none());
     }

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -514,7 +514,7 @@ async fn update_contract_data(
     }
 }
 
-/// Publish the signature and retry if it fails
+/// Publish the signature and retry if it fails, logging the error and retry attempt. Shared by all chain publishers.
 pub async fn execute_publish(publisher: Arc<dyn ChainPublisher>, action: PublishAction) {
     let chain = action.indexed.chain;
     let sign_id = action.indexed.id;
@@ -550,33 +550,37 @@ pub async fn execute_publish(publisher: Arc<dyn ChainPublisher>, action: Publish
         { publisher.publish_signature(&action).await }
     );
 
-    // TODO: consider decoupling publishing from metric recording
-    if publish_res.is_ok() {
-        let elapsed_secs =
-            crate::util::unix_elapsed(action.indexed.unix_timestamp_indexed).as_secs();
-        if elapsed_secs <= chain.expected_response_time_secs() {
-            record_request_latency_since(
-                chain,
-                SignRequestStep::Total,
-                "in_time",
-                action.indexed.unix_timestamp_indexed,
-            );
-        } else {
-            record_request_latency_since(
-                chain,
-                SignRequestStep::Total,
-                "expired",
-                action.indexed.unix_timestamp_indexed,
-            );
-        }
-        record_request_latency_since(chain, SignRequestStep::Responding, "ok", action.timestamp);
-    } else {
-        tracing::info!(
+    // Log error if the publish failed after all retries
+    if publish_res.is_err() {
+        tracing::error!(
             ?sign_id,
             elapsed = ?action.timestamp.elapsed(),
             "exceeded max retries, trashing publish request"
         );
     }
+}
+
+/// Helper to record metrics when a signature is successfully published to a chain.
+pub fn record_publish_metrics(action: &PublishAction) {
+    let chain = action.indexed.chain;
+    let elapsed_secs = crate::util::unix_elapsed(action.indexed.unix_timestamp_indexed).as_secs();
+
+    if elapsed_secs <= chain.expected_response_time_secs() {
+        record_request_latency_since(
+            chain,
+            SignRequestStep::Total,
+            "in_time",
+            action.indexed.unix_timestamp_indexed,
+        );
+    } else {
+        record_request_latency_since(
+            chain,
+            SignRequestStep::Total,
+            "expired",
+            action.indexed.unix_timestamp_indexed,
+        );
+    }
+    record_request_latency_since(chain, SignRequestStep::Responding, "ok", action.timestamp);
 }
 
 #[cfg(test)]
@@ -664,6 +668,7 @@ mod tests {
         }
     }
 
+    // TODO: should be re-used across tests in submodules
     /// Creates a `PublishAction` with a valid signature for the given chain.
     fn make_publish_action(chain: Chain) -> PublishAction {
         let sk = k256::SecretKey::random(&mut rand::thread_rng());

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -9,21 +9,21 @@ use crate::protocol::contract::primitives::{ParticipantMap, Participants};
 use crate::protocol::contract::RunningContractState;
 use crate::protocol::{Chain, IndexedSignRequest, ProtocolState};
 use crate::util::retry::{retry_rpc, RetryConfig};
+use enum_map::EnumMap;
 use std::collections::BTreeSet;
 use std::sync::Arc;
-use enum_map::EnumMap;
 
 // TODO: move clients elsewhere
 pub use canton::CantonClient;
 pub use ethereum::EthClient;
 pub use hydration::HydrationClient;
 
-pub use near::NearClient;
 use cait_sith::protocol::Participant;
 use cait_sith::FullSignature;
 use k256::{AffinePoint, Secp256k1};
-use mpc_primitives::{CheckpointDigest, Signature};
 pub use mpc_contract::primitives::{Read, View};
+use mpc_primitives::{CheckpointDigest, Signature};
+pub use near::NearClient;
 
 use near_account_id::AccountId;
 use std::collections::HashMap;
@@ -43,12 +43,12 @@ const PUBLISH_FIXED_DELAY: Duration = Duration::from_secs(5);
 const BATCH_PUBLISH_MIN_DELAY: Duration = Duration::from_secs(1);
 const BATCH_PUBLISH_MAX_DELAY: Duration = Duration::from_secs(10);
 
-/// Trait for publishing signatures to different blockchains.
+/// Trait for publishing signatures to different blockchains (single attempt, caller handles retries).
 #[async_trait::async_trait]
 pub trait ChainPublisher: Send + Sync + 'static {
     /// Accepts a publish action. The publisher encapsulates how this is executed
     /// (e.g., immediate spawn, or pushing to an internal batching queue).
-    async fn publish_action(&self, action: &PublishAction) -> anyhow::Result<()>;
+    async fn publish_signature(&self, action: &PublishAction) -> anyhow::Result<()>;
 }
 
 #[derive(Clone)]
@@ -428,7 +428,7 @@ impl RpcExecutor {
                 continue;
             };
 
-            let _ = publisher.publish_action(&action).await;
+            let _ = publisher.publish_signature(&action).await;
         }
     }
 }
@@ -535,7 +535,7 @@ pub async fn execute_publish(publisher: Arc<dyn ChainPublisher>, action: Publish
             );
         },
         // Try to publish the signature
-        { publisher.publish_action(&action).await }
+        { publisher.publish_signature(&action).await }
     );
 
     // TODO: consider decoupling publishing from metric recording

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -2,6 +2,8 @@ mod canton;
 mod ethereum;
 mod hydration;
 mod near;
+#[cfg(test)]
+mod test_utils;
 
 use crate::config::Config;
 use crate::metrics::requests::{record_request_latency_since, SignRequestStep};
@@ -587,15 +589,13 @@ pub fn record_publish_metrics(action: &PublishAction) {
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    use super::test_utils::{make_indexed, make_publish_action, make_signature, scalar};
     use super::*;
     use crate::protocol::contract::primitives::{ParticipantInfo, Participants};
     use crate::protocol::contract::{ResharingContractState, RunningContractState};
     use crate::protocol::ProtocolState;
     use cait_sith::protocol::Participant;
-    use k256::elliptic_curve::ops::Reduce;
-    use k256::elliptic_curve::point::DecompressPoint;
-    use mpc_crypto::kdf::derive_secret_key;
-    use mpc_primitives::{SignId, SignKind};
+    use mpc_primitives::SignKind;
 
     /// A publisher that counts the number of times it has been called.
     struct CountingPublisher {
@@ -618,67 +618,6 @@ mod tests {
         async fn publish_signature(&self, _action: &PublishAction) -> anyhow::Result<()> {
             anyhow::bail!("publisher failed")
         }
-    }
-
-    fn scalar(bytes: &[u8; 32]) -> k256::Scalar {
-        <k256::Scalar as Reduce<<Secp256k1 as k256::elliptic_curve::Curve>::Uint>>::reduce_bytes(
-            bytes.into(),
-        )
-    }
-
-    fn make_signature(
-        sk: &k256::SecretKey,
-        epsilon: k256::Scalar,
-        payload: k256::Scalar,
-    ) -> FullSignature<Secp256k1> {
-        let signing_key = k256::ecdsa::SigningKey::from(&derive_secret_key(sk, epsilon));
-        let (ecdsa_sig, _): (k256::ecdsa::Signature, _) =
-            <k256::ecdsa::SigningKey as k256::ecdsa::signature::hazmat::PrehashSigner<_>>::sign_prehash(
-                &signing_key,
-                &payload.to_bytes(),
-            )
-            .expect("signing should succeed");
-        let (r_bytes, _) = ecdsa_sig.split_bytes();
-        let big_r =
-            AffinePoint::decompress(&r_bytes, k256::elliptic_curve::subtle::Choice::from(0))
-                .unwrap();
-        FullSignature {
-            big_r,
-            s: *ecdsa_sig.s().as_ref(),
-        }
-    }
-
-    fn make_indexed(
-        chain: Chain,
-        epsilon: k256::Scalar,
-        payload: k256::Scalar,
-    ) -> IndexedSignRequest {
-        IndexedSignRequest {
-            id: SignId::new([0u8; 32]),
-            args: mpc_primitives::SignArgs {
-                entropy: [0u8; 32],
-                epsilon,
-                payload,
-                path: "test".into(),
-                key_version: 0,
-            },
-            chain,
-            unix_timestamp_indexed: 0,
-            kind: SignKind::Sign,
-        }
-    }
-
-    // TODO: should be re-used across tests in submodules
-    /// Creates a `PublishAction` with a valid signature for the given chain.
-    fn make_publish_action(chain: Chain) -> PublishAction {
-        let sk = k256::SecretKey::random(&mut rand::thread_rng());
-        let pk: AffinePoint = sk.public_key().into();
-        let epsilon = scalar(&[1u8; 32]);
-        let payload = scalar(&[42u8; 32]);
-        let output = make_signature(&sk, epsilon, payload);
-        let indexed = make_indexed(chain, epsilon, payload);
-        PublishAction::new(pk, indexed, output, vec![])
-            .expect("valid signature should produce a publish action")
     }
 
     fn test_participants() -> Participants {
@@ -786,9 +725,12 @@ mod tests {
 
         let (tx, mut rx) = mpsc::channel(16);
         // Send a publish action to the executor.
-        tx.send(RpcAction::Publish(make_publish_action(Chain::Ethereum)))
-            .await
-            .unwrap();
+        tx.send(RpcAction::Publish(make_publish_action(
+            Chain::Ethereum,
+            SignKind::Sign,
+        )))
+        .await
+        .unwrap();
 
         // Closing the channel will cause dispatch_loop to return
         drop(tx);
@@ -817,9 +759,12 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(16);
 
         // Send a publish action for Ethereum (not configured)
-        tx.send(RpcAction::Publish(make_publish_action(Chain::Ethereum)))
-            .await
-            .unwrap();
+        tx.send(RpcAction::Publish(make_publish_action(
+            Chain::Ethereum,
+            SignKind::Sign,
+        )))
+        .await
+        .unwrap();
 
         drop(tx);
 
@@ -846,12 +791,18 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(16);
 
         // Send a publish action for NEAR (which will fail) and then for Solana (which should succeed)
-        tx.send(RpcAction::Publish(make_publish_action(Chain::NEAR)))
-            .await
-            .unwrap();
-        tx.send(RpcAction::Publish(make_publish_action(Chain::Solana)))
-            .await
-            .unwrap();
+        tx.send(RpcAction::Publish(make_publish_action(
+            Chain::NEAR,
+            SignKind::Sign,
+        )))
+        .await
+        .unwrap();
+        tx.send(RpcAction::Publish(make_publish_action(
+            Chain::Solana,
+            SignKind::Sign,
+        )))
+        .await
+        .unwrap();
 
         drop(tx);
 
@@ -889,15 +840,21 @@ mod tests {
 
         // Send multiple publish actions for NEAR and Solana
         for _ in 0..NEAR_ACTION_COUNT {
-            tx.send(RpcAction::Publish(make_publish_action(Chain::NEAR)))
-                .await
-                .unwrap();
+            tx.send(RpcAction::Publish(make_publish_action(
+                Chain::NEAR,
+                SignKind::Sign,
+            )))
+            .await
+            .unwrap();
         }
 
         for _ in 0..SOL_ACTION_COUNT {
-            tx.send(RpcAction::Publish(make_publish_action(Chain::Solana)))
-                .await
-                .unwrap();
+            tx.send(RpcAction::Publish(make_publish_action(
+                Chain::Solana,
+                SignKind::Sign,
+            )))
+            .await
+            .unwrap();
         }
 
         drop(tx);

--- a/chain-signatures/node/src/rpc/near.rs
+++ b/chain-signatures/node/src/rpc/near.rs
@@ -13,6 +13,13 @@ use near_fetch::result::ExecutionFinalResult;
 use serde_json::json;
 use url::Url;
 
+/// Base delay in milliseconds between NEAR RPC retries
+const NEAR_RETRY_BASE_DELAY_MS: u64 = 10;
+/// Maximum number of retry attempts for NEAR RPC calls
+const NEAR_RESPOND_MAX_RETRIES: usize = 3;
+/// Maximum number of retry attempts for NEAR governance calls (vote, join)
+const NEAR_GOVERNANCE_MAX_RETRIES: usize = 5;
+
 #[derive(Clone)]
 pub struct NearClient {
     client: near_fetch::Client,
@@ -68,7 +75,7 @@ impl NearClient {
                 "public_key": public_key
             }))
             .max_gas()
-            .retry_exponential(10, 5)
+            .retry_exponential(NEAR_RETRY_BASE_DELAY_MS, NEAR_GOVERNANCE_MAX_RETRIES)
             .transact()
             .await
             .inspect_err(|err| {
@@ -88,7 +95,7 @@ impl NearClient {
                 "epoch": epoch
             }))
             .max_gas()
-            .retry_exponential(10, 5)
+            .retry_exponential(NEAR_RETRY_BASE_DELAY_MS, NEAR_GOVERNANCE_MAX_RETRIES)
             .transact()
             .await
             .inspect_err(|err| {
@@ -109,7 +116,7 @@ impl NearClient {
                 "sign_pk": self.sign_pk,
             }))
             .max_gas()
-            .retry_exponential(10, 3)
+            .retry_exponential(NEAR_RETRY_BASE_DELAY_MS, NEAR_GOVERNANCE_MAX_RETRIES)
             .transact()
             .await?
             .into_result()?;
@@ -129,6 +136,7 @@ impl NearClient {
                 "signature": response,
             }))
             .max_gas()
+            .retry_exponential(NEAR_RETRY_BASE_DELAY_MS, NEAR_RESPOND_MAX_RETRIES)
             .transact()
             .await
     }
@@ -155,6 +163,7 @@ impl NearClient {
                 "signature": signature,
             }))
             .max_gas()
+            .retry_exponential(NEAR_RETRY_BASE_DELAY_MS, NEAR_RESPOND_MAX_RETRIES)
             .transact()
             .await
     }

--- a/chain-signatures/node/src/rpc/near.rs
+++ b/chain-signatures/node/src/rpc/near.rs
@@ -14,7 +14,7 @@ use serde_json::json;
 use url::Url;
 
 /// Base delay in milliseconds between NEAR RPC retries
-const NEAR_RETRY_BASE_DELAY_MS: u64 = 10; // TODO: 10 ms could be too small, consider increasing
+const NEAR_RETRY_BASE_DELAY_MS: u64 = 500;
 /// Maximum number of retry attempts for NEAR RPC calls
 const NEAR_RESPOND_MAX_RETRIES: usize = 3;
 /// Maximum number of retry attempts for NEAR governance calls (vote, join)

--- a/chain-signatures/node/src/rpc/near.rs
+++ b/chain-signatures/node/src/rpc/near.rs
@@ -11,8 +11,6 @@ use near_account_id::AccountId;
 use near_crypto::InMemorySigner;
 use near_fetch::result::ExecutionFinalResult;
 use serde_json::json;
-use std::sync::Arc;
-use std::time::Instant;
 use url::Url;
 
 #[derive(Clone)]
@@ -160,13 +158,13 @@ impl NearClient {
             .transact()
             .await
     }
+}
 
-    pub async fn publish_signature(
-        &self,
-        action: &PublishAction,
-        timestamp: &Instant,
-        signature: &Signature,
-    ) -> anyhow::Result<()> {
+#[async_trait::async_trait]
+impl ChainPublisher for NearClient {
+    async fn publish_signature(&self, action: &PublishAction) -> anyhow::Result<()> {
+        let timestamp = action.timestamp;
+        let signature = &action.signature;
         let outcome = match &action.indexed.kind {
             SignKind::Checkpoint(checkpoint) => {
                 self.call_respond_checkpoint(checkpoint, signature).await
@@ -201,21 +199,6 @@ impl NearClient {
             elapsed = ?timestamp.elapsed(),
             "published signature sucessfully",
         );
-        Ok(())
-    }
-}
-
-#[async_trait::async_trait]
-impl ChainPublisher for NearClient {
-    async fn publish_action(&self, action: &PublishAction) -> anyhow::Result<()> {
-        let client = self.clone();
-        let action = action.clone();
-
-        // Spawn a new task to publish the signature asynchronously
-        tokio::spawn(async move {
-            super::execute_publish(Arc::new(client), action).await;
-        });
-
         Ok(())
     }
 }

--- a/chain-signatures/node/src/rpc/near.rs
+++ b/chain-signatures/node/src/rpc/near.rs
@@ -1,4 +1,4 @@
-use super::PublishAction;
+use super::{ChainPublisher, PublishAction};
 use crate::config::NetworkConfig;
 use crate::protocol::Governance;
 use crate::util::AffinePointExt as _;
@@ -11,6 +11,7 @@ use near_account_id::AccountId;
 use near_crypto::InMemorySigner;
 use near_fetch::result::ExecutionFinalResult;
 use serde_json::json;
+use std::sync::Arc;
 use std::time::Instant;
 use url::Url;
 
@@ -165,13 +166,14 @@ impl NearClient {
         action: &PublishAction,
         timestamp: &Instant,
         signature: &Signature,
-    ) -> Result<(), near_fetch::Error> {
+    ) -> anyhow::Result<()> {
         let outcome = match &action.indexed.kind {
             SignKind::Checkpoint(checkpoint) => {
                 self.call_respond_checkpoint(checkpoint, signature).await
             }
             _ => self.call_respond(&action.indexed.id, signature).await,
         }
+        .map_err(|e| anyhow::anyhow!("near rpc error: {e}"))
         .inspect_err(|err| {
             tracing::error!(
                 sign_id = ?action.indexed.id,
@@ -180,15 +182,18 @@ impl NearClient {
             );
         })?;
 
-        let _: () = outcome.json().inspect_err(|err| {
-            tracing::error!(
-                sign_id = ?action.indexed.id,
-                big_r = signature.big_r.to_base58(),
-                s = ?signature.s,
-                ?err,
-                "smart contract threw error",
-            );
-        })?;
+        outcome
+            .json::<()>()
+            .map_err(|e| anyhow::anyhow!("contract rejected response: {e}"))
+            .inspect_err(|err| {
+                tracing::error!(
+                    sign_id = ?action.indexed.id,
+                    big_r = signature.big_r.to_base58(),
+                    s = ?signature.s,
+                    ?err,
+                    "smart contract threw error",
+                );
+            })?;
         tracing::info!(
             sign_id = ?action.indexed.id,
             big_r = signature.big_r.to_base58(),
@@ -196,6 +201,21 @@ impl NearClient {
             elapsed = ?timestamp.elapsed(),
             "published signature sucessfully",
         );
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ChainPublisher for NearClient {
+    async fn publish_action(&self, action: &PublishAction) -> anyhow::Result<()> {
+        let client = self.clone();
+        let action = action.clone();
+
+        // Spawn a new task to publish the signature asynchronously
+        tokio::spawn(async move {
+            super::execute_publish(Arc::new(client), action).await;
+        });
+
         Ok(())
     }
 }

--- a/chain-signatures/node/src/rpc/near.rs
+++ b/chain-signatures/node/src/rpc/near.rs
@@ -14,7 +14,7 @@ use serde_json::json;
 use url::Url;
 
 /// Base delay in milliseconds between NEAR RPC retries
-const NEAR_RETRY_BASE_DELAY_MS: u64 = 10;
+const NEAR_RETRY_BASE_DELAY_MS: u64 = 10; // TODO: 10 ms could be too small, consider increasing
 /// Maximum number of retry attempts for NEAR RPC calls
 const NEAR_RESPOND_MAX_RETRIES: usize = 3;
 /// Maximum number of retry attempts for NEAR governance calls (vote, join)
@@ -201,6 +201,7 @@ impl ChainPublisher for NearClient {
                     "smart contract threw error",
                 );
             })?;
+
         tracing::info!(
             sign_id = ?action.indexed.id,
             big_r = signature.big_r.to_base58(),
@@ -208,6 +209,9 @@ impl ChainPublisher for NearClient {
             elapsed = ?timestamp.elapsed(),
             "published signature sucessfully",
         );
+
+        super::record_publish_metrics(action);
+
         Ok(())
     }
 }

--- a/chain-signatures/node/src/rpc/test_utils.rs
+++ b/chain-signatures/node/src/rpc/test_utils.rs
@@ -1,0 +1,68 @@
+use crate::protocol::{Chain, IndexedSignRequest};
+use cait_sith::FullSignature;
+use k256::{AffinePoint, Secp256k1};
+use mpc_crypto::kdf::derive_secret_key;
+use mpc_primitives::{SignArgs, SignId, SignKind};
+
+use super::PublishAction;
+
+pub fn scalar(bytes: &[u8; 32]) -> k256::Scalar {
+    use k256::elliptic_curve::ops::Reduce;
+    <k256::Scalar as Reduce<<Secp256k1 as k256::elliptic_curve::Curve>::Uint>>::reduce_bytes(
+        bytes.into(),
+    )
+}
+
+pub fn make_signature(
+    sk: &k256::SecretKey,
+    epsilon: k256::Scalar,
+    payload: k256::Scalar,
+) -> FullSignature<Secp256k1> {
+    use k256::elliptic_curve::point::DecompressPoint;
+    let signing_key = k256::ecdsa::SigningKey::from(&derive_secret_key(sk, epsilon));
+    let (ecdsa_sig, _): (k256::ecdsa::Signature, _) =
+        <k256::ecdsa::SigningKey as k256::ecdsa::signature::hazmat::PrehashSigner<_>>::sign_prehash(
+            &signing_key,
+            &payload.to_bytes(),
+        )
+        .expect("signing should succeed");
+    let (r_bytes, _) = ecdsa_sig.split_bytes();
+    let big_r =
+        AffinePoint::decompress(&r_bytes, k256::elliptic_curve::subtle::Choice::from(0)).unwrap();
+    FullSignature {
+        big_r,
+        s: *ecdsa_sig.s().as_ref(),
+    }
+}
+
+pub fn make_indexed(
+    chain: Chain,
+    epsilon: k256::Scalar,
+    payload: k256::Scalar,
+) -> IndexedSignRequest {
+    IndexedSignRequest {
+        id: SignId::new([0u8; 32]),
+        args: SignArgs {
+            entropy: [0u8; 32],
+            epsilon,
+            payload,
+            path: "test".into(),
+            key_version: 0,
+        },
+        chain,
+        unix_timestamp_indexed: 0,
+        kind: SignKind::Sign,
+    }
+}
+
+pub fn make_publish_action(chain: Chain, kind: SignKind) -> PublishAction {
+    let sk = k256::SecretKey::random(&mut rand::thread_rng());
+    let pk: AffinePoint = sk.public_key().into();
+    let epsilon = scalar(&[1u8; 32]);
+    let payload = scalar(&[42u8; 32]);
+    let output = make_signature(&sk, epsilon, payload);
+    let mut indexed = make_indexed(chain, epsilon, payload);
+    indexed.kind = kind;
+    PublishAction::new(pk, indexed, output, vec![])
+        .expect("valid signature should produce a publish action")
+}

--- a/chain-signatures/node/src/rpc/test_utils.rs
+++ b/chain-signatures/node/src/rpc/test_utils.rs
@@ -1,3 +1,5 @@
+#![cfg(test)]
+
 use crate::protocol::{Chain, IndexedSignRequest};
 use cait_sith::FullSignature;
 use k256::{AffinePoint, Secp256k1};
@@ -39,6 +41,7 @@ pub fn make_indexed(
     chain: Chain,
     epsilon: k256::Scalar,
     payload: k256::Scalar,
+    kind: SignKind,
 ) -> IndexedSignRequest {
     IndexedSignRequest {
         id: SignId::new([0u8; 32]),
@@ -51,7 +54,7 @@ pub fn make_indexed(
         },
         chain,
         unix_timestamp_indexed: 0,
-        kind: SignKind::Sign,
+        kind,
     }
 }
 
@@ -61,8 +64,7 @@ pub fn make_publish_action(chain: Chain, kind: SignKind) -> PublishAction {
     let epsilon = scalar(&[1u8; 32]);
     let payload = scalar(&[42u8; 32]);
     let output = make_signature(&sk, epsilon, payload);
-    let mut indexed = make_indexed(chain, epsilon, payload);
-    indexed.kind = kind;
+    let indexed = make_indexed(chain, epsilon, payload, kind);
     PublishAction::new(pk, indexed, output, vec![])
         .expect("valid signature should produce a publish action")
 }


### PR DESCRIPTION
This PR addresses some of the concerns mentioned in #871:
- Introduce `ChainPublisher` trait with `publish_signature` method. `RpcExecutor` is now chain-agnostic. 
- Batching is now encapsulated inside `EthClient` (no other clients need it). Executor does not care about the internal publishing mechanism of each client
- All clients publish methods now return `anyhow::Result<()>`, logging is done using `inspect_err`
- Update retry mechanism: retry infinitely (`usize::MAX`) with a capped exponential backoff (1 min)
- Metrics update is extracted into `record_publish_metrics`, which is now used within each client instead of `execute_publish` free function: Ethereum client updates metrics after batch is published successfully, others after single action was published.
- Add `test_utils` and unit tests for `RpcExecutor`