### PR TITLE
refactor: remove redundant `eth_getBlockByNumber` re-fetch for finalized blocks

### DIFF
--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -32,7 +32,10 @@ fn live_blocks_channel() -> (mpsc::Sender<MaybeBlock>, mpsc::Receiver<MaybeBlock
 
 pub struct BlockAndRequests {
     block_number: u64,
-    /// Block timestamp captured from the block we already fetched
+    block_hash: alloy::primitives::B256,
+    /// Block timestamp captured from the block we already fetched, so
+    /// `emit_processed_block` doesn't need to re-fetch the block just to read
+    /// it back. Used for `ChainEvent::SignRequest`'s `block_timestamp` field.
     block_timestamp: u64,
     indexed_requests: Vec<IndexedSignRequest>,
     respond_logs: Vec<Log>,
@@ -42,6 +45,7 @@ pub struct BlockAndRequests {
 impl BlockAndRequests {
     fn new(
         block_number: u64,
+        block_hash: alloy::primitives::B256,
         block_timestamp: u64,
         indexed_requests: Vec<IndexedSignRequest>,
         respond_logs: Vec<Log>,
@@ -49,6 +53,7 @@ impl BlockAndRequests {
     ) -> Self {
         Self {
             block_number,
+            block_hash,
             block_timestamp,
             indexed_requests,
             respond_logs,
@@ -182,17 +187,15 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
 
     /// Process the block and emit relevant ChainEvents from the block.
     ///
-    /// Neither the catchup nor the live path re-fetches the block by number
-    /// during emission: the only consumer of `ChainEvent::Block` treats it as
-    /// finalized (consensus checkpoint signing), and in the production
-    /// (non-optimistic) path `wait_for_finalized_block` already guarantees
-    /// finality before emission. See `emit_processed_block` for the full
-    /// rationale and the Option B note.
-    async fn process_block(&self, block: &Block) -> anyhow::Result<()> {
+    /// `is_finalized` indicates the block is already finalized (true for the
+    /// catchup path over historical history). When set, `emit_processed_block`
+    /// skips the per-block re-fetch + reorg hash check.
+    /// For the live path (`is_finalized = false`).
+    async fn process_block(&self, block: &Block, is_finalized: bool) -> anyhow::Result<()> {
         // Emit telemetry for the indexed block number
         self.telemetry.block_indexed(block.header.number);
         let processed = self.parse_block(block).await?;
-        self.emit_processed_block(processed).await?;
+        self.emit_processed_block(processed, is_finalized).await?;
 
         Ok(())
     }
@@ -268,6 +271,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         // `ChainEvent::Block` even when there are no relevant contract logs.
         Ok(BlockAndRequests::new(
             block_number,
+            block_hash,
             block.header.timestamp,
             sign_requests,
             respond_logs,
@@ -551,18 +555,43 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     }
 
     /// Emits the processed block in-order once we reach finality for it.
+    ///
+    /// `is_finalized` blocks skip the per-block re-fetch + reorg hash check
+    /// (see `process_block`).
     async fn emit_processed_block(
         &self,
         BlockAndRequests {
             block_number,
+            block_hash,
             block_timestamp,
             indexed_requests,
             respond_logs,
             execution_events,
         }: BlockAndRequests,
+        is_finalized: bool,
     ) -> anyhow::Result<()> {
         if !self.eth.optimistic_requests {
             self.wait_for_finalized_block(block_number).await?;
+        }
+
+        // If the block is not finalized, re-fetch it and check that the hash matches
+        if !is_finalized {
+            let Some(block) = self
+                .client
+                .as_ref()
+                .get_block(BlockId::Number(BlockNumberOrTag::Number(block_number)))
+                .await
+            else {
+                anyhow::bail!("ethereum block {block_number} not found during emission");
+            };
+
+            if block.header.hash != block_hash {
+                // The block was reorged after `process_block` produced this payload.
+                // Do not emit stale events for a different canonical block, but also do
+                // not return an error that would cause the catchup path to retry this
+                // same stale payload forever.
+                return Ok(());
+            }
         }
 
         for event in execution_events {
@@ -784,7 +813,9 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
         #[cfg(feature = "bench")]
         let start_process = std::time::Instant::now();
 
-        self.process_block(block).await?;
+        // Catchup runs over historical/finalized history, so the per-block
+        // re-fetch + reorg hash check is dropped
+        self.process_block(block, true).await?;
 
         #[cfg(feature = "bench")]
         {
@@ -802,7 +833,8 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
             anyhow::bail!("ethereum live stream yielded missing block")
         };
 
-        self.process_block(block).await?;
+        // Live blocks are not yet finalized, so keep the reorg hash check
+        self.process_block(block, false).await?;
         Ok(())
     }
 
@@ -995,7 +1027,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn live_process_does_not_refetch_block_for_emission() {
+    async fn live_process_refetches_block_for_reorg_check() {
         let mut server = Server::new_async().await;
 
         let MaybeBlock::Block(block) = test_utils::block(42) else {
@@ -1003,7 +1035,8 @@ mod tests {
         };
         let block_number = block.header.number;
 
-        let receipts_mock = server
+        // `eth_getBlockReceipts` — expected once.
+        server
             .mock("POST", "/")
             .match_body(Matcher::PartialJson(json!({
                 "method": "eth_getBlockReceipts",
@@ -1016,8 +1049,9 @@ mod tests {
             .create_async()
             .await;
 
-        // `eth_getBlockByNumber(Number)` — must NEVER be hit.
-        let block_by_number_mock = server
+        // `eth_getBlockByNumber(Number)` — expected once for the reorg check.
+        // Returns the same block (matching hash) so emission proceeds.
+        server
             .mock("POST", "/")
             .match_body(Matcher::PartialJson(json!({
                 "method": "eth_getBlockByNumber",
@@ -1026,7 +1060,7 @@ mod tests {
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(test_utils::block_response(3, block_number).to_string())
-            .expect(0)
+            .expect(1)
             .create_async()
             .await;
 
@@ -1040,13 +1074,64 @@ mod tests {
             .await
             .expect("live process over a block should succeed");
 
-        receipts_mock.assert_async().await;
-        block_by_number_mock.assert_async().await;
-
         assert!(matches!(
             events_rx.recv().await,
             Some(ChainEvent::Block(n)) if n == block_number
         ));
+    }
+
+    #[tokio::test]
+    async fn live_process_skips_emission_when_block_reorged() {
+        let mut server = Server::new_async().await;
+
+        // Original block we hand to `process` (hash derived from number 42).
+        let MaybeBlock::Block(block) = test_utils::block(42) else {
+            unreachable!("test_utils::block returns MaybeBlock::Block")
+        };
+        let block_number = block.header.number;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockReceipts",
+                "params": [format!("0x{block_number:x}")]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(test_utils::missing_block_response(2).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        // Re-fetch returns a block with a DIFFERENT number/hash (99), so the
+        // hash comparison fails and emission is skipped.
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockByNumber",
+                "params": [format!("0x{block_number:x}"), false]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(test_utils::block_response(3, 99).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let (mut indexer, mut events_rx) = test_utils::TestIndexerBuilder::new(server.url())
+            .build_with_rx()
+            .await;
+
+        indexer
+            .process(&MaybeBlock::Block(block))
+            .await
+            .expect("reorged live block should not error");
+
+        // No events should be emitted for the reorged block.
+        assert!(
+            events_rx.try_recv().is_err(),
+            "no events should be emitted for a reorged live block"
+        );
     }
 
     #[tokio::test]

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -33,6 +33,9 @@ fn live_blocks_channel() -> (mpsc::Sender<MaybeBlock>, mpsc::Receiver<MaybeBlock
 pub struct BlockAndRequests {
     block_number: u64,
     block_hash: alloy::primitives::B256,
+    /// Block timestamp captured from the block we already fetched, so
+    /// it doesn't need to be re-fetched.
+    block_timestamp: u64,
     indexed_requests: Vec<IndexedSignRequest>,
     respond_logs: Vec<Log>,
     execution_events: Vec<ChainEvent>,
@@ -42,6 +45,7 @@ impl BlockAndRequests {
     fn new(
         block_number: u64,
         block_hash: alloy::primitives::B256,
+        block_timestamp: u64,
         indexed_requests: Vec<IndexedSignRequest>,
         respond_logs: Vec<Log>,
         execution_events: Vec<ChainEvent>,
@@ -49,6 +53,7 @@ impl BlockAndRequests {
         Self {
             block_number,
             block_hash,
+            block_timestamp,
             indexed_requests,
             respond_logs,
             execution_events,
@@ -180,11 +185,15 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     }
 
     /// Process the block and emit relevant ChainEvents from the block.
-    async fn process_block(&self, block: &Block) -> anyhow::Result<()> {
+    ///
+    /// `is_finalized` parameter indicates the block is already finalized (true for the
+    /// catchup path over historical history). When set, `emit_processed_block`
+    /// skips the per-block re-fetch + reorg hash check.
+    async fn process_block(&self, block: &Block, is_finalized: bool) -> anyhow::Result<()> {
         // Emit telemetry for the indexed block number
         self.telemetry.block_indexed(block.header.number);
         let processed = self.parse_block(block).await?;
-        self.emit_processed_block(processed).await?;
+        self.emit_processed_block(processed, is_finalized).await?;
 
         Ok(())
     }
@@ -261,6 +270,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         Ok(BlockAndRequests::new(
             block_number,
             block_hash,
+            block.header.timestamp,
             sign_requests,
             respond_logs,
             exec_events,
@@ -543,35 +553,44 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     }
 
     /// Emits the processed block in-order once we reach finality for it.
+    ///
+    /// `is_finalized` blocks skip the per-block re-fetch + reorg hash check.
+    /// For non-finalized (live) blocks we still re-fetch the canonical block
+    /// at that number and compare its hash to detect reorgs.
     async fn emit_processed_block(
         &self,
         BlockAndRequests {
             block_number,
             block_hash,
+            block_timestamp,
             indexed_requests,
             respond_logs,
             execution_events,
         }: BlockAndRequests,
+        is_finalized: bool,
     ) -> anyhow::Result<()> {
         if !self.eth.optimistic_requests {
             self.wait_for_finalized_block(block_number).await?;
         }
 
-        let Some(block) = self
-            .client
-            .as_ref()
-            .get_block(BlockId::Number(BlockNumberOrTag::Number(block_number)))
-            .await
-        else {
-            anyhow::bail!("ethereum block {block_number} not found during emission");
-        };
+        // For non-finalized blocks, re-fetch the canonical block at that number and compare its hash to detect reorgs.
+        if !is_finalized {
+            let Some(block) = self
+                .client
+                .as_ref()
+                .get_block(BlockId::Number(BlockNumberOrTag::Number(block_number)))
+                .await
+            else {
+                anyhow::bail!("ethereum block {block_number} not found during emission");
+            };
 
-        if block.header.hash != block_hash {
-            // The block was reorged after `process_block` produced this payload.
-            // Do not emit stale events for a different canonical block, but also do
-            // not return an error that would cause the catchup path to retry this
-            // same stale payload forever.
-            return Ok(());
+            if block.header.hash != block_hash {
+                // The block was reorged after `process_block` produced this payload.
+                // Do not emit stale events for a different canonical block, but also do
+                // not return an error that would cause the catchup path to retry this
+                // same stale payload forever.
+                return Ok(());
+            }
         }
 
         for event in execution_events {
@@ -585,7 +604,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             self.events_tx
                 .send(ChainEvent::SignRequest {
                     request,
-                    block_timestamp: Some(block.header.timestamp),
+                    block_timestamp: Some(block_timestamp),
                 })
                 .await
                 .context("failed to emit SignRequest event")?;
@@ -793,7 +812,9 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
         #[cfg(feature = "bench")]
         let start_process = std::time::Instant::now();
 
-        self.process_block(block).await?;
+        // Catchup runs over historical/finalized history, so the per-block
+        // re-fetch + reorg hash check is dropped
+        self.process_block(block, true).await?;
 
         #[cfg(feature = "bench")]
         {
@@ -811,7 +832,8 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
             anyhow::bail!("ethereum live stream yielded missing block")
         };
 
-        self.process_block(block).await?;
+        // Live blocks are not yet finalized - keep the reorg hash check.
+        self.process_block(block, false).await?;
         Ok(())
     }
 

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -18,6 +18,7 @@ use mpc_primitives::{
 };
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Notify};
 use tokio::time::{sleep, Duration, Instant};
@@ -71,6 +72,8 @@ pub struct EthereumIndexer<S: StateManager, T: ChainTelemetry> {
     contract_address: Address,
     catchup_complete: Arc<Notify>,
     live_blocks_rx: Option<mpsc::Receiver<MaybeBlock>>,
+    /// The block number of the latest finalized block at the time catchup started. Used to determine which blocks are finalized during catchup.
+    catchup_finalized_head: AtomicU64,
 }
 
 /// Result of a `backfill_execution_confirmation`. `Observed` carries an
@@ -105,6 +108,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             contract_address,
             catchup_complete: Arc::new(Notify::new()),
             live_blocks_rx: None,
+            catchup_finalized_head: AtomicU64::new(0),
         })
     }
 
@@ -131,6 +135,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             contract_address,
             catchup_complete: Arc::new(Notify::new()),
             live_blocks_rx: None,
+            catchup_finalized_head: AtomicU64::new(0),
         }
     }
 
@@ -187,10 +192,15 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
 
     /// Process the block and emit relevant ChainEvents from the block.
     ///
-    /// `is_finalized` indicates the block is already finalized (true for the
-    /// catchup path over historical history). When set, `emit_processed_block`
-    /// skips the per-block re-fetch + reorg hash check.
-    /// For the live path (`is_finalized = false`).
+    /// `is_finalized` indicates the block was already finalized at the time
+    /// it was fetched, so it cannot reorg and `emit_processed_block` can skip
+    /// the per-block re-fetch + reorg hash check (one `eth_getBlockByNumber`
+    /// per block).
+    ///
+    /// For catchup, this is depth-gated against the finalized head sampled once
+    /// at catchup start (`catchup_range`)
+    ///
+    /// For the live path, `is_finalized` is always `false`
     async fn process_block(&self, block: &Block, is_finalized: bool) -> anyhow::Result<()> {
         // Emit telemetry for the indexed block number
         self.telemetry.block_indexed(block.header.number);
@@ -765,6 +775,26 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
 
         let catchup_iter = CatchupIter::new(self.client.clone(), catchup_start, anchor_height);
 
+        // Sample the finalized head once at catchup start, so that blocks at or below it can skip the per-block re-fetch + reorg hash check.
+        if let Some(finalized_block) = self
+            .client
+            .get_block(BlockId::Number(BlockNumberOrTag::Finalized))
+            .await
+        {
+            self.catchup_finalized_head
+                .store(finalized_block.header.number, Ordering::Relaxed);
+            tracing::info!(
+                finalized_head = finalized_block.header.number,
+                catchup_start,
+                anchor_height,
+                "sampled finalized head for catchup reorg-check gating"
+            );
+        } else {
+            tracing::warn!(
+                "could not sample finalized head for catchup; keeping reorg check for all blocks"
+            );
+        }
+
         // Convert the async state machine into a Stream
         let stream = stream::unfold(catchup_iter, |mut state| async move {
             let item = state.next().await;
@@ -813,9 +843,10 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
         #[cfg(feature = "bench")]
         let start_process = std::time::Instant::now();
 
-        // Catchup runs over historical/finalized history, so the per-block
-        // re-fetch + reorg hash check is dropped
-        self.process_block(block, true).await?;
+        // Determine if the block is finalized based on the sampled finalized head at catchup start
+        let f0 = self.catchup_finalized_head.load(Ordering::Relaxed);
+        let is_finalized = block.header.number <= f0;
+        self.process_block(block, is_finalized).await?;
 
         #[cfg(feature = "bench")]
         {
@@ -902,6 +933,7 @@ mod tests {
         LATEST_MPC_KEY_VERSION,
     };
     use serde_json::json;
+    use std::sync::atomic::Ordering;
 
     #[tokio::test]
     async fn missing_catchup_block_is_refetched() {
@@ -969,7 +1001,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn catchup_does_not_refetch_block_for_emission() {
+    async fn catchup_finalized_block_does_not_refetch_for_emission() {
         let mut server = Server::new_async().await;
 
         let block = test_utils::block(42);
@@ -992,7 +1024,9 @@ mod tests {
             .create_async()
             .await;
 
-        // `eth_getBlockByNumber(Number)` for the same block — must NEVER be hit.
+        // `eth_getBlockByNumber(Number)` for the same block — must NEVER be hit,
+        // because this catchup block is at or below the finalized head sampled at
+        // catchup start, so the reorg check is skipped.
         let block_by_number_mock = server
             .mock("POST", "/")
             .match_body(Matcher::PartialJson(json!({
@@ -1010,6 +1044,9 @@ mod tests {
         let (mut indexer, mut events_rx) = test_utils::TestIndexerBuilder::new(server.url())
             .build_with_rx()
             .await;
+        // Block 42 was finalized at fetch time (head sampled at 100), so the
+        // re-fetch + reorg check is skipped.
+        indexer.catchup_finalized_head.store(100, Ordering::Relaxed);
 
         indexer
             .process_catchup(&MaybeBlock::Block(block))
@@ -1020,6 +1057,61 @@ mod tests {
         block_by_number_mock.assert_async().await;
 
         // The block event must still be emitted.
+        assert!(matches!(
+            events_rx.recv().await,
+            Some(ChainEvent::Block(n)) if n == block_number
+        ));
+    }
+
+    #[tokio::test]
+    async fn catchup_unfinalized_block_keeps_reorg_check() {
+        let mut server = Server::new_async().await;
+
+        let block = test_utils::block(42);
+        let MaybeBlock::Block(block) = block else {
+            unreachable!("test_utils::block returns MaybeBlock::Block")
+        };
+        let block_number = block.header.number;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockReceipts",
+                "params": [format!("0x{block_number:x}")]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(test_utils::missing_block_response(2).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        // `eth_getBlockByNumber(Number)` — expected once: block 42 is above the
+        // sampled finalized head (10), so the check runs. Matching hash → emit.
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockByNumber",
+                "params": [format!("0x{block_number:x}"), false]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(test_utils::block_response(3, block_number).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let (mut indexer, mut events_rx) = test_utils::TestIndexerBuilder::new(server.url())
+            .build_with_rx()
+            .await;
+        // Finalized head sampled at 10 → block 42 is unfinalized at fetch time.
+        indexer.catchup_finalized_head.store(10, Ordering::Relaxed);
+
+        indexer
+            .process_catchup(&MaybeBlock::Block(block))
+            .await
+            .expect("catchup over an unfinalized block should succeed");
+
         assert!(matches!(
             events_rx.recv().await,
             Some(ChainEvent::Block(n)) if n == block_number

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -32,9 +32,7 @@ fn live_blocks_channel() -> (mpsc::Sender<MaybeBlock>, mpsc::Receiver<MaybeBlock
 
 pub struct BlockAndRequests {
     block_number: u64,
-    block_hash: alloy::primitives::B256,
-    /// Block timestamp captured from the block we already fetched, so
-    /// it doesn't need to be re-fetched.
+    /// Block timestamp captured from the block we already fetched
     block_timestamp: u64,
     indexed_requests: Vec<IndexedSignRequest>,
     respond_logs: Vec<Log>,
@@ -44,7 +42,6 @@ pub struct BlockAndRequests {
 impl BlockAndRequests {
     fn new(
         block_number: u64,
-        block_hash: alloy::primitives::B256,
         block_timestamp: u64,
         indexed_requests: Vec<IndexedSignRequest>,
         respond_logs: Vec<Log>,
@@ -52,7 +49,6 @@ impl BlockAndRequests {
     ) -> Self {
         Self {
             block_number,
-            block_hash,
             block_timestamp,
             indexed_requests,
             respond_logs,
@@ -186,14 +182,17 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
 
     /// Process the block and emit relevant ChainEvents from the block.
     ///
-    /// `is_finalized` parameter indicates the block is already finalized (true for the
-    /// catchup path over historical history). When set, `emit_processed_block`
-    /// skips the per-block re-fetch + reorg hash check.
-    async fn process_block(&self, block: &Block, is_finalized: bool) -> anyhow::Result<()> {
+    /// Neither the catchup nor the live path re-fetches the block by number
+    /// during emission: the only consumer of `ChainEvent::Block` treats it as
+    /// finalized (consensus checkpoint signing), and in the production
+    /// (non-optimistic) path `wait_for_finalized_block` already guarantees
+    /// finality before emission. See `emit_processed_block` for the full
+    /// rationale and the Option B note.
+    async fn process_block(&self, block: &Block) -> anyhow::Result<()> {
         // Emit telemetry for the indexed block number
         self.telemetry.block_indexed(block.header.number);
         let processed = self.parse_block(block).await?;
-        self.emit_processed_block(processed, is_finalized).await?;
+        self.emit_processed_block(processed).await?;
 
         Ok(())
     }
@@ -269,7 +268,6 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         // `ChainEvent::Block` even when there are no relevant contract logs.
         Ok(BlockAndRequests::new(
             block_number,
-            block_hash,
             block.header.timestamp,
             sign_requests,
             respond_logs,
@@ -553,44 +551,18 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     }
 
     /// Emits the processed block in-order once we reach finality for it.
-    ///
-    /// `is_finalized` blocks skip the per-block re-fetch + reorg hash check.
-    /// For non-finalized (live) blocks we still re-fetch the canonical block
-    /// at that number and compare its hash to detect reorgs.
     async fn emit_processed_block(
         &self,
         BlockAndRequests {
             block_number,
-            block_hash,
             block_timestamp,
             indexed_requests,
             respond_logs,
             execution_events,
         }: BlockAndRequests,
-        is_finalized: bool,
     ) -> anyhow::Result<()> {
         if !self.eth.optimistic_requests {
             self.wait_for_finalized_block(block_number).await?;
-        }
-
-        // For non-finalized blocks, re-fetch the canonical block at that number and compare its hash to detect reorgs.
-        if !is_finalized {
-            let Some(block) = self
-                .client
-                .as_ref()
-                .get_block(BlockId::Number(BlockNumberOrTag::Number(block_number)))
-                .await
-            else {
-                anyhow::bail!("ethereum block {block_number} not found during emission");
-            };
-
-            if block.header.hash != block_hash {
-                // The block was reorged after `process_block` produced this payload.
-                // Do not emit stale events for a different canonical block, but also do
-                // not return an error that would cause the catchup path to retry this
-                // same stale payload forever.
-                return Ok(());
-            }
         }
 
         for event in execution_events {
@@ -812,9 +784,7 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
         #[cfg(feature = "bench")]
         let start_process = std::time::Instant::now();
 
-        // Catchup runs over historical/finalized history, so the per-block
-        // re-fetch + reorg hash check is dropped
-        self.process_block(block, true).await?;
+        self.process_block(block).await?;
 
         #[cfg(feature = "bench")]
         {
@@ -832,8 +802,7 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
             anyhow::bail!("ethereum live stream yielded missing block")
         };
 
-        // Live blocks are not yet finalized - keep the reorg hash check.
-        self.process_block(block, false).await?;
+        self.process_block(block).await?;
         Ok(())
     }
 
@@ -965,6 +934,119 @@ mod tests {
 
         assert!(events_rx.try_recv().is_err());
         assert!(err.to_string().contains("still unavailable after refetch"));
+    }
+
+    #[tokio::test]
+    async fn catchup_does_not_refetch_block_for_emission() {
+        let mut server = Server::new_async().await;
+
+        let block = test_utils::block(42);
+        let MaybeBlock::Block(block) = block else {
+            unreachable!("test_utils::block returns MaybeBlock::Block")
+        };
+        let block_number = block.header.number;
+
+        // `eth_getBlockReceipts` — expected exactly once (empty block: null).
+        let receipts_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockReceipts",
+                "params": [format!("0x{block_number:x}")]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(test_utils::missing_block_response(2).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        // `eth_getBlockByNumber(Number)` for the same block — must NEVER be hit.
+        let block_by_number_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockByNumber",
+                "params": [format!("0x{block_number:x}"), false]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(test_utils::block_response(3, block_number).to_string())
+            .expect(0)
+            .create_async()
+            .await;
+
+        // Optimistic mode (default) so `wait_for_finalized_block` is skipped.
+        let (mut indexer, mut events_rx) = test_utils::TestIndexerBuilder::new(server.url())
+            .build_with_rx()
+            .await;
+
+        indexer
+            .process_catchup(&MaybeBlock::Block(block))
+            .await
+            .expect("catchup over a present finalized block should succeed");
+
+        receipts_mock.assert_async().await;
+        block_by_number_mock.assert_async().await;
+
+        // The block event must still be emitted.
+        assert!(matches!(
+            events_rx.recv().await,
+            Some(ChainEvent::Block(n)) if n == block_number
+        ));
+    }
+
+    #[tokio::test]
+    async fn live_process_does_not_refetch_block_for_emission() {
+        let mut server = Server::new_async().await;
+
+        let MaybeBlock::Block(block) = test_utils::block(42) else {
+            unreachable!("test_utils::block returns MaybeBlock::Block")
+        };
+        let block_number = block.header.number;
+
+        let receipts_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockReceipts",
+                "params": [format!("0x{block_number:x}")]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(test_utils::missing_block_response(2).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        // `eth_getBlockByNumber(Number)` — must NEVER be hit.
+        let block_by_number_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockByNumber",
+                "params": [format!("0x{block_number:x}"), false]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(test_utils::block_response(3, block_number).to_string())
+            .expect(0)
+            .create_async()
+            .await;
+
+        // Optimistic mode (default) so `wait_for_finalized_block` is skipped.
+        let (mut indexer, mut events_rx) = test_utils::TestIndexerBuilder::new(server.url())
+            .build_with_rx()
+            .await;
+
+        indexer
+            .process(&MaybeBlock::Block(block))
+            .await
+            .expect("live process over a block should succeed");
+
+        receipts_mock.assert_async().await;
+        block_by_number_mock.assert_async().await;
+
+        assert!(matches!(
+            events_rx.recv().await,
+            Some(ChainEvent::Block(n)) if n == block_number
+        ));
     }
 
     #[tokio::test]

--- a/chain-signatures/chain-ethereum/src/publisher.rs
+++ b/chain-signatures/chain-ethereum/src/publisher.rs
@@ -76,7 +76,8 @@ impl From<&Signature> for ChainSignatures::Signature {
     }
 }
 
-/// TODO: this should probably get merged with the client used by indexer
+/// An Ethereum client that implements the `ChainPublisher` trait for publishing signatures to an Ethereum smart contract.
+/// This client is separate from the client used by the indexer (separation of concerns: read vs write).
 #[derive(Clone)]
 pub struct EthClient {
     /// The contract instance for interacting with the ChainSignatures contract

--- a/chain-signatures/chain-ethereum/src/test_utils.rs
+++ b/chain-signatures/chain-ethereum/src/test_utils.rs
@@ -182,3 +182,17 @@ pub fn block_response(request_id: u64, number: u64) -> serde_json::Value {
         }
     })
 }
+
+/// Build a deserialized `Block` for a given block `number`, suitable for
+/// feeding directly into `process_catchup` / `process` as `MaybeBlock::Block`.
+/// The hash is `0x{number:064x}` and the timestamp is `0x1`.
+pub fn block(number: u64) -> crate::client::MaybeBlock {
+    use crate::client::MaybeBlock;
+    let value = block_response(1, number)
+        .get("result")
+        .expect("block_response has a result envelope")
+        .clone();
+    let block: alloy::rpc::types::Block =
+        serde_json::from_value(value).expect("block fixture should deserialize");
+    MaybeBlock::Block(block)
+}


### PR DESCRIPTION
This PR removes the redundant per-block `eth_getBlockByNumber(Number)` re-fetch from the catchup path for blocks that were already finalized at fetch time. The original reorg check is kept for live processing (defense-in-depth) and for catchup blocks that were unfinalized at fetch time.

Main changes:

- Add `is_finalized` param for `process_block` and `emit_processed_block` (`true` for catchup blocks at or below the sampled finalized head, `false` otherwise; always `false` for live)
- Add `block_timestamp` field to `BlockAndRequests`
- Add `catchup_finalized_head: AtomicU64` field to `EthereumIndexer` and sample the finalized head once in `catchup_range`
- Add unit tests: 
  - `catchup_does_not_refetch_block_for_emission` - verifies zero `eth_getBlockByNumber(Number)` for catchup
  - `catchup_unfinalized_block_keeps_reorg_check` - verifies a catchup block above the finalized head re-fetches once and emits when hashes match
  - `live_process_refetches_block_for_reorg_check` - verifies the live path re-fetches once and emits when hashes match
  - `live_process_skips_emission_when_block_reorged` - verifies the live path skips emission when the re-fetched hash differs
  
Benchmark (100 blocks range):

- wall time: -5.9%
- blocks_per_sec: +6.2%
- total_rpc: -33%
- total_http: -48.5%