### PR TITLE
refactor: stream modules

### DIFF
--- a/chain-signatures/node/src/indexer_hydration/mod.rs
+++ b/chain-signatures/node/src/indexer_hydration/mod.rs
@@ -4,6 +4,7 @@ use crate::backlog::Backlog;
 use crate::mesh::MeshState;
 use crate::node_client::NodeClient;
 use crate::rpc::ContractStateWatcher;
+use crate::stream::StreamContext;
 use crate::types::CheckpointWatcher;
 
 pub use config::HydrationConfig;
@@ -358,6 +359,23 @@ pub async fn run<T: ChainTelemetry>(
 
     let root_pk = contract_watcher.wait_public_key().await;
 
+    // Create a StreamContext with a dummy RpcChannel (Hydration does not publish)
+    let ctx = {
+        let (rpc_tx, _rpc_rx) = mpsc::channel(1);
+        let rpc = crate::rpc::RpcChannel { tx: rpc_tx };
+        let mut ctx = StreamContext::new(
+            backlog.clone(),
+            sign_tx.clone(),
+            rpc,
+            contract_watcher.clone(),
+            mesh_state.clone(),
+            node_client.clone(),
+            checkpoints_rx.clone(),
+        );
+        ctx.caught_up = true;
+        ctx
+    };
+
     let ws_url: &str = hydration.rpc_ws_url.as_str();
     const RECONNECT_DELAY: Duration = Duration::from_secs(5);
     const STALL_TIMEOUT: Duration = Duration::from_secs(60);
@@ -473,8 +491,6 @@ pub async fn run<T: ChainTelemetry>(
                 continue;
             }
 
-            let sign_tx = sign_tx.clone();
-            let backlog = backlog.clone();
             let root_pk = contract_watcher.public_key().await.unwrap_or(root_pk);
 
             for ev in events.iter() {
@@ -508,13 +524,8 @@ pub async fn run<T: ChainTelemetry>(
                         continue;
                     };
 
-                    if let Err(e) = crate::stream::ops::process_sign_request(
-                        sign_request,
-                        sign_tx.clone(),
-                        backlog.clone(),
-                        true,
-                    )
-                    .await
+                    if let Err(e) =
+                        crate::stream::ops::process_sign_request(sign_request, &ctx).await
                     {
                         tracing::error!("failed to process sign event: {e}");
                     }
@@ -533,14 +544,8 @@ pub async fn run<T: ChainTelemetry>(
                     tracing::info!(
                         "Hydration::Signet::SignatureResponded in block #{number} ({hash:?})"
                     );
-                    if let Err(e) = crate::stream::ops::process_respond_event(
-                        event,
-                        sign_tx.clone(),
-                        root_pk,
-                        &backlog,
-                        true,
-                    )
-                    .await
+                    if let Err(e) =
+                        crate::stream::ops::process_respond_event(event, &ctx, root_pk).await
                     {
                         tracing::error!("failed to process respond event: {e}");
                     }
@@ -570,13 +575,8 @@ pub async fn run<T: ChainTelemetry>(
                         continue;
                     };
 
-                    if let Err(e) = crate::stream::ops::process_sign_request(
-                        sign_request,
-                        sign_tx.clone(),
-                        backlog.clone(),
-                        true,
-                    )
-                    .await
+                    if let Err(e) =
+                        crate::stream::ops::process_sign_request(sign_request, &ctx).await
                     {
                         tracing::error!("failed to process sign event: {e}");
                     }
@@ -617,10 +617,8 @@ pub async fn run<T: ChainTelemetry>(
                             signature,
                             chain: Chain::Hydration,
                         },
-                        sign_tx.clone(),
+                        &ctx,
                         root_pk,
-                        &backlog,
-                        true,
                     )
                     .await
                     {

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -134,9 +134,8 @@ async fn handle_chain_event<T: ChainTelemetry>(
             }
             ctx.caught_up = true;
 
-            requeue_pending_sign_requests(&ctx.backlog, chain, ctx.sign_tx.clone()).await;
-            resume_pending_publish_requests(&ctx.backlog, chain, &ctx.contract_watcher, &ctx.rpc)
-                .await;
+            requeue_pending_sign_requests(ctx, chain).await;
+            resume_pending_publish_requests(ctx, chain).await;
         }
         ChainEvent::SignRequest {
             request,
@@ -151,47 +150,22 @@ async fn handle_chain_event<T: ChainTelemetry>(
                 telemetry.request_indexed();
             }
 
-            process_sign_request(
-                request,
-                ctx.sign_tx.clone(),
-                ctx.backlog.clone(),
-                ctx.caught_up,
-            )
-            .await
-            .context("failed to process sign request")?;
+            process_sign_request(request, ctx)
+                .await
+                .context("failed to process sign request")?;
         }
         ChainEvent::Respond(ev) => {
-            process_respond_event(
-                ev,
-                ctx.sign_tx.clone(),
-                root_pk,
-                &ctx.backlog,
-                ctx.caught_up,
-            )
-            .await
-            .context("failed to process respond event")?;
+            process_respond_event(ev, ctx, root_pk)
+                .await
+                .context("failed to process respond event")?;
         }
         ChainEvent::RespondBidirectional(ev) => {
-            process_respond_bidirectional_event(
-                ev,
-                ctx.sign_tx.clone(),
-                root_pk,
-                &ctx.backlog,
-                ctx.caught_up,
-            )
-            .await
-            .context("failed to process respond bidirectional event")?;
+            process_respond_bidirectional_event(ev, ctx, root_pk)
+                .await
+                .context("failed to process respond bidirectional event")?;
         }
         ChainEvent::Block(block) => {
-            process_block_event(
-                chain,
-                block,
-                &ctx.backlog,
-                &ctx.sign_tx,
-                ctx.caught_up,
-                telemetry,
-            )
-            .await;
+            process_block_event(chain, block, ctx, telemetry).await;
         }
         ChainEvent::ExecutionConfirmed {
             tx_id,
@@ -206,10 +180,8 @@ async fn handle_chain_event<T: ChainTelemetry>(
                 source_chain,
                 block_height,
                 result,
-                &ctx.backlog,
-                ctx.sign_tx.clone(),
+                ctx,
                 chain,
-                ctx.caught_up,
             )
             .await
             .context("failed to process execution confirmation")?;

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -134,7 +134,9 @@ async fn handle_chain_event<T: ChainTelemetry>(
             }
             ctx.caught_up = true;
 
-            requeue_pending_sign_requests(ctx, chain).await;
+            requeue_pending_sign_requests(ctx, chain)
+                .await
+                .context("failed to requeue pending sign requests")?;
             resume_pending_publish_requests(ctx, chain).await;
         }
         ChainEvent::SignRequest {
@@ -165,7 +167,9 @@ async fn handle_chain_event<T: ChainTelemetry>(
                 .context("failed to process respond bidirectional event")?;
         }
         ChainEvent::Block(block) => {
-            process_block_event(chain, block, ctx, telemetry).await;
+            process_block_event(chain, block, ctx, telemetry)
+                .await
+                .context("failed to process block event")?;
         }
         ChainEvent::ExecutionConfirmed {
             tx_id,

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -14,8 +14,9 @@ use crate::types::CheckpointWatcher;
 
 pub use crate::stream::pipeline::ChainPipeline;
 
+use anyhow::Context;
 use mpc_chain_integration_core::{ChainIndexer, ChainStream, ChainTelemetry};
-use mpc_primitives::{ChainEvent, SignCommand};
+use mpc_primitives::{Chain, ChainEvent, SignCommand};
 use tokio::sync::{mpsc, watch};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -99,79 +100,10 @@ pub async fn run_stream<S: ChainStream, T: ChainTelemetry>(
                 let Some(event) = event else {
                     break;
                 };
-                match event {
-                    ChainEvent::CatchupCompleted => {
-                        if ctx.caught_up {
-                            continue;
-                        }
-                        ctx.caught_up = true;
-
-                        requeue_pending_sign_requests(&ctx.backlog, chain, ctx.sign_tx.clone()).await;
-                        resume_pending_publish_requests(&ctx.backlog, chain, &ctx.contract_watcher, &ctx.rpc).await;
-                    }
-                    ChainEvent::SignRequest { request, block_timestamp } => {
-                        // Handle metrics reporting for the sign request event
-                        if let Some(ts) = block_timestamp {
-                            // Report the request was indexed at the given block timestamp is currently used for Ethereum due to ~15 min finality delay
-                            telemetry.request_indexed_at(ts);
-                        } else {
-                            // Other faster chains (e.g. for Solana, Canton, or Hydration) report that a request was indexed without a block timestamp
-                            telemetry.request_indexed();
-                        }
-
-                        if let Err(err) =
-                            process_sign_request(request, ctx.sign_tx.clone(), ctx.backlog.clone(), ctx.caught_up).await
-                        {
-                            tracing::error!(?err, %chain, "failed to process sign request");
-                        }
-                    }
-                    ChainEvent::Respond(ev) => {
-                        if let Err(err) = process_respond_event(
-                            ev,
-                            ctx.sign_tx.clone(),
-                            root_pk,
-                            &ctx.backlog,
-                            ctx.caught_up,
-                        )
-                        .await
-                        {
-                            tracing::error!(?err, %chain, "failed to process respond event");
-                        }
-                    }
-                    ChainEvent::RespondBidirectional(ev) => {
-                        if let Err(err) =
-                            process_respond_bidirectional_event(ev, ctx.sign_tx.clone(), root_pk, &ctx.backlog, ctx.caught_up)
-                                .await
-                        {
-                            tracing::error!(?err, %chain, "failed to process respond bidirectional event");
-                        }
-                    }
-                    ChainEvent::Block(block) => {
-                        process_block_event(chain, block, &ctx.backlog, &ctx.sign_tx, ctx.caught_up, &telemetry).await;
-                    }
-                    ChainEvent::ExecutionConfirmed {
-                        tx_id,
-                        sign_id,
-                        source_chain,
-                        block_height,
-                        result,
-                    } => {
-                        if let Err(err) = process_execution_confirmed(
-                            tx_id,
-                            sign_id,
-                            source_chain,
-                            block_height,
-                            result,
-                            &ctx.backlog,
-                            ctx.sign_tx.clone(),
-                            chain,
-                            ctx.caught_up,
-                        )
-                        .await
-                        {
-                            tracing::error!(?err, %chain, "failed to process execution confirmation");
-                        }
-                    }
+                if let Err(err) =
+                    handle_chain_event(event, &mut ctx, &telemetry, root_pk, chain).await
+                {
+                    tracing::error!(?err, %chain, "failed to process chain event");
                 }
             }
             _ = state_rx.changed() => {
@@ -185,6 +117,106 @@ pub async fn run_stream<S: ChainStream, T: ChainTelemetry>(
 
     tracing::warn!(%chain, "stream shutting down");
     indexer_task.abort();
+}
+
+/// Dispatch a single chain event to the appropriate processor.
+async fn handle_chain_event<T: ChainTelemetry>(
+    event: ChainEvent,
+    ctx: &mut StreamContext,
+    telemetry: &T,
+    root_pk: mpc_primitives::PublicKey,
+    chain: Chain,
+) -> anyhow::Result<()> {
+    match event {
+        ChainEvent::CatchupCompleted => {
+            if ctx.caught_up {
+                return Ok(());
+            }
+            ctx.caught_up = true;
+
+            requeue_pending_sign_requests(&ctx.backlog, chain, ctx.sign_tx.clone()).await;
+            resume_pending_publish_requests(&ctx.backlog, chain, &ctx.contract_watcher, &ctx.rpc)
+                .await;
+        }
+        ChainEvent::SignRequest {
+            request,
+            block_timestamp,
+        } => {
+            // Handle metrics reporting for the sign request event
+            if let Some(ts) = block_timestamp {
+                // Report the request was indexed at the given block timestamp is currently used for Ethereum due to ~15 min finality delay
+                telemetry.request_indexed_at(ts);
+            } else {
+                // Other faster chains (e.g. for Solana, Canton, or Hydration) report that a request was indexed without a block timestamp
+                telemetry.request_indexed();
+            }
+
+            process_sign_request(
+                request,
+                ctx.sign_tx.clone(),
+                ctx.backlog.clone(),
+                ctx.caught_up,
+            )
+            .await
+            .context("failed to process sign request")?;
+        }
+        ChainEvent::Respond(ev) => {
+            process_respond_event(
+                ev,
+                ctx.sign_tx.clone(),
+                root_pk,
+                &ctx.backlog,
+                ctx.caught_up,
+            )
+            .await
+            .context("failed to process respond event")?;
+        }
+        ChainEvent::RespondBidirectional(ev) => {
+            process_respond_bidirectional_event(
+                ev,
+                ctx.sign_tx.clone(),
+                root_pk,
+                &ctx.backlog,
+                ctx.caught_up,
+            )
+            .await
+            .context("failed to process respond bidirectional event")?;
+        }
+        ChainEvent::Block(block) => {
+            process_block_event(
+                chain,
+                block,
+                &ctx.backlog,
+                &ctx.sign_tx,
+                ctx.caught_up,
+                telemetry,
+            )
+            .await;
+        }
+        ChainEvent::ExecutionConfirmed {
+            tx_id,
+            sign_id,
+            source_chain,
+            block_height,
+            result,
+        } => {
+            process_execution_confirmed(
+                tx_id,
+                sign_id,
+                source_chain,
+                block_height,
+                result,
+                &ctx.backlog,
+                ctx.sign_tx.clone(),
+                chain,
+                ctx.caught_up,
+            )
+            .await
+            .context("failed to process execution confirmation")?;
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -1,3 +1,5 @@
+use anyhow::Context;
+
 use crate::respond_bidirectional::CompletedTx;
 use crate::sign_bidirectional::{SignBidirectionalEventExt, SignStatus};
 use crate::stream::StreamContext;
@@ -23,9 +25,7 @@ pub(crate) async fn process_sign_request(
         ctx.sign_tx
             .send(SignCommand::Request(sign_request))
             .await
-            .map_err(|err| {
-                anyhow::anyhow!("failed to send sign request into queue for chain {chain}: {err:?}")
-            })?;
+            .with_context(|| format!("failed to send sign request into queue for chain {chain}"))?;
     }
 
     Ok(())
@@ -41,9 +41,9 @@ pub(crate) async fn requeue_pending_sign_requests(
         ctx.sign_tx
             .send(SignCommand::Request(sign_request))
             .await
-            .map_err(|err| {
-                anyhow::anyhow!(
-                    "failed to requeue sign request after catchup for sign id {sign_id:?} on chain {source_chain}: {err:?}"
+            .with_context(|| {
+                format!(
+                    "failed to requeue sign request after catchup for sign id {sign_id:?} on chain {source_chain}"
                 )
             })?;
     }
@@ -88,12 +88,7 @@ fn verify_entry_signature(
         entry.request.args.payload,
         signature,
     )
-    .map_err(|err| {
-        anyhow::anyhow!(
-            "respond event carried invalid signature for sign id {:?}: {err}",
-            sign_id
-        )
-    })
+    .with_context(|| format!("respond event carried invalid signature for sign id {sign_id:?}"))
 }
 
 pub(crate) async fn process_respond_event(
@@ -121,9 +116,10 @@ pub(crate) async fn process_respond_event(
             tracing::info!(?sign_id, "sign request completed successfully");
             ctx.backlog.remove(source_chain, &sign_id).await;
             if ctx.caught_up {
-                if let Err(err) = ctx.sign_tx.send(SignCommand::Completion(sign_id)).await {
-                    anyhow::bail!("failed to send completion for respond event: {err:?}");
-                }
+                ctx.sign_tx
+                    .send(SignCommand::Completion(sign_id))
+                    .await
+                    .context("failed to send completion for respond event")?;
             }
             return Ok(());
         }
@@ -149,9 +145,9 @@ pub(crate) async fn process_respond_event(
     }
 
     tracing::info!(?sign_id, "bidirectional processing initial respond event");
-    let target_chain = event.target_chain().map_err(|err| {
-        anyhow::anyhow!("failed to process respond event: {err:?} for sign id: {sign_id:?}")
-    })?;
+    let target_chain = event
+        .target_chain()
+        .with_context(|| format!("failed to process respond event for sign id: {sign_id:?}"))?;
 
     // Get the MPC public key and derive the from_address.
     let epsilon = event.epsilon()?;
@@ -195,15 +191,14 @@ pub(crate) async fn process_respond_event(
         "bidirectional tx details before advancement",
     );
 
-    if let Err(err) = ctx
-        .backlog
+    ctx.backlog
         .advance(source_chain, sign_id, bidirectional_tx)
         .await
-    {
-        anyhow::bail!(
-            "advance bidirectional tx to execution failed for sign id {sign_id:?}, tx_id {tx_id:?}, target_chain {target_chain:?}: {err:?}"
-        );
-    }
+        .with_context(|| {
+            format!(
+                "advance bidirectional tx to execution failed for sign id {sign_id:?}, tx_id {tx_id:?}, target_chain {target_chain:?}"
+            )
+        })?;
     tracing::info!(
         ?sign_id,
         ?tx_id,
@@ -248,7 +243,11 @@ pub(crate) async fn process_respond_bidirectional_event(
         ctx.sign_tx
             .send(SignCommand::Completion(sign_id))
             .await
-            .map_err(|err| anyhow::anyhow!("failed to send completion for respond bidirectional: {err:?} for sign id: {sign_id:?}"))?;
+            .with_context(|| {
+                format!(
+                    "failed to send completion for respond bidirectional for sign id {sign_id:?}"
+                )
+            })?;
     }
 
     Ok(())
@@ -309,19 +308,18 @@ pub async fn process_execution_confirmed(
         }
     };
 
-    if let Err(err) = ctx
-        .backlog
+    ctx.backlog
         .set_request(
             pending_tx.source_chain,
             &unwatched_sign_id,
             sign_request.clone(),
         )
         .await
-    {
-        anyhow::bail!(
-            "failed to persist completion request on pending tx for sign id {unwatched_sign_id:?}, tx_id {tx_id:?}, source_chain {source_chain}: {err:?}"
-        );
-    }
+        .with_context(|| {
+            format!(
+                "failed to persist completion request on pending tx for sign id {unwatched_sign_id:?}, tx_id {tx_id:?}, source_chain {source_chain}"
+            )
+        })?;
 
     let set_res = ctx
         .backlog
@@ -347,9 +345,7 @@ pub async fn process_execution_confirmed(
         ctx.sign_tx
             .send(SignCommand::Request(sign_request))
             .await
-            .map_err(|err| {
-                anyhow::anyhow!("failed to send sign request into queue for chain {chain}: {err:?}")
-            })?;
+            .with_context(|| format!("failed to send sign request into queue for chain {chain}"))?;
     }
 
     Ok(())
@@ -384,9 +380,10 @@ pub(crate) async fn process_block_event<T: ChainTelemetry>(
     let sign_id = checkpoint_digest.sign_id();
     tracing::info!(block, ?checkpoint, %chain, ?sign_id, "created checkpoint");
     let sign = SignCommand::Checkpoint(IndexedSignRequest::checkpoint(checkpoint_digest, epsilon));
-    ctx.sign_tx.send(sign).await.map_err(|err| {
-        anyhow::anyhow!("failed to enqueue checkpoint sign request for chain {chain}: {err:?}")
-    })?;
+    ctx.sign_tx
+        .send(sign)
+        .await
+        .with_context(|| format!("failed to enqueue checkpoint sign request for chain {chain}"))?;
 
     Ok(())
 }

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -18,29 +18,36 @@ pub(crate) async fn process_sign_request(
 
     ctx.backlog.insert(sign_request.clone()).await;
 
-    let chain = sign_request.chain;
     if ctx.caught_up {
-        if let Err(err) = ctx.sign_tx.send(SignCommand::Request(sign_request)).await {
-            tracing::error!(?err, %chain, "failed to send sign request into queue");
-        }
+        let chain = sign_request.chain;
+        ctx.sign_tx
+            .send(SignCommand::Request(sign_request))
+            .await
+            .map_err(|err| {
+                anyhow::anyhow!("failed to send sign request into queue for chain {chain}: {err:?}")
+            })?;
     }
 
     Ok(())
 }
 
-pub(crate) async fn requeue_pending_sign_requests(ctx: &StreamContext, source_chain: Chain) {
+pub(crate) async fn requeue_pending_sign_requests(
+    ctx: &StreamContext,
+    source_chain: Chain,
+) -> anyhow::Result<()> {
     for sign_request in ctx.backlog.take_requeueable_requests(source_chain).await {
         let sign_id = sign_request.id;
         let source_chain = sign_request.chain;
-        if let Err(err) = ctx.sign_tx.send(SignCommand::Request(sign_request)).await {
-            tracing::error!(
-                ?err,
-                ?sign_id,
-                ?source_chain,
-                "failed to requeue sign request after catchup"
-            );
-        }
+        ctx.sign_tx
+            .send(SignCommand::Request(sign_request))
+            .await
+            .map_err(|err| {
+                anyhow::anyhow!(
+                    "failed to requeue sign request after catchup for sign id {sign_id:?} on chain {source_chain}: {err:?}"
+                )
+            })?;
     }
+    Ok(())
 }
 
 pub(crate) async fn resume_pending_publish_requests(ctx: &StreamContext, source_chain: Chain) {
@@ -188,29 +195,21 @@ pub(crate) async fn process_respond_event(
         "bidirectional tx details before advancement",
     );
 
-    match ctx
+    if let Err(err) = ctx
         .backlog
         .advance(source_chain, sign_id, bidirectional_tx)
         .await
     {
-        Ok(_) => {
-            tracing::info!(
-                ?sign_id,
-                ?tx_id,
-                ?target_chain,
-                "advance bidirectional tx to execution successful"
-            );
-        }
-        Err(err) => {
-            tracing::error!(
-                ?sign_id,
-                ?tx_id,
-                ?target_chain,
-                ?err,
-                "advance bidirectional tx to execution failed"
-            );
-        }
+        anyhow::bail!(
+            "advance bidirectional tx to execution failed for sign id {sign_id:?}, tx_id {tx_id:?}, target_chain {target_chain:?}: {err:?}"
+        );
     }
+    tracing::info!(
+        ?sign_id,
+        ?tx_id,
+        ?target_chain,
+        "advance bidirectional tx to execution successful"
+    );
 
     Ok(())
 }
@@ -319,14 +318,9 @@ pub async fn process_execution_confirmed(
         )
         .await
     {
-        tracing::error!(
-            ?tx_id,
-            ?unwatched_sign_id,
-            ?source_chain,
-            ?err,
-            "failed to persist completion request on pending tx"
+        anyhow::bail!(
+            "failed to persist completion request on pending tx for sign id {unwatched_sign_id:?}, tx_id {tx_id:?}, source_chain {source_chain}: {err:?}"
         );
-        anyhow::bail!("failed to persist completion request for sign id: {unwatched_sign_id:?}");
     }
 
     let set_res = ctx
@@ -337,13 +331,12 @@ pub async fn process_execution_confirmed(
             SignStatus::PendingGenerationBidirectional,
         )
         .await;
-    let updated_tx = match set_res {
-        Some(tx) => tx,
-        None => {
-            tracing::error!(?tx_id, ?unwatched_sign_id, source_chain = ?pending_tx.source_chain, "failed to set status on pending tx");
-            anyhow::bail!("failed to set status for sign id: {unwatched_sign_id:?}");
-        }
-    };
+    let updated_tx = set_res.ok_or_else(|| {
+        anyhow::anyhow!(
+            "failed to set status on pending tx for sign id {unwatched_sign_id:?}, tx_id {tx_id:?}, source_chain {:?}",
+            pending_tx.source_chain
+        )
+    })?;
     tracing::info!(?tx_id, ?unwatched_sign_id, updated_status = ?updated_tx.status(), "set_status returned transaction");
 
     let chain = sign_request.chain;
@@ -351,9 +344,12 @@ pub async fn process_execution_confirmed(
     // request belongs to the source chain. Do not let the target chain's catchup
     // barrier strand that follow-up work.
     if ctx.caught_up || chain != target_chain {
-        if let Err(err) = ctx.sign_tx.send(SignCommand::Request(sign_request)).await {
-            tracing::error!(?err, %chain, "failed to send sign request into queue");
-        }
+        ctx.sign_tx
+            .send(SignCommand::Request(sign_request))
+            .await
+            .map_err(|err| {
+                anyhow::anyhow!("failed to send sign request into queue for chain {chain}: {err:?}")
+            })?;
     }
 
     Ok(())
@@ -364,16 +360,16 @@ pub(crate) async fn process_block_event<T: ChainTelemetry>(
     block: u64,
     ctx: &StreamContext,
     telemetry: &T,
-) {
+) -> anyhow::Result<()> {
     telemetry.block_finalized(block);
 
     // should not create checkpoint for blocks that are not caught up, as that would
     // try to create signatures for checkpoints where we are not live.
     if !ctx.caught_up {
-        return;
+        return Ok(());
     }
     let Some(checkpoint) = ctx.backlog.set_processed_block(chain, block).await else {
-        return;
+        return Ok(());
     };
 
     telemetry.checkpoint_created(checkpoint.block_height);
@@ -388,9 +384,11 @@ pub(crate) async fn process_block_event<T: ChainTelemetry>(
     let sign_id = checkpoint_digest.sign_id();
     tracing::info!(block, ?checkpoint, %chain, ?sign_id, "created checkpoint");
     let sign = SignCommand::Checkpoint(IndexedSignRequest::checkpoint(checkpoint_digest, epsilon));
-    if let Err(err) = ctx.sign_tx.send(sign).await {
-        tracing::error!(?err, %chain, "failed to enqueue checkpoint sign request");
-    }
+    ctx.sign_tx.send(sign).await.map_err(|err| {
+        anyhow::anyhow!("failed to enqueue checkpoint sign request for chain {chain}: {err:?}")
+    })?;
+
+    Ok(())
 }
 
 /// Decode a [u8; 32] sender into its canonical on-chain address string.

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -1,30 +1,26 @@
-use crate::backlog::Backlog;
 use crate::respond_bidirectional::CompletedTx;
-use crate::rpc::{ContractStateWatcher, RpcChannel};
 use crate::sign_bidirectional::{SignBidirectionalEventExt, SignStatus};
+use crate::stream::StreamContext;
 use mpc_chain_integration_core::ChainTelemetry;
 use mpc_chain_solana::Pubkey;
 use mpc_primitives::{
     BidirectionalTx, BidirectionalTxId, Chain, ExecutionOutcome, IndexedSignRequest,
     RespondBidirectionalEvent, SignCommand, SignId, SignKind, Signature, SignatureRespondedEvent,
 };
-use tokio::sync::mpsc;
 
 pub(crate) async fn process_sign_request(
     sign_request: IndexedSignRequest,
-    sign_tx: mpsc::Sender<SignCommand>,
-    backlog: Backlog,
-    caught_up: bool,
+    ctx: &StreamContext,
 ) -> anyhow::Result<()> {
     if matches!(sign_request.kind, SignKind::RespondBidirectional(_)) {
         anyhow::bail!("Unexpected sign request kind");
     }
 
-    backlog.insert(sign_request.clone()).await;
+    ctx.backlog.insert(sign_request.clone()).await;
 
     let chain = sign_request.chain;
-    if caught_up {
-        if let Err(err) = sign_tx.send(SignCommand::Request(sign_request)).await {
+    if ctx.caught_up {
+        if let Err(err) = ctx.sign_tx.send(SignCommand::Request(sign_request)).await {
             tracing::error!(?err, %chain, "failed to send sign request into queue");
         }
     }
@@ -32,15 +28,11 @@ pub(crate) async fn process_sign_request(
     Ok(())
 }
 
-pub(crate) async fn requeue_pending_sign_requests(
-    backlog: &Backlog,
-    source_chain: Chain,
-    sign_tx: mpsc::Sender<SignCommand>,
-) {
-    for sign_request in backlog.take_requeueable_requests(source_chain).await {
+pub(crate) async fn requeue_pending_sign_requests(ctx: &StreamContext, source_chain: Chain) {
+    for sign_request in ctx.backlog.take_requeueable_requests(source_chain).await {
         let sign_id = sign_request.id;
         let source_chain = sign_request.chain;
-        if let Err(err) = sign_tx.send(SignCommand::Request(sign_request)).await {
+        if let Err(err) = ctx.sign_tx.send(SignCommand::Request(sign_request)).await {
             tracing::error!(
                 ?err,
                 ?sign_id,
@@ -51,18 +43,13 @@ pub(crate) async fn requeue_pending_sign_requests(
     }
 }
 
-pub(crate) async fn resume_pending_publish_requests(
-    backlog: &Backlog,
-    source_chain: Chain,
-    contract_watcher: &ContractStateWatcher,
-    rpc: &RpcChannel,
-) {
-    let publishable = backlog.publishable_requests(source_chain).await;
+pub(crate) async fn resume_pending_publish_requests(ctx: &StreamContext, source_chain: Chain) {
+    let publishable = ctx.backlog.publishable_requests(source_chain).await;
     if publishable.is_empty() {
         return;
     }
 
-    let Some(public_key) = contract_watcher.public_key().await else {
+    let Some(public_key) = ctx.contract_watcher.public_key().await else {
         tracing::warn!(%source_chain, count = publishable.len(), "cannot resume pending publish requests without a public key");
         return;
     };
@@ -72,7 +59,7 @@ pub(crate) async fn resume_pending_publish_requests(
         }
 
         let sign_id = sign_request.id;
-        rpc.publish_signature(
+        ctx.rpc.publish_signature(
             public_key,
             sign_request,
             publish.signature,
@@ -104,14 +91,12 @@ fn verify_entry_signature(
 
 pub(crate) async fn process_respond_event(
     respond_event: SignatureRespondedEvent,
-    sign_tx: mpsc::Sender<SignCommand>,
+    ctx: &StreamContext,
     root_pk: mpc_primitives::PublicKey,
-    backlog: &Backlog,
-    caught_up: bool,
 ) -> anyhow::Result<()> {
     let sign_id = SignId::new(respond_event.request_id);
     let source_chain = respond_event.chain;
-    let Some(entry) = backlog.get(source_chain, &sign_id).await else {
+    let Some(entry) = ctx.backlog.get(source_chain, &sign_id).await else {
         tracing::info!(
             ?sign_id,
             ?source_chain,
@@ -127,9 +112,9 @@ pub(crate) async fn process_respond_event(
     let event = match &entry.request.kind {
         SignKind::Sign => {
             tracing::info!(?sign_id, "sign request completed successfully");
-            backlog.remove(source_chain, &sign_id).await;
-            if caught_up {
-                if let Err(err) = sign_tx.send(SignCommand::Completion(sign_id)).await {
+            ctx.backlog.remove(source_chain, &sign_id).await;
+            if ctx.caught_up {
+                if let Err(err) = ctx.sign_tx.send(SignCommand::Completion(sign_id)).await {
                     anyhow::bail!("failed to send completion for respond event: {err:?}");
                 }
             }
@@ -203,7 +188,8 @@ pub(crate) async fn process_respond_event(
         "bidirectional tx details before advancement",
     );
 
-    match backlog
+    match ctx
+        .backlog
         .advance(source_chain, sign_id, bidirectional_tx)
         .await
     {
@@ -231,16 +217,14 @@ pub(crate) async fn process_respond_event(
 
 pub(crate) async fn process_respond_bidirectional_event(
     event: RespondBidirectionalEvent,
-    sign_tx: mpsc::Sender<SignCommand>,
+    ctx: &StreamContext,
     root_pk: mpc_primitives::PublicKey,
-    backlog: &Backlog,
-    caught_up: bool,
 ) -> anyhow::Result<()> {
     let sign_id = SignId::new(event.request_id);
     let source_chain = event.chain;
     tracing::info!(?sign_id, "processing RespondBidirectionalEvent");
 
-    let Some(entry) = backlog.get(source_chain, &sign_id).await else {
+    let Some(entry) = ctx.backlog.get(source_chain, &sign_id).await else {
         tracing::warn!(?sign_id, "bidirectional tx not found on completion");
         return Ok(());
     };
@@ -254,15 +238,15 @@ pub(crate) async fn process_respond_bidirectional_event(
 
     verify_entry_signature(root_pk, &entry, &event.signature, sign_id)?;
 
-    if backlog.remove(source_chain, &sign_id).await.is_some() {
+    if ctx.backlog.remove(source_chain, &sign_id).await.is_some() {
         tracing::info!(?sign_id, "bidirectional tx completed");
     } else {
         tracing::warn!(?sign_id, "bidirectional tx not found on completion");
         return Ok(());
     }
 
-    if caught_up {
-        sign_tx
+    if ctx.caught_up {
+        ctx.sign_tx
             .send(SignCommand::Completion(sign_id))
             .await
             .map_err(|err| anyhow::anyhow!("failed to send completion for respond bidirectional: {err:?} for sign id: {sign_id:?}"))?;
@@ -273,17 +257,14 @@ pub(crate) async fn process_respond_bidirectional_event(
 
 /// Process an execution confirmation emitted by a chain client.
 /// The target chain is the chain where the execution was observed.
-#[allow(clippy::too_many_arguments)]
 pub async fn process_execution_confirmed(
     tx_id: mpc_primitives::BidirectionalTxId,
     sign_id: SignId,
     source_chain: Chain,
     block_height: u64,
     result: ExecutionOutcome,
-    backlog: &Backlog,
-    sign_tx: mpsc::Sender<SignCommand>,
+    ctx: &StreamContext,
     target_chain: Chain,
-    caught_up: bool,
 ) -> anyhow::Result<()> {
     tracing::info!(
         ?tx_id,
@@ -296,7 +277,7 @@ pub async fn process_execution_confirmed(
 
     // Remove the watcher; if it's not found, it might have been processed already
     let Some((unwatched_sign_id, pending_tx)) =
-        backlog.unwatch_execution(target_chain, &tx_id).await
+        ctx.backlog.unwatch_execution(target_chain, &tx_id).await
     else {
         tracing::warn!(
             ?tx_id,
@@ -308,7 +289,8 @@ pub async fn process_execution_confirmed(
         tracing::warn!(?tx_id, expected = ?unwatched_sign_id, actual = ?sign_id, "sign_id mismatch between event and watcher");
     }
 
-    let chain_ctx = backlog
+    let chain_ctx = ctx
+        .backlog
         .get(pending_tx.source_chain, &unwatched_sign_id)
         .await
         .and_then(|entry| match entry.request.kind {
@@ -328,7 +310,8 @@ pub async fn process_execution_confirmed(
         }
     };
 
-    if let Err(err) = backlog
+    if let Err(err) = ctx
+        .backlog
         .set_request(
             pending_tx.source_chain,
             &unwatched_sign_id,
@@ -346,7 +329,8 @@ pub async fn process_execution_confirmed(
         anyhow::bail!("failed to persist completion request for sign id: {unwatched_sign_id:?}");
     }
 
-    let set_res = backlog
+    let set_res = ctx
+        .backlog
         .set_status(
             pending_tx.source_chain,
             &unwatched_sign_id,
@@ -366,8 +350,8 @@ pub async fn process_execution_confirmed(
     // Execution confirmations are observed on the target chain, but the follow-up
     // request belongs to the source chain. Do not let the target chain's catchup
     // barrier strand that follow-up work.
-    if caught_up || chain != target_chain {
-        if let Err(err) = sign_tx.send(SignCommand::Request(sign_request)).await {
+    if ctx.caught_up || chain != target_chain {
+        if let Err(err) = ctx.sign_tx.send(SignCommand::Request(sign_request)).await {
             tracing::error!(?err, %chain, "failed to send sign request into queue");
         }
     }
@@ -378,19 +362,17 @@ pub async fn process_execution_confirmed(
 pub(crate) async fn process_block_event<T: ChainTelemetry>(
     chain: Chain,
     block: u64,
-    backlog: &Backlog,
-    sign_tx: &mpsc::Sender<SignCommand>,
-    caught_up: bool,
+    ctx: &StreamContext,
     telemetry: &T,
 ) {
     telemetry.block_finalized(block);
 
     // should not create checkpoint for blocks that are not caught up, as that would
     // try to create signatures for checkpoints where we are not live.
-    if !caught_up {
+    if !ctx.caught_up {
         return;
     }
-    let Some(checkpoint) = backlog.set_processed_block(chain, block).await else {
+    let Some(checkpoint) = ctx.backlog.set_processed_block(chain, block).await else {
         return;
     };
 
@@ -406,7 +388,7 @@ pub(crate) async fn process_block_event<T: ChainTelemetry>(
     let sign_id = checkpoint_digest.sign_id();
     tracing::info!(block, ?checkpoint, %chain, ?sign_id, "created checkpoint");
     let sign = SignCommand::Checkpoint(IndexedSignRequest::checkpoint(checkpoint_digest, epsilon));
-    if let Err(err) = sign_tx.send(sign).await {
+    if let Err(err) = ctx.sign_tx.send(sign).await {
         tracing::error!(?err, %chain, "failed to enqueue checkpoint sign request");
     }
 }

--- a/chain-signatures/node/src/stream/ops_tests.rs
+++ b/chain-signatures/node/src/stream/ops_tests.rs
@@ -81,7 +81,9 @@ async fn recover_backlog_requeues_pending_signs() {
     backlog.recover_by_checkpoint(checkpoint).await.unwrap();
 
     let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, false);
-    requeue_pending_sign_requests(&ctx, Chain::Solana).await;
+    requeue_pending_sign_requests(&ctx, Chain::Solana)
+        .await
+        .unwrap();
 
     // We should receive the recovered sign request
     let msg = timeout(Duration::from_secs(1), sign_rx.recv())
@@ -368,7 +370,7 @@ async fn process_execution_confirmed_recovery_requeues_final_respond_after_send_
         tx.target_chain,
     )
     .await
-    .unwrap();
+    .expect_err("send failure should surface as an error");
 
     ctx.backlog.set_processed_block(tx.source_chain, 10).await;
     let checkpoint = ctx.backlog.checkpoint(tx.source_chain).await.unwrap();
@@ -396,7 +398,9 @@ async fn process_execution_confirmed_recovery_requeues_final_respond_after_send_
     recovered.recover_by_checkpoint(checkpoint).await.unwrap();
 
     let recovered_ctx = make_test_stream_context_with_generator_pk(recovered, sign_tx, false);
-    requeue_pending_sign_requests(&recovered_ctx, tx.source_chain).await;
+    requeue_pending_sign_requests(&recovered_ctx, tx.source_chain)
+        .await
+        .unwrap();
 
     let msg = timeout(Duration::from_secs(1), sign_rx.recv())
         .await
@@ -1083,7 +1087,9 @@ async fn requeue_pending_sign_requests_is_chain_scoped() {
     let (sign_tx, mut sign_rx) = mpsc::channel(4);
     let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, false);
 
-    requeue_pending_sign_requests(&ctx, Chain::Solana).await;
+    requeue_pending_sign_requests(&ctx, Chain::Solana)
+        .await
+        .unwrap();
 
     let msg = timeout(Duration::from_secs(1), sign_rx.recv())
         .await
@@ -1115,7 +1121,9 @@ async fn catchup_blocks_do_not_consume_checkpoint_slots() {
     // Process 33 checkpoint intervals at caught_up=false
     let interval = chain.checkpoint_interval().unwrap(); // 100 for Ethereum
     for i in 1..=33 {
-        process_block_event(chain, i * interval, &ctx, &telemetry).await;
+        process_block_event(chain, i * interval, &ctx, &telemetry)
+            .await
+            .unwrap();
     }
 
     // Slots should still be available — no pending checkpoints created

--- a/chain-signatures/node/src/stream/ops_tests.rs
+++ b/chain-signatures/node/src/stream/ops_tests.rs
@@ -3,12 +3,13 @@ use crate::backlog::Backlog;
 use crate::mesh::connection::NodeStatus;
 use crate::mesh::{wait_threshold_active, MeshState};
 use crate::protocol::contract::primitives::ParticipantInfo;
+use crate::rpc::ContractStateWatcher;
 use crate::sign_bidirectional::SignStatus;
 use crate::storage::checkpoint_storage::CheckpointStorage;
 use crate::stream::ops::process_execution_confirmed;
 use crate::stream::test_utils::{
-    respond_event, test_bidirectional_tx, test_canton_sign_bidirectional_request,
-    test_indexed_request, test_sign_args,
+    make_test_stream_context_with_generator_pk, respond_event, test_bidirectional_tx,
+    test_canton_sign_bidirectional_request, test_indexed_request, test_sign_args,
 };
 use crate::util::current_unix_timestamp;
 
@@ -79,7 +80,8 @@ async fn recover_backlog_requeues_pending_signs() {
     let (sign_tx, mut sign_rx) = mpsc::channel(4);
     backlog.recover_by_checkpoint(checkpoint).await.unwrap();
 
-    requeue_pending_sign_requests(&backlog, Chain::Solana, sign_tx).await;
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, false);
+    requeue_pending_sign_requests(&ctx, Chain::Solana).await;
 
     // We should receive the recovered sign request
     let msg = timeout(Duration::from_secs(1), sign_rx.recv())
@@ -136,28 +138,27 @@ async fn process_execution_confirmed_success_creates_respond_request() {
     // ensure watcher exists before processing
     let before_watchers = backlog.get_execution_watchers(tx.target_chain).await;
     assert!(before_watchers.contains_key(&tx.id));
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
     process_execution_confirmed(
         tx_id,
         sign_id,
         tx.source_chain,
         123u64,
         ExecutionOutcome::Success { output: vec![] },
-        &backlog,
-        sign_tx,
+        &ctx,
         tx.target_chain,
-        true,
     )
     .await
     .unwrap();
 
     // Watcher should be removed
-    let watchers = backlog.get_execution_watchers(tx.target_chain).await;
+    let watchers = ctx.backlog.get_execution_watchers(tx.target_chain).await;
     tracing::info!(?watchers, "watchers after execution confirmed");
     assert!(watchers.is_empty());
 
     // Source chain request should now wait for final bidirectional response.
     // inspect the transaction to provide more debugging info on failure
-    let maybe_tx = backlog.get(tx.source_chain, &sign_id).await;
+    let maybe_tx = ctx.backlog.get(tx.source_chain, &sign_id).await;
     assert!(maybe_tx.is_some(), "expected sign tx to still exist");
     let tx_after = maybe_tx.unwrap();
     assert_eq!(
@@ -214,6 +215,7 @@ async fn process_execution_confirmed_is_idempotent_after_first_processing() {
         .await;
 
     let (sign_tx, mut sign_rx) = mpsc::channel(4);
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
 
     process_execution_confirmed(
         tx.id,
@@ -221,10 +223,8 @@ async fn process_execution_confirmed_is_idempotent_after_first_processing() {
         tx.source_chain,
         123u64,
         ExecutionOutcome::Success { output: vec![] },
-        &backlog,
-        sign_tx.clone(),
+        &ctx,
         tx.target_chain,
-        true,
     )
     .await
     .unwrap();
@@ -235,10 +235,8 @@ async fn process_execution_confirmed_is_idempotent_after_first_processing() {
         tx.source_chain,
         124u64,
         ExecutionOutcome::Success { output: vec![] },
-        &backlog,
-        sign_tx,
+        &ctx,
         tx.target_chain,
-        true,
     )
     .await
     .unwrap();
@@ -257,7 +255,8 @@ async fn process_execution_confirmed_is_idempotent_after_first_processing() {
     let no_second = timeout(Duration::from_millis(100), sign_rx.recv()).await;
     assert!(matches!(no_second, Err(_) | Ok(None)));
 
-    assert!(backlog
+    assert!(ctx
+        .backlog
         .get_execution_watchers(tx.target_chain)
         .await
         .is_empty());
@@ -290,6 +289,7 @@ async fn process_execution_confirmed_warns_but_still_uses_watcher_sign_id() {
         .await;
 
     let (sign_tx, mut sign_rx) = mpsc::channel(4);
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
 
     process_execution_confirmed(
         tx.id,
@@ -297,15 +297,13 @@ async fn process_execution_confirmed_warns_but_still_uses_watcher_sign_id() {
         tx.source_chain,
         321u64,
         ExecutionOutcome::Failed,
-        &backlog,
-        sign_tx,
+        &ctx,
         tx.target_chain,
-        true,
     )
     .await
     .unwrap();
 
-    let tx_after = backlog.get(tx.source_chain, &sign_id).await.unwrap();
+    let tx_after = ctx.backlog.get(tx.source_chain, &sign_id).await.unwrap();
     assert_eq!(
         tx_after.status(),
         SignStatus::PendingGenerationBidirectional
@@ -314,7 +312,8 @@ async fn process_execution_confirmed_warns_but_still_uses_watcher_sign_id() {
         tx_after.request.kind,
         SignKind::RespondBidirectional(_)
     ));
-    assert!(backlog
+    assert!(ctx
+        .backlog
         .get_execution_watchers(tx.target_chain)
         .await
         .is_empty());
@@ -357,6 +356,7 @@ async fn process_execution_confirmed_recovery_requeues_final_respond_after_send_
 
     let (sign_tx, sign_rx) = mpsc::channel(4);
     drop(sign_rx);
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
 
     process_execution_confirmed(
         tx.id,
@@ -364,19 +364,17 @@ async fn process_execution_confirmed_recovery_requeues_final_respond_after_send_
         tx.source_chain,
         444u64,
         ExecutionOutcome::Success { output: vec![] },
-        &backlog,
-        sign_tx,
+        &ctx,
         tx.target_chain,
-        true,
     )
     .await
     .unwrap();
 
-    backlog.set_processed_block(tx.source_chain, 10).await;
-    let checkpoint = backlog.checkpoint(tx.source_chain).await.unwrap();
+    ctx.backlog.set_processed_block(tx.source_chain, 10).await;
+    let checkpoint = ctx.backlog.checkpoint(tx.source_chain).await.unwrap();
 
     // Simulate consensus confirmation so storage has the checkpoint
-    backlog
+    ctx.backlog
         .on_consensus_confirmed(tx.source_chain, &checkpoint)
         .await;
 
@@ -397,7 +395,8 @@ async fn process_execution_confirmed_recovery_requeues_final_respond_after_send_
         .unwrap();
     recovered.recover_by_checkpoint(checkpoint).await.unwrap();
 
-    requeue_pending_sign_requests(&recovered, tx.source_chain, sign_tx).await;
+    let recovered_ctx = make_test_stream_context_with_generator_pk(recovered, sign_tx, false);
+    requeue_pending_sign_requests(&recovered_ctx, tx.source_chain).await;
 
     let msg = timeout(Duration::from_secs(1), sign_rx.recv())
         .await
@@ -473,8 +472,9 @@ async fn process_respond_event_rejects_invalid_bidirectional_target_chain() {
         ContractStateWatcher::with_running(&account_id, public_key, 1, Default::default());
 
     let (sign_tx, _sign_rx) = mpsc::channel(4);
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
 
-    let err = process_respond_event(event, sign_tx, public_key, &backlog, true)
+    let err = process_respond_event(event, &ctx, public_key)
         .await
         .expect_err("invalid chain should fail");
     assert!(err.to_string().contains("UnknownCaip2Id(\"not-a-chain\")"));
@@ -505,7 +505,8 @@ async fn process_sign_request_rejects_respond_bidirectional_kind() {
     );
 
     let (sign_tx, _sign_rx) = mpsc::channel(4);
-    let err = process_sign_request(request, sign_tx, backlog, true)
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
+    let err = process_sign_request(request, &ctx)
         .await
         .expect_err("RespondBidirectional should be rejected from the sign queue path");
     assert!(err.to_string().contains("Unexpected sign request kind"));
@@ -543,12 +544,13 @@ async fn process_respond_event_rejects_invalid_signature() {
         ContractStateWatcher::with_running(&account_id, public_key, 1, Default::default());
 
     let (sign_tx, _sign_rx) = mpsc::channel(4);
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
 
-    let err = process_respond_event(event, sign_tx, public_key, &backlog, true)
+    let err = process_respond_event(event, &ctx, public_key)
         .await
         .expect_err("invalid signature should be rejected");
     assert!(err.to_string().contains("invalid signature"));
-    assert!(backlog.get(Chain::Ethereum, &sign_id).await.is_some());
+    assert!(ctx.backlog.get(Chain::Ethereum, &sign_id).await.is_some());
 }
 
 #[tokio::test]
@@ -583,18 +585,13 @@ async fn process_respond_bidirectional_event_duplicate_is_idempotent() {
         ContractStateWatcher::with_running(&account_id, public_key, 1, Default::default());
 
     let (sign_tx, mut sign_rx) = mpsc::channel(4);
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
 
-    process_respond_bidirectional_event(
-        duplicate_event0,
-        sign_tx.clone(),
-        public_key,
-        &backlog,
-        true,
-    )
-    .await
-    .expect("first completion should succeed");
+    process_respond_bidirectional_event(duplicate_event0, &ctx, public_key)
+        .await
+        .expect("first completion should succeed");
 
-    process_respond_bidirectional_event(duplicate_event1, sign_tx, public_key, &backlog, true)
+    process_respond_bidirectional_event(duplicate_event1, &ctx, public_key)
         .await
         .expect("duplicate completion should be ignored");
 
@@ -643,12 +640,13 @@ async fn process_respond_bidirectional_event_rejects_invalid_signature() {
         ContractStateWatcher::with_running(&account_id, public_key, 1, Default::default());
 
     let (sign_tx, _sign_rx) = mpsc::channel(4);
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
 
-    let err = process_respond_bidirectional_event(event, sign_tx, public_key, &backlog, true)
+    let err = process_respond_bidirectional_event(event, &ctx, public_key)
         .await
         .expect_err("invalid signature should be rejected");
     assert!(err.to_string().contains("invalid signature"));
-    assert!(backlog.get(Chain::Solana, &sign_id).await.is_some());
+    assert!(ctx.backlog.get(Chain::Solana, &sign_id).await.is_some());
 }
 
 #[tokio::test]
@@ -680,9 +678,10 @@ async fn process_respond_event_duplicate_ethereum_is_idempotent() {
         ContractStateWatcher::with_running(&account_id, public_key, 1, Default::default());
 
     let (sign_tx, mut sign_rx) = mpsc::channel(4);
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
 
     // First event should complete the request.
-    process_respond_event(event.clone(), sign_tx.clone(), public_key, &backlog, true)
+    process_respond_event(event.clone(), &ctx, public_key)
         .await
         .expect("first respond event should succeed");
 
@@ -699,7 +698,7 @@ async fn process_respond_event_duplicate_ethereum_is_idempotent() {
     // This mirrors production behavior where the same respond log can be
     // emitted repeatedly by the Ethereum indexer pipeline.
     for _ in 0..16 {
-        process_respond_event(event.clone(), sign_tx.clone(), public_key, &backlog, true)
+        process_respond_event(event.clone(), &ctx, public_key)
             .await
             .expect("duplicate respond event should be idempotent");
     }
@@ -785,12 +784,14 @@ async fn process_respond_event_advances_bidirectional_from_pending_publish() {
         ContractStateWatcher::with_running(&account_id, public_key, 1, Default::default());
 
     let (sign_tx, _sign_rx) = mpsc::channel(4);
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, false);
 
-    process_respond_event(event, sign_tx, public_key, &backlog, false)
+    process_respond_event(event, &ctx, public_key)
         .await
         .expect("respond event should advance pending publish bidirectional entries");
 
-    let entry = backlog
+    let entry = ctx
+        .backlog
         .get(Chain::Ethereum, &sign_id)
         .await
         .expect("entry should remain in backlog");
@@ -803,7 +804,7 @@ async fn process_respond_event_advances_bidirectional_from_pending_publish() {
         .expect("pending execution entries should store the execution transaction")
         .id;
 
-    let watchers = backlog.get_execution_watchers(Chain::Solana).await;
+    let watchers = ctx.backlog.get_execution_watchers(Chain::Solana).await;
     assert_eq!(watchers.len(), 1);
     assert!(watchers.contains_key(&execution_tx_id));
 }
@@ -839,6 +840,7 @@ async fn process_execution_confirmed_failed_creates_error_respond_request() {
         .await;
 
     let (sign_tx, mut sign_rx) = mpsc::channel(4);
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
 
     process_execution_confirmed(
         tx.id,
@@ -846,25 +848,24 @@ async fn process_execution_confirmed_failed_creates_error_respond_request() {
         tx.source_chain,
         456u64,
         ExecutionOutcome::Failed,
-        &backlog,
-        sign_tx,
+        &ctx,
         tx.target_chain,
-        true,
     )
     .await
     .unwrap();
 
     // Watcher removed
-    let watchers = backlog.get_execution_watchers(tx.target_chain).await;
+    let watchers = ctx.backlog.get_execution_watchers(tx.target_chain).await;
     assert!(watchers.is_empty());
 
     // Source chain should now wait for final bidirectional response.
-    let waiting = backlog
+    let waiting = ctx
+        .backlog
         .pending_generation_bidirectionals(tx.source_chain)
         .await;
     assert!(waiting.contains_key(&sign_id));
 
-    let tx_after = backlog.get(tx.source_chain, &sign_id).await.unwrap();
+    let tx_after = ctx.backlog.get(tx.source_chain, &sign_id).await.unwrap();
     assert!(matches!(
         tx_after.request.kind,
         SignKind::RespondBidirectional(_)
@@ -938,16 +939,15 @@ async fn process_execution_confirmed_cross_chain_emits_before_target_catchup() {
         .await;
 
     let (sign_tx, mut sign_rx) = mpsc::channel(4);
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, false);
     process_execution_confirmed(
         tx.id,
         sign_id,
         tx.source_chain,
         789u64,
         ExecutionOutcome::Failed,
-        &backlog,
-        sign_tx,
+        &ctx,
         tx.target_chain,
-        false,
     )
     .await
     .unwrap();
@@ -988,6 +988,7 @@ async fn process_execution_confirmed_carries_canton_chain_ctx_to_final_request()
         .await;
 
     let (sign_tx, mut sign_rx) = mpsc::channel(4);
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
 
     process_execution_confirmed(
         tx.id,
@@ -995,10 +996,8 @@ async fn process_execution_confirmed_carries_canton_chain_ctx_to_final_request()
         tx.source_chain,
         456u64,
         ExecutionOutcome::Success { output: vec![1] },
-        &backlog,
-        sign_tx,
+        &ctx,
         tx.target_chain,
-        true,
     )
     .await
     .unwrap();
@@ -1009,11 +1008,12 @@ async fn process_execution_confirmed_carries_canton_chain_ctx_to_final_request()
         assert_eq!(decoded.sign_event_contract_id, sign_event_contract_id);
     };
 
-    assert!(backlog
+    assert!(ctx
+        .backlog
         .get_execution_watchers(tx.target_chain)
         .await
         .is_empty());
-    let tx_after = backlog.get(tx.source_chain, &sign_id).await.unwrap();
+    let tx_after = ctx.backlog.get(tx.source_chain, &sign_id).await.unwrap();
     assert_eq!(
         tx_after.status(),
         SignStatus::PendingGenerationBidirectional
@@ -1081,8 +1081,9 @@ async fn requeue_pending_sign_requests_is_chain_scoped() {
         .await;
 
     let (sign_tx, mut sign_rx) = mpsc::channel(4);
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, false);
 
-    requeue_pending_sign_requests(&backlog, Chain::Solana, sign_tx).await;
+    requeue_pending_sign_requests(&ctx, Chain::Solana).await;
 
     let msg = timeout(Duration::from_secs(1), sign_rx.recv())
         .await
@@ -1109,24 +1110,17 @@ async fn catchup_blocks_do_not_consume_checkpoint_slots() {
     let backlog = Backlog::new();
     let (sign_tx, _sign_rx) = mpsc::channel(4);
     let telemetry = NoopChainTelemetry;
+    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, false);
 
     // Process 33 checkpoint intervals at caught_up=false
     let interval = chain.checkpoint_interval().unwrap(); // 100 for Ethereum
     for i in 1..=33 {
-        process_block_event(
-            chain,
-            i * interval,
-            &backlog,
-            &sign_tx,
-            false, // caught_up
-            &telemetry,
-        )
-        .await;
+        process_block_event(chain, i * interval, &ctx, &telemetry).await;
     }
 
     // Slots should still be available — no pending checkpoints created
     assert!(
-        backlog.has_checkpoint_slot(chain).await,
+        ctx.backlog.has_checkpoint_slot(chain).await,
         "catchup should not consume checkpoint slots; 33 intervals without caught_up \
          would fill the 32-slot cap and cause a permanent stall"
     );

--- a/chain-signatures/node/src/stream/ops_tests.rs
+++ b/chain-signatures/node/src/stream/ops_tests.rs
@@ -481,7 +481,13 @@ async fn process_respond_event_rejects_invalid_bidirectional_target_chain() {
     let err = process_respond_event(event, &ctx, public_key)
         .await
         .expect_err("invalid chain should fail");
-    assert!(err.to_string().contains("UnknownCaip2Id(\"not-a-chain\")"));
+    // The underlying `UnknownCaip2Id` cause is carried in the error's source chain.
+    let cause = err
+        .chain()
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(cause.contains("unknown CAIP-2 chain ID: not-a-chain"));
 }
 
 #[tokio::test]

--- a/chain-signatures/node/src/stream/pipeline.rs
+++ b/chain-signatures/node/src/stream/pipeline.rs
@@ -99,6 +99,37 @@ impl<I: ChainIndexer> ChainPipeline<I> {
         (this, state_rx)
     }
 
+    /// Evaluate the outcome of a regression check and transition to Recovery if needed.
+    fn evaluate_regression_outcome(
+        &self,
+        result: RegressionOutcome,
+    ) -> Option<Option<ChainStreaming>> {
+        match result {
+            RegressionOutcome::Recovery => {
+                let new_state = ChainStreaming::Recovery { load_local: false };
+                let _ = self.state_tx.send(new_state);
+                Some(Some(new_state))
+            }
+            RegressionOutcome::Aligned => None,
+            RegressionOutcome::Shutdown => Some(None),
+        }
+    }
+
+    /// Watchdog-timeout handler shared by `handle_catchup` and `handle_live`.
+    async fn handle_watchdog_timeout(&mut self, context: &str) -> Option<ChainStreaming> {
+        let chain = I::CHAIN;
+        let timeout = self.watchdog_timeout;
+        let has_slot = self.backlog.has_checkpoint_slot(chain).await;
+        let pending = self.backlog.pending_checkpoint_count(chain).await;
+        tracing::warn!(
+            %chain, ?timeout, has_checkpoint_slot = has_slot,
+            pending_checkpoints = pending, "{} processing timed out; restarting pipeline", context
+        );
+        let new_state = ChainStreaming::Recovery { load_local: false };
+        let _ = self.state_tx.send(new_state);
+        Some(new_state)
+    }
+
     pub async fn run(mut self) {
         let chain = I::CHAIN;
         tracing::info!(%chain, "starting ChainStream pipeline");
@@ -226,21 +257,9 @@ impl<I: ChainIndexer> ChainPipeline<I> {
                                 tokio::time::sleep(I::RETRY_DELAY).await;
                             }
                             Err(_) => {
-                                let has_slot =
-                                    self.backlog.has_checkpoint_slot(chain).await;
-                                let pending =
-                                    self.backlog.pending_checkpoint_count(chain).await;
-                                tracing::warn!(
-                                    %chain,
-                                    ?timeout,
-                                    has_checkpoint_slot = has_slot,
-                                    pending_checkpoints = pending,
-                                    "catchup block processing timed out; restarting pipeline"
-                                );
-                                let new_state =
-                                    ChainStreaming::Recovery { load_local: false };
-                                let _ = self.state_tx.send(new_state);
-                                return Some(new_state);
+                                return self
+                                    .handle_watchdog_timeout("catchup block")
+                                    .await;
                             }
                         }
                     }
@@ -250,30 +269,13 @@ impl<I: ChainIndexer> ChainPipeline<I> {
                     &self.backlog,
                     chain,
                 ) => {
-                    match result {
-                        RegressionOutcome::Recovery => {
-                            let new_state = ChainStreaming::Recovery { load_local: false };
-                            let _ = self.state_tx.send(new_state);
-                            return Some(new_state);
-                        }
-                        RegressionOutcome::Aligned => {}
-                        RegressionOutcome::Shutdown => return None,
+                    if let Some(ret) = self.evaluate_regression_outcome(result) {
+                        return ret;
                     }
                 }
                 // Watchdog: if no catchup block is processed within the chain-specific timeout
                 _ = tokio::time::sleep(timeout) => {
-                    let has_slot = self.backlog.has_checkpoint_slot(chain).await;
-                    let pending = self.backlog.pending_checkpoint_count(chain).await;
-                    tracing::warn!(
-                        %chain,
-                        ?timeout,
-                        has_checkpoint_slot = has_slot,
-                        pending_checkpoints = pending,
-                        "catchup stalled; no block processed within timeout; restarting pipeline"
-                    );
-                    let new_state = ChainStreaming::Recovery { load_local: false };
-                    let _ = self.state_tx.send(new_state);
-                    return Some(new_state);
+                    return self.handle_watchdog_timeout("catchup").await;
                 }
             }
         }
@@ -302,31 +304,14 @@ impl<I: ChainIndexer> ChainPipeline<I> {
                     &self.backlog,
                     chain,
                 ) => {
-                    match result {
-                        RegressionOutcome::Recovery => {
-                            let new_state = ChainStreaming::Recovery { load_local: false };
-                            let _ = self.state_tx.send(new_state);
-                            return Some(new_state);
-                        }
-                        RegressionOutcome::Aligned => {}
-                        RegressionOutcome::Shutdown => return None,
+                    if let Some(ret) = self.evaluate_regression_outcome(result) {
+                        return ret;
                     }
                 }
                 // Watchdog: if no block is processed within the chain-specific timeout,
                 // the background producer is assumed stalled and the pipeline restarts.
                 _ = tokio::time::sleep(timeout) => {
-                    let has_slot = self.backlog.has_checkpoint_slot(chain).await;
-                    let pending = self.backlog.pending_checkpoint_count(chain).await;
-                    tracing::warn!(
-                        %chain,
-                        ?timeout,
-                        has_checkpoint_slot = has_slot,
-                        pending_checkpoints = pending,
-                        "live block processing timed out; restarting pipeline"
-                    );
-                    let new_state = ChainStreaming::Recovery { load_local: false };
-                    let _ = self.state_tx.send(new_state);
-                    return Some(new_state);
+                    return self.handle_watchdog_timeout("live block").await;
                 }
             }
         }

--- a/chain-signatures/node/src/stream/stream_tests.rs
+++ b/chain-signatures/node/src/stream/stream_tests.rs
@@ -5,14 +5,17 @@ use crate::node_client::NodeClient;
 use crate::rpc::{ContractStateWatcher, RpcAction};
 use crate::storage::checkpoint_storage::CheckpointStorage;
 use crate::stream::test_utils::{
-    run_stream_with_two_node_mesh, signature_responded_event, test_rpc_channel, test_sign_args,
+    run_stream_with_two_node_mesh, signature_responded_event, test_bidirectional_tx,
+    test_rpc_channel, test_sign_args,
 };
 use crate::util::current_unix_timestamp;
 use async_trait::async_trait;
 use k256::{AffinePoint, Scalar};
 use mpc_chain_integration_core::{NoopChainTelemetry, StateManager};
 use mpc_chain_solana::Pubkey;
-use mpc_primitives::{Chain, CheckpointDigest, IndexedSignRequest, SignCommand, SignId, Signature};
+use mpc_primitives::{
+    Chain, CheckpointDigest, IndexedSignRequest, SignArgs, SignCommand, SignId, Signature,
+};
 use near_primitives::types::AccountId;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -391,109 +394,16 @@ async fn test_stream_handles_sign_and_respond() {
     }
 }
 
-#[tokio::test]
-async fn test_stream_handles_sign_bidirectional_block_and_recover() {
-    let _ = tracing_subscriber::fmt::try_init();
-    use crate::sign_bidirectional::SignStatus;
+/// Build a `SignKind::SignBidirectional` request from Solana to Ethereum.
+/// Returns `(IndexedSignRequest, SignArgs, SecretKey)`
+fn build_solana_to_ethereum_bidirectional_request(
+    seed: u8,
+) -> (IndexedSignRequest, SignArgs, k256::SecretKey) {
     use mpc_primitives::SignBidirectionalEvent as SBE;
 
-    // shared storage so checkpoint persistence is visible to recovered backlog
-    let storage = crate::storage::checkpoint_storage::CheckpointStorage::in_memory();
-    let backlog = Backlog::persisted(storage.clone());
+    let sign_id = SignId::new([seed; 32]);
+    let args = test_sign_args(seed);
 
-    // client implemented with a channel so the test can control pacing
-    struct LocalStream {
-        rx: mpsc::Receiver<ChainEvent>,
-    }
-
-    #[async_trait]
-    impl ChainStream for LocalStream {
-        type Indexer = DisabledChainIndexer;
-
-        async fn start(&mut self) -> anyhow::Result<Self::Indexer> {
-            Ok(DisabledChainIndexer::silent())
-        }
-
-        async fn next_event(&mut self) -> Option<ChainEvent> {
-            self.rx.recv().await
-        }
-    }
-
-    pub struct DisabledChainIndexer {
-        events_tx: Option<mpsc::Sender<ChainEvent>>,
-    }
-
-    impl DisabledChainIndexer {
-        pub fn silent() -> Self {
-            Self { events_tx: None }
-        }
-    }
-
-    #[async_trait]
-    impl ChainIndexer for DisabledChainIndexer {
-        const CHAIN: Chain = Chain::Solana;
-        type Block = ();
-        type Iter = futures_util::stream::Empty<Self::Block>;
-
-        async fn next(&mut self) -> Option<Self::Block> {
-            None
-        }
-
-        async fn catchup_range(&self, _anchor_height: u64) -> Self::Iter {
-            futures_util::stream::empty()
-        }
-
-        async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {
-            if let Some(events_tx) = &self.events_tx {
-                events_tx.send(ChainEvent::CatchupCompleted).await?;
-            }
-            Ok(())
-        }
-    }
-
-    let (events_tx, rx) = mpsc::channel(8);
-    let client = LocalStream { rx };
-
-    let (sign_tx, mut sign_rx) = mpsc::channel(8);
-
-    let root_sk = k256::SecretKey::random(&mut rand::thread_rng());
-    let root_pk = root_sk.public_key().to_projective().to_affine();
-
-    let (contract_watcher, _tx) = ContractStateWatcher::with_running(
-        &"test.near".parse::<AccountId>().unwrap(),
-        root_pk,
-        0,
-        Default::default(),
-    );
-    let (_mesh_state_tx, mesh_state_rx) = watch::channel(MeshState::default());
-    let (_cp_tx, cp_rx) = watch::channel(None);
-    let node_client = NodeClient::new(&Default::default());
-    let (rpc, _rpc_rx) = test_rpc_channel(8);
-
-    // Start indexer in background (clone backlog so the test retains ownership)
-    let backlog_for_run = backlog.clone();
-    let sign_tx_for_run = sign_tx.clone();
-    let run_handle = tokio::spawn(async move {
-        run_stream(
-            client,
-            StreamContext::new(
-                backlog_for_run,
-                sign_tx_for_run,
-                rpc,
-                contract_watcher,
-                mesh_state_rx,
-                node_client,
-                cp_rx,
-            ),
-            NoopChainTelemetry,
-        )
-        .await;
-    });
-
-    // prepare a SignBidirectional request
-    let sign_id = SignId::new([42u8; 32]);
-    let args = test_sign_args(0);
-    let program_id = Pubkey::new_unique();
     // Minimal legacy unsigned Ethereum tx encoded as RLP so sign_and_hash can parse it
     let mut rlp_s = rlp::RlpStream::new_list(9);
     rlp_s.append(&0u64); // nonce
@@ -518,7 +428,7 @@ async fn test_stream_handles_sign_bidirectional_block_and_recover() {
         dest: Chain::Ethereum.to_string(),
         params: "".to_string(),
         chain: Chain::Solana,
-        chain_ctx: Some(program_id.to_bytes().to_vec()),
+        chain_ctx: Some(Pubkey::new_unique().to_bytes().to_vec()),
         output_deserialization_schema: vec![],
         respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
     };
@@ -531,182 +441,235 @@ async fn test_stream_handles_sign_bidirectional_block_and_recover() {
         sign_bidir,
     );
 
-    events_tx.send(ChainEvent::CatchupCompleted).await.unwrap();
+    let root_sk = k256::SecretKey::random(&mut rand::thread_rng());
+    (request, args, root_sk)
+}
 
-    // push SignRequest
-    events_tx
-        .send(ChainEvent::SignRequest {
+/// Receiving a `ChainEvent::SignRequest` with a bidirectional event should
+/// insert it into the backlog and enqueue a `SignCommand`.
+#[tokio::test]
+async fn test_bidirectional_sign_request_enqueues_command() {
+    let backlog = Backlog::new();
+    let (request, _args, root_sk) = build_solana_to_ethereum_bidirectional_request(42);
+    let sign_id = request.id;
+    let root_pk = root_sk.public_key().to_projective().to_affine();
+    let client = SolanaTestStream::new(vec![
+        Some(ChainEvent::CatchupCompleted),
+        Some(ChainEvent::SignRequest {
             request: request.clone(),
             block_timestamp: None,
-        })
-        .await
-        .unwrap();
+        }),
+        None,
+    ]);
 
-    // we should receive a SignCommand::Request
+    let (sign_tx, mut sign_rx) = mpsc::channel(8);
+    let (contract_watcher, _tx) = ContractStateWatcher::with_running(
+        &"test.near".parse::<AccountId>().unwrap(),
+        root_pk,
+        0,
+        Default::default(),
+    );
+    let (_mesh_state_tx, mesh_state_rx) = watch::channel(MeshState::default());
+    let (_cp_tx, cp_rx) = watch::channel(None);
+    let node_client = NodeClient::new(&Default::default());
+    let (rpc, _rpc_rx) = test_rpc_channel(8);
+
+    run_stream(
+        client,
+        StreamContext::new(
+            backlog.clone(),
+            sign_tx,
+            rpc,
+            contract_watcher,
+            mesh_state_rx,
+            node_client,
+            cp_rx,
+        ),
+        NoopChainTelemetry,
+    )
+    .await;
+
+    // A SignCommand::Request should have been emitted for the bidirectional request
     let msg = timeout(Duration::from_secs(1), sign_rx.recv())
         .await
         .unwrap()
         .unwrap();
+
     match msg {
         SignCommand::Request(req) => assert_eq!(req.id, sign_id),
-        _ => panic!("expected sign request"),
+        other => panic!("expected SignCommand::Request, got {other:?}"),
     }
 
-    let mpc_sig = mpc_crypto::generate_signature(&root_sk, &args);
+    // The request should be persisted in the backlog after the sign request is processed
+    let entry = backlog
+        .get(Chain::Solana, &sign_id)
+        .await
+        .expect("bidirectional sign request should be tracked in the backlog");
 
+    assert!(matches!(
+        entry.request.kind,
+        mpc_primitives::SignKind::SignBidirectional(_)
+    ));
+}
+
+/// A `ChainEvent::Respond` against an entry that is already in `PendingPublish`
+/// should advance it to `PendingExecution` and register an execution watcher on
+/// the target chain.
+#[tokio::test]
+async fn test_respond_event_advances_to_pending_execution() {
+    use crate::sign_bidirectional::{PublishState, SignStatus};
+
+    let backlog = Backlog::new();
+    let (request, args, root_sk) = build_solana_to_ethereum_bidirectional_request(7);
+    let sign_id = request.id;
+    let root_pk = root_sk.public_key().to_projective().to_affine();
+
+    // Pre-seed the backlog with the bidirectional entry and mark it as already
+    // published so the incoming respond event advances it into execution pending.
+    backlog.insert(request).await;
+    let mpc_sig = mpc_crypto::generate_signature(&root_sk, &args);
     backlog
         .set_status(
             Chain::Solana,
             &sign_id,
             SignStatus::PendingPublish {
-                publish: crate::sign_bidirectional::PublishState {
+                publish: PublishState {
                     signature: mpc_sig,
-                    participants: vec![cait_sith::protocol::Participant::from(0u32)],
+                    participants: vec![],
                     is_proposer: true,
                 },
             },
         )
         .await;
 
-    // Prepare a SignatureRespondedEvent that will advance to bidirectional and register watcher
     let sig_responded = signature_responded_event(sign_id, mpc_sig, Chain::Solana);
-    events_tx
-        .send(ChainEvent::Respond(sig_responded))
+    let client = SolanaTestStream::new(vec![
+        Some(ChainEvent::CatchupCompleted),
+        Some(ChainEvent::Respond(sig_responded)),
+        None,
+    ]);
+
+    let (sign_tx, _sign_rx) = mpsc::channel(8);
+    let (contract_watcher, _tx) = ContractStateWatcher::with_running(
+        &"test.near".parse::<AccountId>().unwrap(),
+        root_pk,
+        0,
+        Default::default(),
+    );
+    let (_mesh_state_tx, mesh_state_rx) = watch::channel(MeshState::default());
+    let (_cp_tx, cp_rx) = watch::channel(None);
+    let node_client = NodeClient::new(&Default::default());
+    let (rpc, _rpc_rx) = test_rpc_channel(8);
+
+    run_stream(
+        client,
+        StreamContext::new(
+            backlog.clone(),
+            sign_tx,
+            rpc,
+            contract_watcher,
+            mesh_state_rx,
+            node_client,
+            cp_rx,
+        ),
+        NoopChainTelemetry,
+    )
+    .await;
+
+    // The respond event should have advanced the entry to PendingExecution and
+    // registered an execution watcher for the derived bidirectional tx on the
+    // target chain (Ethereum).
+    let entry = backlog
+        .get(Chain::Solana, &sign_id)
         .await
-        .unwrap();
+        .expect("entry should remain in backlog after respond event");
+    assert!(
+        matches!(entry.status(), SignStatus::PendingExecution { .. }),
+        "expected PendingExecution, got {:?}",
+        entry.status()
+    );
 
-    // wait for the indexer to register an execution watcher for the target chain
-    let target_chain = Chain::Ethereum;
-    timeout(Duration::from_secs(1), async {
-        loop {
-            let watchers = backlog.get_execution_watchers(target_chain).await;
-            if watchers.values().any(|(s, _)| *s == sign_id) {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .unwrap();
+    let watchers = backlog.get_execution_watchers(Chain::Ethereum).await;
+    assert_eq!(watchers.len(), 1, "expected exactly one execution watcher");
+    let (watched_sign_id, _watched_tx) = watchers.values().next().unwrap();
+    assert_eq!(*watched_sign_id, sign_id);
+}
 
-    // mark status as PendingExecution so it will be included in checkpoints
-    let execution = backlog
-        .get_execution_watchers(target_chain)
-        .await
-        .into_iter()
-        .find_map(|(_, (watched_sign_id, watched_tx))| {
-            (watched_sign_id == sign_id).then_some(watched_tx)
-        })
-        .expect("expected execution watcher to exist");
-    let execution_id = execution.id;
-    backlog
-        .set_status(
-            Chain::Solana,
-            &sign_id,
-            SignStatus::PendingExecution { tx: execution },
-        )
-        .await;
+/// `process_execution_confirmed` on a watched bidirectional tx should advance the
+/// source-chain entry into a follow-up `RespondBidirectional` request and enqueue
+/// a new `SignCommand::Request` carrying that request.
+#[tokio::test]
+async fn test_execution_confirmation_advances_to_respond_bidirectional() {
+    use mpc_primitives::{ExecutionOutcome, SignKind};
 
-    // send a block event for this chain and ensure checkpoint is persisted
-    let block = Chain::Solana.checkpoint_interval().unwrap_or(1);
-    events_tx.send(ChainEvent::Block(block)).await.unwrap();
+    let backlog = Backlog::new();
+    let seed = 42;
+    let sign_id = SignId::new([seed; 32]);
 
-    // give the indexer a brief moment to persist the checkpoint
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    let checkpoint = backlog
-        .latest_checkpoint(Chain::Solana)
-        .await
-        .expect("checkpoint should exist");
+    // Pre-seed the backlog with a bidirectional request
+    let (request, _args, _root_sk) = build_solana_to_ethereum_bidirectional_request(seed);
+    let program_id_bytes = match &request.kind {
+        mpc_primitives::SignKind::SignBidirectional(event) => event.chain_ctx.clone(),
+        _ => unreachable!("helper always produces a SignBidirectional request"),
+    };
+    backlog.insert(request).await;
 
-    // recover into a new backlog and verify watchers restored
-    let recovered = Backlog::persisted(storage.clone());
-    recovered
-        .recover_by_checkpoint(checkpoint.clone())
-        .await
-        .expect("recovery failed");
+    // Register an execution watcher for the derived bidirectional tx on the target chain (Ethereum)
+    let tx = test_bidirectional_tx(seed, Chain::Solana, Chain::Ethereum);
+    let tx_id = tx.id;
+    backlog.watch_execution(Chain::Ethereum, sign_id, tx).await;
 
-    let old_watchers = backlog.get_execution_watchers(target_chain).await;
-    let new_watchers = recovered.get_execution_watchers(target_chain).await;
-    assert_eq!(old_watchers.len(), new_watchers.len());
-    for (tx_id, (s, _)) in old_watchers {
-        assert!(new_watchers.contains_key(&tx_id));
-        assert_eq!(new_watchers.get(&tx_id).unwrap().0, s);
-    }
-
-    // now send an execution confirmation event to advance to RespondBidirectional
+    let (sign_tx, mut sign_rx) = mpsc::channel(8);
     let ctx = crate::stream::test_utils::make_test_stream_context_with_generator_pk(
         backlog.clone(),
-        sign_tx.clone(),
+        sign_tx,
         true,
     );
+
     crate::stream::ops::process_execution_confirmed(
-        execution_id,
+        tx_id,
         sign_id,
         Chain::Solana,
-        block,
-        mpc_primitives::ExecutionOutcome::Success { output: vec![] },
+        123u64,
+        ExecutionOutcome::Success { output: vec![] },
         &ctx,
         Chain::Ethereum,
     )
     .await
-    .unwrap();
+    .expect("execution confirmation should advance to a RespondBidirectional request");
 
-    // we should receive a SignCommand::Request because of the execution being confirmed
-    let check = tokio::time::sleep(Duration::from_secs(1));
-    tokio::pin!(check);
-    loop {
-        tokio::select! {
-            _ = &mut check => panic!("expected sign request for RespondBidirectional"),
-            msg_req = sign_rx.recv() => match msg_req {
-                Some(SignCommand::Request(req)) => {
-                    assert_eq!(req.id, sign_id);
-                    break;
-                }
-                Some(SignCommand::Checkpoint(_)) => continue,
-                _ => panic!("expected sign request for RespondBidirectional"),
-            }
-        }
-    }
-
-    // Fetch the updated request from the backlog to get the new epsilon and payload
-    let entry = backlog.get(Chain::Solana, &sign_id).await.unwrap();
-    let new_args = &entry.request.args;
-    let new_mpc_sig = mpc_crypto::generate_signature(&root_sk, new_args);
-
-    // now send a RespondBidirectional event to complete the request
-    // RespondBidirectional should also carry a valid signature
-    let respond_bidirectional = mpc_primitives::RespondBidirectionalEvent {
-        request_id: sign_id.request_id,
-        signature: new_mpc_sig,
-        chain: Chain::Solana,
-    };
-    events_tx
-        .send(ChainEvent::RespondBidirectional(respond_bidirectional))
-        .await
-        .unwrap();
-
-    // we should receive completion
-    let mut msg2 = timeout(Duration::from_secs(1), sign_rx.recv())
+    let msg = timeout(Duration::from_secs(1), sign_rx.recv())
         .await
         .unwrap()
         .unwrap();
-    while matches!(msg2, SignCommand::Checkpoint(_)) {
-        msg2 = timeout(Duration::from_secs(1), sign_rx.recv())
+    match msg {
+        SignCommand::Request(req) => {
+            assert_eq!(
+                req.id, sign_id,
+                "follow-up request should reuse the sign id"
+            );
+            match req.kind {
+                SignKind::RespondBidirectional(rb) => {
+                    assert_eq!(rb.tx_id, tx_id, "tx_id should match the watched tx");
+                    assert_eq!(
+                        rb.chain_ctx, program_id_bytes,
+                        "chain_ctx should be forwarded from the originating request",
+                    );
+                }
+                other => panic!("expected RespondBidirectional, got {other:?}"),
+            }
+        }
+        other => panic!("expected SignCommand::Request, got {other:?}"),
+    }
+
+    // The watcher should have been consumed by the handler.
+    assert!(
+        ctx.backlog
+            .get_execution_watchers(Chain::Ethereum)
             .await
-            .unwrap()
-            .unwrap();
-    }
-    match msg2 {
-        SignCommand::Completion(id) => assert_eq!(id, sign_id),
-        _ => panic!("expected completion"),
-    }
-
-    // backlog entry should be removed
-    assert!(backlog.get(Chain::Solana, &sign_id).await.is_none());
-
-    // stop the client and wait for the indexer to finish
-    drop(events_tx);
-    run_handle.await.unwrap();
+            .is_empty(),
+        "execution watcher should be removed after confirmation"
+    );
 }
 
 #[tokio::test]

--- a/chain-signatures/node/src/stream/stream_tests.rs
+++ b/chain-signatures/node/src/stream/stream_tests.rs
@@ -634,16 +634,19 @@ async fn test_stream_handles_sign_bidirectional_block_and_recover() {
     }
 
     // now send an execution confirmation event to advance to RespondBidirectional
+    let ctx = crate::stream::test_utils::make_test_stream_context_with_generator_pk(
+        backlog.clone(),
+        sign_tx.clone(),
+        true,
+    );
     crate::stream::ops::process_execution_confirmed(
         execution_id,
         sign_id,
         Chain::Solana,
         block,
         mpc_primitives::ExecutionOutcome::Success { output: vec![] },
-        &backlog,
-        sign_tx.clone(),
+        &ctx,
         Chain::Ethereum,
-        true,
     )
     .await
     .unwrap();

--- a/chain-signatures/node/src/stream/test_utils.rs
+++ b/chain-signatures/node/src/stream/test_utils.rs
@@ -9,7 +9,7 @@ use crate::rpc::{ContractStateWatcher, RpcAction, RpcChannel};
 use crate::stream::{run_stream, StreamContext};
 use crate::util::current_unix_timestamp;
 use alloy::primitives::{Address, B256};
-use k256::{AffinePoint, Scalar};
+use k256::{AffinePoint, ProjectivePoint, Scalar};
 use mockito::Server;
 use mpc_chain_canton::CantonChainCtx;
 use mpc_chain_integration_core::{ChainStream, NoopChainTelemetry};
@@ -119,6 +119,48 @@ pub fn signature_responded_event(
 pub fn test_rpc_channel(buffer: usize) -> (RpcChannel, mpsc::Receiver<RpcAction>) {
     let (tx, rx) = mpsc::channel(buffer);
     (RpcChannel { tx }, rx)
+}
+
+/// Build a [`StreamContext`] for unit tests, wiring the given `backlog`,
+/// `sign_tx` and `caught_up` flag into it
+pub fn make_test_stream_context(
+    backlog: Backlog,
+    sign_tx: mpsc::Sender<SignCommand>,
+    caught_up: bool,
+    root_pk: AffinePoint,
+) -> StreamContext {
+    let account_id: AccountId = "test.near".parse().unwrap();
+    let (contract_watcher, _tx) =
+        ContractStateWatcher::with_running(&account_id, root_pk, 1, Default::default());
+    let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
+    let (_cp_tx, cp_rx) = watch::channel(None);
+    let node_client = NodeClient::new(&Default::default());
+    let (rpc, _rpc_rx) = test_rpc_channel(8);
+    let mut ctx = StreamContext::new(
+        backlog,
+        sign_tx,
+        rpc,
+        contract_watcher,
+        mesh_rx,
+        node_client,
+        cp_rx,
+    );
+    ctx.caught_up = caught_up;
+    ctx
+}
+
+/// Convenience wrapper around [`make_test_stream_context`] for tests that don't need a specific root public key.
+pub fn make_test_stream_context_with_generator_pk(
+    backlog: Backlog,
+    sign_tx: mpsc::Sender<SignCommand>,
+    caught_up: bool,
+) -> StreamContext {
+    make_test_stream_context(
+        backlog,
+        sign_tx,
+        caught_up,
+        ProjectivePoint::GENERATOR.to_affine(),
+    )
 }
 
 /// Drive `run_stream` against a two-node mesh backed by in-memory Mockito HTTP


### PR DESCRIPTION
Various improvements for `/stream`:
- Update `ops.rs` methods to accept `StreamContext` instead of 9 params (for example `process_execution_confirmed`)
- Centralize error handling in `/stream` modules (add `anyhow` context for methods and log once)
- Break down ~170 lines god test `test_stream_handles_sign_bidirectional_block_and_recover` into three: `test_bidirectional_sign_request_enqueues_command`, `test_respond_event_advances_to_pending_execution` and `test_execution_confirmation_advances_to_respond_bidirectional`
- Reduce watchdog timeout handling duplication in `pipeline.rs`