### PR TITLE
fix: adjust log level for `mpc-*` crates in Dockerfile and Terraform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY --from=node-builder /usr/src/app/target/release/mpc-node /usr/local/bin/mpc
 COPY chain-signatures/node/redis.conf /etc/redis/redis.conf
 
 # Create a script to start both Redis and the Rust app
-RUN echo "#!/bin/bash\nredis-server /etc/redis/redis.conf &\nexec env RUST_LOG=${RUST_LOG:-mpc_node=debug,mpc=info,helios=info} mpc-node start" > /start.sh \
+RUN echo "#!/bin/bash\nredis-server /etc/redis/redis.conf &\nexec env RUST_LOG=${RUST_LOG:-mpc=debug,helios=info} mpc-node start" > /start.sh \
     && chmod +x /start.sh
 
 WORKDIR /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY --from=node-builder /usr/src/app/target/release/mpc-node /usr/local/bin/mpc
 COPY chain-signatures/node/redis.conf /etc/redis/redis.conf
 
 # Create a script to start both Redis and the Rust app
-RUN echo "#!/bin/bash\nredis-server /etc/redis/redis.conf &\nexec env RUST_LOG=${RUST_LOG:-mpc_node=debug,helios=info} mpc-node start" > /start.sh \
+RUN echo "#!/bin/bash\nredis-server /etc/redis/redis.conf &\nexec env RUST_LOG=${RUST_LOG:-mpc_node=debug,mpc=info,helios=info} mpc-node start" > /start.sh \
     && chmod +x /start.sh
 
 WORKDIR /usr/local/bin

--- a/infra/modules/multichain/main.tf
+++ b/infra/modules/multichain/main.tf
@@ -124,7 +124,7 @@ resource "google_cloud_run_v2_service" "node" {
       }
       env {
         name  = "RUST_LOG"
-        value = "mpc_node=debug"
+        value = "mpc_node=debug,mpc=info"
       }
 
       ports {

--- a/infra/modules/multichain/main.tf
+++ b/infra/modules/multichain/main.tf
@@ -124,7 +124,7 @@ resource "google_cloud_run_v2_service" "node" {
       }
       env {
         name  = "RUST_LOG"
-        value = "mpc_node=debug,mpc=info"
+        value = "mpc=debug"
       }
 
       ports {

--- a/infra/partner-mainnet/variables.tf
+++ b/infra/partner-mainnet/variables.tf
@@ -125,7 +125,7 @@ variable "static_env" {
     },
     {
       name  = "RUST_LOG"
-      value = "mpc_node=info"
+      value = "mpc=info"
     },
     {
       name  = "MPC_INDEXER_S3_REGION"

--- a/infra/partner-testnet/variables.tf
+++ b/infra/partner-testnet/variables.tf
@@ -121,7 +121,7 @@ variable "static_env" {
     },
     {
       name  = "RUST_LOG"
-      value = "mpc_node=debug,mpc=info"
+      value = "mpc=debug"
     },
     {
       name  = "MPC_INDEXER_S3_REGION"

--- a/infra/partner-testnet/variables.tf
+++ b/infra/partner-testnet/variables.tf
@@ -121,7 +121,7 @@ variable "static_env" {
     },
     {
       name  = "RUST_LOG"
-      value = "mpc_node=debug"
+      value = "mpc_node=debug,mpc=info"
     },
     {
       name  = "MPC_INDEXER_S3_REGION"


### PR DESCRIPTION
Closes #975 

Add `mpc=info` and `mpc=debug` directives, so `RUST_LOG` covers logs from all `mpc-*` crates (and new `mpc-chain-*` specifically)