### PR TITLE
refactor: update Eth indexer to prefetch batches concurrently

### DIFF
--- a/chain-signatures/chain-ethereum/README.md
+++ b/chain-signatures/chain-ethereum/README.md
@@ -35,6 +35,7 @@ config, not constructed by hand.
 | `refresh_finalized_interval` | —                | no        | blocks between finalized-head polls |
 | `optimistic_requests`     | `OPTIMISTIC`        | no        | default on; set `0` to disable optimistic requests and exercise per-block `wait_for_finalized_block` polling |
 | `light_client`            | —                   | no        | set `true` to select the Helios backend (`helios` feature required) |
+| `catchup_concurrent_batches` | `CATCHUP_CONCURRENT_BATCHES` / `MPC_ETH_CATCHUP_CONCURRENT_BATCHES` | no | number of catchup batches fetched in parallel via `buffered(N)`; default `3`, clamped to `1..=8`. Helios forces `1`.
 
 ## Benchmarking catchup
 
@@ -82,6 +83,7 @@ cargo run --example bench_catchup --features bench
 | `START`          | no        | inclusive start; if omitted only `END-1` is processed |
 | `NETWORK`        | no        | default `sepolia` |
 | `OPTIMISTIC`     | no        | `1` (default) enables optimistic requests; `0` exercises finality polling |
+| `CATCHUP_CONCURRENT_BATCHES` | no | concurrent catchup batches via `buffered(N)`; default `3`, clamped `1..=8` |
 | `RUST_LOG`       | no        | tracing filter — `mpc_chain_ethereum::bench=info` for just the report |
 
 ## Features

--- a/chain-signatures/chain-ethereum/examples/bench_catchup.rs
+++ b/chain-signatures/chain-ethereum/examples/bench_catchup.rs
@@ -31,7 +31,9 @@
 
 use anyhow::anyhow;
 use futures_util::StreamExt;
-use mpc_chain_ethereum::{EthConfig, EthereumStream};
+use mpc_chain_ethereum::{
+    EthConfig, EthereumStream, DEFAULT_CATCHUP_CONCURRENT_BATCHES, MAX_CATCHUP_CONCURRENT_BATCHES,
+};
 use mpc_chain_integration_core::{
     ChainIndexer, ChainStream, MockStateManager, NoopChainTelemetry, StateManager,
 };
@@ -74,6 +76,12 @@ fn make_config() -> anyhow::Result<EthConfig> {
         refresh_finalized_interval: 1,
         optimistic_requests: env_bool("OPTIMISTIC", true)?,
         light_client: false,
+        catchup_concurrent_batches: env_u64("CATCHUP_CONCURRENT_BATCHES")
+            .ok()
+            .filter(|&n| n >= 1)
+            .map(|n| n as usize)
+            .unwrap_or(DEFAULT_CATCHUP_CONCURRENT_BATCHES)
+            .min(MAX_CATCHUP_CONCURRENT_BATCHES),
     })
 }
 

--- a/chain-signatures/chain-ethereum/src/bench.rs
+++ b/chain-signatures/chain-ethereum/src/bench.rs
@@ -28,6 +28,7 @@ struct RpcCount {
 // `EthereumIndexer` (per-instance) so each catchup reports independently
 static RPC_STATS: Mutex<Option<HashMap<&'static str, RpcCount>>> = Mutex::new(None);
 static BATCH_FETCH_NS: AtomicU64 = AtomicU64::new(0);
+static BATCH_WAIT_NS: AtomicU64 = AtomicU64::new(0);
 static REFETCH_NS: AtomicU64 = AtomicU64::new(0);
 static PROCESS_TIME_NS: AtomicU64 = AtomicU64::new(0);
 static BLOCKS_PROCESSED: AtomicU64 = AtomicU64::new(0);
@@ -68,6 +69,7 @@ pub fn rpc_reset() {
         m.clear();
     }
     BATCH_FETCH_NS.store(0, Ordering::Relaxed);
+    BATCH_WAIT_NS.store(0, Ordering::Relaxed);
     REFETCH_NS.store(0, Ordering::Relaxed);
     PROCESS_TIME_NS.store(0, Ordering::Relaxed);
     BLOCKS_PROCESSED.store(0, Ordering::Relaxed);
@@ -81,6 +83,12 @@ pub fn rpc_reset() {
 /// nanoseconds to preserve sub-millisecond precision.
 pub fn add_batch_fetch_time(d: Duration) {
     BATCH_FETCH_NS.fetch_add(d.as_nanos() as u64, Ordering::Relaxed);
+}
+
+/// Accumulate time the catchup consumer spent blocked waiting for the next
+/// batch future to resolve.
+pub fn add_batch_wait_time(d: Duration) {
+    BATCH_WAIT_NS.fetch_add(d.as_nanos() as u64, Ordering::Relaxed);
 }
 
 /// Accumulate time spent in the per-block single-block refetch path inside
@@ -121,6 +129,7 @@ pub fn report_metrics(stage: &str) {
     let total_rpc: u64 = rpcs.iter().map(|(_, c)| c.logical).sum();
     let total_http: u64 = rpcs.iter().map(|(_, c)| c.http).sum();
     let batch_fetch_ms = (BATCH_FETCH_NS.load(Ordering::Relaxed) as f64 / 1e6).round() as u64;
+    let batch_wait_ms = (BATCH_WAIT_NS.load(Ordering::Relaxed) as f64 / 1e6).round() as u64;
     let refetch_ms = (REFETCH_NS.load(Ordering::Relaxed) as f64 / 1e6).round() as u64;
     let per_block_process_ms =
         (PROCESS_TIME_NS.load(Ordering::Relaxed) as f64 / 1e6).round() as u64;
@@ -154,6 +163,6 @@ pub fn report_metrics(stage: &str) {
 
     tracing::info!(
         target: TARGET,
-        "Catchup Benchmark Report\n{label}\n  blocks_per_sec  {blocks_per_sec:.1}\n  rpc_per_sec    {rpc_per_sec:.1}  (http_per_sec {http_per_sec:.1})\n  total_rpc      {total_rpc}  (total_http {total_http})\n  batch_fetch_ms {batch_fetch_ms}\n  refetch_ms     {refetch_ms}\n  process_ms     {per_block_process_ms}\n  rpc_breakdown (logical, http round-trips):\n{breakdown}"
+        "Catchup Benchmark Report\n{label}\n  blocks_per_sec  {blocks_per_sec:.1}\n  rpc_per_sec    {rpc_per_sec:.1}  (http_per_sec {http_per_sec:.1})\n  total_rpc      {total_rpc}  (total_http {total_http})\n  batch_fetch_ms {batch_fetch_ms} (summed, overlaps under prefetch)\n  batch_wait_ms   {batch_wait_ms} (critical-path fetch wait)\n  refetch_ms     {refetch_ms}\n  process_ms     {per_block_process_ms}\n  rpc_breakdown (logical, http round-trips):\n{breakdown}"
     );
 }

--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -15,9 +15,6 @@ use super::indexer_eth_helios;
 /// Catchup batch size for [`CatchupIter`]
 pub const CATCHUP_BLOCK_BATCH_SIZE: u64 = 32;
 
-/// Maximum number of concurrent catchup batches to fetch in parallel
-pub const CATCHUP_CONCURRENT_BATCHES: usize = 3;
-
 /// Block number alias shared by the client and indexer.
 pub type BlockNumber = u64;
 

--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -1,7 +1,8 @@
 use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::Address;
 use alloy::rpc::types::{Block, BlockId, TransactionReceipt};
-use std::sync::Arc;
+use futures_util::stream::{self, Stream, StreamExt};
+use std::pin::Pin;
 use std::time::Duration;
 
 use crate::indexer_eth_direct_rpc;
@@ -12,7 +13,6 @@ use mpc_chain_integration_core::utils::retry::{retry_rpc, RetryConfig};
 use super::indexer_eth_helios;
 
 // TODO: check if our RPC providers support higher batch sizes
-/// Catchup batch size for [`CatchupIter`]
 pub const CATCHUP_BLOCK_BATCH_SIZE: u64 = 32;
 
 /// Block number alias shared by the client and indexer.
@@ -26,7 +26,7 @@ pub enum MaybeBlock {
     Missing(BlockId),
 }
 
-/// Catchup item yielded by [`CatchupIter`] and consumed by `process_catchup`.
+/// Catchup item yielded by [`EthereumClient::catchup_batch_stream`] and consumed by `process_catchup`.
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum CatchupItem {
@@ -42,59 +42,6 @@ pub enum CatchupItem {
     /// A block from the live stream. Receipts are fetched lazily in
     /// `process`.
     LiveBlock(Block),
-}
-
-/// Lazy batching iterator over `[start_block, end_block)` range.
-pub struct CatchupIter {
-    client: Arc<EthereumClient>,
-    next_block: BlockNumber,
-    end_block: BlockNumber,
-    buffered_blocks: std::vec::IntoIter<CatchupItem>,
-}
-
-impl CatchupIter {
-    pub fn new(
-        client: Arc<EthereumClient>,
-        start_block: BlockNumber,
-        end_block: BlockNumber,
-    ) -> Self {
-        Self {
-            client,
-            next_block: start_block,
-            end_block,
-            buffered_blocks: Vec::new().into_iter(),
-        }
-    }
-
-    async fn fetch_next_batch(&mut self) {
-        if self.next_block >= self.end_block {
-            return;
-        }
-
-        let batch_end = self
-            .next_block
-            .saturating_add(CATCHUP_BLOCK_BATCH_SIZE)
-            .min(self.end_block);
-
-        let items = self.client.fetch_batch(self.next_block, batch_end).await;
-
-        self.buffered_blocks = items.into_iter();
-        self.next_block = batch_end;
-    }
-
-    pub async fn next(&mut self) -> Option<CatchupItem> {
-        loop {
-            if let Some(block) = self.buffered_blocks.next() {
-                return Some(block);
-            }
-
-            if self.next_block >= self.end_block {
-                return None;
-            }
-
-            self.fetch_next_batch().await;
-        }
-    }
 }
 
 // Constants for Ethereum RPC client retry behavior
@@ -336,6 +283,37 @@ impl EthereumClient {
         items
     }
 
+    /// Returns a stream of catchup items for the range `[start, end)`, fetching up to `concurrency` batches in parallel.
+    pub fn catchup_batch_stream(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+        concurrency: usize,
+    ) -> Pin<Box<dyn Stream<Item = CatchupItem> + Send + 'static>> {
+        let client = self.clone();
+        let stream = stream::iter(
+            (start..end)
+                .step_by(CATCHUP_BLOCK_BATCH_SIZE as usize)
+                .map(move |s| (s, s.saturating_add(CATCHUP_BLOCK_BATCH_SIZE).min(end))),
+        )
+        .map(move |(s, e)| {
+            let client = client.clone();
+            async move { client.fetch_batch(s, e).await }
+        })
+        .buffered(concurrency)
+        .flat_map(stream::iter);
+
+        #[cfg(feature = "bench")]
+        let stream = stream::unfold(stream, |mut s| async move {
+            let t = std::time::Instant::now();
+            let item = s.next().await;
+            crate::bench::add_batch_wait_time(t.elapsed());
+            item.map(|b| (b, s))
+        });
+
+        Box::pin(stream)
+    }
+
     pub async fn get_nonce(&self, address: Address, block_id: BlockId) -> anyhow::Result<u64> {
         retry_rpc!(ETH_RPC_TIMEOUT, self.retry_strategy, "get_nonce", {
             match &self.inner {
@@ -543,7 +521,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn catchup_iter_fetches_batches_lazily() {
+    async fn catchup_stream_yields_blocks_in_order_and_terminates() {
         let mut server = mockito::Server::new_async().await;
 
         let first_batch = (10..42)
@@ -576,8 +554,6 @@ mod tests {
             .create_async()
             .await;
 
-        // Receipt mocks: return an empty array for any eth_getBlockReceipts call.
-        // This test verifies block-batch laziness, not receipt content.
         let _receipts_mock = server
             .mock("POST", "/")
             .match_body(Matcher::Regex("eth_getBlockReceipts".to_string()))
@@ -587,11 +563,11 @@ mod tests {
             .create_async()
             .await;
 
-        let client = Arc::new(test_utils::create_test_ethereum_client(&server.url()).await);
-        let mut iter = CatchupIter::new(client, 10, 43);
+        let client = test_utils::create_test_ethereum_client(&server.url()).await;
+        let mut stream = client.catchup_batch_stream(10, 43, 1);
 
-        for expected_number in 10..42 {
-            let next = iter.next().await;
+        for expected_number in 10..=42 {
+            let next = stream.next().await;
             assert!(
                 matches!(
                     &next,
@@ -603,24 +579,13 @@ mod tests {
             );
         }
 
+        assert!(stream.next().await.is_none());
         assert!(first_batch_mock.matched_async().await);
-        assert!(!second_batch_mock.matched_async().await);
-
-        let next = iter.next().await;
-        assert!(
-            matches!(
-                &next,
-                Some(CatchupItem::BatchBlock { block, .. }) if block.header.number == 42
-            ),
-            "Expected block 42, got {:?}",
-            next
-        );
         assert!(second_batch_mock.matched_async().await);
-        assert!(iter.next().await.is_none());
     }
 
     #[tokio::test]
-    async fn catchup_iter_splits_requests_into_32_32_1_batches() {
+    async fn catchup_stream_splits_requests_into_32_32_1_batches() {
         let mut server = mockito::Server::new_async().await;
 
         let first_batch = (0..32)
@@ -682,11 +647,11 @@ mod tests {
             .create_async()
             .await;
 
-        let client = Arc::new(test_utils::create_test_ethereum_client(&server.url()).await);
-        let mut iter = CatchupIter::new(client, 0, 65);
+        let client = test_utils::create_test_ethereum_client(&server.url()).await;
+        let mut stream = client.catchup_batch_stream(0, 65, 3);
 
         for expected_number in 0..65 {
-            let next = iter.next().await;
+            let next = stream.next().await;
             assert!(
                 matches!(
                     &next,
@@ -698,7 +663,7 @@ mod tests {
             );
         }
 
-        assert!(iter.next().await.is_none());
+        assert!(stream.next().await.is_none());
         assert!(first_batch_mock.matched_async().await);
         assert!(second_batch_mock.matched_async().await);
         assert!(third_batch_mock.matched_async().await);
@@ -812,7 +777,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn catchup_iter_receipt_batch_order_preservation() {
+    async fn catchup_stream_receipt_batch_order_preservation() {
         let mut server = mockito::Server::new_async().await;
 
         // 2 blocks: 10 (0xa), 11 (0xb). IDs 1 and 2 (counter starts at 1).
@@ -861,11 +826,11 @@ mod tests {
             .create_async()
             .await;
 
-        let client = Arc::new(test_utils::create_test_ethereum_client(&server.url()).await);
-        let mut iter = CatchupIter::new(client, 10, 12);
+        let client = test_utils::create_test_ethereum_client(&server.url()).await;
+        let mut stream = client.catchup_batch_stream(10, 12, 1);
 
-        let item1 = iter.next().await.unwrap();
-        let item2 = iter.next().await.unwrap();
+        let item1 = stream.next().await.unwrap();
+        let item2 = stream.next().await.unwrap();
 
         // Block 10 → 1 receipt (ID 3 was second in response but maps to block 10)
         if let CatchupItem::BatchBlock { block, receipts } = item1 {

--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -11,6 +11,7 @@ use mpc_chain_integration_core::utils::retry::{retry_rpc, RetryConfig};
 #[cfg(feature = "helios")]
 use super::indexer_eth_helios;
 
+// TODO: check if our RPC providers support higher batch sizes
 /// Catchup batch size for [`CatchupIter`]
 pub const CATCHUP_BLOCK_BATCH_SIZE: u64 = 32;
 
@@ -74,45 +75,8 @@ impl CatchupIter {
             .next_block
             .saturating_add(CATCHUP_BLOCK_BATCH_SIZE)
             .min(self.end_block);
-        let batch_block_ids = (self.next_block..batch_end)
-            .map(|block_number| BlockId::Number(BlockNumberOrTag::Number(block_number)))
-            .collect::<Vec<_>>();
 
-        #[cfg(feature = "bench")]
-        let start = std::time::Instant::now();
-
-        // Fetch blocks and receipts in parallel
-        let (blocks, receipts) = tokio::join!(
-            self.client.get_blocks(&batch_block_ids),
-            self.client.get_block_receipts_batch(&batch_block_ids)
-        );
-
-        // If receipts fetch fails, treat all blocks as missing receipts.
-        // Consistent with the behavior of get_blocks, which returns MaybeBlock::Missing for all blocks if the batch fails.
-        let items: Vec<CatchupItem> = if let Ok(receipts) = receipts {
-            blocks
-                .into_iter()
-                .zip(receipts)
-                .zip(batch_block_ids)
-                .map(
-                    |((maybe_block, maybe_receipts), block_id)| match maybe_block {
-                        MaybeBlock::Block(block) => CatchupItem::BatchBlock {
-                            block,
-                            receipts: maybe_receipts.unwrap_or_default(),
-                        },
-                        MaybeBlock::Missing(_) => CatchupItem::Missing(block_id),
-                    },
-                )
-                .collect()
-        } else {
-            batch_block_ids
-                .into_iter()
-                .map(CatchupItem::Missing)
-                .collect()
-        };
-
-        #[cfg(feature = "bench")]
-        crate::bench::add_batch_fetch_time(start.elapsed());
+        let items = fetch_batch(self.client.clone(), self.next_block, batch_end).await;
 
         self.buffered_blocks = items.into_iter();
         self.next_block = batch_end;
@@ -131,6 +95,55 @@ impl CatchupIter {
             self.fetch_next_batch().await;
         }
     }
+}
+
+/// Fetch one catchup batch covering the half-open block range `[start, end)`.
+async fn fetch_batch(
+    client: Arc<EthereumClient>,
+    start: BlockNumber,
+    end: BlockNumber,
+) -> Vec<CatchupItem> {
+    let batch_block_ids = (start..end)
+        .map(|block_number| BlockId::Number(BlockNumberOrTag::Number(block_number)))
+        .collect::<Vec<_>>();
+
+    #[cfg(feature = "bench")]
+    let start_time = std::time::Instant::now();
+
+    // Fetch blocks and receipts in parallel
+    let (blocks, receipts) = tokio::join!(
+        client.get_blocks(&batch_block_ids),
+        client.get_block_receipts_batch(&batch_block_ids)
+    );
+
+    // If receipts fetch fails, treat all blocks as missing receipts.
+    // Consistent with the behavior of get_blocks, which returns MaybeBlock::Missing for all blocks if the batch fails.
+    let items: Vec<CatchupItem> = if let Ok(receipts) = receipts {
+        blocks
+            .into_iter()
+            .zip(receipts)
+            .zip(batch_block_ids)
+            .map(
+                |((maybe_block, maybe_receipts), block_id)| match maybe_block {
+                    MaybeBlock::Block(block) => CatchupItem::BatchBlock {
+                        block,
+                        receipts: maybe_receipts.unwrap_or_default(),
+                    },
+                    MaybeBlock::Missing(_) => CatchupItem::Missing(block_id),
+                },
+            )
+            .collect()
+    } else {
+        batch_block_ids
+            .into_iter()
+            .map(CatchupItem::Missing)
+            .collect()
+    };
+
+    #[cfg(feature = "bench")]
+    crate::bench::add_batch_fetch_time(start_time.elapsed());
+
+    items
 }
 
 // Constants for Ethereum RPC client retry behavior

--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -15,6 +15,9 @@ use super::indexer_eth_helios;
 /// Catchup batch size for [`CatchupIter`]
 pub const CATCHUP_BLOCK_BATCH_SIZE: u64 = 32;
 
+/// Maximum number of concurrent catchup batches to fetch in parallel
+pub const CATCHUP_CONCURRENT_BATCHES: usize = 3;
+
 /// Block number alias shared by the client and indexer.
 pub type BlockNumber = u64;
 
@@ -76,7 +79,7 @@ impl CatchupIter {
             .saturating_add(CATCHUP_BLOCK_BATCH_SIZE)
             .min(self.end_block);
 
-        let items = fetch_batch(self.client.clone(), self.next_block, batch_end).await;
+        let items = self.client.fetch_batch(self.next_block, batch_end).await;
 
         self.buffered_blocks = items.into_iter();
         self.next_block = batch_end;
@@ -95,55 +98,6 @@ impl CatchupIter {
             self.fetch_next_batch().await;
         }
     }
-}
-
-/// Fetch one catchup batch covering the half-open block range `[start, end)`.
-async fn fetch_batch(
-    client: Arc<EthereumClient>,
-    start: BlockNumber,
-    end: BlockNumber,
-) -> Vec<CatchupItem> {
-    let batch_block_ids = (start..end)
-        .map(|block_number| BlockId::Number(BlockNumberOrTag::Number(block_number)))
-        .collect::<Vec<_>>();
-
-    #[cfg(feature = "bench")]
-    let start_time = std::time::Instant::now();
-
-    // Fetch blocks and receipts in parallel
-    let (blocks, receipts) = tokio::join!(
-        client.get_blocks(&batch_block_ids),
-        client.get_block_receipts_batch(&batch_block_ids)
-    );
-
-    // If receipts fetch fails, treat all blocks as missing receipts.
-    // Consistent with the behavior of get_blocks, which returns MaybeBlock::Missing for all blocks if the batch fails.
-    let items: Vec<CatchupItem> = if let Ok(receipts) = receipts {
-        blocks
-            .into_iter()
-            .zip(receipts)
-            .zip(batch_block_ids)
-            .map(
-                |((maybe_block, maybe_receipts), block_id)| match maybe_block {
-                    MaybeBlock::Block(block) => CatchupItem::BatchBlock {
-                        block,
-                        receipts: maybe_receipts.unwrap_or_default(),
-                    },
-                    MaybeBlock::Missing(_) => CatchupItem::Missing(block_id),
-                },
-            )
-            .collect()
-    } else {
-        batch_block_ids
-            .into_iter()
-            .map(CatchupItem::Missing)
-            .collect()
-    };
-
-    #[cfg(feature = "bench")]
-    crate::bench::add_batch_fetch_time(start_time.elapsed());
-
-    items
 }
 
 // Constants for Ethereum RPC client retry behavior
@@ -342,6 +296,47 @@ impl EthereumClient {
                 }
             }
         )
+    }
+
+    pub async fn fetch_batch(&self, start: BlockNumber, end: BlockNumber) -> Vec<CatchupItem> {
+        let batch_block_ids = (start..end)
+            .map(|block_number| BlockId::Number(BlockNumberOrTag::Number(block_number)))
+            .collect::<Vec<_>>();
+
+        #[cfg(feature = "bench")]
+        let start_time = std::time::Instant::now();
+
+        let (blocks, receipts) = tokio::join!(
+            self.get_blocks(&batch_block_ids),
+            self.get_block_receipts_batch(&batch_block_ids)
+        );
+
+        let items: Vec<CatchupItem> = if let Ok(receipts) = receipts {
+            blocks
+                .into_iter()
+                .zip(receipts)
+                .zip(batch_block_ids)
+                .map(
+                    |((maybe_block, maybe_receipts), block_id)| match maybe_block {
+                        MaybeBlock::Block(block) => CatchupItem::BatchBlock {
+                            block,
+                            receipts: maybe_receipts.unwrap_or_default(),
+                        },
+                        MaybeBlock::Missing(_) => CatchupItem::Missing(block_id),
+                    },
+                )
+                .collect()
+        } else {
+            batch_block_ids
+                .into_iter()
+                .map(CatchupItem::Missing)
+                .collect()
+        };
+
+        #[cfg(feature = "bench")]
+        crate::bench::add_batch_fetch_time(start_time.elapsed());
+
+        items
     }
 
     pub async fn get_nonce(&self, address: Address, block_id: BlockId) -> anyhow::Result<u64> {

--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -242,6 +242,7 @@ impl EthereumClient {
         )
     }
 
+    /// Fetch a batch of blocks and their receipts in parallel, returning a vector of `CatchupItem`s.
     pub async fn fetch_batch(&self, start: BlockNumber, end: BlockNumber) -> Vec<CatchupItem> {
         let batch_block_ids = (start..end)
             .map(|block_number| BlockId::Number(BlockNumberOrTag::Number(block_number)))

--- a/chain-signatures/chain-ethereum/src/config.rs
+++ b/chain-signatures/chain-ethereum/src/config.rs
@@ -1,5 +1,8 @@
 use std::fmt;
 
+pub const DEFAULT_CATCHUP_CONCURRENT_BATCHES: usize = 3;
+pub const MAX_CATCHUP_CONCURRENT_BATCHES: usize = 8;
+
 #[derive(Clone)]
 pub struct EthConfig {
     /// The ethereum account secret key used to sign eth respond txn.
@@ -20,6 +23,7 @@ pub struct EthConfig {
     pub optimistic_requests: bool,
     /// light client is true if using helios, false if using direct rpc
     pub light_client: bool,
+    pub catchup_concurrent_batches: usize,
 }
 
 impl EthConfig {
@@ -48,6 +52,10 @@ impl fmt::Debug for EthConfig {
             )
             .field("optimistic_requests", &self.optimistic_requests)
             .field("light_client", &self.light_client)
+            .field(
+                "catchup_concurrent_batches",
+                &self.catchup_concurrent_batches,
+            )
             .finish()
     }
 }

--- a/chain-signatures/chain-ethereum/src/config.rs
+++ b/chain-signatures/chain-ethereum/src/config.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 
+/// Default number of concurrent batches to fetch during catchup.
 pub const DEFAULT_CATCHUP_CONCURRENT_BATCHES: usize = 3;
+/// Maximum number of concurrent batches to fetch during catchup.
 pub const MAX_CATCHUP_CONCURRENT_BATCHES: usize = 8;
 
 #[derive(Clone)]

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -784,7 +784,7 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
             );
         }
 
-        // Determine the concurrency for catchup.  
+        // Determine the concurrency for catchup.
         let concurrency = if self.eth.light_client {
             1
         } else {

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -1,5 +1,8 @@
 use crate::abi::ChainSignatures;
-use crate::client::{BlockNumber, CatchupItem, CatchupIter, EthereumClient, MaybeBlock};
+use crate::client::{
+    BlockNumber, CatchupItem, EthereumClient, MaybeBlock, CATCHUP_BLOCK_BATCH_SIZE,
+    CATCHUP_CONCURRENT_BATCHES,
+};
 use crate::event_parsing::{emit_respond_events, is_contract_call, parse_filtered_logs};
 use crate::EthConfig;
 use alloy::consensus::Transaction;
@@ -9,7 +12,7 @@ use alloy::rpc::types::{Block, BlockId, Log, TransactionReceipt};
 use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use async_trait::async_trait;
-use futures_util::stream;
+use futures_util::stream::{self, StreamExt};
 use mpc_chain_integration_core::utils::stream::chain_event_channel;
 use mpc_chain_integration_core::{ChainIndexer, ChainStream, ChainTelemetry, StateManager};
 use mpc_primitives::{
@@ -764,8 +767,6 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
             .client
             .clamp_oldest_supported(current_block, anchor_height);
 
-        let catchup_iter = CatchupIter::new(self.client.clone(), catchup_start, anchor_height);
-
         // Sample the finalized head once at catchup start, so that blocks at or below it can skip the per-block re-fetch + reorg hash check.
         if let Some(finalized_block) = self
             .client
@@ -786,11 +787,23 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
             );
         }
 
-        // Convert the async state machine into a Stream
-        let stream = stream::unfold(catchup_iter, |mut state| async move {
-            let item = state.next().await;
-            item.map(|block| (block, state))
-        });
+        let client = self.client.clone();
+        let stream = stream::iter(
+            (catchup_start..anchor_height)
+                .step_by(CATCHUP_BLOCK_BATCH_SIZE as usize)
+                .map(move |start| {
+                    let end = start
+                        .saturating_add(CATCHUP_BLOCK_BATCH_SIZE)
+                        .min(anchor_height);
+                    (start, end)
+                }),
+        )
+        .map(move |(start, end)| {
+            let client = client.clone();
+            async move { client.fetch_batch(start, end).await }
+        })
+        .buffered(CATCHUP_CONCURRENT_BATCHES)
+        .flat_map(stream::iter);
 
         Box::pin(stream)
     }

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -1,10 +1,9 @@
 use crate::abi::ChainSignatures;
 use crate::client::{
     BlockNumber, CatchupItem, EthereumClient, MaybeBlock, CATCHUP_BLOCK_BATCH_SIZE,
-    CATCHUP_CONCURRENT_BATCHES,
 };
 use crate::event_parsing::{emit_respond_events, is_contract_call, parse_filtered_logs};
-use crate::EthConfig;
+use crate::{EthConfig, MAX_CATCHUP_CONCURRENT_BATCHES};
 use alloy::consensus::Transaction;
 use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::{Address, B256};
@@ -788,6 +787,14 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
         }
 
         let client = self.client.clone();
+        // Number of concurrent catchup batches to fetch
+        let concurrent = if self.eth.light_client {
+            1
+        } else {
+            self.eth
+                .catchup_concurrent_batches
+                .clamp(1, MAX_CATCHUP_CONCURRENT_BATCHES)
+        };
         let stream = stream::iter(
             (catchup_start..anchor_height)
                 .step_by(CATCHUP_BLOCK_BATCH_SIZE as usize)
@@ -802,7 +809,7 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
             let client = client.clone();
             async move { client.fetch_batch(start, end).await }
         })
-        .buffered(CATCHUP_CONCURRENT_BATCHES)
+        .buffered(concurrent)
         .flat_map(stream::iter);
 
         Box::pin(stream)

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -784,7 +784,8 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
             );
         }
 
-        let concurrent = if self.eth.light_client {
+        // Determine the concurrency for catchup.  
+        let concurrency = if self.eth.light_client {
             1
         } else {
             self.eth
@@ -792,7 +793,7 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
                 .clamp(1, MAX_CATCHUP_CONCURRENT_BATCHES)
         };
         self.client
-            .catchup_batch_stream(catchup_start, anchor_height, concurrent)
+            .catchup_batch_stream(catchup_start, anchor_height, concurrency)
     }
 
     async fn process_catchup(&mut self, item: &Self::Block) -> anyhow::Result<()> {

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -1,7 +1,5 @@
 use crate::abi::ChainSignatures;
-use crate::client::{
-    BlockNumber, CatchupItem, EthereumClient, MaybeBlock, CATCHUP_BLOCK_BATCH_SIZE,
-};
+use crate::client::{BlockNumber, CatchupItem, EthereumClient, MaybeBlock};
 use crate::event_parsing::{emit_respond_events, is_contract_call, parse_filtered_logs};
 use crate::{EthConfig, MAX_CATCHUP_CONCURRENT_BATCHES};
 use alloy::consensus::Transaction;
@@ -11,7 +9,7 @@ use alloy::rpc::types::{Block, BlockId, Log, TransactionReceipt};
 use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use async_trait::async_trait;
-use futures_util::stream::{self, StreamExt};
+use futures_util::Stream;
 use mpc_chain_integration_core::utils::stream::chain_event_channel;
 use mpc_chain_integration_core::{ChainIndexer, ChainStream, ChainTelemetry, StateManager};
 use mpc_primitives::{
@@ -718,7 +716,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
 impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> {
     const CHAIN: Chain = Chain::Ethereum;
     type Block = CatchupItem;
-    type Iter = std::pin::Pin<Box<dyn stream::Stream<Item = Self::Block> + Send + 'static>>;
+    type Iter = std::pin::Pin<Box<dyn Stream<Item = Self::Block> + Send + 'static>>;
 
     async fn livestream(&mut self) -> anyhow::Result<Option<u64>> {
         let start_block_number = loop {
@@ -786,8 +784,6 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
             );
         }
 
-        let client = self.client.clone();
-        // Number of concurrent catchup batches to fetch
         let concurrent = if self.eth.light_client {
             1
         } else {
@@ -795,24 +791,8 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
                 .catchup_concurrent_batches
                 .clamp(1, MAX_CATCHUP_CONCURRENT_BATCHES)
         };
-        let stream = stream::iter(
-            (catchup_start..anchor_height)
-                .step_by(CATCHUP_BLOCK_BATCH_SIZE as usize)
-                .map(move |start| {
-                    let end = start
-                        .saturating_add(CATCHUP_BLOCK_BATCH_SIZE)
-                        .min(anchor_height);
-                    (start, end)
-                }),
-        )
-        .map(move |(start, end)| {
-            let client = client.clone();
-            async move { client.fetch_batch(start, end).await }
-        })
-        .buffered(concurrent)
-        .flat_map(stream::iter);
-
-        Box::pin(stream)
+        self.client
+            .catchup_batch_stream(catchup_start, anchor_height, concurrent)
     }
 
     async fn process_catchup(&mut self, item: &Self::Block) -> anyhow::Result<()> {
@@ -981,6 +961,7 @@ mod tests {
     use alloy::eips::BlockNumberOrTag;
     use alloy::primitives::{address, b256};
     use alloy::rpc::types::BlockId;
+    use futures_util::stream::StreamExt;
     use mockito::{Matcher, Server};
     use mpc_chain_integration_core::ChainIndexer;
     use mpc_primitives::{
@@ -1071,9 +1052,9 @@ mod tests {
         // Ensure blocks are considered finalized to avoid reorg-check refetches in process_catchup
         indexer.catchup_finalized_head.store(100, Ordering::Relaxed);
 
-        let mut iter = crate::client::CatchupIter::new(indexer.client.clone(), 1, 33);
+        let mut stream = indexer.client.catchup_batch_stream(1, 33, 1);
         for n in 1..=32 {
-            let item = iter.next().await.expect("expected item");
+            let item = stream.next().await.expect("expected item");
             indexer
                 .process_catchup(&item)
                 .await
@@ -1131,16 +1112,16 @@ mod tests {
             .await;
         indexer.catchup_finalized_head.store(100, Ordering::Relaxed);
 
-        let mut iter = crate::client::CatchupIter::new(indexer.client.clone(), 10, 12);
+        let mut stream = indexer.client.catchup_batch_stream(10, 12, 1);
 
-        let item1 = iter.next().await.unwrap();
+        let item1 = stream.next().await.unwrap();
         indexer.process_catchup(&item1).await.unwrap();
         assert!(matches!(
             events_rx.recv().await,
             Some(ChainEvent::Block(10))
         ));
 
-        let item2 = iter.next().await.unwrap();
+        let item2 = stream.next().await.unwrap();
         indexer.process_catchup(&item2).await.unwrap();
         assert!(matches!(
             events_rx.recv().await,
@@ -1245,8 +1226,8 @@ mod tests {
         // Ensure block is considered finalized to avoid the reorg-check refetch
         indexer.catchup_finalized_head.store(100, Ordering::Relaxed);
 
-        let mut iter = crate::client::CatchupIter::new(indexer.client.clone(), 42, 43);
-        let item = iter.next().await.unwrap();
+        let mut stream = indexer.client.catchup_batch_stream(42, 43, 1);
+        let item = stream.next().await.unwrap();
 
         indexer
             .process_catchup(&item)

--- a/chain-signatures/chain-ethereum/src/lib.rs
+++ b/chain-signatures/chain-ethereum/src/lib.rs
@@ -17,5 +17,5 @@ mod test_utils;
 mod util;
 
 pub use client::MaybeBlock;
-pub use config::EthConfig;
+pub use config::{EthConfig, DEFAULT_CATCHUP_CONCURRENT_BATCHES, MAX_CATCHUP_CONCURRENT_BATCHES};
 pub use indexer::EthereumStream;

--- a/chain-signatures/chain-ethereum/src/publisher.rs
+++ b/chain-signatures/chain-ethereum/src/publisher.rs
@@ -349,6 +349,8 @@ impl ChainPublisher for EthClient {
 
 #[cfg(test)]
 mod tests {
+    use crate::DEFAULT_CATCHUP_CONCURRENT_BATCHES;
+
     use super::*;
     use alloy::primitives::{B256, U256};
     use k256::{AffinePoint, Scalar};
@@ -372,6 +374,7 @@ mod tests {
             refresh_finalized_interval: 1000,
             optimistic_requests: false,
             light_client: false,
+            catchup_concurrent_batches: DEFAULT_CATCHUP_CONCURRENT_BATCHES,
         }
     }
 

--- a/chain-signatures/chain-ethereum/src/test_utils.rs
+++ b/chain-signatures/chain-ethereum/src/test_utils.rs
@@ -1,6 +1,6 @@
 use crate::client::{CatchupItem, EthereumClient};
 use crate::indexer::EthereumIndexer;
-use crate::EthConfig;
+use crate::{EthConfig, DEFAULT_CATCHUP_CONCURRENT_BATCHES};
 use alloy::primitives::Address;
 use mpc_chain_integration_core::utils::retry::RetryConfig;
 use mpc_chain_integration_core::{MockStateManager, NoopChainTelemetry};
@@ -31,6 +31,7 @@ pub async fn create_test_ethereum_client(url: &str) -> EthereumClient {
         helios_data_path: "".to_string(),
         refresh_finalized_interval: 0,
         optimistic_requests: false,
+        catchup_concurrent_batches: DEFAULT_CATCHUP_CONCURRENT_BATCHES,
     };
 
     EthereumClient::new_with_strategy(eth, retry_strategy)
@@ -66,6 +67,7 @@ impl TestIndexerBuilder {
                 refresh_finalized_interval: DEFAULT_REFRESH_FINALIZED_INTERVAL,
                 optimistic_requests: true,
                 light_client: false,
+                catchup_concurrent_batches: DEFAULT_CATCHUP_CONCURRENT_BATCHES,
             },
             state_manager: MockStateManager::new(),
             optimistic_requests: true,

--- a/chain-signatures/node/src/cli/args/ethereum.rs
+++ b/chain-signatures/node/src/cli/args/ethereum.rs
@@ -1,4 +1,6 @@
-use mpc_chain_ethereum::{EthConfig, MAX_CATCHUP_CONCURRENT_BATCHES, DEFAULT_CATCHUP_CONCURRENT_BATCHES};
+use mpc_chain_ethereum::{
+    EthConfig, DEFAULT_CATCHUP_CONCURRENT_BATCHES, MAX_CATCHUP_CONCURRENT_BATCHES,
+};
 use secrecy::{ExposeSecret, SecretString};
 
 // Configures Ethereum indexer.
@@ -73,12 +75,8 @@ pub struct EthArgs {
     #[clap(long, env("MPC_ETH_OPTIMISTIC_REQUESTS"), default_value = "false")]
     pub eth_optimistic_requests: bool,
 
-    /// Number of concurrent catchup batches to fetch. 
-    #[clap(
-        long,
-        env("MPC_ETH_CATCHUP_CONCURRENT_BATCHES"),
-        default_value = "3"
-    )]
+    /// Number of concurrent catchup batches to fetch.
+    #[clap(long, env("MPC_ETH_CATCHUP_CONCURRENT_BATCHES"), default_value = "3")]
     pub eth_catchup_concurrent_batches: usize,
 }
 
@@ -180,8 +178,7 @@ impl EthArgs {
                 eth_refresh_finalized_interval: 0,
                 eth_optimistic_requests: false,
                 eth_light_client: false,
-                eth_catchup_concurrent_batches:
-                    DEFAULT_CATCHUP_CONCURRENT_BATCHES,
+                eth_catchup_concurrent_batches: DEFAULT_CATCHUP_CONCURRENT_BATCHES,
             },
         }
     }

--- a/chain-signatures/node/src/cli/args/ethereum.rs
+++ b/chain-signatures/node/src/cli/args/ethereum.rs
@@ -1,4 +1,4 @@
-use mpc_chain_ethereum::EthConfig;
+use mpc_chain_ethereum::{EthConfig, MAX_CATCHUP_CONCURRENT_BATCHES, DEFAULT_CATCHUP_CONCURRENT_BATCHES};
 use secrecy::{ExposeSecret, SecretString};
 
 // Configures Ethereum indexer.
@@ -72,6 +72,14 @@ pub struct EthArgs {
     /// Useful for testing where we do not want to reach finality due to how long it takes.
     #[clap(long, env("MPC_ETH_OPTIMISTIC_REQUESTS"), default_value = "false")]
     pub eth_optimistic_requests: bool,
+
+    /// Number of concurrent catchup batches to fetch. 
+    #[clap(
+        long,
+        env("MPC_ETH_CATCHUP_CONCURRENT_BATCHES"),
+        default_value = "3"
+    )]
+    pub eth_catchup_concurrent_batches: usize,
 }
 
 impl EthArgs {
@@ -111,6 +119,10 @@ impl EthArgs {
         if self.eth_optimistic_requests {
             args.push("--eth-optimistic-requests".to_string());
         }
+        args.extend([
+            "--eth-catchup-concurrent-batches".to_string(),
+            self.eth_catchup_concurrent_batches.to_string(),
+        ]);
         if self.eth_light_client {
             args.push("--eth-light-client".to_string());
         }
@@ -138,6 +150,9 @@ impl EthArgs {
             light_client: self.eth_light_client,
             #[cfg(not(feature = "helios"))]
             light_client: false,
+            catchup_concurrent_batches: self
+                .eth_catchup_concurrent_batches
+                .clamp(1, MAX_CATCHUP_CONCURRENT_BATCHES),
         })
     }
 
@@ -153,6 +168,7 @@ impl EthArgs {
                 eth_refresh_finalized_interval: config.refresh_finalized_interval,
                 eth_optimistic_requests: config.optimistic_requests,
                 eth_light_client: config.light_client,
+                eth_catchup_concurrent_batches: config.catchup_concurrent_batches,
             },
             _ => Self {
                 eth_account_sk: None,
@@ -164,6 +180,8 @@ impl EthArgs {
                 eth_refresh_finalized_interval: 0,
                 eth_optimistic_requests: false,
                 eth_light_client: false,
+                eth_catchup_concurrent_batches:
+                    DEFAULT_CATCHUP_CONCURRENT_BATCHES,
             },
         }
     }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -20,7 +20,7 @@ use alloy::primitives::{Address, U256};
 use anyhow::Context as _;
 use cluster::spawner::ClusterSpawner;
 use mpc_chain_canton::CantonConfig;
-use mpc_chain_ethereum::{DEFAULT_CATCHUP_CONCURRENT_BATCHES, EthConfig};
+use mpc_chain_ethereum::{EthConfig, DEFAULT_CATCHUP_CONCURRENT_BATCHES};
 use mpc_chain_solana::SolConfig;
 use mpc_contract::config::{PresignatureConfig, ProtocolConfig, TripleConfig};
 use mpc_contract::primitives::CandidateInfo;

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -20,7 +20,7 @@ use alloy::primitives::{Address, U256};
 use anyhow::Context as _;
 use cluster::spawner::ClusterSpawner;
 use mpc_chain_canton::CantonConfig;
-use mpc_chain_ethereum::EthConfig;
+use mpc_chain_ethereum::{DEFAULT_CATCHUP_CONCURRENT_BATCHES, EthConfig};
 use mpc_chain_solana::SolConfig;
 use mpc_contract::config::{PresignatureConfig, ProtocolConfig, TripleConfig};
 use mpc_contract::primitives::CandidateInfo;
@@ -394,6 +394,7 @@ pub async fn setup(spawner: &mut ClusterSpawner) -> anyhow::Result<Context> {
             refresh_finalized_interval: 1_000,
             optimistic_requests: true,
             light_client: false,
+            catchup_concurrent_batches: DEFAULT_CATCHUP_CONCURRENT_BATCHES,
         });
 
         ethereum = Some(EthereumContext {

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -6,7 +6,7 @@ use std::vec;
 use clap::Parser;
 use integration_tests::cluster::spawner::ClusterSpawner;
 use integration_tests::NodeConfig;
-use mpc_chain_ethereum::{DEFAULT_CATCHUP_CONCURRENT_BATCHES, EthConfig};
+use mpc_chain_ethereum::{EthConfig, DEFAULT_CATCHUP_CONCURRENT_BATCHES};
 use near_account_id::AccountId;
 use near_crypto::PublicKey;
 use serde_json::json;

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -6,7 +6,7 @@ use std::vec;
 use clap::Parser;
 use integration_tests::cluster::spawner::ClusterSpawner;
 use integration_tests::NodeConfig;
-use mpc_chain_ethereum::EthConfig;
+use mpc_chain_ethereum::{DEFAULT_CATCHUP_CONCURRENT_BATCHES, EthConfig};
 use near_account_id::AccountId;
 use near_crypto::PublicKey;
 use serde_json::json;
@@ -76,6 +76,7 @@ async fn main() -> anyhow::Result<()> {
                     refresh_finalized_interval: eth_refresh_finalized_interval,
                     optimistic_requests: false,
                     light_client: false,
+                    catchup_concurrent_batches: DEFAULT_CATCHUP_CONCURRENT_BATCHES,
                 }),
                 ..Default::default()
             };

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -10,7 +10,7 @@ use integration_tests::eth;
 use k256::elliptic_curve::sec1::ToEncodedPoint as _;
 use k256::{AffinePoint, Scalar};
 use mpc_chain_ethereum::abi::ChainSignatures::{self, SignRequest};
-use mpc_chain_ethereum::{DEFAULT_CATCHUP_CONCURRENT_BATCHES, EthConfig, EthereumStream};
+use mpc_chain_ethereum::{EthConfig, EthereumStream, DEFAULT_CATCHUP_CONCURRENT_BATCHES};
 use mpc_chain_integration_core::{ChainStream, ChainTelemetry, NoopChainTelemetry, StateManager};
 use mpc_crypto::kdf::generate_signature;
 use mpc_node::backlog::Backlog;

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -10,7 +10,7 @@ use integration_tests::eth;
 use k256::elliptic_curve::sec1::ToEncodedPoint as _;
 use k256::{AffinePoint, Scalar};
 use mpc_chain_ethereum::abi::ChainSignatures::{self, SignRequest};
-use mpc_chain_ethereum::{EthConfig, EthereumStream};
+use mpc_chain_ethereum::{DEFAULT_CATCHUP_CONCURRENT_BATCHES, EthConfig, EthereumStream};
 use mpc_chain_integration_core::{ChainStream, ChainTelemetry, NoopChainTelemetry, StateManager};
 use mpc_crypto::kdf::generate_signature;
 use mpc_node::backlog::Backlog;
@@ -162,6 +162,7 @@ impl EthereumTestEnvironment {
             refresh_finalized_interval: 500,
             optimistic_requests,
             light_client: false,
+            catchup_concurrent_batches: DEFAULT_CATCHUP_CONCURRENT_BATCHES,
         }
     }
 


### PR DESCRIPTION
- **Config**: add `EthConfig.catchup_concurrent_batches: usize`, with `DEFAULT_CATCHUP_CONCURRENT_BATCHES` (3) and `MAX_CATCHUP_CONCURRENT_BATCHES` (8)
- **Client**: delete `CatchupIter` struct and add `EthereumClient::catchup_batch_stream(&self, start, end, concurrency)`, which returns a stream of `CatchupItem`
- **Indexer**: `type Iter` changed to `futures_util::Stream`
- **Benchmark**: include `batch_wait_ms` metric for critical-path fetch wait