### PR TITLE
feat: add Ethereum as a SignBidirectional source chain

### DIFF
--- a/chain-signatures/chain-integration-core/src/utils/hashing.rs
+++ b/chain-signatures/chain-integration-core/src/utils/hashing.rs
@@ -28,6 +28,39 @@ pub fn compute_request_id(
     keccak256(&encoded).0
 }
 
+/// Computes the request id for the `signBidirectional` flow, shared by every
+/// source chain that mirrors the Solana program's packed scheme:
+/// keccak256(abi.encodePacked(sender, serializedTransaction, caip2Id, keyVersion, path, algo, dest, params)).
+///
+/// `sender_bytes` is the chain's canonical sender representation packed as raw
+/// bytes: the 20-byte address on EVM chains, the base58 pubkey string on
+/// Solana, the ss58 address string on Hydration.
+#[allow(clippy::too_many_arguments)]
+pub fn compute_bidirectional_request_id(
+    sender_bytes: &[u8],
+    serialized_transaction: &[u8],
+    caip2_id: &str,
+    key_version: u32,
+    path: &str,
+    algo: &str,
+    dest: &str,
+    params: &str,
+) -> [u8; 32] {
+    let encoded = (
+        sender_bytes.to_vec(),
+        serialized_transaction.to_vec(),
+        caip2_id,
+        key_version,
+        path,
+        algo,
+        dest,
+        params,
+    )
+        .abi_encode_packed();
+
+    keccak256(&encoded).0
+}
+
 /// Computes the Keccak256 hash of the given payload.
 pub fn hash_payload(data: &[u8]) -> [u8; 32] {
     keccak256(data).0
@@ -167,6 +200,66 @@ mod tests {
         // u32::MAX should not panic
         let id = compute_request_id(sender, &payload, path, u32::MAX, chain, algo, dest, params);
         assert_eq!(id.len(), 32);
+    }
+
+    /// Golden arguments matching signet-evm-program's `generateBidirectionalRequestId`
+    /// fixture (viem): 20-byte EVM sender address + the shared field set.
+    fn bidirectional_golden_args() -> ([u8; 20], Vec<u8>) {
+        (
+            [
+                0xf3, 0x9f, 0xd6, 0xe5, 0x1a, 0xad, 0x88, 0xf6, 0xf4, 0xce, 0x6a, 0xb8, 0x82, 0x72,
+                0x79, 0xcf, 0xff, 0xb9, 0x22, 0x66,
+            ],
+            vec![0x02, 0xde, 0xad, 0xbe, 0xef, 0x01],
+        )
+    }
+
+    #[test]
+    fn compute_bidirectional_request_id_matches_signet_evm_program_golden() {
+        let (sender, tx) = bidirectional_golden_args();
+        // Golden from signet-evm-program's generateBidirectionalRequestId (viem).
+        let expected: [u8; 32] = [
+            0x10, 0x78, 0x2c, 0xf9, 0x6b, 0xc2, 0xf9, 0x33, 0xdb, 0xd8, 0xa5, 0xfd, 0xa4, 0x9d,
+            0x31, 0xbf, 0x5a, 0x6b, 0x50, 0x02, 0x7e, 0xba, 0x1a, 0xa9, 0xa1, 0x15, 0x65, 0x0c,
+            0xc2, 0x61, 0xd4, 0x98,
+        ];
+        let id = compute_bidirectional_request_id(
+            &sender,
+            &tx,
+            "eip155:1",
+            1,
+            "test-bidirectional-path",
+            "secp256k1",
+            "ethereum",
+            "{}",
+        );
+        assert_eq!(id, expected);
+    }
+
+    #[test]
+    fn compute_bidirectional_request_id_differs_by_sender() {
+        let (sender, tx) = bidirectional_golden_args();
+        let id1 = compute_bidirectional_request_id(
+            &sender,
+            &tx,
+            "eip155:1",
+            1,
+            "path",
+            "secp256k1",
+            "ethereum",
+            "{}",
+        );
+        let id2 = compute_bidirectional_request_id(
+            b"other-sender",
+            &tx,
+            "eip155:1",
+            1,
+            "path",
+            "secp256k1",
+            "ethereum",
+            "{}",
+        );
+        assert_ne!(id1, id2);
     }
 
     #[test]

--- a/chain-signatures/node/src/indexer_eth/abi.rs
+++ b/chain-signatures/node/src/indexer_eth/abi.rs
@@ -59,6 +59,47 @@ alloy::sol! {
             address responder,
             string error
         );
+
+        struct SignBidirectionalRequest {
+            bytes serializedTransaction;
+            string caip2Id;
+            uint32 keyVersion;
+            string path;
+            string algo;
+            string dest;
+            string params;
+            bytes outputDeserializationSchema;
+            bytes respondSerializationSchema;
+        }
+
+        function signBidirectional(SignBidirectionalRequest memory _request) external payable;
+        function respondBidirectional(
+            bytes32 _requestId,
+            bytes calldata _serializedOutput,
+            Signature calldata _signature
+        ) external;
+
+        event SignBidirectional(
+            address sender,
+            bytes serializedTransaction,
+            string caip2Id,
+            uint32 keyVersion,
+            uint256 deposit,
+            uint256 chainId,
+            string path,
+            string algo,
+            string dest,
+            string params,
+            bytes outputDeserializationSchema,
+            bytes respondSerializationSchema
+        );
+
+        event RespondBidirectional(
+            bytes32 indexed requestId,
+            address responder,
+            bytes serializedOutput,
+            Signature signature
+        );
     }
 
     event SignatureRequestedEncoding(
@@ -75,5 +116,26 @@ alloy::sol! {
     struct ChainSignaturesConstructor {
         address mpcNetwork;
         uint256 signatureDeposit;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ChainSignatures;
+    use alloy::primitives::b256;
+    use alloy::sol_types::SolEvent;
+
+    #[test]
+    fn bidirectional_event_topics_match_contract() {
+        // keccak256("SignBidirectional(address,bytes,string,uint32,uint256,uint256,string,string,string,string,bytes,bytes)")
+        assert_eq!(
+            ChainSignatures::SignBidirectional::SIGNATURE_HASH,
+            b256!("27f9d88f0144f82d39d07d3e314ac47018991ad27af3fb62129dd7cd725846e8"),
+        );
+        // keccak256("RespondBidirectional(bytes32,address,bytes,((uint256,uint256),uint256,uint8))")
+        assert_eq!(
+            ChainSignatures::RespondBidirectional::SIGNATURE_HASH,
+            b256!("23a9a92895272f15b4a10136e9902bae33c369c40c448b2d184f9a06e33fc3df"),
+        );
     }
 }

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -13,7 +13,7 @@ use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::hex::{self, ToHexExt};
 use alloy::primitives::{Address, Bytes, U256};
 use alloy::rpc::types::{Block, BlockId, Log};
-use alloy::sol_types::SolEvent;
+use alloy::sol_types::{SolEvent, SolValue};
 use anyhow::Context as _;
 use async_trait::async_trait;
 pub use client::EthereumClient;
@@ -22,7 +22,9 @@ use futures_util::stream;
 use k256::elliptic_curve::sec1::FromEncodedPoint;
 use k256::{AffinePoint as K256AffinePoint, EncodedPoint, FieldBytes, Scalar};
 use mpc_chain_integration_core::utils::stream::chain_event_channel;
-use mpc_chain_integration_core::{ChainIndexer, ChainStream, ChainTelemetry, StateManager};
+use mpc_chain_integration_core::{
+    utils::hashing::hash_payload, ChainIndexer, ChainStream, ChainTelemetry, StateManager,
+};
 use mpc_crypto::{kdf::derive_epsilon_eth, ScalarExt as _};
 use mpc_primitives::{
     BidirectionalTx, BidirectionalTxId, Chain, ChainEvent, ExecutionOutcome, IndexedSignRequest,
@@ -106,6 +108,7 @@ pub struct BlockAndRequests {
     block_hash: alloy::primitives::B256,
     indexed_requests: Vec<IndexedSignRequest>,
     respond_logs: Vec<Log>,
+    respond_bidirectional_logs: Vec<Log>,
     execution_events: Vec<ChainEvent>,
 }
 
@@ -115,6 +118,7 @@ impl BlockAndRequests {
         block_hash: alloy::primitives::B256,
         indexed_requests: Vec<IndexedSignRequest>,
         respond_logs: Vec<Log>,
+        respond_bidirectional_logs: Vec<Log>,
         execution_events: Vec<ChainEvent>,
     ) -> Self {
         Self {
@@ -122,6 +126,7 @@ impl BlockAndRequests {
             block_hash,
             indexed_requests,
             respond_logs,
+            respond_bidirectional_logs,
             execution_events,
         }
     }
@@ -268,6 +273,107 @@ fn parse_filtered_logs(logs: Vec<Log>) -> Vec<IndexedSignRequest> {
     indexed_requests
 }
 
+fn sign_bidirectional_request_from_filtered_log(log: Log) -> Option<IndexedSignRequest> {
+    let event = match ChainSignatures::SignBidirectional::decode_log(&log.inner) {
+        Ok(event) => event.data,
+        Err(err) => {
+            tracing::warn!(?err, "failed to decode SignBidirectional event");
+            return None;
+        }
+    };
+    tracing::debug!("found eth bidirectional event: {:?}", event.caip2Id);
+
+    let sign_id = SignId::new(generate_bidirectional_request_id(&event));
+
+    if event.deposit == U256::ZERO {
+        tracing::warn!(?sign_id, "deposit is 0, skipping sign request");
+        return None;
+    }
+
+    if event.keyVersion > LATEST_MPC_KEY_VERSION {
+        tracing::warn!(?sign_id, "unsupported key version: {}", event.keyVersion);
+        return None;
+    }
+
+    // caip2_id is the mainnet CAIP-2 chain id of the target chain. Skip the
+    // event if it is invalid since it cannot be handled downstream anyway.
+    if let Err(err) = Chain::from_caip2_chain_id(&event.caip2Id) {
+        tracing::warn!(
+            ?sign_id,
+            "invalid caip2 chain id in sign bidirectional event: {err:?}"
+        );
+        return None;
+    }
+
+    let unsigned_tx_hash = hash_payload(&event.serializedTransaction);
+    let Some(payload) = Scalar::from_bytes(unsigned_tx_hash) else {
+        tracing::warn!(
+            ?sign_id,
+            "eth `signBidirectional` did not produce payload hash correctly: {unsigned_tx_hash:?}"
+        );
+        return None;
+    };
+
+    if payload > *MAX_SECP256K1_SCALAR {
+        tracing::warn!(?sign_id, ?payload, "payload exceeds secp256k1 curve order");
+        return None;
+    }
+
+    let epsilon = derive_epsilon_eth(
+        event.keyVersion,
+        format!("0x{}", event.sender.encode_hex()).as_str(),
+        &event.path,
+    );
+
+    // Store the sender as its ABI word: 12 zero bytes then the 20-byte address.
+    let mut sender = [0u8; 32];
+    sender[12..].copy_from_slice(event.sender.as_slice());
+
+    // Use transaction hash as entropy
+    let entropy = log.transaction_hash.unwrap_or_default();
+
+    tracing::info!(?sign_id, "eth bidirectional signature requested");
+
+    Some(IndexedSignRequest::sign_bidirectional(
+        sign_id,
+        SignArgs {
+            entropy: entropy.into(),
+            epsilon,
+            payload,
+            path: event.path.clone(),
+            key_version: event.keyVersion,
+        },
+        Chain::Ethereum,
+        crate::util::current_unix_timestamp(),
+        mpc_primitives::SignBidirectionalEvent {
+            sender,
+            serialized_transaction: event.serializedTransaction.to_vec(),
+            caip2_id: event.caip2Id,
+            key_version: event.keyVersion,
+            deposit: event.deposit.saturating_to::<u64>(),
+            path: event.path,
+            algo: event.algo,
+            dest: event.dest,
+            params: event.params,
+            output_deserialization_schema: event.outputDeserializationSchema.to_vec(),
+            respond_serialization_schema: event.respondSerializationSchema.to_vec(),
+            chain: Chain::Ethereum,
+            chain_ctx: None,
+        },
+    ))
+}
+
+fn parse_bidirectional_filtered_logs(logs: Vec<Log>) -> Vec<IndexedSignRequest> {
+    let mut indexed_requests = Vec::new();
+    for log in logs {
+        match sign_bidirectional_request_from_filtered_log(log.clone()) {
+            Some(request) => indexed_requests.push(request),
+            None => tracing::warn!("Failed to parse Ethereum SignBidirectional log: {:?}", log),
+        }
+    }
+    indexed_requests
+}
+
 async fn emit_respond_events(logs: &[Log], events_tx: mpsc::Sender<ChainEvent>) {
     for log in logs {
         let Some(sign_id) = sign_id_from_signature_responded_log(log) else {
@@ -331,6 +437,62 @@ fn sign_id_from_signature_responded_log(log: &Log) -> Option<SignId> {
     Some(SignId { request_id })
 }
 
+/// Decode a `RespondBidirectional` contract log into the primitives event.
+fn respond_bidirectional_event_from_log(
+    log: &Log,
+) -> Option<mpc_primitives::RespondBidirectionalEvent> {
+    let decoded = match ChainSignatures::RespondBidirectional::decode_log(&log.inner) {
+        Ok(decoded) => decoded.data,
+        Err(err) => {
+            tracing::warn!(?err, "failed to decode RespondBidirectional event");
+            return None;
+        }
+    };
+    let sign_id = SignId::new(decoded.requestId.into());
+
+    let Some(signature) = mpc_signature_from_abi(&decoded.signature) else {
+        tracing::warn!(
+            ?sign_id,
+            "ethereum respond bidirectional event, invalid signature"
+        );
+        return None;
+    };
+
+    Some(mpc_primitives::RespondBidirectionalEvent {
+        request_id: sign_id.request_id,
+        signature,
+        chain: Chain::Ethereum,
+    })
+}
+
+/// Convert the contract's ABI signature struct into the MPC signature type.
+fn mpc_signature_from_abi(signature: &ChainSignatures::Signature) -> Option<MpcSignature> {
+    let x_bytes: [u8; 32] = signature.bigR.x.to_be_bytes();
+    let y_bytes: [u8; 32] = signature.bigR.y.to_be_bytes();
+    let x_field = FieldBytes::from_slice(&x_bytes);
+    let y_field = FieldBytes::from_slice(&y_bytes);
+    let encoded_r = EncodedPoint::from_affine_coordinates(x_field, y_field, false);
+    let big_r = K256AffinePoint::from_encoded_point(&encoded_r).into_option()?;
+    let s = Scalar::from_bytes(signature.s.to_be_bytes())?;
+    Some(MpcSignature::new(big_r, s, signature.recoveryId))
+}
+
+async fn emit_respond_bidirectional_events(logs: &[Log], events_tx: mpsc::Sender<ChainEvent>) {
+    for log in logs {
+        let Some(respond_event) = respond_bidirectional_event_from_log(log) else {
+            continue;
+        };
+        let sign_id = SignId::new(respond_event.request_id);
+        tracing::info!(?sign_id, "emitting RespondBidirectional event");
+        if let Err(err) = events_tx
+            .send(ChainEvent::RespondBidirectional(respond_event))
+            .await
+        {
+            tracing::error!(?err, "failed to emit RespondBidirectional event");
+        }
+    }
+}
+
 #[derive(Debug)]
 struct SignatureRequestedEvent {
     requester: Address,
@@ -363,6 +525,25 @@ impl SignatureRequestedEvent {
         let abi_encoded = self.encode_abi();
         alloy::primitives::keccak256(abi_encoded).into()
     }
+}
+
+/// Request id for the `signBidirectional` flow, mirroring the Solana program's
+/// packed scheme with the EVM address as the sender:
+/// keccak256(abi.encodePacked(sender, serializedTransaction, caip2Id, keyVersion, path, algo, dest, params))
+fn generate_bidirectional_request_id(event: &ChainSignatures::SignBidirectional) -> [u8; 32] {
+    let encoded = (
+        event.sender,
+        event.serializedTransaction.clone(),
+        event.caip2Id.clone(),
+        event.keyVersion,
+        event.path.clone(),
+        event.algo.clone(),
+        event.dest.clone(),
+        event.params.clone(),
+    )
+        .abi_encode_packed();
+
+    alloy::primitives::keccak256(encoded).into()
 }
 
 pub struct EthereumIndexer<S: StateManager, T: ChainTelemetry> {
@@ -514,10 +695,24 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             })
             .collect();
 
-        let (respond_logs, potential_request_logs): (Vec<Log>, Vec<Log>) =
+        let (respond_logs, rest): (Vec<Log>, Vec<Log>) =
             relevant_logs.into_iter().partition(|log| {
                 log.topic0().is_some_and(|topic| {
                     *topic == ChainSignatures::SignatureResponded::SIGNATURE_HASH
+                })
+            });
+
+        let (respond_bidirectional_logs, rest): (Vec<Log>, Vec<Log>) =
+            rest.into_iter().partition(|log| {
+                log.topic0().is_some_and(|topic| {
+                    *topic == ChainSignatures::RespondBidirectional::SIGNATURE_HASH
+                })
+            });
+
+        let (bidirectional_request_logs, potential_request_logs): (Vec<Log>, Vec<Log>) =
+            rest.into_iter().partition(|log| {
+                log.topic0().is_some_and(|topic| {
+                    *topic == ChainSignatures::SignBidirectional::SIGNATURE_HASH
                 })
             });
 
@@ -534,6 +729,12 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             sign_requests.extend(parse_filtered_logs(request_logs));
         }
 
+        if !bidirectional_request_logs.is_empty() {
+            sign_requests.extend(parse_bidirectional_filtered_logs(
+                bidirectional_request_logs,
+            ));
+        }
+
         // Collect execution confirmations (if any) and emit ExecutionConfirmed events
         let exec_events = self
             .collect_execution_confirmations(block_number, block_receipts)
@@ -546,6 +747,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             block_hash,
             sign_requests,
             respond_logs,
+            respond_bidirectional_logs,
             exec_events,
         ))
     }
@@ -833,6 +1035,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             block_hash,
             indexed_requests,
             respond_logs,
+            respond_bidirectional_logs,
             execution_events,
         }: BlockAndRequests,
     ) -> anyhow::Result<()> {
@@ -876,6 +1079,11 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
 
         if !respond_logs.is_empty() {
             emit_respond_events(&respond_logs, self.events_tx.clone()).await;
+        }
+
+        if !respond_bidirectional_logs.is_empty() {
+            emit_respond_bidirectional_events(&respond_bidirectional_logs, self.events_tx.clone())
+                .await;
         }
 
         self.events_tx
@@ -1090,7 +1298,7 @@ mod tests {
     #[cfg(feature = "helios")]
     use crate::indexer_eth::indexer_eth_helios;
     use alloy::eips::BlockNumberOrTag;
-    use alloy::primitives::{address, b256, Address};
+    use alloy::primitives::{address, b256, hex, Address};
     use alloy::rpc::types::BlockId;
     use mockito::{Matcher, Server};
     use mpc_chain_integration_core::{ChainIndexer, NoopChainTelemetry};
@@ -1589,5 +1797,179 @@ mod tests {
         assert!(is_contract_call(&Bytes::from(vec![
             0xa9, 0x05, 0x9c, 0xbb, 0x00
         ])));
+    }
+
+    fn golden_sign_bidirectional_event() -> super::abi::ChainSignatures::SignBidirectional {
+        use alloy::primitives::{bytes, U256};
+        super::abi::ChainSignatures::SignBidirectional {
+            sender: address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+            serializedTransaction: bytes!("02deadbeef01"),
+            caip2Id: "eip155:1".to_string(),
+            keyVersion: 1,
+            deposit: U256::from(1u64),
+            chainId: U256::from(31337u64),
+            path: "test-bidirectional-path".to_string(),
+            algo: "secp256k1".to_string(),
+            dest: "ethereum".to_string(),
+            params: "{}".to_string(),
+            outputDeserializationSchema: alloy::primitives::Bytes::from_static(
+                br#"[{"name":"output","type":"bool"}]"#,
+            ),
+            respondSerializationSchema: alloy::primitives::Bytes::from_static(
+                br#"[{"name":"output","type":"bool"}]"#,
+            ),
+        }
+    }
+
+    #[test]
+    fn bidirectional_request_id_matches_signet_evm_program_golden() {
+        // Golden from signet-evm-program's generateBidirectionalRequestId (viem).
+        let event = golden_sign_bidirectional_event();
+        assert_eq!(
+            super::generate_bidirectional_request_id(&event),
+            b256!("10782cf96bc2f933dbd8a5fda49d31bf5a6b50027eba1aa9a115650cc261d498").0,
+        );
+    }
+
+    fn rpc_log_from_sign_bidirectional(
+        event: &super::abi::ChainSignatures::SignBidirectional,
+        tx_hash: alloy::primitives::B256,
+    ) -> alloy::rpc::types::Log {
+        use alloy::sol_types::SolEvent as _;
+        alloy::rpc::types::Log {
+            inner: alloy::primitives::Log {
+                address: Address::ZERO,
+                data: event.encode_log_data(),
+            },
+            transaction_hash: Some(tx_hash),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn decodes_sign_bidirectional_log_into_indexed_request() {
+        let event = golden_sign_bidirectional_event();
+        let tx_hash = b256!("00000000000000000000000000000000000000000000000000000000000000aa");
+        let log = rpc_log_from_sign_bidirectional(&event, tx_hash);
+
+        let request = super::sign_bidirectional_request_from_filtered_log(log)
+            .expect("valid SignBidirectional log must decode");
+
+        // Request id golden from signet-evm-program (viem encodePacked).
+        assert_eq!(
+            request.id.request_id,
+            b256!("10782cf96bc2f933dbd8a5fda49d31bf5a6b50027eba1aa9a115650cc261d498").0
+        );
+        assert_eq!(request.chain, Chain::Ethereum);
+        assert_eq!(request.args.path, "test-bidirectional-path");
+        assert_eq!(request.args.key_version, 1);
+        assert_eq!(request.args.entropy, tx_hash.0);
+
+        // Payload golden: keccak256(0x02deadbeef01).
+        let expected_payload =
+            b256!("851f5c635201a456296e1f11b98bff2542d846afae32795cb4c64c6891d2980c");
+        assert_eq!(
+            request.args.payload.to_bytes().as_slice(),
+            expected_payload.as_slice()
+        );
+
+        let expected_epsilon = mpc_crypto::kdf::derive_epsilon_eth(
+            1,
+            "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            "test-bidirectional-path",
+        );
+        assert_eq!(request.args.epsilon, expected_epsilon);
+
+        let mpc_primitives::SignKind::SignBidirectional(inner) = request.kind else {
+            panic!("expected SignBidirectional kind");
+        };
+        assert_eq!(inner.chain, Chain::Ethereum);
+        assert_eq!(inner.chain_ctx, None);
+        assert_eq!(inner.sender[..12], [0u8; 12]);
+        assert_eq!(
+            inner.sender[12..],
+            address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266").into_array()
+        );
+        assert_eq!(
+            inner.serialized_transaction,
+            hex::decode("02deadbeef01").unwrap()
+        );
+        assert_eq!(inner.caip2_id, "eip155:1");
+        assert_eq!(inner.deposit, 1);
+        assert_eq!(
+            inner.respond_serialization_schema,
+            br#"[{"name":"output","type":"bool"}]"#.to_vec()
+        );
+    }
+
+    #[test]
+    fn skips_sign_bidirectional_with_zero_deposit() {
+        let mut event = golden_sign_bidirectional_event();
+        event.deposit = alloy::primitives::U256::ZERO;
+        let log = rpc_log_from_sign_bidirectional(&event, alloy::primitives::B256::ZERO);
+        assert!(super::sign_bidirectional_request_from_filtered_log(log).is_none());
+    }
+
+    #[test]
+    fn skips_sign_bidirectional_with_unsupported_key_version() {
+        let mut event = golden_sign_bidirectional_event();
+        event.keyVersion = LATEST_MPC_KEY_VERSION + 1;
+        let log = rpc_log_from_sign_bidirectional(&event, alloy::primitives::B256::ZERO);
+        assert!(super::sign_bidirectional_request_from_filtered_log(log).is_none());
+    }
+
+    #[test]
+    fn skips_sign_bidirectional_with_invalid_caip2() {
+        let mut event = golden_sign_bidirectional_event();
+        event.caip2Id = "not-a-chain".to_string();
+        let log = rpc_log_from_sign_bidirectional(&event, alloy::primitives::B256::ZERO);
+        assert!(super::sign_bidirectional_request_from_filtered_log(log).is_none());
+    }
+
+    #[test]
+    fn decodes_respond_bidirectional_log_into_event() {
+        use alloy::primitives::hex as alloy_hex;
+        use k256::elliptic_curve::point::AffineCoordinates as _;
+
+        let topics = vec![
+            b256!("23a9a92895272f15b4a10136e9902bae33c369c40c448b2d184f9a06e33fc3df"),
+            b256!("10782cf96bc2f933dbd8a5fda49d31bf5a6b50027eba1aa9a115650cc261d498"),
+        ];
+        let data = alloy_hex::decode(
+            "000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb9226\
+             600000000000000000000000000000000000000000000000000000000000000c0\
+             79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798\
+             483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8\
+             000000000000000000000000000000000000000000000000000000000000002a\
+             0000000000000000000000000000000000000000000000000000000000000001\
+             0000000000000000000000000000000000000000000000000000000000000020\
+             0000000000000000000000000000000000000000000000000000000000000001",
+        )
+        .unwrap();
+
+        let log = alloy::rpc::types::Log {
+            inner: alloy::primitives::Log::new(Address::ZERO, topics, data.into())
+                .expect("valid log"),
+            ..Default::default()
+        };
+
+        let event = super::respond_bidirectional_event_from_log(&log)
+            .expect("valid RespondBidirectional log must decode");
+
+        assert_eq!(
+            event.request_id,
+            b256!("10782cf96bc2f933dbd8a5fda49d31bf5a6b50027eba1aa9a115650cc261d498").0
+        );
+        assert_eq!(event.chain, Chain::Ethereum);
+        assert_eq!(event.signature.big_r, k256::AffinePoint::GENERATOR);
+        assert_eq!(event.signature.s, k256::Scalar::from(42u64));
+        assert_eq!(event.signature.recovery_id, 1);
+        // sanity: generator x-coordinate round-trips
+        assert_eq!(
+            event.signature.big_r.x().as_slice(),
+            alloy_hex::decode("79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
+                .unwrap()
+                .as_slice()
+        );
     }
 }

--- a/chain-signatures/node/src/indexer_eth/mod.rs
+++ b/chain-signatures/node/src/indexer_eth/mod.rs
@@ -13,7 +13,7 @@ use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::hex::{self, ToHexExt};
 use alloy::primitives::{Address, Bytes, U256};
 use alloy::rpc::types::{Block, BlockId, Log};
-use alloy::sol_types::{SolEvent, SolValue};
+use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use async_trait::async_trait;
 pub use client::EthereumClient;
@@ -23,7 +23,8 @@ use k256::elliptic_curve::sec1::FromEncodedPoint;
 use k256::{AffinePoint as K256AffinePoint, EncodedPoint, FieldBytes, Scalar};
 use mpc_chain_integration_core::utils::stream::chain_event_channel;
 use mpc_chain_integration_core::{
-    utils::hashing::hash_payload, ChainIndexer, ChainStream, ChainTelemetry, StateManager,
+    utils::hashing::{compute_bidirectional_request_id, hash_payload},
+    ChainIndexer, ChainStream, ChainTelemetry, StateManager,
 };
 use mpc_crypto::{kdf::derive_epsilon_eth, ScalarExt as _};
 use mpc_primitives::{
@@ -283,12 +284,33 @@ fn sign_bidirectional_request_from_filtered_log(log: Log) -> Option<IndexedSignR
     };
     tracing::debug!("found eth bidirectional event: {:?}", event.caip2Id);
 
-    let sign_id = SignId::new(generate_bidirectional_request_id(&event));
+    let sign_id = SignId::new(compute_bidirectional_request_id(
+        event.sender.as_slice(),
+        &event.serializedTransaction,
+        &event.caip2Id,
+        event.keyVersion,
+        &event.path,
+        &event.algo,
+        &event.dest,
+        &event.params,
+    ));
 
     if event.deposit == U256::ZERO {
         tracing::warn!(?sign_id, "deposit is 0, skipping sign request");
         return None;
     }
+
+    // The shared event stores the deposit as u64; skip larger values instead
+    // of silently misrecording them (Hydration rejects oversized deposits the
+    // same way).
+    let Ok(deposit) = u64::try_from(event.deposit) else {
+        tracing::warn!(
+            ?sign_id,
+            deposit = %event.deposit,
+            "deposit exceeds u64::MAX, skipping sign request"
+        );
+        return None;
+    };
 
     if event.keyVersion > LATEST_MPC_KEY_VERSION {
         tracing::warn!(?sign_id, "unsupported key version: {}", event.keyVersion);
@@ -350,7 +372,7 @@ fn sign_bidirectional_request_from_filtered_log(log: Log) -> Option<IndexedSignR
             serialized_transaction: event.serializedTransaction.to_vec(),
             caip2_id: event.caip2Id,
             key_version: event.keyVersion,
-            deposit: event.deposit.saturating_to::<u64>(),
+            deposit,
             path: event.path,
             algo: event.algo,
             dest: event.dest,
@@ -527,25 +549,6 @@ impl SignatureRequestedEvent {
     }
 }
 
-/// Request id for the `signBidirectional` flow, mirroring the Solana program's
-/// packed scheme with the EVM address as the sender:
-/// keccak256(abi.encodePacked(sender, serializedTransaction, caip2Id, keyVersion, path, algo, dest, params))
-fn generate_bidirectional_request_id(event: &ChainSignatures::SignBidirectional) -> [u8; 32] {
-    let encoded = (
-        event.sender,
-        event.serializedTransaction.clone(),
-        event.caip2Id.clone(),
-        event.keyVersion,
-        event.path.clone(),
-        event.algo.clone(),
-        event.dest.clone(),
-        event.params.clone(),
-    )
-        .abi_encode_packed();
-
-    alloy::primitives::keccak256(encoded).into()
-}
-
 pub struct EthereumIndexer<S: StateManager, T: ChainTelemetry> {
     eth: EthConfig,
     state_manager: S,
@@ -695,35 +698,24 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             })
             .collect();
 
-        let (respond_logs, rest): (Vec<Log>, Vec<Log>) =
-            relevant_logs.into_iter().partition(|log| {
-                log.topic0().is_some_and(|topic| {
-                    *topic == ChainSignatures::SignatureResponded::SIGNATURE_HASH
-                })
-            });
-
-        let (respond_bidirectional_logs, rest): (Vec<Log>, Vec<Log>) =
-            rest.into_iter().partition(|log| {
-                log.topic0().is_some_and(|topic| {
-                    *topic == ChainSignatures::RespondBidirectional::SIGNATURE_HASH
-                })
-            });
-
-        let (bidirectional_request_logs, potential_request_logs): (Vec<Log>, Vec<Log>) =
-            rest.into_iter().partition(|log| {
-                log.topic0().is_some_and(|topic| {
-                    *topic == ChainSignatures::SignBidirectional::SIGNATURE_HASH
-                })
-            });
-
-        let request_logs: Vec<Log> = potential_request_logs
-            .into_iter()
-            .filter(|log| {
-                log.topic0().is_some_and(|topic| {
-                    *topic == ChainSignatures::SignatureRequested::SIGNATURE_HASH
-                })
-            })
-            .collect();
+        let mut respond_logs = Vec::new();
+        let mut respond_bidirectional_logs = Vec::new();
+        let mut bidirectional_request_logs = Vec::new();
+        let mut request_logs = Vec::new();
+        for log in relevant_logs {
+            let Some(topic) = log.topic0().copied() else {
+                continue;
+            };
+            if topic == ChainSignatures::SignatureResponded::SIGNATURE_HASH {
+                respond_logs.push(log);
+            } else if topic == ChainSignatures::RespondBidirectional::SIGNATURE_HASH {
+                respond_bidirectional_logs.push(log);
+            } else if topic == ChainSignatures::SignBidirectional::SIGNATURE_HASH {
+                bidirectional_request_logs.push(log);
+            } else if topic == ChainSignatures::SignatureRequested::SIGNATURE_HASH {
+                request_logs.push(log);
+            }
+        }
 
         if !request_logs.is_empty() {
             sign_requests.extend(parse_filtered_logs(request_logs));
@@ -1821,16 +1813,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn bidirectional_request_id_matches_signet_evm_program_golden() {
-        // Golden from signet-evm-program's generateBidirectionalRequestId (viem).
-        let event = golden_sign_bidirectional_event();
-        assert_eq!(
-            super::generate_bidirectional_request_id(&event),
-            b256!("10782cf96bc2f933dbd8a5fda49d31bf5a6b50027eba1aa9a115650cc261d498").0,
-        );
-    }
-
     fn rpc_log_from_sign_bidirectional(
         event: &super::abi::ChainSignatures::SignBidirectional,
         tx_hash: alloy::primitives::B256,
@@ -1922,6 +1904,14 @@ mod tests {
     fn skips_sign_bidirectional_with_invalid_caip2() {
         let mut event = golden_sign_bidirectional_event();
         event.caip2Id = "not-a-chain".to_string();
+        let log = rpc_log_from_sign_bidirectional(&event, alloy::primitives::B256::ZERO);
+        assert!(super::sign_bidirectional_request_from_filtered_log(log).is_none());
+    }
+
+    #[test]
+    fn skips_sign_bidirectional_with_deposit_above_u64() {
+        let mut event = golden_sign_bidirectional_event();
+        event.deposit = alloy::primitives::U256::from(u64::MAX) + alloy::primitives::U256::from(1);
         let log = rpc_log_from_sign_bidirectional(&event, alloy::primitives::B256::ZERO);
         assert!(super::sign_bidirectional_request_from_filtered_log(log).is_none());
     }

--- a/chain-signatures/node/src/respond_bidirectional.rs
+++ b/chain-signatures/node/src/respond_bidirectional.rs
@@ -11,6 +11,7 @@ const MAGIC_ERROR_PREFIX: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
 const SOLANA_RESPOND_BIDIRECTIONAL_PATH: &str = "solana response key";
 const HYDRATION_RESPOND_BIDIRECTIONAL_PATH: &str = "hydration response key";
 pub const CANTON_RESPOND_BIDIRECTIONAL_PATH: &str = "canton response key";
+pub const ETHEREUM_RESPOND_BIDIRECTIONAL_PATH: &str = "ethereum response key";
 // Use Abi as this is what we are using for ethereum
 pub(crate) const OUTPUT_DESERIALIZATION_FORMAT: SerDeserFormat = SerDeserFormat::Abi;
 
@@ -94,6 +95,7 @@ impl CompletedTx {
             Chain::Solana => SOLANA_RESPOND_BIDIRECTIONAL_PATH.to_string(),
             Chain::Hydration => HYDRATION_RESPOND_BIDIRECTIONAL_PATH.to_string(),
             Chain::Canton => CANTON_RESPOND_BIDIRECTIONAL_PATH.to_string(),
+            Chain::Ethereum => ETHEREUM_RESPOND_BIDIRECTIONAL_PATH.to_string(),
             _ => anyhow::bail!("Unsupported chain: {}", chain),
         };
         let epsilon = self.tx.epsilon(&path)?;
@@ -261,6 +263,34 @@ mod tests {
         let SignKind::RespondBidirectional(respond) = abi.kind else {
             panic!("expected RespondBidirectional kind");
         };
+        let mut expected = MAGIC_ERROR_PREFIX.to_vec();
+        expected.extend_from_slice(&[0u8; 32]);
+        *expected.last_mut().unwrap() = 1;
+        assert_eq!(respond.output, expected);
+    }
+
+    #[tokio::test]
+    async fn create_failed_sign_request_ethereum_uses_abi_and_response_path() {
+        let mut tx = sample_bidirectional_tx();
+        tx.source_chain = Chain::Ethereum;
+        let mut sender = [0u8; 32];
+        sender[12..].copy_from_slice(
+            alloy::primitives::address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266").as_slice(),
+        );
+        tx.sender = sender;
+        let completed = CompletedTx::new(tx);
+
+        let request = completed
+            .create_failed_sign_request(Chain::Ethereum, None)
+            .await
+            .unwrap();
+
+        assert_eq!(request.args.path, ETHEREUM_RESPOND_BIDIRECTIONAL_PATH);
+        assert_eq!(request.chain, Chain::Ethereum);
+        let SignKind::RespondBidirectional(respond) = request.kind else {
+            panic!("expected RespondBidirectional kind");
+        };
+        // ABI failure encoding: 0xdeadbeef ++ 32-byte ABI bool true.
         let mut expected = MAGIC_ERROR_PREFIX.to_vec();
         expected.extend_from_slice(&[0u8; 32]);
         *expected.last_mut().unwrap() = 1;

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -1,5 +1,6 @@
 use crate::indexer_eth::abi::ChainSignatures;
 use crate::indexer_eth::EthConfig;
+use alloy::contract::RawCallBuilder;
 use alloy::network::EthereumWallet;
 use alloy::primitives::{Address, B256, U256};
 use alloy::providers::{
@@ -220,11 +221,13 @@ impl EthClient {
         )
     }
 
-    async fn send_responses(
+    /// Send a prepared contract call with retry, refetching the pending nonce
+    /// on every attempt.
+    async fn send_call(
         &self,
-        responses: Vec<ChainSignatures::Response>,
-        gas: u64,
+        call: RawCallBuilder<&EthContractFillProvider>,
         sign_ids: &[SignId],
+        op: &str,
     ) -> anyhow::Result<B256> {
         let send_retry = RetryConfig {
             max_times: ETH_SEND_MAX_ATTEMPTS,
@@ -240,7 +243,7 @@ impl EthClient {
                 tracing::warn!(
                     ?sign_ids,
                     attempt,
-                    "send eth tx failed: {err}, retrying in {sleep:?}"
+                    "send eth {op} tx failed: {err}, retrying in {sleep:?}"
                 );
             },
             {
@@ -256,13 +259,12 @@ impl EthClient {
 
                 tracing::info!(
                     nonce,
-                    "will send eth tx with nonce {nonce} for sign_ids: {:?}",
+                    "will send eth {op} tx with nonce {nonce} for sign_ids: {:?}",
                     sign_ids
                 );
 
-                self.contract
-                    .respond(responses.clone()) // Need to clone because closure has to implement `FnMut` (otherwise it's `FnOnce`)
-                    .gas(gas)
+                // Need to clone because closure has to implement `FnMut` (otherwise it's `FnOnce`)
+                call.clone()
                     .nonce(nonce)
                     .send()
                     .await
@@ -273,25 +275,36 @@ impl EthClient {
     }
 
     /// Shared logic to send the transaction, wait for the receipt, and verify success.
+    async fn send_call_and_verify(
+        &self,
+        call: RawCallBuilder<&EthContractFillProvider>,
+        sign_ids: &[SignId],
+        op: &str,
+    ) -> anyhow::Result<B256> {
+        let tx_hash = self.send_call(call, sign_ids, op).await?;
+        let receipt = self.wait_for_transaction_receipt(tx_hash, sign_ids).await?;
+
+        if !receipt.status() {
+            tracing::error!(?sign_ids, ?tx_hash, "ethereum {op} transaction failed");
+            anyhow::bail!("Ethereum {op} transaction reverted");
+        }
+
+        tracing::info!(
+            ?sign_ids,
+            ?tx_hash,
+            "ethereum {op} transaction published successfully"
+        );
+        Ok(tx_hash)
+    }
+
     async fn execute_publish(
         &self,
         responses: Vec<ChainSignatures::Response>,
         gas: u64,
         sign_ids: &[SignId],
     ) -> anyhow::Result<()> {
-        let tx_hash = self.send_responses(responses, gas, sign_ids).await?;
-        let receipt = self.wait_for_transaction_receipt(tx_hash, sign_ids).await?;
-
-        if !receipt.status() {
-            tracing::error!(?sign_ids, ?tx_hash, "ethereum transaction failed");
-            anyhow::bail!("Ethereum transaction reverted");
-        }
-
-        tracing::info!(
-            ?sign_ids,
-            ?tx_hash,
-            "ethereum transaction published successfully"
-        );
+        let call = self.contract.respond(responses).gas(gas).clear_decoder();
+        self.send_call_and_verify(call, sign_ids, "respond").await?;
         Ok(())
     }
 
@@ -336,67 +349,18 @@ impl EthClient {
         id: &SignId,
         serialized_output: Vec<u8>,
         signature: &Signature,
-    ) -> anyhow::Result<B256> {
-        let sign_ids = [*id];
-        let send_retry = RetryConfig {
-            max_times: ETH_SEND_MAX_ATTEMPTS,
-            min_delay: ETH_SEND_MIN_DELAY,
-            max_delay: ETH_SEND_MAX_DELAY,
-            jitter: true,
-        };
-
+    ) -> anyhow::Result<()> {
         let abi_signature: ChainSignatures::Signature = signature.into();
         let request_id: B256 = id.request_id.into();
         let output: alloy::primitives::Bytes = serialized_output.into();
 
-        let tx_hash = retry_rpc!(
-            ETH_SEND_TIMEOUT,
-            send_retry,
-            |attempt, err, sleep| {
-                tracing::warn!(
-                    ?sign_ids,
-                    attempt,
-                    "send eth respondBidirectional tx failed: {err}, retrying in {sleep:?}"
-                );
-            },
-            {
-                // Fetch nonce inside the retry loop, otherwise we may reuse a stale nonce.
-                let nonce = self
-                    .contract
-                    .provider()
-                    .get_transaction_count(self.contract.provider().default_signer_address())
-                    .pending()
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to fetch nonce: {e}"))?;
-
-                self.contract
-                    .respondBidirectional(request_id, output.clone(), abi_signature.clone())
-                    .nonce(nonce)
-                    .send()
-                    .await
-                    .map(|pending| *pending.tx_hash())
-                    .map_err(|e| anyhow::anyhow!("RPC Error: {e}"))
-            }
-        )?;
-
-        let receipt = self
-            .wait_for_transaction_receipt(tx_hash, &sign_ids)
+        let call = self
+            .contract
+            .respondBidirectional(request_id, output, abi_signature)
+            .clear_decoder();
+        self.send_call_and_verify(call, &[*id], "respondBidirectional")
             .await?;
-        if !receipt.status() {
-            tracing::error!(
-                ?sign_ids,
-                ?tx_hash,
-                "ethereum respondBidirectional transaction failed"
-            );
-            anyhow::bail!("Ethereum respondBidirectional transaction reverted");
-        }
-
-        tracing::info!(
-            ?sign_ids,
-            ?tx_hash,
-            "ethereum respondBidirectional published successfully"
-        );
-        Ok(tx_hash)
+        Ok(())
     }
 }
 
@@ -647,8 +611,9 @@ mod tests {
         );
 
         // Attempt to send
+        let call = client.contract.respond(vec![]).gas(21000).clear_decoder();
         let result = client
-            .send_responses(vec![], 21000, &[SignId::new([3u8; 32])])
+            .send_call(call, &[SignId::new([3u8; 32])], "respond")
             .await;
 
         // Verify it failed completely

--- a/chain-signatures/node/src/rpc/ethereum.rs
+++ b/chain-signatures/node/src/rpc/ethereum.rs
@@ -15,7 +15,7 @@ use mpc_chain_integration_core::{
     utils::retry::{retry_rpc, RetryConfig},
     ChainPublisher, PublishAction, PublisherTelemetry,
 };
-use mpc_primitives::{SignId, Signature};
+use mpc_primitives::{SignId, SignKind, Signature};
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -327,16 +327,108 @@ impl EthClient {
         tracing::info!(num_requests, "batch publish complete");
         Ok(())
     }
+
+    /// Publish a bidirectional execution result via `respondBidirectional`.
+    /// Single logical attempt (short send retries only); the caller
+    /// (`rpc::execute_publish`) handles infinite retries.
+    async fn call_respond_bidirectional(
+        &self,
+        id: &SignId,
+        serialized_output: Vec<u8>,
+        signature: &Signature,
+    ) -> anyhow::Result<B256> {
+        let sign_ids = [*id];
+        let send_retry = RetryConfig {
+            max_times: ETH_SEND_MAX_ATTEMPTS,
+            min_delay: ETH_SEND_MIN_DELAY,
+            max_delay: ETH_SEND_MAX_DELAY,
+            jitter: true,
+        };
+
+        let abi_signature: ChainSignatures::Signature = signature.into();
+        let request_id: B256 = id.request_id.into();
+        let output: alloy::primitives::Bytes = serialized_output.into();
+
+        let tx_hash = retry_rpc!(
+            ETH_SEND_TIMEOUT,
+            send_retry,
+            |attempt, err, sleep| {
+                tracing::warn!(
+                    ?sign_ids,
+                    attempt,
+                    "send eth respondBidirectional tx failed: {err}, retrying in {sleep:?}"
+                );
+            },
+            {
+                // Fetch nonce inside the retry loop, otherwise we may reuse a stale nonce.
+                let nonce = self
+                    .contract
+                    .provider()
+                    .get_transaction_count(self.contract.provider().default_signer_address())
+                    .pending()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to fetch nonce: {e}"))?;
+
+                self.contract
+                    .respondBidirectional(request_id, output.clone(), abi_signature.clone())
+                    .nonce(nonce)
+                    .send()
+                    .await
+                    .map(|pending| *pending.tx_hash())
+                    .map_err(|e| anyhow::anyhow!("RPC Error: {e}"))
+            }
+        )?;
+
+        let receipt = self
+            .wait_for_transaction_receipt(tx_hash, &sign_ids)
+            .await?;
+        if !receipt.status() {
+            tracing::error!(
+                ?sign_ids,
+                ?tx_hash,
+                "ethereum respondBidirectional transaction failed"
+            );
+            anyhow::bail!("Ethereum respondBidirectional transaction reverted");
+        }
+
+        tracing::info!(
+            ?sign_ids,
+            ?tx_hash,
+            "ethereum respondBidirectional published successfully"
+        );
+        Ok(tx_hash)
+    }
 }
 
 #[async_trait::async_trait]
 impl ChainPublisher for EthClient {
     async fn publish_signature(&self, action: &PublishAction) -> anyhow::Result<()> {
-        // Push to internal batching queue
-        self.batch_tx
-            .send(action.clone())
-            .await
-            .map_err(|e| anyhow::anyhow!("eth: batch channel closed: {e}"))
+        match &action.indexed.kind {
+            SignKind::Sign | SignKind::SignBidirectional(_) => {
+                // Push to internal batching queue
+                self.batch_tx
+                    .send(action.clone())
+                    .await
+                    .map_err(|e| anyhow::anyhow!("eth: batch channel closed: {e}"))
+            }
+            SignKind::RespondBidirectional(respond_bidirectional_tx) => {
+                self.call_respond_bidirectional(
+                    &action.indexed.id,
+                    respond_bidirectional_tx.output.clone(),
+                    &action.signature,
+                )
+                .await?;
+                self.telemetry.record_publish_metrics(action);
+                Ok(())
+            }
+            SignKind::Checkpoint(_) => {
+                tracing::error!(
+                    sign_id = ?action.indexed.id,
+                    "eth: checkpoint publishing not supported"
+                );
+                anyhow::bail!("checkpoint publishing not supported on Ethereum");
+            }
+        }
     }
 }
 
@@ -685,6 +777,156 @@ mod tests {
         assert!(
             result.is_ok(),
             "The happy path should complete successfully"
+        );
+    }
+
+    fn respond_bidirectional_action() -> PublishAction {
+        use mpc_primitives::{BidirectionalTxId, RespondBidirectionalTx, SignArgs, SignId};
+
+        let indexed = mpc_primitives::IndexedSignRequest::respond_bidirectional(
+            SignId::new([9u8; 32]),
+            SignArgs {
+                entropy: [0u8; 32],
+                epsilon: k256::Scalar::ONE,
+                payload: k256::Scalar::ONE,
+                path: "ethereum response key".to_string(),
+                key_version: 1,
+            },
+            mpc_primitives::Chain::Ethereum,
+            0,
+            RespondBidirectionalTx {
+                tx_id: BidirectionalTxId([1u8; 32]),
+                output: {
+                    let mut out = vec![0u8; 32];
+                    *out.last_mut().unwrap() = 1;
+                    out
+                },
+                chain_ctx: None,
+            },
+        );
+
+        PublishAction {
+            public_key: AffinePoint::GENERATOR,
+            indexed,
+            signature: create_test_signature(),
+            participants: vec![],
+            timestamp: std::time::Instant::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_publish_respond_bidirectional_success() {
+        let mut server = Server::new_async().await;
+        let tx_hash = B256::repeat_byte(0x66);
+        mock_alloy_background_rpcs(&mut server).await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_getTransactionCount"}),
+            ))
+            .with_status(200)
+            .with_body(json!({"jsonrpc": "2.0", "id": 1, "result": "0x1"}).to_string())
+            .create_async()
+            .await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_sendRawTransaction"}),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({"jsonrpc": "2.0", "id": 1, "result": format!("{tx_hash:#x}")}).to_string(),
+            )
+            .create_async()
+            .await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_getTransactionReceipt"}),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0", "id": 1,
+                    "result": mock_receipt_json(tx_hash, "0x1")
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let client = EthClient::new(
+            &mock_config(&server.url()),
+            Arc::new(NoopPublisherTelemetry),
+        );
+
+        let result = client
+            .publish_signature(&respond_bidirectional_action())
+            .await;
+        assert!(
+            result.is_ok(),
+            "respondBidirectional publish should succeed: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_publish_respond_bidirectional_fails_on_reverted_tx() {
+        let mut server = Server::new_async().await;
+        let tx_hash = B256::repeat_byte(0x67);
+        mock_alloy_background_rpcs(&mut server).await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_getTransactionCount"}),
+            ))
+            .with_status(200)
+            .with_body(json!({"jsonrpc": "2.0", "id": 1, "result": "0x1"}).to_string())
+            .create_async()
+            .await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_sendRawTransaction"}),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({"jsonrpc": "2.0", "id": 1, "result": format!("{tx_hash:#x}")}).to_string(),
+            )
+            .create_async()
+            .await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_getTransactionReceipt"}),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0", "id": 1,
+                    "result": mock_receipt_json(tx_hash, "0x0")
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let client = EthClient::new(
+            &mock_config(&server.url()),
+            Arc::new(NoopPublisherTelemetry),
+        );
+
+        let result = client
+            .publish_signature(&respond_bidirectional_action())
+            .await;
+        assert!(
+            result.is_err(),
+            "reverted respondBidirectional must error for outer retry"
         );
     }
 }

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -121,6 +121,11 @@ impl SignBidirectionalEventExt for SignBidirectionalEvent {
                 &self.sender_string()?,
                 &self.path,
             )),
+            Chain::Ethereum => Ok(mpc_crypto::kdf::derive_epsilon_eth(
+                self.key_version,
+                &self.sender_string()?,
+                &self.path,
+            )),
             _ => anyhow::bail!("Unsupported chain for epsilon derivation: {:?}", self.chain),
         }
     }
@@ -157,6 +162,11 @@ impl BidirectionalTxExt for BidirectionalTx {
                 path,
             )),
             Chain::Canton => Ok(mpc_crypto::kdf::derive_epsilon_canton(
+                self.key_version,
+                &self.sender_string()?,
+                path,
+            )),
+            Chain::Ethereum => Ok(mpc_crypto::kdf::derive_epsilon_eth(
                 self.key_version,
                 &self.sender_string()?,
                 path,
@@ -520,6 +530,72 @@ mod derive_tests {
             .unwrap();
 
         assert_eq!(derive_user_address(mpc_pk, derivation_epsilon), expected);
+    }
+}
+
+#[cfg(test)]
+mod ethereum_epsilon_tests {
+    use super::{BidirectionalTxExt, SignBidirectionalEventExt};
+    use mpc_primitives::{BidirectionalTx, BidirectionalTxId, Chain, SignBidirectionalEvent};
+
+    const ETH_SENDER: &str = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+
+    fn eth_sender_word() -> [u8; 32] {
+        let address = alloy::primitives::address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+        let mut sender = [0u8; 32];
+        sender[12..].copy_from_slice(address.as_slice());
+        sender
+    }
+
+    #[test]
+    fn sign_bidirectional_event_derives_ethereum_epsilon() {
+        let event = SignBidirectionalEvent {
+            sender: eth_sender_word(),
+            serialized_transaction: vec![1, 2, 3],
+            caip2_id: "eip155:1".to_string(),
+            key_version: 1,
+            deposit: 1,
+            path: "test-bidirectional-path".to_string(),
+            algo: "secp256k1".to_string(),
+            dest: "ethereum".to_string(),
+            params: "{}".to_string(),
+            output_deserialization_schema: vec![],
+            respond_serialization_schema: vec![],
+            chain: Chain::Ethereum,
+            chain_ctx: None,
+        };
+
+        assert_eq!(event.sender_string().unwrap(), ETH_SENDER);
+        let expected =
+            mpc_crypto::kdf::derive_epsilon_eth(1, ETH_SENDER, "test-bidirectional-path");
+        assert_eq!(event.epsilon().unwrap(), expected);
+    }
+
+    #[test]
+    fn bidirectional_tx_derives_ethereum_epsilon() {
+        let tx = BidirectionalTx {
+            id: BidirectionalTxId([0xab; 32]),
+            sender: eth_sender_word(),
+            serialized_transaction: Vec::new(),
+            source_chain: Chain::Ethereum,
+            target_chain: Chain::Ethereum,
+            caip2_id: "eip155:1".to_string(),
+            key_version: 1,
+            deposit: 0,
+            path: "unused-request-path".to_string(),
+            algo: String::new(),
+            dest: String::new(),
+            params: String::new(),
+            output_deserialization_schema: vec![],
+            respond_serialization_schema: vec![],
+            request_id: [0x22; 32],
+            from_address: [0u8; 20],
+            nonce: 0,
+        };
+
+        assert_eq!(tx.sender_string().unwrap(), ETH_SENDER);
+        let expected = mpc_crypto::kdf::derive_epsilon_eth(1, ETH_SENDER, "ethereum response key");
+        assert_eq!(tx.epsilon("ethereum response key").unwrap(), expected);
     }
 }
 

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -424,6 +424,10 @@ pub(crate) fn sender_string(sender: [u8; 32], source_chain: Chain) -> anyhow::Re
         Chain::Hydration => Ok(crate::indexer_hydration::ss58_address_from_account32(
             sender,
         )),
+        // The Ethereum sender word is the ABI-encoded address: 12 zero bytes
+        // followed by the 20-byte address. Lowercase hex matches the KDF input
+        // used by `derive_epsilon_eth` everywhere else.
+        Chain::Ethereum => Ok(format!("0x{}", hex::encode(&sender[12..]))),
         _ => anyhow::bail!("Unsupported chain: {source_chain}"),
     }
 }
@@ -544,6 +548,17 @@ mod tests {
         assert_eq!(sig.s, s_scalar);
         assert_eq!(sig.big_r, big_r);
         assert_eq!(event.chain, Chain::Ethereum);
+    }
+
+    #[test]
+    fn sender_string_formats_ethereum_address() {
+        let address = alloy::primitives::address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+        let mut sender = [0u8; 32];
+        sender[12..].copy_from_slice(address.as_slice());
+        assert_eq!(
+            sender_string(sender, Chain::Ethereum).unwrap(),
+            "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+        );
     }
 
     #[tokio::test]

--- a/chain-signatures/primitives/src/chain.rs
+++ b/chain-signatures/primitives/src/chain.rs
@@ -141,7 +141,8 @@ impl Chain {
 
     pub fn respond_serialization_format(&self) -> SerDeserFormat {
         match self {
-            Chain::Canton => SerDeserFormat::Abi,
+            // Canton and Ethereum contracts consume ABI-encoded bidirectional responses.
+            Chain::Canton | Chain::Ethereum => SerDeserFormat::Abi,
             // Solana and Hydration use Borsh for bidirectional responses.
             _ => SerDeserFormat::Borsh,
         }
@@ -174,5 +175,30 @@ impl FromStr for Chain {
             "canton" | "ctn" => Ok(Chain::Canton),
             other => Err(format!("unknown or unsupported chain {other}")),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn respond_serialization_format_is_abi_for_evm_and_canton() {
+        assert_eq!(
+            Chain::Ethereum.respond_serialization_format(),
+            SerDeserFormat::Abi
+        );
+        assert_eq!(
+            Chain::Canton.respond_serialization_format(),
+            SerDeserFormat::Abi
+        );
+        assert_eq!(
+            Chain::Solana.respond_serialization_format(),
+            SerDeserFormat::Borsh
+        );
+        assert_eq!(
+            Chain::Hydration.respond_serialization_format(),
+            SerDeserFormat::Borsh
+        );
     }
 }

--- a/integration-tests/fixtures/eth/ChainSignatures.json
+++ b/integration-tests/fixtures/eth/ChainSignatures.json
@@ -1,0 +1,877 @@
+{
+  "_format": "hh3-artifact-1",
+  "contractName": "ChainSignatures",
+  "sourceName": "contracts/ChainSignatures.sol",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_admin",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_signatureDeposit",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "AccessControlBadConfirmation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "neededRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "AccessControlUnauthorizedAccount",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InsufficientDeposit",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InsufficientFunds",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidRecipient",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidTransaction",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "TransferFailed",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "oldDeposit",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newDeposit",
+          "type": "uint256"
+        }
+      ],
+      "name": "DepositUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        }
+      ],
+      "name": "FundsWithdrawn",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "requestId",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "responder",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes",
+          "name": "serializedOutput",
+          "type": "bytes"
+        },
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "x",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "y",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct ChainSignatures.AffinePoint",
+              "name": "bigR",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint256",
+              "name": "s",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint8",
+              "name": "recoveryId",
+              "type": "uint8"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct ChainSignatures.Signature",
+          "name": "signature",
+          "type": "tuple"
+        }
+      ],
+      "name": "RespondBidirectional",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "previousAdminRole",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "newAdminRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "RoleAdminChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleGranted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleRevoked",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes",
+          "name": "serializedTransaction",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "caip2Id",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "keyVersion",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "deposit",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "chainId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "path",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "algo",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "dest",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "params",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes",
+          "name": "outputDeserializationSchema",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes",
+          "name": "respondSerializationSchema",
+          "type": "bytes"
+        }
+      ],
+      "name": "SignBidirectional",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "requestId",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "responder",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "errorMessage",
+          "type": "string"
+        }
+      ],
+      "name": "SignatureError",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "payload",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "keyVersion",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "deposit",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "chainId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "path",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "algo",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "dest",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "params",
+          "type": "string"
+        }
+      ],
+      "name": "SignatureRequested",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "requestId",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "responder",
+          "type": "address"
+        },
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "x",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "y",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct ChainSignatures.AffinePoint",
+              "name": "bigR",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint256",
+              "name": "s",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint8",
+              "name": "recoveryId",
+              "type": "uint8"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct ChainSignatures.Signature",
+          "name": "signature",
+          "type": "tuple"
+        }
+      ],
+      "name": "SignatureResponded",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DEFAULT_ADMIN_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getRoleAdmin",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getSignatureDeposit",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "grantRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "hasRole",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "callerConfirmation",
+          "type": "address"
+        }
+      ],
+      "name": "renounceRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "requestId",
+              "type": "bytes32"
+            },
+            {
+              "components": [
+                {
+                  "components": [
+                    {
+                      "internalType": "uint256",
+                      "name": "x",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "y",
+                      "type": "uint256"
+                    }
+                  ],
+                  "internalType": "struct ChainSignatures.AffinePoint",
+                  "name": "bigR",
+                  "type": "tuple"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "s",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "recoveryId",
+                  "type": "uint8"
+                }
+              ],
+              "internalType": "struct ChainSignatures.Signature",
+              "name": "signature",
+              "type": "tuple"
+            }
+          ],
+          "internalType": "struct ChainSignatures.Response[]",
+          "name": "_responses",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "respond",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_requestId",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_serializedOutput",
+          "type": "bytes"
+        },
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "x",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "y",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct ChainSignatures.AffinePoint",
+              "name": "bigR",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint256",
+              "name": "s",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint8",
+              "name": "recoveryId",
+              "type": "uint8"
+            }
+          ],
+          "internalType": "struct ChainSignatures.Signature",
+          "name": "_signature",
+          "type": "tuple"
+        }
+      ],
+      "name": "respondBidirectional",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "requestId",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "string",
+              "name": "errorMessage",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct ChainSignatures.ErrorResponse[]",
+          "name": "_errors",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "respondError",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "revokeRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "setSignatureDeposit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "payload",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "string",
+              "name": "path",
+              "type": "string"
+            },
+            {
+              "internalType": "uint32",
+              "name": "keyVersion",
+              "type": "uint32"
+            },
+            {
+              "internalType": "string",
+              "name": "algo",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "dest",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "params",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct ChainSignatures.SignRequest",
+          "name": "_request",
+          "type": "tuple"
+        }
+      ],
+      "name": "sign",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes",
+              "name": "serializedTransaction",
+              "type": "bytes"
+            },
+            {
+              "internalType": "string",
+              "name": "caip2Id",
+              "type": "string"
+            },
+            {
+              "internalType": "uint32",
+              "name": "keyVersion",
+              "type": "uint32"
+            },
+            {
+              "internalType": "string",
+              "name": "path",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "algo",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "dest",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "params",
+              "type": "string"
+            },
+            {
+              "internalType": "bytes",
+              "name": "outputDeserializationSchema",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "respondSerializationSchema",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct ChainSignatures.SignBidirectionalRequest",
+          "name": "_request",
+          "type": "tuple"
+        }
+      ],
+      "name": "signBidirectional",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        }
+      ],
+      "name": "supportsInterface",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_receiver",
+          "type": "address"
+        }
+      ],
+      "name": "withdraw",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x608060405234801561000f575f5ffd5b506040516112b93803806112b983398101604081905261002e916100eb565b6100385f83610042565b5060015550610122565b5f828152602081815260408083206001600160a01b038516845290915281205460ff166100e2575f838152602081815260408083206001600160a01b03861684529091529020805460ff1916600117905561009a3390565b6001600160a01b0316826001600160a01b0316847f2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d60405160405180910390a45060016100e5565b505f5b92915050565b5f5f604083850312156100fc575f5ffd5b82516001600160a01b0381168114610112575f5ffd5b6020939093015192949293505050565b61118a8061012f5f395ff3fe6080604052600436106100e3575f3560e01c80635f45af8811610087578063ae650b9511610057578063ae650b9514610258578063d547741f1461026c578063dfb4366b1461028b578063fb0dc1261461029e575f5ffd5b80635f45af88146101f457806391d1485414610213578063a03b5c3b14610232578063a217fddf14610245575f5ffd5b806328dd39d4116100c257806328dd39d4146101785780632f2ff15d1461019757806336568abe146101b657806343ec0d4c146101d5575f5ffd5b8062f714ce146100e757806301ffc9a714610108578063248a9ca31461013c575b5f5ffd5b3480156100f2575f5ffd5b506101066101013660046108f3565b6102bd565b005b348015610113575f5ffd5b5061012761012236600461091d565b6103c6565b60405190151581526020015b60405180910390f35b348015610147575f5ffd5b5061016a61015636600461094b565b5f9081526020819052604090206001015490565b604051908152602001610133565b348015610183575f5ffd5b50610106610192366004610962565b6103fc565b3480156101a2575f5ffd5b506101066101b13660046108f3565b610440565b3480156101c1575f5ffd5b506101066101d03660046108f3565b61046a565b3480156101e0575f5ffd5b506101066101ef3660046109f1565b6104a2565b3480156101ff575f5ffd5b5061010661020e36600461094b565b610544565b34801561021e575f5ffd5b5061012761022d3660046108f3565b610594565b610106610240366004610b61565b6105bc565b348015610250575f5ffd5b5061016a5f81565b348015610263575f5ffd5b5060015461016a565b348015610277575f5ffd5b506101066102863660046108f3565b610640565b610106610299366004610c64565b610664565b3480156102a9575f5ffd5b506101066102b8366004610e08565b610712565b5f6102c781610792565b6001600160a01b0382166102ee57604051634e46966960e11b815260040160405180910390fd5b4783111561030f5760405163356680b760e01b815260040160405180910390fd5b5f826001600160a01b0316846040515f6040518083038185875af1925050503d805f8114610358576040519150601f19603f3d011682016040523d82523d5f602084013e61035d565b606091505b505090508061037f576040516312171d8360e31b815260040160405180910390fd5b604080518581526001600160a01b03851660208201527f6141b54b56b8a52a8c6f5cd2a857f6117b18ffbf4d46bd3106f300a839cbf5ea910160405180910390a150505050565b5f6001600160e01b03198216637965db0b60e01b14806103f657506301ffc9a760e01b6001600160e01b03198316145b92915050565b837f23a9a92895272f15b4a10136e9902bae33c369c40c448b2d184f9a06e33fc3df338585856040516104329493929190610ec7565b60405180910390a250505050565b5f8281526020819052604090206001015461045a81610792565b610464838361079f565b50505050565b6001600160a01b03811633146104935760405163334bd91960e11b815260040160405180910390fd5b61049d828261082e565b505050565b5f5b8181101561049d578282828181106104be576104be610f03565b90506020028101906104d09190610f17565b357f3a8c98eb820de2bc0f92e6c44a3bc0245111e8d203e7aa5e8f2cb783b61ca1243385858581811061050557610505610f03565b90506020028101906105179190610f17565b610525906020810190610f35565b60405161053493929190610f7e565b60405180910390a26001016104a4565b5f61054e81610792565b600180549083905560408051828152602081018590527f4c0c144abc1788db200c21df3378b55ee4ab0980465c120061c995a62f7626d8910160405180910390a1505050565b5f918252602082815260408084206001600160a01b0393909316845291905290205460ff1690565b6001543410156105df5760405163070f6eed60e11b815260040160405180910390fd5b7f6c77c4e5e031dca0c4944909e0d4d343c9c5b16eda4ef1d4be0762693e02672233825f0151836040015134468660200151876060015188608001518960a0015160405161063599989796959493929190610fd0565b60405180910390a150565b5f8281526020819052604090206001015461065a81610792565b610464838361082e565b6001543410156106875760405163070f6eed60e11b815260040160405180910390fd5b8051515f036106a95760405163280503e760e11b815260040160405180910390fd5b7f27f9d88f0144f82d39d07d3e314ac47018991ad27af3fb62129dd7cd725846e833825f0151836020015184604001513446876060015188608001518960a001518a60c001518b60e001518c61010001516040516106359c9b9a9998979695949392919061105b565b5f5b8181101561049d5782828281811061072e5761072e610f03565b905060a002015f01357f8fefda2f6c146df62efa1de95f8ff0b9c29ae07b9846e61fbce6e618897397ff3385858581811061076b5761076b610f03565b905060a00201602001604051610782929190611137565b60405180910390a2600101610714565b61079c8133610897565b50565b5f6107aa8383610594565b610827575f838152602081815260408083206001600160a01b03861684529091529020805460ff191660011790556107df3390565b6001600160a01b0316826001600160a01b0316847f2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d60405160405180910390a45060016103f6565b505f6103f6565b5f6108398383610594565b15610827575f838152602081815260408083206001600160a01b0386168085529252808320805460ff1916905551339286917ff6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b9190a45060016103f6565b6108a18282610594565b6108d45760405163e2517d3f60e01b81526001600160a01b03821660048201526024810183905260440160405180910390fd5b5050565b80356001600160a01b03811681146108ee575f5ffd5b919050565b5f5f60408385031215610904575f5ffd5b82359150610914602084016108d8565b90509250929050565b5f6020828403121561092d575f5ffd5b81356001600160e01b031981168114610944575f5ffd5b9392505050565b5f6020828403121561095b575f5ffd5b5035919050565b5f5f5f5f84860360c0811215610976575f5ffd5b8535945060208601356001600160401b03811115610992575f5ffd5b8601601f810188136109a2575f5ffd5b80356001600160401b038111156109b7575f5ffd5b8860208284010111156109c8575f5ffd5b602091909101945092506080603f19820112156109e3575f5ffd5b509295919450926040019150565b5f5f60208385031215610a02575f5ffd5b82356001600160401b03811115610a17575f5ffd5b8301601f81018513610a27575f5ffd5b80356001600160401b03811115610a3c575f5ffd5b8560208260051b8401011115610a50575f5ffd5b6020919091019590945092505050565b634e487b7160e01b5f52604160045260245ffd5b60405160c081016001600160401b0381118282101715610a9657610a96610a60565b60405290565b60405161012081016001600160401b0381118282101715610a9657610a96610a60565b5f82601f830112610ace575f5ffd5b8135602083015f5f6001600160401b03841115610aed57610aed610a60565b50604051601f19601f85018116603f011681018181106001600160401b0382111715610b1b57610b1b610a60565b604052838152905080828401871015610b32575f5ffd5b838360208301375f602085830101528094505050505092915050565b803563ffffffff811681146108ee575f5ffd5b5f60208284031215610b71575f5ffd5b81356001600160401b03811115610b86575f5ffd5b820160c08185031215610b97575f5ffd5b610b9f610a74565b8135815260208201356001600160401b03811115610bbb575f5ffd5b610bc786828501610abf565b602083015250610bd960408301610b4e565b604082015260608201356001600160401b03811115610bf6575f5ffd5b610c0286828501610abf565b60608301525060808201356001600160401b03811115610c20575f5ffd5b610c2c86828501610abf565b60808301525060a08201356001600160401b03811115610c4a575f5ffd5b610c5686828501610abf565b60a083015250949350505050565b5f60208284031215610c74575f5ffd5b81356001600160401b03811115610c89575f5ffd5b82016101208185031215610c9b575f5ffd5b610ca3610a9c565b81356001600160401b03811115610cb8575f5ffd5b610cc486828501610abf565b82525060208201356001600160401b03811115610cdf575f5ffd5b610ceb86828501610abf565b602083015250610cfd60408301610b4e565b604082015260608201356001600160401b03811115610d1a575f5ffd5b610d2686828501610abf565b60608301525060808201356001600160401b03811115610d44575f5ffd5b610d5086828501610abf565b60808301525060a08201356001600160401b03811115610d6e575f5ffd5b610d7a86828501610abf565b60a08301525060c08201356001600160401b03811115610d98575f5ffd5b610da486828501610abf565b60c08301525060e08201356001600160401b03811115610dc2575f5ffd5b610dce86828501610abf565b60e0830152506101008201356001600160401b03811115610ded575f5ffd5b610df986828501610abf565b61010083015250949350505050565b5f5f60208385031215610e19575f5ffd5b82356001600160401b03811115610e2e575f5ffd5b8301601f81018513610e3e575f5ffd5b80356001600160401b03811115610e53575f5ffd5b85602060a083028401011115610a50575f5ffd5b81835281816020850137505f828201602090810191909152601f909101601f19169091010190565b803582526020808201359083015260408082013590830152606081013560ff8116808214610ebb575f5ffd5b80606085015250505050565b6001600160a01b038516815260c0602082018190525f90610eeb9083018587610e67565b9050610efa6040830184610e8f565b95945050505050565b634e487b7160e01b5f52603260045260245ffd5b5f8235603e19833603018112610f2b575f5ffd5b9190910192915050565b5f5f8335601e19843603018112610f4a575f5ffd5b8301803591506001600160401b03821115610f63575f5ffd5b602001915036819003821315610f77575f5ffd5b9250929050565b6001600160a01b03841681526040602082018190525f90610efa9083018486610e67565b5f81518084528060208401602086015e5f602082860101526020601f19601f83011685010191505092915050565b60018060a01b038a16815288602082015263ffffffff8816604082015286606082015285608082015261012060a08201525f611010610120830187610fa2565b82810360c08401526110228187610fa2565b905082810360e08401526110368186610fa2565b905082810361010084015261104b8185610fa2565b9c9b505050505050505050505050565b6001600160a01b038d16815261018060208201525f61107e61018083018e610fa2565b8281036040840152611090818e610fa2565b63ffffffff8d16606085015290508a60808401528960a084015282810360c08401526110bc818a610fa2565b905082810360e08401526110d08189610fa2565b90508281036101008401526110e58188610fa2565b90508281036101208401526110fa8187610fa2565b905082810361014084015261110f8186610fa2565b90508281036101608401526111248185610fa2565b9f9e505050505050505050505050505050565b6001600160a01b038316815260a081016109446020830184610e8f56fea26469706673582212200c5616b037a1ff32a0127a22a32179636d90fb0b9f83fd4565124837ee62c64664736f6c63430008230033",
+  "deployedBytecode": "0x6080604052600436106100e3575f3560e01c80635f45af8811610087578063ae650b9511610057578063ae650b9514610258578063d547741f1461026c578063dfb4366b1461028b578063fb0dc1261461029e575f5ffd5b80635f45af88146101f457806391d1485414610213578063a03b5c3b14610232578063a217fddf14610245575f5ffd5b806328dd39d4116100c257806328dd39d4146101785780632f2ff15d1461019757806336568abe146101b657806343ec0d4c146101d5575f5ffd5b8062f714ce146100e757806301ffc9a714610108578063248a9ca31461013c575b5f5ffd5b3480156100f2575f5ffd5b506101066101013660046108f3565b6102bd565b005b348015610113575f5ffd5b5061012761012236600461091d565b6103c6565b60405190151581526020015b60405180910390f35b348015610147575f5ffd5b5061016a61015636600461094b565b5f9081526020819052604090206001015490565b604051908152602001610133565b348015610183575f5ffd5b50610106610192366004610962565b6103fc565b3480156101a2575f5ffd5b506101066101b13660046108f3565b610440565b3480156101c1575f5ffd5b506101066101d03660046108f3565b61046a565b3480156101e0575f5ffd5b506101066101ef3660046109f1565b6104a2565b3480156101ff575f5ffd5b5061010661020e36600461094b565b610544565b34801561021e575f5ffd5b5061012761022d3660046108f3565b610594565b610106610240366004610b61565b6105bc565b348015610250575f5ffd5b5061016a5f81565b348015610263575f5ffd5b5060015461016a565b348015610277575f5ffd5b506101066102863660046108f3565b610640565b610106610299366004610c64565b610664565b3480156102a9575f5ffd5b506101066102b8366004610e08565b610712565b5f6102c781610792565b6001600160a01b0382166102ee57604051634e46966960e11b815260040160405180910390fd5b4783111561030f5760405163356680b760e01b815260040160405180910390fd5b5f826001600160a01b0316846040515f6040518083038185875af1925050503d805f8114610358576040519150601f19603f3d011682016040523d82523d5f602084013e61035d565b606091505b505090508061037f576040516312171d8360e31b815260040160405180910390fd5b604080518581526001600160a01b03851660208201527f6141b54b56b8a52a8c6f5cd2a857f6117b18ffbf4d46bd3106f300a839cbf5ea910160405180910390a150505050565b5f6001600160e01b03198216637965db0b60e01b14806103f657506301ffc9a760e01b6001600160e01b03198316145b92915050565b837f23a9a92895272f15b4a10136e9902bae33c369c40c448b2d184f9a06e33fc3df338585856040516104329493929190610ec7565b60405180910390a250505050565b5f8281526020819052604090206001015461045a81610792565b610464838361079f565b50505050565b6001600160a01b03811633146104935760405163334bd91960e11b815260040160405180910390fd5b61049d828261082e565b505050565b5f5b8181101561049d578282828181106104be576104be610f03565b90506020028101906104d09190610f17565b357f3a8c98eb820de2bc0f92e6c44a3bc0245111e8d203e7aa5e8f2cb783b61ca1243385858581811061050557610505610f03565b90506020028101906105179190610f17565b610525906020810190610f35565b60405161053493929190610f7e565b60405180910390a26001016104a4565b5f61054e81610792565b600180549083905560408051828152602081018590527f4c0c144abc1788db200c21df3378b55ee4ab0980465c120061c995a62f7626d8910160405180910390a1505050565b5f918252602082815260408084206001600160a01b0393909316845291905290205460ff1690565b6001543410156105df5760405163070f6eed60e11b815260040160405180910390fd5b7f6c77c4e5e031dca0c4944909e0d4d343c9c5b16eda4ef1d4be0762693e02672233825f0151836040015134468660200151876060015188608001518960a0015160405161063599989796959493929190610fd0565b60405180910390a150565b5f8281526020819052604090206001015461065a81610792565b610464838361082e565b6001543410156106875760405163070f6eed60e11b815260040160405180910390fd5b8051515f036106a95760405163280503e760e11b815260040160405180910390fd5b7f27f9d88f0144f82d39d07d3e314ac47018991ad27af3fb62129dd7cd725846e833825f0151836020015184604001513446876060015188608001518960a001518a60c001518b60e001518c61010001516040516106359c9b9a9998979695949392919061105b565b5f5b8181101561049d5782828281811061072e5761072e610f03565b905060a002015f01357f8fefda2f6c146df62efa1de95f8ff0b9c29ae07b9846e61fbce6e618897397ff3385858581811061076b5761076b610f03565b905060a00201602001604051610782929190611137565b60405180910390a2600101610714565b61079c8133610897565b50565b5f6107aa8383610594565b610827575f838152602081815260408083206001600160a01b03861684529091529020805460ff191660011790556107df3390565b6001600160a01b0316826001600160a01b0316847f2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d60405160405180910390a45060016103f6565b505f6103f6565b5f6108398383610594565b15610827575f838152602081815260408083206001600160a01b0386168085529252808320805460ff1916905551339286917ff6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b9190a45060016103f6565b6108a18282610594565b6108d45760405163e2517d3f60e01b81526001600160a01b03821660048201526024810183905260440160405180910390fd5b5050565b80356001600160a01b03811681146108ee575f5ffd5b919050565b5f5f60408385031215610904575f5ffd5b82359150610914602084016108d8565b90509250929050565b5f6020828403121561092d575f5ffd5b81356001600160e01b031981168114610944575f5ffd5b9392505050565b5f6020828403121561095b575f5ffd5b5035919050565b5f5f5f5f84860360c0811215610976575f5ffd5b8535945060208601356001600160401b03811115610992575f5ffd5b8601601f810188136109a2575f5ffd5b80356001600160401b038111156109b7575f5ffd5b8860208284010111156109c8575f5ffd5b602091909101945092506080603f19820112156109e3575f5ffd5b509295919450926040019150565b5f5f60208385031215610a02575f5ffd5b82356001600160401b03811115610a17575f5ffd5b8301601f81018513610a27575f5ffd5b80356001600160401b03811115610a3c575f5ffd5b8560208260051b8401011115610a50575f5ffd5b6020919091019590945092505050565b634e487b7160e01b5f52604160045260245ffd5b60405160c081016001600160401b0381118282101715610a9657610a96610a60565b60405290565b60405161012081016001600160401b0381118282101715610a9657610a96610a60565b5f82601f830112610ace575f5ffd5b8135602083015f5f6001600160401b03841115610aed57610aed610a60565b50604051601f19601f85018116603f011681018181106001600160401b0382111715610b1b57610b1b610a60565b604052838152905080828401871015610b32575f5ffd5b838360208301375f602085830101528094505050505092915050565b803563ffffffff811681146108ee575f5ffd5b5f60208284031215610b71575f5ffd5b81356001600160401b03811115610b86575f5ffd5b820160c08185031215610b97575f5ffd5b610b9f610a74565b8135815260208201356001600160401b03811115610bbb575f5ffd5b610bc786828501610abf565b602083015250610bd960408301610b4e565b604082015260608201356001600160401b03811115610bf6575f5ffd5b610c0286828501610abf565b60608301525060808201356001600160401b03811115610c20575f5ffd5b610c2c86828501610abf565b60808301525060a08201356001600160401b03811115610c4a575f5ffd5b610c5686828501610abf565b60a083015250949350505050565b5f60208284031215610c74575f5ffd5b81356001600160401b03811115610c89575f5ffd5b82016101208185031215610c9b575f5ffd5b610ca3610a9c565b81356001600160401b03811115610cb8575f5ffd5b610cc486828501610abf565b82525060208201356001600160401b03811115610cdf575f5ffd5b610ceb86828501610abf565b602083015250610cfd60408301610b4e565b604082015260608201356001600160401b03811115610d1a575f5ffd5b610d2686828501610abf565b60608301525060808201356001600160401b03811115610d44575f5ffd5b610d5086828501610abf565b60808301525060a08201356001600160401b03811115610d6e575f5ffd5b610d7a86828501610abf565b60a08301525060c08201356001600160401b03811115610d98575f5ffd5b610da486828501610abf565b60c08301525060e08201356001600160401b03811115610dc2575f5ffd5b610dce86828501610abf565b60e0830152506101008201356001600160401b03811115610ded575f5ffd5b610df986828501610abf565b61010083015250949350505050565b5f5f60208385031215610e19575f5ffd5b82356001600160401b03811115610e2e575f5ffd5b8301601f81018513610e3e575f5ffd5b80356001600160401b03811115610e53575f5ffd5b85602060a083028401011115610a50575f5ffd5b81835281816020850137505f828201602090810191909152601f909101601f19169091010190565b803582526020808201359083015260408082013590830152606081013560ff8116808214610ebb575f5ffd5b80606085015250505050565b6001600160a01b038516815260c0602082018190525f90610eeb9083018587610e67565b9050610efa6040830184610e8f565b95945050505050565b634e487b7160e01b5f52603260045260245ffd5b5f8235603e19833603018112610f2b575f5ffd5b9190910192915050565b5f5f8335601e19843603018112610f4a575f5ffd5b8301803591506001600160401b03821115610f63575f5ffd5b602001915036819003821315610f77575f5ffd5b9250929050565b6001600160a01b03841681526040602082018190525f90610efa9083018486610e67565b5f81518084528060208401602086015e5f602082860101526020601f19601f83011685010191505092915050565b60018060a01b038a16815288602082015263ffffffff8816604082015286606082015285608082015261012060a08201525f611010610120830187610fa2565b82810360c08401526110228187610fa2565b905082810360e08401526110368186610fa2565b905082810361010084015261104b8185610fa2565b9c9b505050505050505050505050565b6001600160a01b038d16815261018060208201525f61107e61018083018e610fa2565b8281036040840152611090818e610fa2565b63ffffffff8d16606085015290508a60808401528960a084015282810360c08401526110bc818a610fa2565b905082810360e08401526110d08189610fa2565b90508281036101008401526110e58188610fa2565b90508281036101208401526110fa8187610fa2565b905082810361014084015261110f8186610fa2565b90508281036101608401526111248185610fa2565b9f9e505050505050505050505050505050565b6001600160a01b038316815260a081016109446020830184610e8f56fea26469706673582212200c5616b037a1ff32a0127a22a32179636d90fb0b9f83fd4565124837ee62c64664736f6c63430008230033",
+  "linkReferences": {},
+  "deployedLinkReferences": {},
+  "immutableReferences": {},
+  "inputSourceName": "project/contracts/ChainSignatures.sol",
+  "buildInfoId": "solc-0_8_35-9e0c68c577f77ebffa2ce1be3a1ec4f181b78621"
+}

--- a/integration-tests/fixtures/eth/README.md
+++ b/integration-tests/fixtures/eth/README.md
@@ -1,0 +1,20 @@
+# Ethereum Contract Fixtures
+
+This fixture is the prebuilt Hardhat artifact of the SigNet EVM chain signatures contract (`ChainSignatures.sol`): the ABI + bytecode bundle the integration tests deploy to the local Anvil sandbox.
+
+- **Source repository:** `signet-evm-program` (the source of truth for the EVM contract)
+- **Source contract:** `contracts/ChainSignatures.sol` (checked in as `ChainSignatures.json`)
+- **Built with:** Hardhat via `pnpm install && npx hardhat compile` in that repo
+
+## Regenerate
+
+```bash
+# in the signet-evm-program repo
+pnpm install
+npx hardhat compile
+# in this repo
+cp <signet-evm-program-repo>/artifacts/contracts/ChainSignatures.sol/ChainSignatures.json \
+   <this-directory>/ChainSignatures.json
+```
+
+Integration tests embed the artifact at compile time via `include_bytes!` in `integration-tests/src/eth.rs` (`deploy_chain_signatures`) and deploy it with `(address admin, uint256 signatureDeposit)` constructor args.

--- a/integration-tests/src/eth.rs
+++ b/integration-tests/src/eth.rs
@@ -56,9 +56,10 @@ pub async fn deploy_chain_signatures<P>(
 where
     P: Provider + Clone + 'static,
 {
-    let artifact: Value = serde_json::from_slice(include_bytes!(
-        "../../chain-signatures/contract-eth/artifacts/contracts/ChainSignatures.sol/ChainSignatures.json"
-    ))?;
+    // Prebuilt fixture from the signet-evm-program repo (the contract's source
+    // of truth) — see integration-tests/fixtures/eth/README.md to regenerate.
+    let artifact: Value =
+        serde_json::from_slice(include_bytes!("../fixtures/eth/ChainSignatures.json"))?;
 
     let bytecode = artifact
         .get("bytecode")

--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -1,18 +1,27 @@
+use alloy::consensus::{SignableTransaction, TxEip1559};
+use alloy::eips::eip2718::Encodable2718;
 use alloy::network::{Ethereum, TransactionBuilder};
-use alloy::primitives::U256;
-use alloy::providers::Provider;
+use alloy::primitives::{Bytes, FixedBytes, TxKind, B256, U256};
+use alloy::providers::ext::AnvilApi;
+use alloy::providers::{Provider, ProviderBuilder};
 use alloy::rpc::types::request::TransactionRequest;
 use alloy::rpc::types::Filter;
-use alloy::sol_types::SolEvent;
+use alloy::sol_types::{SolEvent, SolValue};
 use anyhow::{anyhow, Context, Result};
 use integration_tests::cluster::Cluster;
 use integration_tests::{actions, cluster, eth};
 use k256::ecdsa::VerifyingKey;
+use k256::elliptic_curve::ops::Reduce;
 use k256::elliptic_curve::sec1::FromEncodedPoint;
-use k256::{AffinePoint, EncodedPoint, FieldBytes, PublicKey as K256PublicKey};
+use k256::{AffinePoint, EncodedPoint, FieldBytes, PublicKey as K256PublicKey, Secp256k1};
 use mpc_crypto::derive_key;
-use mpc_crypto::kdf::derive_epsilon_eth;
-use mpc_node::sign_bidirectional::public_key_to_address;
+use mpc_crypto::kdf::{check_ec_signature, derive_epsilon_eth};
+use mpc_node::respond_bidirectional::{
+    calculate_respond_bidirectional_hash_message, ETHEREUM_RESPOND_BIDIRECTIONAL_PATH,
+};
+use mpc_node::sign_bidirectional::{
+    derive_user_address, public_key_to_address, sign_and_hash_transaction,
+};
 use mpc_primitives::{Chain, Checkpoint, LATEST_MPC_KEY_VERSION};
 use test_log::test;
 use tokio::time::Duration;
@@ -154,6 +163,282 @@ async fn test_signature_ethereum() -> Result<()> {
         recovered_address == expected_address,
         "signature recovered address mismatch: expected {expected_address:?}, got {recovered_address:?}"
     );
+
+    Ok(())
+}
+
+/// End-to-end bidirectional flow with Ethereum as BOTH source and target chain:
+/// `signBidirectional` on the contract -> MPC responds via `respond` -> the test
+/// broadcasts the signed destination tx -> the indexer observes execution -> MPC
+/// publishes via `respondBidirectional` -> the test verifies the output and the
+/// outcome signature against the "ethereum response key" child key.
+#[test(tokio::test)]
+async fn test_ethereum_eth_bidirectional_flow() -> Result<()> {
+    let key_version = LATEST_MPC_KEY_VERSION;
+    let cluster = cluster::spawn().ethereum().await?;
+    cluster.wait().signable().await?;
+
+    let ctx = cluster.nodes.ctx();
+    let eth_ctx = ctx
+        .ethereum
+        .as_ref()
+        .context("ethereum sandbox not initialized")?;
+    let endpoint = eth_ctx.sandbox.external_http_endpoint.clone();
+    let secret_key = eth_ctx.sandbox.secret_key.clone();
+    let chain_id = eth_ctx.sandbox.chain_id;
+    let contract_address = eth_ctx.contract_address;
+
+    let (client, requester) = eth::client(&endpoint, &secret_key, chain_id)?;
+    let contract = eth::ChainSignatures::new(contract_address, client.clone());
+    let anvil = ProviderBuilder::new().connect_http(endpoint.parse()?);
+
+    let path = "ethereum::ethereum::bridge";
+    let algo = "secp256k1";
+    let dest = "ethereum";
+    let params = "{}";
+
+    // Derive the MPC child account that will broadcast on the target chain.
+    let network_public_key = cluster.root_public_key().await?;
+    let mut network_pk = vec![0x04];
+    network_pk.extend_from_slice(&network_public_key.as_bytes()[1..]);
+    let encoded_network_pk =
+        EncodedPoint::from_bytes(&network_pk).context("invalid network public key encoding")?;
+    let root_pk = AffinePoint::from_encoded_point(&encoded_network_pk)
+        .into_option()
+        .ok_or_else(|| anyhow!("invalid network public key"))?;
+
+    let sender_hex = format!("0x{}", hex::encode(requester));
+    let sign_epsilon = derive_epsilon_eth(key_version, &sender_hex, path);
+    let user_address = derive_user_address(root_pk, sign_epsilon);
+    anvil
+        .anvil_set_balance(user_address, U256::from(10_000_000_000_000_000_000u128))
+        .await?;
+
+    // Destination-chain tx: a plain transfer (non-contract-call output path).
+    let user_nonce = client.get_transaction_count(user_address).pending().await?;
+    let destination_tx = TxEip1559 {
+        chain_id,
+        nonce: user_nonce,
+        gas_limit: 21_000,
+        max_fee_per_gas: 20_000_000_000,
+        max_priority_fee_per_gas: 1_000_000_000,
+        to: TxKind::Call(alloy::primitives::Address::ZERO),
+        value: U256::ZERO,
+        access_list: Default::default(),
+        input: Bytes::new(),
+    };
+    let unsigned_bytes = destination_tx.encoded_for_signing();
+
+    // Submit the bidirectional request on the source contract.
+    let request = eth::ChainSignatures::SignBidirectionalRequest {
+        serializedTransaction: unsigned_bytes.clone().into(),
+        caip2Id: Chain::Ethereum.caip2_chain_id().to_string(),
+        keyVersion: key_version,
+        path: path.to_string(),
+        algo: algo.to_string(),
+        dest: dest.to_string(),
+        params: params.to_string(),
+        outputDeserializationSchema: Bytes::new(),
+        respondSerializationSchema: br#"[{"name":"output","type":"bool"}]"#.to_vec().into(),
+    };
+    let pending = contract
+        .signBidirectional(request)
+        .value(U256::from(1_u64))
+        .send()
+        .await?;
+    let receipt = pending.get_receipt().await?;
+    let from_block = receipt
+        .block_number
+        .context("missing block number in receipt")?;
+
+    // Expected request id: packed scheme from signet-evm-program.
+    let encoded = (
+        requester,
+        unsigned_bytes.clone(),
+        Chain::Ethereum.caip2_chain_id().to_string(),
+        key_version,
+        path.to_string(),
+        algo.to_string(),
+        dest.to_string(),
+        params.to_string(),
+    )
+        .abi_encode_packed();
+    let expected_request_id = alloy::primitives::keccak256(&encoded);
+
+    // 1. Wait for the MPC to respond with the destination tx signature.
+    let signature_responded_topic = alloy::primitives::keccak256(
+        "SignatureResponded(bytes32,address,((uint256,uint256),uint256,uint8))",
+    );
+    let mut matching_event = None;
+    for _ in 0..60 {
+        let latest_block = client.get_block_number().await?;
+        let filter = Filter::new()
+            .address(contract_address)
+            .from_block(from_block)
+            .to_block(latest_block)
+            .event_signature(signature_responded_topic);
+        let events = client.get_logs(&filter).await?;
+        if let Some(found) = events.into_iter().find_map(|log| {
+            alloy::primitives::Log::new(
+                log.address(),
+                log.topics().to_vec(),
+                log.data().data.clone(),
+            )
+            .and_then(|prim_log| {
+                eth::SignatureResponded::decode_log(&prim_log)
+                    .ok()
+                    .filter(|event| event.requestId == expected_request_id)
+            })
+        }) {
+            matching_event = Some(found);
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+    let event = matching_event
+        .ok_or_else(|| anyhow!("did not observe signature response for bidirectional request"))?;
+
+    // Rebuild the MPC signature and verify it against the derived child key.
+    let mut x_bytes = [0u8; 32];
+    x_bytes.copy_from_slice(&event.signature.bigR.x.to_be_bytes::<32>());
+    let mut y_bytes = [0u8; 32];
+    y_bytes.copy_from_slice(&event.signature.bigR.y.to_be_bytes::<32>());
+    let encoded_r = EncodedPoint::from_affine_coordinates(
+        FieldBytes::from_slice(&x_bytes),
+        FieldBytes::from_slice(&y_bytes),
+        false,
+    );
+    let big_r = AffinePoint::from_encoded_point(&encoded_r)
+        .into_option()
+        .ok_or_else(|| anyhow!("invalid R component in signature"))?;
+    let s_scalar =
+        <k256::Scalar as Reduce<<Secp256k1 as k256::elliptic_curve::Curve>::Uint>>::reduce_bytes(
+            FieldBytes::from_slice(&event.signature.s.to_be_bytes::<32>()),
+        );
+    let mpc_signature = mpc_primitives::Signature::new(big_r, s_scalar, event.signature.recoveryId);
+
+    let user_pk = derive_key(root_pk, sign_epsilon);
+    let signing_hash: [u8; 32] = alloy::primitives::keccak256(&unsigned_bytes).into();
+    let payload_scalar = <k256::Scalar as Reduce<
+        <Secp256k1 as k256::elliptic_curve::Curve>::Uint,
+    >>::reduce_bytes((&signing_hash).into());
+    check_ec_signature(
+        &user_pk,
+        &mpc_signature.big_r,
+        &mpc_signature.s,
+        payload_scalar,
+        mpc_signature.recovery_id,
+    )
+    .map_err(|err| anyhow!("mpc signature did not verify against derived user key: {err:?}"))?;
+
+    // 2. Broadcast the signed destination transaction (the MPC does not broadcast).
+    let y_parity = mpc_signature.recovery_id == 1;
+    let r_bytes: [u8; 32] = mpc_crypto::x_coordinate(&mpc_signature.big_r)
+        .to_bytes()
+        .into();
+    let s_bytes: [u8; 32] = mpc_signature.s.to_bytes().into();
+    let signed_bytes = destination_tx
+        .clone()
+        .into_signed(alloy::primitives::Signature::from_scalars_and_parity(
+            FixedBytes::from_slice(&r_bytes),
+            FixedBytes::from_slice(&s_bytes),
+            y_parity,
+        ))
+        .encoded_2718();
+    let (watched_tx_hash, _) = sign_and_hash_transaction(&unsigned_bytes, mpc_signature)?;
+
+    let pending_tx = anvil.send_raw_transaction(&signed_bytes).await?;
+    let tx_hash = *pending_tx.tx_hash();
+    assert_eq!(
+        tx_hash,
+        B256::from(watched_tx_hash),
+        "MPC watcher tx hash mismatch"
+    );
+    let broadcast_receipt = pending_tx.get_receipt().await?;
+    anyhow::ensure!(
+        broadcast_receipt.status(),
+        "destination transaction reverted"
+    );
+
+    // 3. Wait for the MPC to publish respondBidirectional back on the source contract.
+    let respond_topic = alloy::primitives::keccak256(
+        "RespondBidirectional(bytes32,address,bytes,((uint256,uint256),uint256,uint8))",
+    );
+    let mut respond_event = None;
+    for _ in 0..90 {
+        let latest_block = client.get_block_number().await?;
+        let filter = Filter::new()
+            .address(contract_address)
+            .from_block(from_block)
+            .to_block(latest_block)
+            .event_signature(respond_topic);
+        let events = client.get_logs(&filter).await?;
+        if let Some(found) = events.into_iter().find_map(|log| {
+            alloy::primitives::Log::new(
+                log.address(),
+                log.topics().to_vec(),
+                log.data().data.clone(),
+            )
+            .and_then(|prim_log| {
+                eth::ChainSignatures::RespondBidirectional::decode_log(&prim_log)
+                    .ok()
+                    .filter(|event| event.requestId == expected_request_id)
+            })
+        }) {
+            respond_event = Some(found);
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+    let respond_event = respond_event
+        .ok_or_else(|| anyhow!("did not observe RespondBidirectional event on ethereum"))?;
+
+    // Plain transfers serialize to the ABI default: bool true in one 32-byte word.
+    let mut expected_output = vec![0u8; 32];
+    *expected_output.last_mut().unwrap() = 1;
+    assert_eq!(respond_event.serializedOutput.to_vec(), expected_output);
+
+    // 4. Verify the outcome signature against the "ethereum response key" child key.
+    let mut x_bytes = [0u8; 32];
+    x_bytes.copy_from_slice(&respond_event.signature.bigR.x.to_be_bytes::<32>());
+    let mut y_bytes = [0u8; 32];
+    y_bytes.copy_from_slice(&respond_event.signature.bigR.y.to_be_bytes::<32>());
+    let encoded_r = EncodedPoint::from_affine_coordinates(
+        FieldBytes::from_slice(&x_bytes),
+        FieldBytes::from_slice(&y_bytes),
+        false,
+    );
+    let respond_big_r = AffinePoint::from_encoded_point(&encoded_r)
+        .into_option()
+        .ok_or_else(|| anyhow!("invalid R component in respond signature"))?;
+    let respond_s =
+        <k256::Scalar as Reduce<<Secp256k1 as k256::elliptic_curve::Curve>::Uint>>::reduce_bytes(
+            FieldBytes::from_slice(&respond_event.signature.s.to_be_bytes::<32>()),
+        );
+
+    let respond_hash = calculate_respond_bidirectional_hash_message(
+        expected_request_id.as_slice(),
+        &respond_event.serializedOutput,
+    );
+    let respond_payload_scalar = <k256::Scalar as Reduce<
+        <Secp256k1 as k256::elliptic_curve::Curve>::Uint,
+    >>::reduce_bytes((&respond_hash).into());
+    let respond_epsilon = derive_epsilon_eth(
+        key_version,
+        &sender_hex,
+        ETHEREUM_RESPOND_BIDIRECTIONAL_PATH,
+    );
+    let respond_pk = derive_key(root_pk, respond_epsilon);
+    check_ec_signature(
+        &respond_pk,
+        &respond_big_r,
+        &respond_s,
+        respond_payload_scalar,
+        respond_event.signature.recoveryId,
+    )
+    .map_err(|err| {
+        anyhow!("respond signature did not verify against ethereum response key: {err:?}")
+    })?;
 
     Ok(())
 }

--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -6,7 +6,7 @@ use alloy::providers::ext::AnvilApi;
 use alloy::providers::{Provider, ProviderBuilder};
 use alloy::rpc::types::request::TransactionRequest;
 use alloy::rpc::types::Filter;
-use alloy::sol_types::{SolEvent, SolValue};
+use alloy::sol_types::SolEvent;
 use anyhow::{anyhow, Context, Result};
 use integration_tests::cluster::Cluster;
 use integration_tests::{actions, cluster, eth};
@@ -14,6 +14,7 @@ use k256::ecdsa::VerifyingKey;
 use k256::elliptic_curve::ops::Reduce;
 use k256::elliptic_curve::sec1::FromEncodedPoint;
 use k256::{AffinePoint, EncodedPoint, FieldBytes, PublicKey as K256PublicKey, Secp256k1};
+use mpc_chain_integration_core::utils::hashing::compute_bidirectional_request_id;
 use mpc_crypto::derive_key;
 use mpc_crypto::kdf::{check_ec_signature, derive_epsilon_eth};
 use mpc_node::respond_bidirectional::{
@@ -252,18 +253,16 @@ async fn test_ethereum_eth_bidirectional_flow() -> Result<()> {
         .context("missing block number in receipt")?;
 
     // Expected request id: packed scheme from signet-evm-program.
-    let encoded = (
-        requester,
-        unsigned_bytes.clone(),
-        Chain::Ethereum.caip2_chain_id().to_string(),
+    let expected_request_id = B256::from(compute_bidirectional_request_id(
+        requester.as_slice(),
+        &unsigned_bytes,
+        Chain::Ethereum.caip2_chain_id(),
         key_version,
-        path.to_string(),
-        algo.to_string(),
-        dest.to_string(),
-        params.to_string(),
-    )
-        .abi_encode_packed();
-    let expected_request_id = alloy::primitives::keccak256(&encoded);
+        path,
+        algo,
+        dest,
+        params,
+    ));
 
     // 1. Wait for the MPC to respond with the destination tx signature.
     let signature_responded_topic = alloy::primitives::keccak256(

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -2,7 +2,6 @@ use alloy::network::{Ethereum, TransactionBuilder};
 use alloy::primitives::{Address, B256, U256};
 use alloy::providers::Provider;
 use alloy::rpc::types::request::TransactionRequest;
-use alloy::sol_types::SolValue;
 use anyhow::{Context, Result};
 use cait_sith::protocol::Participant;
 use integration_tests::cluster::spawner::ClusterSpawner;
@@ -10,6 +9,7 @@ use integration_tests::containers::EthereumSandbox;
 use integration_tests::eth::{self, ChainSignatures, SignRequest};
 use k256::elliptic_curve::sec1::ToEncodedPoint as _;
 use k256::{AffinePoint, Scalar};
+use mpc_chain_integration_core::utils::hashing::compute_bidirectional_request_id;
 use mpc_chain_integration_core::{ChainStream, ChainTelemetry, NoopChainTelemetry, StateManager};
 use mpc_crypto::kdf::generate_signature;
 use mpc_node::backlog::Backlog;
@@ -1261,18 +1261,16 @@ async fn test_ethereum_stream_parse_sign_bidirectional() -> Result<()> {
     assert_eq!(req.args.key_version, LATEST_MPC_KEY_VERSION);
 
     // Request id must follow the packed scheme from signet-evm-program.
-    let encoded = (
-        ctx.wallet,
-        serialized_transaction.clone(),
-        Chain::Ethereum.caip2_chain_id().to_string(),
+    let expected_request_id = compute_bidirectional_request_id(
+        ctx.wallet.as_slice(),
+        &serialized_transaction,
+        Chain::Ethereum.caip2_chain_id(),
         LATEST_MPC_KEY_VERSION,
-        path.to_string(),
-        "secp256k1".to_string(),
-        "ethereum".to_string(),
-        "{}".to_string(),
-    )
-        .abi_encode_packed();
-    let expected_request_id: [u8; 32] = alloy::primitives::keccak256(&encoded).into();
+        path,
+        "secp256k1",
+        "ethereum",
+        "{}",
+    );
     assert_eq!(req.id.request_id, expected_request_id);
 
     // Payload is keccak256 of the serialized destination transaction.

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -2,6 +2,7 @@ use alloy::network::{Ethereum, TransactionBuilder};
 use alloy::primitives::{Address, B256, U256};
 use alloy::providers::Provider;
 use alloy::rpc::types::request::TransactionRequest;
+use alloy::sol_types::SolValue;
 use anyhow::{Context, Result};
 use cait_sith::protocol::Participant;
 use integration_tests::cluster::spawner::ClusterSpawner;
@@ -224,6 +225,49 @@ async fn submit_sign_request_with_block(
             .block_number
             .context("sign transaction missing block number")?,
     ))
+}
+
+async fn submit_sign_bidirectional_request(
+    ctx: &EthereumTestEnvironment,
+    serialized_transaction: Vec<u8>,
+    path: &str,
+) -> Result<B256> {
+    let contract = ctx.contract();
+    let request = ChainSignatures::SignBidirectionalRequest {
+        serializedTransaction: serialized_transaction.into(),
+        caip2Id: Chain::Ethereum.caip2_chain_id().to_string(),
+        keyVersion: LATEST_MPC_KEY_VERSION,
+        path: path.to_string(),
+        algo: "secp256k1".to_string(),
+        dest: "ethereum".to_string(),
+        params: "{}".to_string(),
+        outputDeserializationSchema: alloy::primitives::Bytes::new(),
+        respondSerializationSchema: br#"[{"name":"output","type":"bool"}]"#.to_vec().into(),
+    };
+
+    let call = contract
+        .signBidirectional(request)
+        .value(signature_deposit());
+    let pending_tx = call.send().await?;
+    let receipt = pending_tx
+        .get_receipt()
+        .await
+        .context("failed to mine signBidirectional transaction")?;
+    Ok(receipt.transaction_hash)
+}
+
+fn unsigned_legacy_transfer_rlp() -> Vec<u8> {
+    let mut rlp_s = rlp::RlpStream::new_list(9);
+    rlp_s.append(&0u64);
+    rlp_s.append(&0u64);
+    rlp_s.append(&0u64);
+    rlp_s.append(&Vec::<u8>::new());
+    rlp_s.append(&0u64);
+    rlp_s.append(&Vec::<u8>::new());
+    rlp_s.append(&1u64);
+    rlp_s.append(&0u64);
+    rlp_s.append(&0u64);
+    rlp_s.out().to_vec()
 }
 
 async fn submit_eth_transfer(ctx: &EthereumTestEnvironment) -> Result<B256> {
@@ -1188,5 +1232,127 @@ async fn test_ethereum_stream_sign_and_respond_flow() -> Result<()> {
     }
 
     assert!(saw_respond, "did not receive SignatureResponded event");
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_ethereum_stream_parse_sign_bidirectional() -> Result<()> {
+    let ctx = EthereumTestEnvironment::new().await?;
+    let backlog = ctx.backlog();
+    let mut stream = stream_ethereum(&ctx, backlog).await?;
+
+    let serialized_transaction = unsigned_legacy_transfer_rlp();
+    let path = "eth-bidirectional-path";
+    submit_sign_bidirectional_request(&ctx, serialized_transaction.clone(), path).await?;
+
+    let req = loop {
+        match next_event_within(&mut stream, Duration::from_secs(10)).await? {
+            ChainEvent::SignRequest { request, .. }
+                if matches!(request.kind, SignKind::SignBidirectional(_)) =>
+            {
+                break request;
+            }
+            _ => continue,
+        }
+    };
+
+    assert_eq!(req.chain, Chain::Ethereum);
+    assert_eq!(req.args.path, path);
+    assert_eq!(req.args.key_version, LATEST_MPC_KEY_VERSION);
+
+    // Request id must follow the packed scheme from signet-evm-program.
+    let encoded = (
+        ctx.wallet,
+        serialized_transaction.clone(),
+        Chain::Ethereum.caip2_chain_id().to_string(),
+        LATEST_MPC_KEY_VERSION,
+        path.to_string(),
+        "secp256k1".to_string(),
+        "ethereum".to_string(),
+        "{}".to_string(),
+    )
+        .abi_encode_packed();
+    let expected_request_id: [u8; 32] = alloy::primitives::keccak256(&encoded).into();
+    assert_eq!(req.id.request_id, expected_request_id);
+
+    // Payload is keccak256 of the serialized destination transaction.
+    let expected_payload: [u8; 32] = alloy::primitives::keccak256(&serialized_transaction).into();
+    assert_eq!(req.args.payload.to_bytes(), expected_payload.into());
+
+    let expected_epsilon = mpc_crypto::kdf::derive_epsilon_eth(
+        LATEST_MPC_KEY_VERSION,
+        &format!("0x{}", hex::encode(ctx.wallet.as_slice())),
+        path,
+    );
+    assert_eq!(req.args.epsilon, expected_epsilon);
+
+    let SignKind::SignBidirectional(event) = req.kind else {
+        panic!("expected SignBidirectional kind");
+    };
+    assert_eq!(event.chain, Chain::Ethereum);
+    assert_eq!(event.chain_ctx, None);
+    assert_eq!(event.serialized_transaction, serialized_transaction);
+    assert_eq!(event.caip2_id, Chain::Ethereum.caip2_chain_id());
+    assert_eq!(event.sender[..12], [0u8; 12]);
+    assert_eq!(&event.sender[12..], ctx.wallet.as_slice());
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_ethereum_stream_parse_respond_bidirectional() -> Result<()> {
+    let ctx = EthereumTestEnvironment::new().await?;
+    let backlog = ctx.backlog();
+    let mut stream = stream_ethereum(&ctx, backlog).await?;
+
+    let request_id = [0x5a; 32];
+    let serialized_output: Vec<u8> = {
+        let mut out = vec![0u8; 32];
+        *out.last_mut().unwrap() = 1;
+        out
+    };
+
+    let expected_big_r = k256::ProjectivePoint::GENERATOR.to_affine();
+    let expected_s = k256::Scalar::from(11u64);
+    let expected_recovery_id: u8 = 1;
+
+    let enc = k256::ProjectivePoint::GENERATOR.to_encoded_point(false);
+    let signature = ChainSignatures::Signature {
+        bigR: ChainSignatures::AffinePoint {
+            x: U256::from_be_slice(enc.x().expect("generator must have x coordinate")),
+            y: U256::from_be_slice(enc.y().expect("generator must have y coordinate")),
+        },
+        s: U256::from_be_bytes(expected_s.to_bytes().into()),
+        recoveryId: expected_recovery_id,
+    };
+
+    let contract = ctx.contract();
+    let call = contract.respondBidirectional(
+        request_id.into(),
+        serialized_output.clone().into(),
+        signature,
+    );
+    let pending_tx = call.send().await?;
+    pending_tx
+        .get_receipt()
+        .await
+        .context("respondBidirectional transaction execution failed")?;
+
+    let mut saw_respond = false;
+    for _ in 0..8 {
+        match next_event_within(&mut stream, Duration::from_secs(10)).await? {
+            ChainEvent::RespondBidirectional(ev) => {
+                assert_eq!(ev.chain, mpc_primitives::Chain::Ethereum);
+                assert_eq!(ev.request_id, request_id);
+                assert_eq!(ev.signature.big_r, expected_big_r);
+                assert_eq!(ev.signature.s, expected_s);
+                assert_eq!(ev.signature.recovery_id, expected_recovery_id);
+                saw_respond = true;
+                break;
+            }
+            _ => continue,
+        }
+    }
+
+    assert!(saw_respond, "did not receive RespondBidirectional event");
     Ok(())
 }


### PR DESCRIPTION
## Why

The bidirectional signing flow (source chain requests a signature over a destination-chain tx; the MPC returns the phase-1 signature and, after observing execution, the phase-2 outcome — both published back to the source contract) existed for Solana, Canton, and Hydration but not for EVM chains. The EVM contract (`signet-evm-program`, already implemented and validated) needed its node-side counterpart so EVM users can drive cross-chain transactions the same way.

## What

- `indexer_eth`: index `SignBidirectional` events into the bidirectional pipeline (packed request id mirroring the Solana scheme, payload = keccak256 of the destination tx, epsilon via `derive_epsilon_eth`) and `RespondBidirectional` events for completion tracking; log partition extended from two to four topic buckets, legacy paths byte-identical.
- Chain dispatch arms, mirroring the other source chains: ABI respond serialization, sender-word decoding, epsilon derivation in both bidirectional ext traits, and the `"ethereum response key"` respond path.
- `rpc/ethereum`: `EthClient::publish_signature` now dispatches on `SignKind` like `HydrationClient` — `Sign`/`SignBidirectional` keep the batched `respond()`, `RespondBidirectional` publishes via `respondBidirectional()` with receipt verification.
- Test contract artifact vendored as `integration-tests/fixtures/eth/ChainSignatures.json` (+ provenance README), following the Canton DAR fixture pattern; `include_bytes!` in the harness repointed. The Solidity source stays in `signet-evm-program` (single source of truth).
- Tests: golden-anchored unit tests (goldens generated with viem from signet-evm-program: request id, payload, event topics), two eth stream integration tests, and a full-cluster e2e (`test_ethereum_eth_bidirectional_flow`: 3-node MPC + Anvil, both phases verified cryptographically, broadcast hash matched against the node's watched hash).

Verification: mpc-node 202/202 + mpc-primitives 4/4 unit tests, eth stream suite 11/11 against the new contract, e2e PASS, and regressions green for `test_signature_ethereum` and `test_solana_eth_bidirectional_flow`. fmt + clippy clean in both workspaces.

## ⚠️ Follow-up needed: `chain-signatures/contract-eth` is now orphaned

With the harness deploying the vendored fixture, nothing consumes contract-eth's artifact anymore — but CI still compiles it and runs its JS tests (`unit.yml`, `integration.yml`), and the `Dockerfile` still builds it. The old contract source there predates `signBidirectional`, so anyone editing it would be changing a contract nothing deploys, with green CI hiding the divergence. Needs a decision in this PR's review or a fast follow: remove/deprecate contract-eth or repoint those CI steps.

Unrelated pre-existing note: `indexer_sol::client::tests::get_slot_retries_on_500_then_succeeds` is flaky (~1/3 failure rate in isolation, untouched by this branch) — worth a tracking issue if it reddens CI here.

## Review fixes (applied in this PR)

- Deposits above `u64::MAX` are now skipped with a warn via a checked conversion (mirrors Hydration's `try_into` handling) instead of silently clamping into the shared `u64` event field.
- The eth publish paths share one `send_call`/`send_call_and_verify` pipeline — `respond()` and `respondBidirectional()` both go through the pre-existing retry/nonce-refetch/receipt/revert machinery via `clear_decoder()` instead of a forked copy (which had already drifted: dropped gas heuristic comment context and a discarded tx-hash return).
- Bidirectional request-id packing moved next to `compute_request_id` in `chain-integration-core` as `compute_bidirectional_request_id`, pinned by the viem golden; the eth indexer and both integration tests call it directly instead of keeping three inline copies.
- Block-log classification is a single `topic0` pass building the four buckets, matching the Solana indexer's event dispatch, instead of three chained partitions.

## Deferred follow-ups (from review)

- Restrict the CAIP-2 target validation consistently across all three source indexers (`indexer_eth`/`indexer_sol`/`indexer_hydration`): they accept any known chain today, but only EVM targets are executable/watchable, so a request targeting e.g. `near:mainnet` is phase-1 signed, consumes the deposit, and pins a `PendingExecution` entry (and its watcher) in the backlog forever.
- Serialize or locally manage the eth publisher nonce (existing TODO in `send_call`): `respondBidirectional` publishes now run per-action alongside the batch task on the same wallet, so two concurrent sends can fetch the same pending nonce; the inner retry refetches and self-heals, but a mutex or local nonce tracking would remove the retry churn.
- Harden `Backlog::insert` against clobbering in-flight entries: the deterministic bidirectional request id means a duplicate identical submission resets `PendingExecution` state and re-signs with fresh entropy (same exposure exists for Solana; the fix belongs in the shared backlog, e.g. refuse to regress an entry past `PendingGeneration`).
- Migrate `indexer_sol`/`indexer_hydration` request-id packing onto `compute_bidirectional_request_id`; their inline copies currently have no unit-test coverage, and delegating extends the viem golden to them.
- Drop the redundant outer warn + per-log clone in `parse_filtered_logs`/`parse_bidirectional_filtered_logs` together — every failure path inside the callees already emits a specific warn.
