### PR TITLE
refactor: introduce `StreamContext` to hold `run_stream` dependencies

### DIFF
--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -21,7 +21,7 @@ use crate::storage::checkpoint_storage::CheckpointStorage;
 use crate::storage::presignature_storage::PresignatureStorage;
 use crate::storage::secret_storage::SecretNodeStorageVariant;
 use crate::storage::triple_storage::{TriplePair, TripleStorage};
-use crate::stream::run_stream;
+use crate::stream::{run_stream, StreamContext};
 use crate::{logs, storage, web};
 pub use args::{canton::CantonArgs, ethereum::EthArgs, hydration::HydrationArgs, solana::SolArgs};
 
@@ -787,14 +787,16 @@ async fn spawn_indexers(
                 tracing::info!("ethereum indexer stream created successfully");
                 tokio::spawn(run_stream(
                     eth_stream,
-                    sign_tx.clone(),
-                    rpc_channel.clone(),
-                    backlog.clone(),
+                    StreamContext::new(
+                        backlog.clone(),
+                        sign_tx.clone(),
+                        rpc_channel.clone(),
+                        contract_watcher.clone(),
+                        mesh_state.clone(),
+                        node_client.clone(),
+                        checkpoints_rx[Chain::Ethereum].clone(),
+                    ),
                     eth_telemetry,
-                    contract_watcher.clone(),
-                    mesh_state.clone(),
-                    node_client.clone(),
-                    checkpoints_rx[Chain::Ethereum].clone(),
                 ));
             }
             Err(err) => {
@@ -810,14 +812,16 @@ async fn spawn_indexers(
                 tracing::info!("solana indexer stream created successfully");
                 tokio::spawn(run_stream(
                     sol_stream,
-                    sign_tx.clone(),
-                    rpc_channel.clone(),
-                    backlog.clone(),
+                    StreamContext::new(
+                        backlog.clone(),
+                        sign_tx.clone(),
+                        rpc_channel.clone(),
+                        contract_watcher.clone(),
+                        mesh_state.clone(),
+                        node_client.clone(),
+                        checkpoints_rx[Chain::Solana].clone(),
+                    ),
                     sol_telemetry,
-                    contract_watcher.clone(),
-                    mesh_state.clone(),
-                    node_client.clone(),
-                    checkpoints_rx[Chain::Solana].clone(),
                 ));
             }
             Err(err) => {
@@ -847,14 +851,16 @@ async fn spawn_indexers(
                 tracing::info!("canton indexer stream created successfully");
                 tokio::spawn(run_stream(
                     canton_stream,
-                    sign_tx,
-                    rpc_channel,
-                    backlog,
+                    StreamContext::new(
+                        backlog,
+                        sign_tx,
+                        rpc_channel,
+                        contract_watcher,
+                        mesh_state,
+                        node_client,
+                        checkpoints_rx[Chain::Canton].clone(),
+                    ),
                     canton_telemetry,
-                    contract_watcher,
-                    mesh_state,
-                    node_client,
-                    checkpoints_rx[Chain::Canton].clone(),
                 ));
             }
             Err(err) => {

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -25,23 +25,51 @@ pub enum ChainStreaming {
     Live,
 }
 
+/// Shared, per-chain dependencies
+pub struct StreamContext {
+    pub backlog: Backlog,
+    pub sign_tx: mpsc::Sender<SignCommand>,
+    pub rpc: RpcChannel,
+    pub contract_watcher: ContractStateWatcher,
+    pub mesh_state: watch::Receiver<MeshState>,
+    pub node_client: NodeClient,
+    pub checkpoints_rx: CheckpointWatcher,
+    pub caught_up: bool,
+}
+
+impl StreamContext {
+    pub fn new(
+        backlog: Backlog,
+        sign_tx: mpsc::Sender<SignCommand>,
+        rpc: RpcChannel,
+        contract_watcher: ContractStateWatcher,
+        mesh_state: watch::Receiver<MeshState>,
+        node_client: NodeClient,
+        checkpoints_rx: CheckpointWatcher,
+    ) -> Self {
+        Self {
+            backlog,
+            sign_tx,
+            rpc,
+            contract_watcher,
+            mesh_state,
+            node_client,
+            checkpoints_rx,
+            caught_up: false,
+        }
+    }
+}
+
 /// Shared indexer loop: recovers backlog then processes events from the stream
-#[allow(clippy::too_many_arguments)]
 pub async fn run_stream<S: ChainStream, T: ChainTelemetry>(
     mut stream: S,
-    sign_tx: mpsc::Sender<SignCommand>,
-    rpc: RpcChannel,
-    backlog: Backlog,
+    mut ctx: StreamContext,
     telemetry: T,
-    mut contract_watcher: ContractStateWatcher,
-    mesh_state: watch::Receiver<MeshState>,
-    node_client: NodeClient,
-    checkpoints_rx: CheckpointWatcher,
 ) {
     let chain = S::Indexer::CHAIN;
     tracing::info!(%chain, "starting stream");
 
-    let threshold = contract_watcher.wait_threshold().await;
+    let threshold = ctx.contract_watcher.wait_threshold().await;
 
     let indexer = match stream.start().await {
         Ok(indexer) => indexer,
@@ -53,19 +81,18 @@ pub async fn run_stream<S: ChainStream, T: ChainTelemetry>(
 
     let (pipeline, mut state_rx) = ChainPipeline::new(
         indexer,
-        checkpoints_rx.clone(),
-        backlog.clone(),
-        sign_tx.clone(),
-        mesh_state.clone(),
-        node_client,
+        ctx.checkpoints_rx.clone(),
+        ctx.backlog.clone(),
+        ctx.sign_tx.clone(),
+        ctx.mesh_state.clone(),
+        ctx.node_client.clone(),
         threshold,
-        contract_watcher.account_id().clone(),
+        ctx.contract_watcher.account_id().clone(),
     );
     let indexer_task = tokio::spawn(pipeline.run());
 
-    let root_pk = contract_watcher.wait_public_key().await;
+    let root_pk = ctx.contract_watcher.wait_public_key().await;
 
-    let mut caught_up = false;
     loop {
         tokio::select! {
             event = stream.next_event() => {
@@ -74,13 +101,13 @@ pub async fn run_stream<S: ChainStream, T: ChainTelemetry>(
                 };
                 match event {
                     ChainEvent::CatchupCompleted => {
-                        if caught_up {
+                        if ctx.caught_up {
                             continue;
                         }
-                        caught_up = true;
+                        ctx.caught_up = true;
 
-                        requeue_pending_sign_requests(&backlog, chain, sign_tx.clone()).await;
-                        resume_pending_publish_requests(&backlog, chain, &contract_watcher, &rpc).await;
+                        requeue_pending_sign_requests(&ctx.backlog, chain, ctx.sign_tx.clone()).await;
+                        resume_pending_publish_requests(&ctx.backlog, chain, &ctx.contract_watcher, &ctx.rpc).await;
                     }
                     ChainEvent::SignRequest { request, block_timestamp } => {
                         // Handle metrics reporting for the sign request event
@@ -93,7 +120,7 @@ pub async fn run_stream<S: ChainStream, T: ChainTelemetry>(
                         }
 
                         if let Err(err) =
-                            process_sign_request(request, sign_tx.clone(), backlog.clone(), caught_up).await
+                            process_sign_request(request, ctx.sign_tx.clone(), ctx.backlog.clone(), ctx.caught_up).await
                         {
                             tracing::error!(?err, %chain, "failed to process sign request");
                         }
@@ -101,10 +128,10 @@ pub async fn run_stream<S: ChainStream, T: ChainTelemetry>(
                     ChainEvent::Respond(ev) => {
                         if let Err(err) = process_respond_event(
                             ev,
-                            sign_tx.clone(),
+                            ctx.sign_tx.clone(),
                             root_pk,
-                            &backlog,
-                            caught_up,
+                            &ctx.backlog,
+                            ctx.caught_up,
                         )
                         .await
                         {
@@ -113,14 +140,14 @@ pub async fn run_stream<S: ChainStream, T: ChainTelemetry>(
                     }
                     ChainEvent::RespondBidirectional(ev) => {
                         if let Err(err) =
-                            process_respond_bidirectional_event(ev, sign_tx.clone(), root_pk, &backlog, caught_up)
+                            process_respond_bidirectional_event(ev, ctx.sign_tx.clone(), root_pk, &ctx.backlog, ctx.caught_up)
                                 .await
                         {
                             tracing::error!(?err, %chain, "failed to process respond bidirectional event");
                         }
                     }
                     ChainEvent::Block(block) => {
-                        process_block_event(chain, block, &backlog, &sign_tx, caught_up, &telemetry).await;
+                        process_block_event(chain, block, &ctx.backlog, &ctx.sign_tx, ctx.caught_up, &telemetry).await;
                     }
                     ChainEvent::ExecutionConfirmed {
                         tx_id,
@@ -135,10 +162,10 @@ pub async fn run_stream<S: ChainStream, T: ChainTelemetry>(
                             source_chain,
                             block_height,
                             result,
-                            &backlog,
-                            sign_tx.clone(),
+                            &ctx.backlog,
+                            ctx.sign_tx.clone(),
                             chain,
-                            caught_up,
+                            ctx.caught_up,
                         )
                         .await
                         {
@@ -150,7 +177,7 @@ pub async fn run_stream<S: ChainStream, T: ChainTelemetry>(
             _ = state_rx.changed() => {
                 let state = *state_rx.borrow_and_update();
                 if matches!(state, ChainStreaming::Recovery { .. } | ChainStreaming::Catchup { .. }) {
-                    caught_up = false;
+                    ctx.caught_up = false;
                 }
             }
         }

--- a/chain-signatures/node/src/stream/stream_tests.rs
+++ b/chain-signatures/node/src/stream/stream_tests.rs
@@ -358,14 +358,16 @@ async fn test_stream_handles_sign_and_respond() {
     // Run the indexer
     run_stream(
         client,
-        sign_tx.clone(),
-        rpc,
-        backlog.clone(),
+        StreamContext::new(
+            backlog.clone(),
+            sign_tx.clone(),
+            rpc,
+            contract_watcher,
+            mesh_state_rx,
+            node_client,
+            cp_rx,
+        ),
         NoopChainTelemetry,
-        contract_watcher,
-        mesh_state_rx,
-        node_client,
-        cp_rx,
     )
     .await;
 
@@ -474,14 +476,16 @@ async fn test_stream_handles_sign_bidirectional_block_and_recover() {
     let run_handle = tokio::spawn(async move {
         run_stream(
             client,
-            sign_tx_for_run,
-            rpc,
-            backlog_for_run,
+            StreamContext::new(
+                backlog_for_run,
+                sign_tx_for_run,
+                rpc,
+                contract_watcher,
+                mesh_state_rx,
+                node_client,
+                cp_rx,
+            ),
             NoopChainTelemetry,
-            contract_watcher,
-            mesh_state_rx,
-            node_client,
-            cp_rx,
         )
         .await;
     });
@@ -855,14 +859,16 @@ async fn test_stream_resumes_pending_publish_after_catchup() {
     let run_handle = tokio::spawn(async move {
         run_stream(
             client,
-            sign_tx,
-            rpc,
-            backlog,
+            StreamContext::new(
+                backlog,
+                sign_tx,
+                rpc,
+                contract_watcher,
+                mesh_state_rx,
+                node_client,
+                cp_rx,
+            ),
             NoopChainTelemetry,
-            contract_watcher,
-            mesh_state_rx,
-            node_client,
-            cp_rx,
         )
         .await;
     });
@@ -933,14 +939,16 @@ async fn test_stream_does_not_resume_non_proposer_pending_publish_after_catchup(
     let run_handle = tokio::spawn(async move {
         run_stream(
             client,
-            sign_tx,
-            rpc,
-            backlog,
+            StreamContext::new(
+                backlog,
+                sign_tx,
+                rpc,
+                contract_watcher,
+                mesh_state_rx,
+                node_client,
+                cp_rx,
+            ),
             NoopChainTelemetry,
-            contract_watcher,
-            mesh_state_rx,
-            node_client,
-            cp_rx,
         )
         .await;
     });

--- a/chain-signatures/node/src/stream/test_utils.rs
+++ b/chain-signatures/node/src/stream/test_utils.rs
@@ -6,7 +6,7 @@ use crate::mesh::MeshState;
 use crate::node_client::NodeClient;
 use crate::protocol::ParticipantInfo;
 use crate::rpc::{ContractStateWatcher, RpcAction, RpcChannel};
-use crate::stream::run_stream;
+use crate::stream::{run_stream, StreamContext};
 use crate::util::current_unix_timestamp;
 use alloy::primitives::{Address, B256};
 use k256::{AffinePoint, Scalar};
@@ -171,14 +171,16 @@ pub async fn run_stream_with_two_node_mesh<S: ChainStream>(
 
     run_stream(
         client,
-        sign_tx,
-        rpc,
-        backlog,
+        StreamContext::new(
+            backlog,
+            sign_tx,
+            rpc,
+            contract_watcher,
+            mesh_state_rx,
+            node_client,
+            cp_rx,
+        ),
         NoopChainTelemetry,
-        contract_watcher,
-        mesh_state_rx,
-        node_client,
-        cp_rx,
     )
     .await;
 }

--- a/integration-tests/src/mpc_fixture/fixture_tasks.rs
+++ b/integration-tests/src/mpc_fixture/fixture_tasks.rs
@@ -13,7 +13,7 @@ use mpc_node::mesh::MeshState;
 use mpc_node::node_client::NodeClient;
 use mpc_node::protocol::message::{MessageOutbox, SendMessage, SignedMessage};
 use mpc_node::rpc::{ContractStateWatcher, RpcAction, RpcChannel};
-use mpc_node::stream::run_stream;
+use mpc_node::stream::{run_stream, StreamContext};
 use mpc_primitives::SignCommand;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -116,15 +116,16 @@ pub(super) fn start_mock_stream_tasks(
     for stream in mock_streams {
         tokio::spawn(run_stream(
             stream.clone(),
-            sign_tx.clone(),
-            rpc.clone(),
-            backlog.clone(),
+            StreamContext::new(
+                backlog.clone(),
+                sign_tx.clone(),
+                rpc.clone(),
+                contract_watcher.clone(),
+                mesh_state.clone(),
+                NodeClient::new(&Default::default()),
+                checkpoints_rx.clone(),
+            ),
             NoopChainTelemetry,
-            contract_watcher.clone(),
-            mesh_state.clone(),
-            // Only used for backlog recovery - not implemented in component tests yet
-            NodeClient::new(&Default::default()),
-            checkpoints_rx.clone(),
         ));
     }
 }

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -20,7 +20,7 @@ use mpc_node::protocol::ParticipantInfo;
 use mpc_node::rpc::{ContractStateWatcher, RpcChannel};
 use mpc_node::sign_bidirectional::{PublishState, SignStatus};
 use mpc_node::storage::checkpoint_storage::CheckpointStorage;
-use mpc_node::stream::{run_stream, ChainPipeline, ChainStreaming};
+use mpc_node::stream::{run_stream, ChainPipeline, ChainStreaming, StreamContext};
 use mpc_node::util::current_unix_timestamp;
 use mpc_primitives::{
     Chain, ChainEvent, CheckpointDigest, IndexedSignRequest, SignArgs,
@@ -472,14 +472,16 @@ async fn test_ethereum_stream_resume_starts_after_checkpoint_height() -> Result<
     let (_cp_tx, checkpoints_rx) = watch::channel(None);
     let run_handle = tokio::spawn(run_stream(
         stream,
-        sign_tx,
-        rpc,
-        backlog,
+        StreamContext::new(
+            backlog.clone(),
+            sign_tx.clone(),
+            rpc.clone(),
+            contract_watcher.clone(),
+            mesh_rx.clone(),
+            NodeClient::new(&Default::default()),
+            checkpoints_rx.clone(),
+        ),
         NoopChainTelemetry,
-        contract_watcher,
-        mesh_rx,
-        NodeClient::new(&Default::default()),
-        checkpoints_rx,
     ));
 
     let mut saw_replayed_payload = false;
@@ -653,14 +655,16 @@ async fn test_ethereum_stream_linear_catchup_from_checkpoint() -> Result<()> {
     let (_cp_tx, checkpoints_rx) = watch::channel(None);
     let run_handle = tokio::spawn(run_stream(
         stream,
-        sign_tx,
-        rpc,
-        backlog.clone(),
+        StreamContext::new(
+            backlog.clone(),
+            sign_tx.clone(),
+            rpc.clone(),
+            contract_watcher.clone(),
+            mesh_rx.clone(),
+            NodeClient::new(&Default::default()),
+            checkpoints_rx.clone(),
+        ),
         NoopChainTelemetry,
-        contract_watcher,
-        mesh_rx,
-        NodeClient::new(&Default::default()),
-        checkpoints_rx,
     ));
 
     let mut saw_execution_follow_up = false;
@@ -841,14 +845,16 @@ async fn test_ethereum_stream_backfills_late_execution_watcher_after_catchup() -
     let (_cp_tx, checkpoints_rx) = watch::channel(None);
     let run_handle = tokio::spawn(run_stream(
         stream,
-        sign_tx,
-        rpc,
-        backlog.clone(),
+        StreamContext::new(
+            backlog.clone(),
+            sign_tx.clone(),
+            rpc.clone(),
+            contract_watcher.clone(),
+            mesh_rx.clone(),
+            NodeClient::new(&Default::default()),
+            checkpoints_rx.clone(),
+        ),
         NoopChainTelemetry,
-        contract_watcher,
-        mesh_rx,
-        NodeClient::new(&Default::default()),
-        checkpoints_rx,
     ));
 
     let mut saw_catchup_flush = false;

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -13,7 +13,7 @@ use mpc_node::protocol::contract::primitives::{ParticipantInfo, Participants};
 use mpc_node::rpc::{ContractStateWatcher, RpcAction, RpcChannel};
 use mpc_node::sign_bidirectional::{PublishState, SignStatus};
 use mpc_node::storage::checkpoint_storage::CheckpointStorage;
-use mpc_node::stream::{run_stream, ChainPipeline, ChainStreaming};
+use mpc_node::stream::{run_stream, ChainPipeline, ChainStreaming, StreamContext};
 use mpc_primitives::{
     Chain, ChainEvent, CheckpointDigest, IndexedSignRequest, SignArgs, SignCommand, SignId,
     Signature, LATEST_MPC_KEY_VERSION,
@@ -518,14 +518,16 @@ async fn test_solana_stream_republishes_pending_publish_after_checkpoint_recover
     let run_handle = tokio::spawn(async move {
         run_stream(
             stream,
-            sign_tx,
-            rpc,
-            recovered_backlog,
+            StreamContext::new(
+                recovered_backlog.clone(),
+                sign_tx.clone(),
+                rpc.clone(),
+                contract_watcher.clone(),
+                mesh_rx.clone(),
+                node_client.clone(),
+                checkpoints_rx.clone(),
+            ),
             NoopChainTelemetry,
-            contract_watcher,
-            mesh_rx,
-            node_client,
-            checkpoints_rx,
         )
         .await;
     });


### PR DESCRIPTION
Add `StreamContext` to avoid too many arguments in `run_stream`