### PR TITLE
test: mine empty eth blocks via anvil_mine to avoid nonce races

### DIFF
--- a/integration-tests/tests/cases/ethereum.rs
+++ b/integration-tests/tests/cases/ethereum.rs
@@ -1,7 +1,5 @@
-use alloy::network::{Ethereum, TransactionBuilder};
 use alloy::primitives::U256;
 use alloy::providers::Provider;
-use alloy::rpc::types::request::TransactionRequest;
 use alloy::rpc::types::Filter;
 use alloy::sol_types::SolEvent;
 use anyhow::{anyhow, Context, Result};
@@ -291,10 +289,10 @@ async fn test_proper_indexer_checkpoint() -> Result<()> {
 
     tracing::info!("signature response observed on-chain");
 
-    // Checkpoints are emitted on interval boundaries. Produce enough non-contract
-    // empty transfers so Anvil mines blocks and the indexer can publish the next
-    // checkpoint after the response has been observed.
-    produce_empty_eth_blocks(&client, requester, checkpoint_interval).await?;
+    // Checkpoints are emitted on interval boundaries. Mine enough empty blocks
+    // so the indexer can publish the next checkpoint after the response has
+    // been observed.
+    produce_empty_eth_blocks(&client, checkpoint_interval).await?;
 
     let min_next_checkpoint_height =
         ((checkpoint_height / checkpoint_interval) + 1) * checkpoint_interval;
@@ -340,7 +338,7 @@ async fn test_checkpoint_recovery_after_offline() -> anyhow::Result<()> {
         .ethereum
         .as_ref()
         .context("ethereum sandbox not initialized")?;
-    let (eth_client, requester) = eth::client(
+    let (eth_client, _requester) = eth::client(
         &eth_ctx.sandbox.external_http_endpoint,
         &eth_ctx.sandbox.secret_key,
         eth_ctx.sandbox.chain_id,
@@ -375,7 +373,7 @@ async fn test_checkpoint_recovery_after_offline() -> anyhow::Result<()> {
         eth::submit_sign_request(&eth_contract, seed).await?;
     }
 
-    produce_empty_eth_blocks_for_duration(&eth_client, requester, Duration::from_secs(12)).await?;
+    produce_empty_eth_blocks_for_duration(&eth_client, Duration::from_secs(12)).await?;
 
     // Wait for active node to create a new checkpoint beyond the initial one
     let node_active_checkpoint = wait_node_checkpoint(
@@ -456,47 +454,24 @@ async fn test_checkpoint_recovery_after_offline() -> anyhow::Result<()> {
 
 async fn produce_empty_eth_blocks(
     client: &eth::SandboxMiddleware,
-    sender: alloy::primitives::Address,
     block_count: u64,
 ) -> anyhow::Result<()> {
-    // Use a non-contract sink address so these transactions only advance block height.
-    let sink = alloy::primitives::Address::from([
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    ]);
-
-    for _ in 0..block_count {
-        let nonce = client.get_transaction_count(sender).pending().await?;
-        let tx = <TransactionRequest as TransactionBuilder<Ethereum>>::with_nonce(
-            <TransactionRequest as TransactionBuilder<Ethereum>>::with_gas_limit(
-                <TransactionRequest as TransactionBuilder<Ethereum>>::with_value(
-                    <TransactionRequest as TransactionBuilder<Ethereum>>::with_to(
-                        <TransactionRequest as TransactionBuilder<Ethereum>>::with_from(
-                            TransactionRequest::default(),
-                            sender,
-                        ),
-                        sink,
-                    ),
-                    U256::ZERO,
-                ),
-                21_000,
-            ),
-            nonce,
-        );
-
-        client.send_transaction(tx).await?.get_receipt().await?;
-    }
-
+    // Mine empty blocks directly instead of sending transactions: the sandbox
+    // account is shared with the node publishers, so submitting transactions
+    // from it here races on nonces ("replacement transaction underpriced").
+    client
+        .raw_request::<_, ()>("anvil_mine".into(), [U256::from(block_count)])
+        .await?;
     Ok(())
 }
 
 async fn produce_empty_eth_blocks_for_duration(
     client: &eth::SandboxMiddleware,
-    sender: alloy::primitives::Address,
     duration: Duration,
 ) -> anyhow::Result<()> {
     let start = tokio::time::Instant::now();
     while start.elapsed() < duration {
-        produce_empty_eth_blocks(client, sender, 1).await?;
+        produce_empty_eth_blocks(client, 1).await?;
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
     Ok(())


### PR DESCRIPTION
`produce_empty_eth_blocks` sent txs from the sandbox account that node publishers also use, racing on nonces (`-32003 replacement transaction underpriced`) and flaking `test_checkpoint_recovery_after_offline`. Mine blocks via `anvil_mine` instead.