### PR TITLE
 fix: checkpoint on interval boundary crossing instead of exact multiple

### DIFF
--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -535,6 +535,7 @@ impl Backlog {
         interval: u64,
     ) -> Option<Checkpoint> {
         let mut pending = self.pending(&chain).write().await;
+        let prev = pending.processed_block_height().unwrap_or(0);
         pending.set_processed_block(height);
 
         tracing::trace!(
@@ -544,8 +545,23 @@ impl Backlog {
             "backlog updated processed block height"
         );
 
-        // Create a checkpoint on interval
-        if height.is_multiple_of(interval) {
+        if interval == 0 {
+            return None;
+        }
+
+        // Create a checkpoint when crossing an interval boundary, not only
+        // when landing exactly on an interval multiple. This matters for chains
+        // like Solana where the indexer only observes slots containing
+        // program-relevant transactions; sparse traffic may jump from slot 119
+        // to 500 and never observe slot 120 exactly.
+        //
+        // Caveat: this does not checkpoint every sparse request immediately. If
+        // the last processed height and the new height are in the same interval
+        // bucket, the request waits until the next observed height crosses a
+        // boundary. On restart/recovery, the node still resumes from the latest
+        // confirmed checkpoint and replays only the post-checkpoint same-bucket
+        // tail.
+        if height / interval > prev / interval {
             let tx_count = pending.len();
             drop(pending);
             if let Some(checkpoint) = self.checkpoint(chain).await {
@@ -1865,6 +1881,110 @@ mod tests {
         let checkpoint = checkpoint.unwrap();
         assert_eq!(checkpoint.block_height, interval);
         assert_eq!(checkpoint.chain, Chain::Solana);
+    }
+
+    async fn seed_pending_solana_request(backlog: &Backlog) {
+        let tx = create_test_tx(1);
+        insert_bidirectional_with_status(
+            backlog,
+            Chain::Solana,
+            tx.clone(),
+            pending_execution_status(&tx),
+            "solana",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_boundary_crossing_sparse_request_waits_until_next_bucket() {
+        let backlog = Backlog::new();
+        seed_pending_solana_request(&backlog).await;
+
+        // This documents the main caveat of boundary-crossing checkpointing:
+        // sparse requests still wait if the next observed slot remains in the
+        // same interval bucket.
+        //
+        // 480 -> 500: same bucket (both / 120 == 4), no checkpoint.
+        backlog
+            .set_processed_block_interval(Chain::Solana, 480, 120)
+            .await;
+        let cp = backlog
+            .set_processed_block_interval(Chain::Solana, 500, 120)
+            .await;
+        assert!(cp.is_none());
+
+        // 500 -> 600: crosses from bucket 4 to bucket 5
+        let cp = backlog
+            .set_processed_block_interval(Chain::Solana, 600, 120)
+            .await;
+        assert!(cp.is_some());
+        let cp = cp.unwrap();
+        assert_eq!(cp.block_height, 600);
+        assert_eq!(cp.pending_requests.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_boundary_crossing_same_bucket_no_checkpoint() {
+        let backlog = Backlog::new();
+        seed_pending_solana_request(&backlog).await;
+
+        // 121 crosses from bucket 0 to bucket 1
+        let cp = backlog
+            .set_processed_block_interval(Chain::Solana, 121, 120)
+            .await;
+        assert!(cp.is_some());
+
+        // 130 stays in bucket 1; no new boundary crossed
+        let cp = backlog
+            .set_processed_block_interval(Chain::Solana, 130, 120)
+            .await;
+        assert!(cp.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_boundary_crossing_within_first_bucket_no_checkpoint() {
+        let backlog = Backlog::new();
+        seed_pending_solana_request(&backlog).await;
+
+        // First observed slot 50 is still in bucket 0 (50 / 120 == 0 == prev default 0)
+        let cp = backlog
+            .set_processed_block_interval(Chain::Solana, 50, 120)
+            .await;
+        assert!(cp.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_boundary_crossing_exact_multiple_still_checkpoints() {
+        let backlog = Backlog::new();
+        seed_pending_solana_request(&backlog).await;
+
+        let cp = backlog
+            .set_processed_block_interval(Chain::Solana, 119, 120)
+            .await;
+        assert!(cp.is_none());
+
+        // Exact multiple still works; it crosses from bucket 0 to bucket 1
+        let cp = backlog
+            .set_processed_block_interval(Chain::Solana, 120, 120)
+            .await;
+        assert!(cp.is_some());
+        assert_eq!(cp.unwrap().block_height, 120);
+    }
+
+    #[tokio::test]
+    async fn test_boundary_crossing_first_observed_height_above_interval() {
+        let backlog = Backlog::new();
+        seed_pending_solana_request(&backlog).await;
+
+        // First ever processed block is 500 (prev defaults to 0)
+        // 500 / 120 = 4 > 0, so a boundary was crossed.
+        let cp = backlog
+            .set_processed_block_interval(Chain::Solana, 500, 120)
+            .await;
+        assert!(cp.is_some());
+        let cp = cp.unwrap();
+        assert_eq!(cp.block_height, 500);
+        assert_eq!(cp.pending_requests.len(), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Solana indexer only observes slots containing program-relevant transactions may never land on an exact multiple of the checkpoint interval. With sparse traffic, a pending request could sit uncheckpointed indefinitely because no visible slot happened to be divisible by 120. https://github.com/sig-net/mpc/issues/977

This PR replaces `height.is_multiple_of(interval)` with a bucket-crossing check (`height / interval > prev / interval`) so that a checkpoint is created the first time a visible slot crosses any interval boundary, regardless of the exact slot number.

### Root cause

The Solana indexer uses a WebSocket subscription filtered to transactions that mention the MPC program (`logs_subscribe` with `Mentions(program_id)`). Unlike Ethereum which processes every finalized block, the Solana indexer only emits `ChainEvent::Block(slot)` for slots where the program is mentioned. With the previous exact-multiple check, a checkpoint was only created when the observed slot number was exactly divisible by the interval (120). On devnet with ~4 visible slots per minute, the probability of hitting an exact multiple was ~1/30, resulting in roughly one checkpoint every 30 minutes instead of the expected ~48 seconds.

### Caveat

This does not checkpoint every sparse request immediately. If the last processed height and the new height are in the same interval bucket, the request waits until the next observed height crosses a boundary. On restart/recovery, the node resumes from the latest confirmed checkpoint and replays only the post-checkpoint same-bucket tail.

## Test plan

- [x] `test_boundary_crossing_sparse_request_waits_until_next_bucket` — 480→500 same bucket (no checkpoint), 500→600 crosses (checkpoint)
- [x] `test_boundary_crossing_same_bucket_no_checkpoint` — 121 crosses, 130 stays in same bucket
- [x] `test_boundary_crossing_within_first_bucket_no_checkpoint` — first observed slot 50 stays in bucket 0
- [x] `test_boundary_crossing_exact_multiple_still_checkpoints` — 119→120 exact multiple still works
- [x] `test_boundary_crossing_first_observed_height_above_interval` — first ever slot 500 with no previous height
- [x] Existing `test_automatic_checkpoint_on_interval` and `test_automatic_checkpoint_solana_interval` still pass