### PR TITLE
chore: bump checkpoint storage to v12

### DIFF
--- a/chain-signatures/node/src/storage/checkpoint_storage.rs
+++ b/chain-signatures/node/src/storage/checkpoint_storage.rs
@@ -10,7 +10,7 @@ use tokio::sync::RwLock;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-const CHECKPOINT_VERSION: &str = "v11";
+const CHECKPOINT_VERSION: &str = "v12";
 
 #[derive(Clone, Debug)]
 pub enum CheckpointStorage {


### PR DESCRIPTION
bump storage to v12 for checkpoints such that we clear the previous out of sync checkpoint