### PR TITLE
fix: near contract read checkpoint

### DIFF
--- a/.github/workflows/deploy-dev-contract.yml
+++ b/.github/workflows/deploy-dev-contract.yml
@@ -5,6 +5,8 @@ on:
     types: [closed]
     branches:
       - develop
+    paths:
+      - 'chain-signatures/contract/**'
 
 jobs:
   deploy-contract:

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -1144,6 +1144,9 @@ mod tests {
         key_index: u32,
     }
 
+    // Mirrors near-sdk's `IterableMap::with_hasher` layout for the map half:
+    // `LatestCheckpoints` is split into a vector of iterable keys under
+    // `<prefix>v` and a lookup map under `<prefix>m`.
     fn latest_checkpoints_map_prefix() -> Vec<u8> {
         let mut prefix = Vec::new();
         StorageKey::LatestCheckpoints
@@ -1152,6 +1155,10 @@ mod tests {
         [prefix.as_slice(), b"m"].concat()
     }
 
+    // Seed only the lookup-map entry and intentionally do not seed the vector
+    // key entry. This reproduces the observed devnet state where
+    // `latest_checkpoint(chain)` works because it uses `.get()`, while
+    // `IterableMap::iter()` returns no checkpoints.
     fn seed_checkpoint_lookup_without_iterable_key(chain: Chain, checkpoint: SignedCheckpoint) {
         let mut key_bytes = latest_checkpoints_map_prefix();
         chain.serialize(&mut key_bytes).unwrap();
@@ -1239,6 +1246,8 @@ mod tests {
 
         seed_checkpoint_lookup_without_iterable_key(Chain::Solana, signed_checkpoint.clone());
 
+        // Construct a contract whose `latest_checkpoints` map points at the
+        // seeded storage. The map itself has an empty iterable key vector.
         let contract = VersionedMpcContract::V0(MpcContract {
             protocol_state: ProtocolContractState::NotInitialized,
             pending_requests: IterableMap::new(StorageKey::PendingRequests),
@@ -1247,6 +1256,8 @@ mod tests {
             latest_checkpoints: IterableMap::new(StorageKey::LatestCheckpoints),
         });
 
+        // Prove the test setup matches production: direct lookup sees the
+        // checkpoint, but iteration over the same map does not.
         assert!(
             contract.latest_checkpoint(Chain::Solana).is_some(),
             "direct checkpoint lookup should reproduce production .get() behavior"
@@ -1256,6 +1267,8 @@ mod tests {
             "test setup should reproduce the broken iterable index"
         );
 
+        // `read(Checkpoints)` is the path nodes use to learn confirmed
+        // checkpoints. It must not rely on `IterableMap::iter()` here.
         let checkpoints = contract
             .read(vec![Read::Checkpoints])
             .into_iter()

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -811,9 +811,11 @@ impl VersionedMpcContract {
                 Read::State => View::State(self.state().clone()),
                 Read::Config => View::Config(self.config().clone()),
                 Read::Checkpoints => View::Checkpoints(
-                    self.checkpoints()
-                        .iter()
-                        .map(|(chain, checkpoint)| (*chain, checkpoint.clone()))
+                    Chain::iter()
+                        .into_iter()
+                        .filter_map(|chain| {
+                            self.checkpoints().get(&chain).map(|cp| (chain, cp.clone()))
+                        })
                         .collect(),
                 ),
             };

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -1121,6 +1121,7 @@ impl VersionedMpcContract {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use near_sdk::borsh::BorshSerialize;
     use near_sdk::test_utils::VMContextBuilder;
     use near_sdk::testing_env;
 
@@ -1135,6 +1136,33 @@ mod tests {
     #[derive(BorshSerialize)]
     enum VersionedOldMpcContractTest {
         V0(OldMpcContractTest),
+    }
+
+    #[derive(BorshSerialize)]
+    struct IterableMapValueAndIndexForTest<V> {
+        value: V,
+        key_index: u32,
+    }
+
+    fn latest_checkpoints_map_prefix() -> Vec<u8> {
+        let mut prefix = Vec::new();
+        StorageKey::LatestCheckpoints
+            .serialize(&mut prefix)
+            .unwrap();
+        [prefix.as_slice(), b"m"].concat()
+    }
+
+    fn seed_checkpoint_lookup_without_iterable_key(chain: Chain, checkpoint: SignedCheckpoint) {
+        let mut key_bytes = latest_checkpoints_map_prefix();
+        chain.serialize(&mut key_bytes).unwrap();
+        let storage_key = env::sha256_array(&key_bytes);
+
+        let value = IterableMapValueAndIndexForTest {
+            value: checkpoint,
+            key_index: 0,
+        };
+        let value_bytes = borsh::to_vec(&value).unwrap();
+        env::storage_write(&storage_key, &value_bytes);
     }
 
     #[test]
@@ -1190,5 +1218,57 @@ mod tests {
                 assert!(contract.latest_checkpoints.is_empty());
             }
         }
+    }
+
+    #[test]
+    fn test_checkpoint_read_handles_missing_iterable_keys() {
+        let context = VMContextBuilder::new()
+            .current_account_id("contract.near".parse().unwrap())
+            .build();
+        testing_env!(context);
+
+        let checkpoint = ConsensusCheckpointDigest::new(Chain::Solana, 120, [7u8; 32]);
+        let signed_checkpoint = SignedCheckpoint {
+            checkpoint,
+            signature: Signature {
+                big_r: k256::AffinePoint::GENERATOR,
+                s: Scalar::ONE,
+                recovery_id: 0,
+            },
+        };
+
+        seed_checkpoint_lookup_without_iterable_key(Chain::Solana, signed_checkpoint.clone());
+
+        let contract = VersionedMpcContract::V0(MpcContract {
+            protocol_state: ProtocolContractState::NotInitialized,
+            pending_requests: IterableMap::new(StorageKey::PendingRequests),
+            proposed_updates: ProposedUpdates::default(),
+            config: Config::default(),
+            latest_checkpoints: IterableMap::new(StorageKey::LatestCheckpoints),
+        });
+
+        assert!(
+            contract.latest_checkpoint(Chain::Solana).is_some(),
+            "direct checkpoint lookup should reproduce production .get() behavior"
+        );
+        assert!(
+            contract.checkpoints().iter().next().is_none(),
+            "test setup should reproduce the broken iterable index"
+        );
+
+        let checkpoints = contract
+            .read(vec![Read::Checkpoints])
+            .into_iter()
+            .find_map(|view| match view {
+                View::Checkpoints(checkpoints) => Some(checkpoints),
+                _ => None,
+            })
+            .expect("read should return checkpoints view");
+
+        let stored = checkpoints
+            .get(&Chain::Solana)
+            .expect("read(Checkpoints) should not rely on IterableMap::iter()");
+        assert_eq!(stored.checkpoint.height, checkpoint.height);
+        assert_eq!(stored.checkpoint.digest, checkpoint.digest);
     }
 }

--- a/chain-signatures/contract/tests/sign.rs
+++ b/chain-signatures/contract/tests/sign.rs
@@ -457,10 +457,9 @@ async fn test_contract_checkpoint_verification() -> anyhow::Result<()> {
 }
 
 /// Verifies that checkpoints written via `respond_checkpoint` are readable
-/// via the `read` view endpoint in a **separate** transaction. This catches
-/// IterableMap iteration bugs where `.get()` works but `.iter()` does not
-/// after a contract migration, which is the same code path that
-/// `update_contract_data` uses to feed the node's checkpoint watcher.
+/// through the external `read` view endpoint. The lower-level regression test
+/// in `src/lib.rs` covers the broken storage shape where `.get()` works but
+/// iterable keys are missing.
 #[tokio::test]
 async fn test_checkpoint_read_after_respond() -> anyhow::Result<()> {
     let (_, contract, _, sk) = init_env().await;
@@ -496,7 +495,7 @@ async fn test_checkpoint_read_after_respond() -> anyhow::Result<()> {
         recovery_id,
     };
 
-    // Write checkpoint in one transaction
+    // Write checkpoint in one transaction.
     let respond = contract
         .call("respond_checkpoint")
         .args_json(serde_json::json!({
@@ -532,6 +531,15 @@ async fn test_checkpoint_read_after_respond() -> anyhow::Result<()> {
         .expect("Solana checkpoint must be present after respond_checkpoint");
     assert_eq!(stored.checkpoint.height, 120);
     assert_eq!(stored.checkpoint.digest, checkpoint.digest);
+
+    // Also verify the per-chain view path.
+    let latest: Option<SignedCheckpoint> = contract
+        .view("latest_checkpoint")
+        .args_json(serde_json::json!({ "chain": Chain::Solana }))
+        .await?
+        .json()?;
+    let latest = latest.expect("latest_checkpoint should return the checkpoint");
+    assert_eq!(latest.checkpoint.height, 120);
 
     Ok(())
 }

--- a/chain-signatures/contract/tests/sign.rs
+++ b/chain-signatures/contract/tests/sign.rs
@@ -5,7 +5,7 @@ use digest::Digest as _;
 use k256::elliptic_curve::point::DecompressPoint as _;
 use k256::elliptic_curve::subtle::Choice;
 use mpc_contract::errors;
-use mpc_contract::primitives::{CandidateInfo, SignRequest};
+use mpc_contract::primitives::{CandidateInfo, Read, SignRequest, SignedCheckpoint, View};
 use mpc_crypto::kdf;
 use mpc_primitives::{Chain, ConsensusCheckpointDigest, Signature, LATEST_MPC_KEY_VERSION};
 use near_workspaces::types::{AccountId, NearToken};
@@ -452,6 +452,86 @@ async fn test_contract_checkpoint_verification() -> anyhow::Result<()> {
         respond_root_key.is_failure(),
         "respond_checkpoint with root key signature should have failed"
     );
+
+    Ok(())
+}
+
+/// Verifies that checkpoints written via `respond_checkpoint` are readable
+/// via the `read` view endpoint in a **separate** transaction. This catches
+/// IterableMap iteration bugs where `.get()` works but `.iter()` does not
+/// after a contract migration, which is the same code path that
+/// `update_contract_data` uses to feed the node's checkpoint watcher.
+#[tokio::test]
+async fn test_checkpoint_read_after_respond() -> anyhow::Result<()> {
+    let (_, contract, _, sk) = init_env().await;
+
+    let checkpoint = ConsensusCheckpointDigest::new(Chain::Solana, 120, [7u8; 32]);
+
+    let epsilon = kdf::derive_epsilon_checkpoint(checkpoint.chain, checkpoint.height);
+    let derived_sk = kdf::derive_secret_key(&sk, epsilon);
+    let derived_pk = mpc_crypto::derive_key(sk.public_key().into(), epsilon);
+
+    let signing_key = k256::ecdsa::SigningKey::from(&derived_sk);
+    let digest = <k256::Secp256k1 as ecdsa::hazmat::DigestPrimitive>::Digest::new_with_prefix(
+        checkpoint.sign_payload_bytes(),
+    );
+    let (signature, _): (ecdsa::Signature<k256::Secp256k1>, _) =
+        signing_key.try_sign_digest(digest).unwrap();
+    let s = signature.s();
+    let (r_bytes, _) = signature.split_bytes();
+    let big_r = k256::AffinePoint::decompress(&r_bytes, Choice::from(0)).unwrap();
+    let s: k256::Scalar = *s.as_ref();
+    let recovery_id =
+        if kdf::check_ec_signature(&derived_pk, &big_r, &s, checkpoint.sign_payload_scalar(), 0)
+            .is_ok()
+        {
+            0
+        } else {
+            1
+        };
+
+    let valid_signature = Signature {
+        big_r,
+        s,
+        recovery_id,
+    };
+
+    // Write checkpoint in one transaction
+    let respond = contract
+        .call("respond_checkpoint")
+        .args_json(serde_json::json!({
+            "checkpoint": checkpoint,
+            "signature": valid_signature,
+        }))
+        .max_gas()
+        .transact()
+        .await?;
+    assert!(
+        respond.is_success(),
+        "respond_checkpoint failed: {respond:?}"
+    );
+
+    // Read checkpoints back via the `read` view in a separate transaction.
+    // This is the same path that `update_contract_data` uses in the node.
+    let views: Vec<View> = contract
+        .view("read")
+        .args_json(serde_json::json!({ "reads": [Read::Checkpoints] }))
+        .await?
+        .json()?;
+
+    let checkpoints: HashMap<Chain, SignedCheckpoint> = views
+        .into_iter()
+        .find_map(|v| match v {
+            View::Checkpoints(cp) => Some(cp),
+            _ => None,
+        })
+        .expect("read should return a Checkpoints view");
+
+    let stored = checkpoints
+        .get(&Chain::Solana)
+        .expect("Solana checkpoint must be present after respond_checkpoint");
+    assert_eq!(stored.checkpoint.height, 120);
+    assert_eq!(stored.checkpoint.digest, checkpoint.digest);
 
     Ok(())
 }


### PR DESCRIPTION
**Summary**

Fixes contract checkpoint reads so nodes can observe confirmed checkpoints even when IterableMap iteration metadata is missing. Should resolve https://github.com/sig-net/mpc/issues/952

The dev contract had a state where:
- latest_checkpoint({"chain":"Solana"}) returned the latest checkpoint
- read({"reads":["Checkpoints"]}) returned an empty checkpoint map
<img width="677" height="432" alt="Screenshot 2026-07-08 at 2 56 47 PM" src="https://github.com/user-attachments/assets/682dcd5f-b82c-45cc-acb2-1ebce38238d7" />


Nodes rely on read(Checkpoints) to update their checkpoint watcher. When that view returned empty, nodes never called on_consensus_confirmed(), so local pending checkpoints accumulated until hitting the cap.

**Changes**
- Changed Read::Checkpoints to build the checkpoint map by iterating known Chain values and using direct .get(&chain) lookups instead of relying on IterableMap::iter().
- Added a unit test `test_checkpoint_read_handles_missing_iterable_keys` that reproduces the broken storage shape: direct checkpoint lookup works, but iterable keys are
    missing.
- Added `test_checkpoint_read_after_respond` to verify respond_checkpoint -> read(Checkpoints) view path.

**Testing**

```cargo test -p mpc-contract test_checkpoint_read_handles_missing_iterable_keys -- --nocapture```

```cargo test -p mpc-contract test_checkpoint_read_after_respond -- --nocapture```

Also verified the new unit test fails when read(Checkpoints) is temporarily reverted to the old .iter() implementation.