### PR TITLE
feat: bloom-filtered logs and targeted tx receipts (Ethereum indexer)

### DIFF
--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -25,6 +25,11 @@ pub enum MaybeBlock {
     Missing(BlockId),
 }
 
+/// Returns `true` if the block's logs bloom may contain logs emitted by `address`.
+pub fn block_may_contain_logs(block: &Block, address: Address) -> bool {
+    block.header.logs_bloom.contains_raw_log(address, &[])
+}
+
 /// Catchup item yielded by [`CatchupIter`] and consumed by `process_catchup`.
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
@@ -494,6 +499,7 @@ impl EthereumClient {
 mod tests {
     use super::*;
     use crate::test_utils;
+    use alloy::primitives::Bloom;
     use mockito::{Matcher, Server};
     use serde_json::json;
 
@@ -940,5 +946,61 @@ mod tests {
         } else {
             panic!("Expected BatchBlock for block 11, got {:?}", item2);
         }
+    }
+
+    /// Build a `Block` with the given `logs_bloom`.
+    fn block_with_bloom(bloom: alloy::primitives::Bloom) -> Block {
+        let mut block: Block = serde_json::from_value(
+            test_utils::block_response(1, 7)
+                .get("result")
+                .expect("envelope present")
+                .clone(),
+        )
+        .expect("fixture should deserialize");
+        block.header.logs_bloom = bloom;
+        block
+    }
+
+    #[test]
+    fn block_may_contain_logs_empty_bloom_returns_false() {
+        let block = block_with_bloom(Bloom::default());
+        let addr = Address::with_last_byte(0x42);
+
+        assert!(!block_may_contain_logs(&block, addr));
+    }
+
+    #[test]
+    fn block_may_contain_logs_accrued_address_returns_true() {
+        let addr = Address::with_last_byte(0x42);
+        let mut bloom = Bloom::default();
+        bloom.accrue_raw_log(addr, &[]);
+
+        let block = block_with_bloom(bloom);
+
+        // Bloom accrued with our address → true (no false negative).
+        assert!(block_may_contain_logs(&block, addr));
+    }
+
+    #[test]
+    fn block_may_contain_logs_disjoint_address_returns_false() {
+        let addr = Address::with_last_byte(0x42);
+        let other = Address::with_last_byte(0x07);
+
+        let mut bloom = Bloom::default();
+        bloom.accrue_raw_log(other, &[]);
+
+        let block = block_with_bloom(bloom);
+
+        // Bloom accrued with a different address must NOT report our address → false (no false positive).
+        assert!(!block_may_contain_logs(&block, addr));
+    }
+
+    #[test]
+    fn block_may_contain_logs_saturated_bloom_is_false_positive_tolerated() {
+        let addr = Address::with_last_byte(0x42);
+        // An all-ones bloom matches every address — false positive, but we tolerate it.
+        let block = block_with_bloom(Bloom::from([0xffu8; 256]));
+
+        assert!(block_may_contain_logs(&block, addr));
     }
 }

--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -1,6 +1,6 @@
 use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::Address;
-use alloy::rpc::types::{Block, BlockId, TransactionReceipt};
+use alloy::rpc::types::{Block, BlockId, Log, TransactionReceipt};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -325,6 +325,44 @@ impl EthereumClient {
                     }
                     EthereumClientInner::DirectRpc(client) => {
                         client.get_block_receipts_batch(block_ids).await
+                    }
+                }
+            }
+        )
+    }
+
+    /// Fetch all logs emitted by `address` within `block_id` via a single
+    /// server-filtered `eth_getLogs`.
+    pub async fn get_logs(&self, address: Address, block_id: BlockId) -> anyhow::Result<Vec<Log>> {
+        retry_rpc!(ETH_RPC_TIMEOUT, self.retry_strategy, "get_logs", {
+            match &self.inner {
+                #[cfg(feature = "helios")]
+                EthereumClientInner::Helios(client) => client.get_logs(address, block_id).await,
+                EthereumClientInner::DirectRpc(client) => client.get_logs(address, block_id).await,
+            }
+        })
+    }
+
+    /// Fetch `eth_getLogs` for multiple blocks in a single JSON-RPC batch POST,
+    /// returning one `Vec<Log>` per input `block_id`, in input order.
+    /// Each request is address-filtered to the same `address`.
+    pub async fn get_logs_batch(
+        &self,
+        address: Address,
+        block_ids: &[BlockId],
+    ) -> anyhow::Result<Vec<Vec<Log>>> {
+        retry_rpc!(
+            ETH_RPC_BATCH_TIMEOUT,
+            self.retry_strategy,
+            "get_logs_batch",
+            {
+                match &self.inner {
+                    #[cfg(feature = "helios")]
+                    EthereumClientInner::Helios(client) => {
+                        client.get_logs_batch(address, block_ids).await
+                    }
+                    EthereumClientInner::DirectRpc(client) => {
+                        client.get_logs_batch(address, block_ids).await
                     }
                 }
             }

--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -45,6 +45,13 @@ pub enum CatchupItem {
     LiveBlock(Block),
 }
 
+/// Intermediate state of a block during catchup batch processing.
+enum BlockSlot {
+    Missing(BlockId),
+    NoLogs(Block),
+    PendingLogs(Block, BlockId),
+}
+
 /// Lazy batching iterator over `[start_block, end_block)` range.
 pub struct CatchupIter {
     client: Arc<EthereumClient>,
@@ -79,74 +86,71 @@ impl CatchupIter {
             .next_block
             .saturating_add(CATCHUP_BLOCK_BATCH_SIZE)
             .min(self.end_block);
-        let batch_block_ids = (self.next_block..batch_end)
-            .map(|block_number| BlockId::Number(BlockNumberOrTag::Number(block_number)))
-            .collect::<Vec<_>>();
+
+        let batch_block_ids: Vec<BlockId> = (self.next_block..batch_end)
+            .map(|n| BlockId::Number(BlockNumberOrTag::Number(n)))
+            .collect();
 
         #[cfg(feature = "bench")]
         let start = std::time::Instant::now();
 
-        // Fetch blocks
         let blocks = self.client.get_blocks(&batch_block_ids).await;
 
-        // For each block, check if the bloom indicates that the contract may have emitted logs.
-        let mut bloom_positive_ids: Vec<BlockId> = Vec::new();
-        let mut logs_index: Vec<Option<usize>> = Vec::with_capacity(batch_block_ids.len());
-        let mut present_blocks: Vec<Option<Block>> = Vec::with_capacity(batch_block_ids.len());
-        for maybe in blocks {
-            match maybe {
+        // Classify each block: missing, bloom-negative (no logs to fetch), or
+        // bloom-positive (needs a slot in the logs batch request).
+        let slots: Vec<BlockSlot> = blocks
+            .into_iter()
+            .zip(&batch_block_ids)
+            .map(|(maybe, &block_id)| match maybe {
+                MaybeBlock::Missing(_) => BlockSlot::Missing(block_id),
                 MaybeBlock::Block(block) => {
-                    let positive = block_may_contain_logs(&block, self.contract_address);
-                    let idx = if positive {
-                        let i = bloom_positive_ids.len();
-                        bloom_positive_ids.push(BlockId::Number(BlockNumberOrTag::Number(
-                            block.header.number,
-                        )));
-                        Some(i)
+                    if block_may_contain_logs(&block, self.contract_address) {
+                        BlockSlot::PendingLogs(block, block_id)
                     } else {
-                        None
-                    };
-                    logs_index.push(idx);
-                    present_blocks.push(Some(block));
+                        BlockSlot::NoLogs(block)
+                    }
                 }
-                MaybeBlock::Missing(_) => {
-                    logs_index.push(None);
-                    present_blocks.push(None);
-                }
-            }
-        }
+            })
+            .collect();
 
-        // Fetch logs for blocks whose bloom indicates the contract may have emitted logs.
-        let (logs_results, logs_failed) = if bloom_positive_ids.is_empty() {
-            (Vec::new(), false)
+        let logs_request_ids: Vec<BlockId> = slots
+            .iter()
+            .filter_map(|slot| match slot {
+                BlockSlot::PendingLogs(_, id) => Some(*id),
+                _ => None,
+            })
+            .collect();
+
+        // Fetch logs for bloom-positive blocks. On failure, those blocks are
+        // reported as missing so the caller refetches them individually.
+        let (mut logs_iter, logs_failed) = if logs_request_ids.is_empty() {
+            (Vec::new().into_iter(), false)
         } else {
             match self
                 .client
-                .get_logs_batch(self.contract_address, &bloom_positive_ids)
+                .get_logs_batch(self.contract_address, &logs_request_ids)
                 .await
             {
-                Ok(v) => (v, false),
-                Err(_) => (Vec::new(), true),
+                Ok(logs) => (logs.into_iter(), false),
+                Err(_) => (Vec::new().into_iter(), true),
             }
         };
 
-        let mut logs_iter = logs_results.into_iter();
-        let items: Vec<CatchupItem> = present_blocks
+        // Reconstruct the batch items in the original order, with logs for bloom-positive blocks.
+        let items: Vec<CatchupItem> = slots
             .into_iter()
-            .zip(batch_block_ids)
-            .zip(logs_index)
-            .map(|((maybe, block_id), idx_opt)| match maybe {
-                None => CatchupItem::Missing(block_id),
-                Some(block) => match idx_opt {
-                    None => CatchupItem::BatchBlock {
-                        block,
-                        logs: Vec::new(),
-                    },
-                    Some(_) if logs_failed => CatchupItem::Missing(block_id),
-                    Some(_) => CatchupItem::BatchBlock {
-                        block,
-                        logs: logs_iter.next().unwrap_or_default(),
-                    },
+            .map(|slot| match slot {
+                BlockSlot::Missing(block_id) => CatchupItem::Missing(block_id),
+                BlockSlot::NoLogs(block) => CatchupItem::BatchBlock {
+                    block,
+                    logs: Vec::new(),
+                },
+                BlockSlot::PendingLogs(_block, block_id) if logs_failed => {
+                    CatchupItem::Missing(block_id)
+                }
+                BlockSlot::PendingLogs(block, _) => CatchupItem::BatchBlock {
+                    block,
+                    logs: logs_iter.next().unwrap_or_default(),
                 },
             })
             .collect();

--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -37,7 +37,7 @@ pub enum CatchupItem {
     /// A block fetched as part of a catchup batch, plus its logs.
     /// `logs` is `Vec::new()` for blocks with no relevant logs.
     BatchBlock { block: Block, logs: Vec<Log> },
-/// A block that was missing from the catchup batch response.
+    /// A block that was missing from the catchup batch response.
     /// `process_catchup` refetches both block and receipts individually.
     Missing(BlockId),
     /// A block from the live stream. Receipts are fetched lazily in

--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -1,5 +1,5 @@
 use alloy::eips::BlockNumberOrTag;
-use alloy::primitives::Address;
+use alloy::primitives::{Address, B256};
 use alloy::rpc::types::{Block, BlockId, Log, TransactionReceipt};
 use std::sync::Arc;
 use std::time::Duration;
@@ -325,6 +325,31 @@ impl EthereumClient {
                     }
                     EthereumClientInner::DirectRpc(client) => {
                         client.get_block_receipts_batch(block_ids).await
+                    }
+                }
+            }
+        )
+    }
+
+    /// Fetch a single transaction's receipt via `eth_getTransactionReceipt`.
+    ///
+    /// Returns `None` for an unknown or pending (not-yet-mined) tx.
+    pub async fn get_transaction_receipt(
+        &self,
+        tx_hash: B256,
+    ) -> anyhow::Result<Option<TransactionReceipt>> {
+        retry_rpc!(
+            ETH_RPC_TIMEOUT,
+            self.retry_strategy,
+            "get_transaction_receipt",
+            {
+                match &self.inner {
+                    #[cfg(feature = "helios")]
+                    EthereumClientInner::Helios(client) => {
+                        client.get_transaction_receipt(tx_hash).await
+                    }
+                    EthereumClientInner::DirectRpc(client) => {
+                        client.get_transaction_receipt(tx_hash).await
                     }
                 }
             }

--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -34,13 +34,10 @@ pub fn block_may_contain_logs(block: &Block, address: Address) -> bool {
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum CatchupItem {
-    /// A block fetched as part of a catchup batch, plus receipts.
-    /// `receipts` is `Vec::new()` for blocks with no transactions.
-    BatchBlock {
-        block: Block,
-        receipts: Vec<TransactionReceipt>,
-    },
-    /// A block that was missing from the catchup batch response.
+    /// A block fetched as part of a catchup batch, plus its logs.
+    /// `logs` is `Vec::new()` for blocks with no relevant logs.
+    BatchBlock { block: Block, logs: Vec<Log> },
+/// A block that was missing from the catchup batch response.
     /// `process_catchup` refetches both block and receipts individually.
     Missing(BlockId),
     /// A block from the live stream. Receipts are fetched lazily in
@@ -51,6 +48,7 @@ pub enum CatchupItem {
 /// Lazy batching iterator over `[start_block, end_block)` range.
 pub struct CatchupIter {
     client: Arc<EthereumClient>,
+    contract_address: Address,
     next_block: BlockNumber,
     end_block: BlockNumber,
     buffered_blocks: std::vec::IntoIter<CatchupItem>,
@@ -61,9 +59,11 @@ impl CatchupIter {
         client: Arc<EthereumClient>,
         start_block: BlockNumber,
         end_block: BlockNumber,
+        contract_address: Address,
     ) -> Self {
         Self {
             client,
+            contract_address,
             next_block: start_block,
             end_block,
             buffered_blocks: Vec::new().into_iter(),
@@ -86,35 +86,70 @@ impl CatchupIter {
         #[cfg(feature = "bench")]
         let start = std::time::Instant::now();
 
-        // Fetch blocks and receipts in parallel
-        let (blocks, receipts) = tokio::join!(
-            self.client.get_blocks(&batch_block_ids),
-            self.client.get_block_receipts_batch(&batch_block_ids)
-        );
+        // Fetch blocks
+        let blocks = self.client.get_blocks(&batch_block_ids).await;
 
-        // If receipts fetch fails, treat all blocks as missing receipts.
-        // Consistent with the behavior of get_blocks, which returns MaybeBlock::Missing for all blocks if the batch fails.
-        let items: Vec<CatchupItem> = if let Ok(receipts) = receipts {
-            blocks
-                .into_iter()
-                .zip(receipts)
-                .zip(batch_block_ids)
-                .map(
-                    |((maybe_block, maybe_receipts), block_id)| match maybe_block {
-                        MaybeBlock::Block(block) => CatchupItem::BatchBlock {
-                            block,
-                            receipts: maybe_receipts.unwrap_or_default(),
-                        },
-                        MaybeBlock::Missing(_) => CatchupItem::Missing(block_id),
-                    },
-                )
-                .collect()
+        // For each block, check if the bloom indicates that the contract may have emitted logs.
+        let mut bloom_positive_ids: Vec<BlockId> = Vec::new();
+        let mut logs_index: Vec<Option<usize>> = Vec::with_capacity(batch_block_ids.len());
+        let mut present_blocks: Vec<Option<Block>> = Vec::with_capacity(batch_block_ids.len());
+        for maybe in blocks {
+            match maybe {
+                MaybeBlock::Block(block) => {
+                    let positive = block_may_contain_logs(&block, self.contract_address);
+                    let idx = if positive {
+                        let i = bloom_positive_ids.len();
+                        bloom_positive_ids.push(BlockId::Number(BlockNumberOrTag::Number(
+                            block.header.number,
+                        )));
+                        Some(i)
+                    } else {
+                        None
+                    };
+                    logs_index.push(idx);
+                    present_blocks.push(Some(block));
+                }
+                MaybeBlock::Missing(_) => {
+                    logs_index.push(None);
+                    present_blocks.push(None);
+                }
+            }
+        }
+
+        // Fetch logs for blocks whose bloom indicates the contract may have emitted logs.
+        let (logs_results, logs_failed) = if bloom_positive_ids.is_empty() {
+            (Vec::new(), false)
         } else {
-            batch_block_ids
-                .into_iter()
-                .map(CatchupItem::Missing)
-                .collect()
+            match self
+                .client
+                .get_logs_batch(self.contract_address, &bloom_positive_ids)
+                .await
+            {
+                Ok(v) => (v, false),
+                Err(_) => (Vec::new(), true),
+            }
         };
+
+        let mut logs_iter = logs_results.into_iter();
+        let items: Vec<CatchupItem> = present_blocks
+            .into_iter()
+            .zip(batch_block_ids)
+            .zip(logs_index)
+            .map(|((maybe, block_id), idx_opt)| match maybe {
+                None => CatchupItem::Missing(block_id),
+                Some(block) => match idx_opt {
+                    None => CatchupItem::BatchBlock {
+                        block,
+                        logs: Vec::new(),
+                    },
+                    Some(_) if logs_failed => CatchupItem::Missing(block_id),
+                    Some(_) => CatchupItem::BatchBlock {
+                        block,
+                        logs: logs_iter.next().unwrap_or_default(),
+                    },
+                },
+            })
+            .collect();
 
         #[cfg(feature = "bench")]
         crate::bench::add_batch_fetch_time(start.elapsed());
@@ -283,57 +318,6 @@ impl EthereumClient {
                 block_ids.iter().copied().map(MaybeBlock::Missing).collect()
             }
         }
-    }
-
-    pub async fn get_block_receipts(
-        &self,
-        block_id: BlockId,
-    ) -> anyhow::Result<Option<Vec<alloy::rpc::types::TransactionReceipt>>> {
-        retry_rpc!(
-            ETH_RPC_TIMEOUT,
-            self.retry_strategy,
-            "get_block_receipts",
-            {
-                match &self.inner {
-                    #[cfg(feature = "helios")]
-                    EthereumClientInner::Helios(client) => {
-                        client.get_block_receipts(block_id).await
-                    }
-                    EthereumClientInner::DirectRpc(client) => {
-                        client.get_block_receipts(block_id).await
-                    }
-                }
-            }
-        )
-    }
-
-    /// Fetch receipts for multiple blocks in a single JSON-RPC batch POST.
-    ///
-    /// Returns one `Option<Vec<TransactionReceipt>>` per input `block_id`,
-    /// in the same order as `block_ids`
-    ///
-    /// On permanent failure the whole batch fails (consistent with
-    /// `get_blocks`). The retry wrapper retries the entire batch.
-    pub async fn get_block_receipts_batch(
-        &self,
-        block_ids: &[BlockId],
-    ) -> anyhow::Result<Vec<Option<Vec<alloy::rpc::types::TransactionReceipt>>>> {
-        retry_rpc!(
-            ETH_RPC_BATCH_TIMEOUT,
-            self.retry_strategy,
-            "get_block_receipts_batch",
-            {
-                match &self.inner {
-                    #[cfg(feature = "helios")]
-                    EthereumClientInner::Helios(client) => {
-                        client.get_block_receipts_batch(block_ids).await
-                    }
-                    EthereumClientInner::DirectRpc(client) => {
-                        client.get_block_receipts_batch(block_ids).await
-                    }
-                }
-            }
-        )
     }
 
     /// Fetch a single transaction's receipt via `eth_getTransactionReceipt`.
@@ -614,7 +598,7 @@ mod tests {
             .enumerate()
             .map(|(index, block_number)| test_utils::block_response(index as u64 + 1, block_number))
             .collect::<Vec<_>>();
-        let second_batch = vec![test_utils::block_response(65, 42)];
+        let second_batch = vec![test_utils::block_response(33, 42)];
 
         let second_batch_mock = server
             .mock("POST", "/")
@@ -640,19 +624,10 @@ mod tests {
             .create_async()
             .await;
 
-        // Receipt mocks: return an empty array for any eth_getBlockReceipts call.
-        // This test verifies block-batch laziness, not receipt content.
-        let _receipts_mock = server
-            .mock("POST", "/")
-            .match_body(Matcher::Regex("eth_getBlockReceipts".to_string()))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body("[]")
-            .create_async()
-            .await;
+        let contract_address = Address::with_last_byte(0x42);
 
         let client = Arc::new(test_utils::create_test_ethereum_client(&server.url()).await);
-        let mut iter = CatchupIter::new(client, 10, 43);
+        let mut iter = CatchupIter::new(client, 10, 43, contract_address);
 
         for expected_number in 10..42 {
             let next = iter.next().await;
@@ -694,10 +669,10 @@ mod tests {
         let second_batch = (0..32)
             .enumerate()
             .map(|(idx, block_number)| {
-                test_utils::block_response((idx + 65) as u64, block_number + 32)
+                test_utils::block_response((idx + 33) as u64, block_number + 32)
             })
             .collect::<Vec<_>>();
-        let third_batch = vec![test_utils::block_response(129, 64)];
+        let third_batch = vec![test_utils::block_response(65, 64)];
 
         let first_batch_mock = server
             .mock("POST", "/")
@@ -735,19 +710,10 @@ mod tests {
             .create_async()
             .await;
 
-        // Receipt mocks: return an empty array for any eth_getBlockReceipts call.
-        // This test verifies block-batch splitting, not receipt content.
-        let _receipts_mock = server
-            .mock("POST", "/")
-            .match_body(Matcher::Regex("eth_getBlockReceipts".to_string()))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body("[]")
-            .create_async()
-            .await;
+        let contract_address = Address::with_last_byte(0x42);
 
         let client = Arc::new(test_utils::create_test_ethereum_client(&server.url()).await);
-        let mut iter = CatchupIter::new(client, 0, 65);
+        let mut iter = CatchupIter::new(client, 0, 65, contract_address);
 
         for expected_number in 0..65 {
             let next = iter.next().await;
@@ -876,13 +842,86 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn catchup_iter_receipt_batch_order_preservation() {
+    async fn catchup_iter_logs_batch_order_preservation() {
         let mut server = mockito::Server::new_async().await;
+        let contract_address = Address::with_last_byte(0x42);
+        let bloom = test_utils::bloom_containing_address(contract_address);
 
-        // 2 blocks: 10 (0xa), 11 (0xb). IDs 1 and 2 (counter starts at 1).
+        // 2 blocks: 10 and 11, both bloom-positive so both enter the logs batch.
         server
             .mock("POST", "/")
             .match_body(Matcher::Regex("eth_getBlockByNumber".to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!([
+                    test_utils::block_response_with_bloom(1, 10, &bloom),
+                    test_utils::block_response_with_bloom(2, 11, &bloom),
+                ])
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        // Logs batch: request IDs are 3 (block 10) and 4 (block 11). Return
+        // them SWAPPED (4 then 3) to test batch_execute reorders by id so
+        // block 10 → 1 log, block 11 → 2 logs.
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex("eth_getLogs".to_string()))
+            .expect(1)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                test_utils::logs_batch_response(&[
+                    (
+                        4,
+                        vec![
+                            test_utils::log_value(contract_address, 11, 0),
+                            test_utils::log_value(contract_address, 11, 1),
+                        ],
+                    ),
+                    (3, vec![test_utils::log_value(contract_address, 10, 0)]),
+                ])
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let client = Arc::new(test_utils::create_test_ethereum_client(&server.url()).await);
+        let mut iter = CatchupIter::new(client, 10, 12, contract_address);
+
+        let item1 = iter.next().await.unwrap();
+        let item2 = iter.next().await.unwrap();
+
+        if let CatchupItem::BatchBlock { block, logs } = item1 {
+            assert_eq!(block.header.number, 10, "first item should be block 10");
+            assert_eq!(logs.len(), 1, "block 10 should have 1 log");
+            assert_eq!(logs[0].address(), contract_address);
+        } else {
+            panic!("Expected BatchBlock for block 10, got {:?}", item1);
+        }
+
+        if let CatchupItem::BatchBlock { block, logs } = item2 {
+            assert_eq!(block.header.number, 11, "second item should be block 11");
+            assert_eq!(logs.len(), 2, "block 11 should have 2 logs");
+            assert_eq!(logs[0].address(), contract_address);
+        } else {
+            panic!("Expected BatchBlock for block 11, got {:?}", item2);
+        }
+    }
+
+    #[tokio::test]
+    async fn catchup_iter_bloom_negative_block_skips_logs_fetch() {
+        let mut server = mockito::Server::new_async().await;
+        let contract_address = Address::with_last_byte(0x42);
+
+        // 2 blocks with empty blooms → both bloom-negative. The eth_getLogs
+        // mock is set up to FAIL the test if hit.
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex("eth_getBlockByNumber".to_string()))
+            .expect(1)
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
@@ -895,57 +934,30 @@ mod tests {
             .create_async()
             .await;
 
-        // Receipts batch IDs are 3 and 4. Return them SWAPPED (4 then 3) to test
-        // that batch_execute reorders by ID so block 10 → 1 receipt, block 11 → 2 receipts.
         server
             .mock("POST", "/")
-            .match_body(Matcher::Regex("eth_getBlockReceipts".to_string()))
+            .match_body(Matcher::Regex("eth_getLogs".to_string()))
+            .expect(0)
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(
-                test_utils::receipts_batch_response(&[
-                    // ID 4 first (block 11 → 2 receipts)
-                    (
-                        4,
-                        Some(json!([
-                            test_utils::receipt_value("0x0000000000000000000000000000000000000000000000000000000000000002", 11),
-                            test_utils::receipt_value("0x0000000000000000000000000000000000000000000000000000000000000003", 11),
-                        ])),
-                    ),
-                    // ID 3 second (block 10 → 1 receipt)
-                    (
-                        3,
-                        Some(json!([
-                            test_utils::receipt_value("0x0000000000000000000000000000000000000000000000000000000000000001", 10),
-                        ])),
-                    ),
-                ])
-                .to_string(),
-            )
+            .with_body("[]")
             .create_async()
             .await;
 
         let client = Arc::new(test_utils::create_test_ethereum_client(&server.url()).await);
-        let mut iter = CatchupIter::new(client, 10, 12);
+        let mut iter = CatchupIter::new(client, 10, 12, contract_address);
 
-        let item1 = iter.next().await.unwrap();
-        let item2 = iter.next().await.unwrap();
-
-        // Block 10 → 1 receipt (ID 3 was second in response but maps to block 10)
-        if let CatchupItem::BatchBlock { block, receipts } = item1 {
-            assert_eq!(block.header.number, 10, "first item should be block 10");
-            assert_eq!(receipts.len(), 1, "block 10 should have 1 receipt");
-        } else {
-            panic!("Expected BatchBlock for block 10, got {:?}", item1);
+        for expected_number in [10u64, 11] {
+            let item = iter.next().await.expect("expected item");
+            match item {
+                CatchupItem::BatchBlock { block, logs } => {
+                    assert_eq!(block.header.number, expected_number);
+                    assert!(logs.is_empty(), "bloom-negative block must have no logs");
+                }
+                other => panic!("expected BatchBlock for {expected_number}, got {other:?}"),
+            }
         }
-
-        // Block 11 → 2 receipts (ID 4 was first in response but maps to block 11)
-        if let CatchupItem::BatchBlock { block, receipts } = item2 {
-            assert_eq!(block.header.number, 11, "second item should be block 11");
-            assert_eq!(receipts.len(), 2, "block 11 should have 2 receipts");
-        } else {
-            panic!("Expected BatchBlock for block 11, got {:?}", item2);
-        }
+        assert!(iter.next().await.is_none());
     }
 
     /// Build a `Block` with the given `logs_bloom`.

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -442,6 +442,8 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         // a failed extraction stays pending for retry, not flagged Failed.
         let mut observed_tx_ids = HashSet::new();
 
+        // TODO: submit as batch or parallelize the per-watcher `eth_getTransactionReceipt` calls once
+        // we have a way to track rate-limits and backoff for all requests (right now we just retry individually on failure)
         // Per-watcher `eth_getTransactionReceipt`
         for (tx_id, (sign_id, pending_tx)) in watchers {
             tracing::info!(?tx_id, ?sign_id, "querying receipt for bidirectional tx");

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -229,9 +229,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         Ok(())
     }
 
-    /// Parse already-filtered contract logs out of a block and assemble the
-    /// [`BlockAndRequests`] (sign requests, respond logs, execution
-    /// confirmations).
+    /// Parse the block and its relevant logs into a `BlockAndRequests` payload.
     async fn parse_block(
         &self,
         block: &Block,
@@ -965,7 +963,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn catchup_batch_receipts_single_batch_post() {
+    async fn catchup_batch_logs_skipped_on_empty_bloom() {
         let mut server = Server::new_async().await;
 
         // 32-block catchup: blocks have empty blooms so the batch issues exactly

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -1,11 +1,13 @@
 use crate::abi::ChainSignatures;
-use crate::client::{BlockNumber, CatchupItem, CatchupIter, EthereumClient, MaybeBlock};
+use crate::client::{
+    block_may_contain_logs, BlockNumber, CatchupItem, CatchupIter, EthereumClient, MaybeBlock,
+};
 use crate::event_parsing::{emit_respond_events, is_contract_call, parse_filtered_logs};
 use crate::EthConfig;
 use alloy::consensus::Transaction;
 use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::Address;
-use alloy::rpc::types::{Block, BlockId, Log, TransactionReceipt};
+use alloy::rpc::types::{Block, BlockId, Log};
 use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use async_trait::async_trait;
@@ -190,6 +192,17 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         }
     }
 
+    /// Fetch the contract-relevant logs for a single `block`, gated by its
+    /// bloom filter.
+    async fn fetch_block_logs(&self, block: &Block) -> anyhow::Result<Vec<Log>> {
+        if !block_may_contain_logs(block, self.contract_address) {
+            return Ok(Vec::new());
+        }
+        self.client
+            .get_logs(self.contract_address, block.header.number.into())
+            .await
+    }
+
     /// Process the block and emit relevant ChainEvents from the block.
     ///
     /// `is_finalized` indicates the block was already finalized at the time
@@ -204,26 +217,13 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     async fn process_block(
         &self,
         block: &Block,
-        receipts: &[TransactionReceipt],
+        relevant_logs: &[Log],
         is_finalized: bool,
     ) -> anyhow::Result<()> {
         // Emit telemetry for the indexed block number
         self.telemetry.block_indexed(block.header.number);
 
-        // Temporary
-        let relevant_logs: Vec<Log> = receipts
-            .iter()
-            .flat_map(|receipt| {
-                receipt
-                    .inner
-                    .logs()
-                    .iter()
-                    .filter(|log| log.address() == self.contract_address)
-                    .cloned()
-            })
-            .collect();
-
-        let processed = self.parse_block(block, &relevant_logs).await?;
+        let processed = self.parse_block(block, relevant_logs).await?;
         self.emit_processed_block(processed, is_finalized).await?;
 
         Ok(())
@@ -729,7 +729,12 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
             .client
             .clamp_oldest_supported(current_block, anchor_height);
 
-        let catchup_iter = CatchupIter::new(self.client.clone(), catchup_start, anchor_height);
+        let catchup_iter = CatchupIter::new(
+            self.client.clone(),
+            catchup_start,
+            anchor_height,
+            self.contract_address,
+        );
 
         // Sample the finalized head once at catchup start, so that blocks at or below it can skip the per-block re-fetch + reorg hash check.
         if let Some(finalized_block) = self
@@ -765,10 +770,10 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
         // it, since it `block` is of reference type. Maybe the language will let
         // us elide this in the future, but for now we need to introduce a new var.
         let _block;
-        let _receipts;
+        let _logs;
 
-        let (block, receipts) = match item {
-            CatchupItem::BatchBlock { block, receipts } => (block, receipts.as_slice()),
+        let (block, logs) = match item {
+            CatchupItem::BatchBlock { block, logs } => (block, logs.as_slice()),
             CatchupItem::Missing(block_id) => {
                 tracing::warn!(
                     ?block_id,
@@ -778,33 +783,24 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
                 #[cfg(feature = "bench")]
                 let start = std::time::Instant::now();
 
-                // Refetch the block and receipts
-                let (block_res, receipts_res) = tokio::join!(
-                    self.client.get_block(*block_id),
-                    self.client.get_block_receipts(*block_id)
-                );
-
-                let Some(block) = block_res else {
+                // Refetch the block, then bloom-gate a single-block `eth_getLogs`.
+                let Some(block) = self.client.get_block(*block_id).await else {
                     anyhow::bail!(
                         "ethereum catchup block {block_id:?} is still unavailable after refetch"
                     )
                 };
-                let r = receipts_res?.unwrap_or_default();
+                let l = self.fetch_block_logs(&block).await?;
 
                 #[cfg(feature = "bench")]
                 crate::bench::add_refetch_time(start.elapsed());
 
                 _block = block;
-                _receipts = r;
-                (&_block, _receipts.as_slice())
+                _logs = l;
+                (&_block, _logs.as_slice())
             }
             CatchupItem::LiveBlock(block) => {
-                _receipts = self
-                    .client
-                    .get_block_receipts(block.header.number.into())
-                    .await?
-                    .unwrap_or_default();
-                (block, _receipts.as_slice())
+                _logs = self.fetch_block_logs(block).await?;
+                (block, _logs.as_slice())
             }
         };
 
@@ -819,7 +815,7 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
         // Determine if the block is finalized based on the sampled finalized head at catchup start
         let f0 = self.catchup_finalized_head.load(Ordering::Relaxed);
         let is_finalized = block.header.number <= f0;
-        self.process_block(block, receipts, is_finalized).await?;
+        self.process_block(block, logs, is_finalized).await?;
 
         #[cfg(feature = "bench")]
         {
@@ -834,38 +830,28 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
 
     async fn process(&mut self, item: &Self::Block) -> anyhow::Result<()> {
         let _block;
-        let _receipts;
+        let _logs;
 
-        let (block, receipts) = match item {
+        let (block, logs) = match item {
             CatchupItem::LiveBlock(block) => {
-                _receipts = self
-                    .client
-                    .get_block_receipts(block.header.number.into())
-                    .await?
-                    .unwrap_or_default();
-                (block, _receipts.as_slice())
+                _logs = self.fetch_block_logs(block).await?;
+                (block, _logs.as_slice())
             }
-            CatchupItem::BatchBlock { block, receipts } => (block, receipts.as_slice()),
+            CatchupItem::BatchBlock { block, logs } => (block, logs.as_slice()),
             CatchupItem::Missing(block_id) => {
-                // Refetch the block and receipts
-                let (block_res, receipts_res) = tokio::join!(
-                    self.client.get_block(*block_id),
-                    self.client.get_block_receipts(*block_id)
-                );
-
-                let Some(b) = block_res else {
+                let Some(b) = self.client.get_block(*block_id).await else {
                     anyhow::bail!(
                         "ethereum live stream yielded missing block {block_id:?} and refetch failed"
                     )
                 };
-                _receipts = receipts_res?.unwrap_or_default();
+                _logs = self.fetch_block_logs(&b).await?;
                 _block = b;
-                (&_block, _receipts.as_slice())
+                (&_block, _logs.as_slice())
             }
         };
 
         // Live blocks are not yet finalized, so keep the reorg hash check
-        self.process_block(block, receipts, false).await?;
+        self.process_block(block, logs, false).await?;
         Ok(())
     }
 
@@ -953,13 +939,11 @@ mod tests {
 
         server
             .mock("POST", "/")
-            .match_body(Matcher::PartialJson(json!({
-                "method": "eth_getBlockReceipts",
-                "params": ["0xc"]
-            })))
+            .match_body(Matcher::Regex("eth_getLogs".to_string()))
+            .expect(0)
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(test_utils::missing_block_response(2).to_string())
+            .with_body("[]")
             .create_async()
             .await;
 
@@ -984,7 +968,8 @@ mod tests {
     async fn catchup_batch_receipts_single_batch_post() {
         let mut server = Server::new_async().await;
 
-        // 32-block catchup: assert exactly 1 eth_getBlockReceipts(batch)
+        // 32-block catchup: blocks have empty blooms so the batch issues exactly
+        // 1 eth_getBlockByNumber(batch) and ZERO eth_getLogs (bloom gate skips).
         let blocks: Vec<_> = (1..=32)
             .map(|n| test_utils::block_response(n as u64, n as u64))
             .collect();
@@ -998,15 +983,13 @@ mod tests {
             .create_async()
             .await;
 
-        // client.get_block_receipts_batch is called next, taking AtomicU64 IDs 33..=64
-        let receipts_resp = (33..=64).map(|n| (n, Some(json!([])))).collect::<Vec<_>>();
-        let receipts_mock = server
+        let logs_mock = server
             .mock("POST", "/")
-            .match_body(Matcher::Regex("eth_getBlockReceipts".to_string()))
+            .match_body(Matcher::Regex("eth_getLogs".to_string()))
+            .expect(0)
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(test_utils::receipts_batch_response(&receipts_resp).to_string())
-            .expect(1)
+            .with_body("[]")
             .create_async()
             .await;
 
@@ -1016,7 +999,12 @@ mod tests {
         // Ensure blocks are considered finalized to avoid reorg-check refetches in process_catchup
         indexer.catchup_finalized_head.store(100, Ordering::Relaxed);
 
-        let mut iter = crate::client::CatchupIter::new(indexer.client.clone(), 1, 33);
+        let mut iter = crate::client::CatchupIter::new(
+            indexer.client.clone(),
+            1,
+            33,
+            indexer.contract_address,
+        );
         for n in 1..=32 {
             let item = iter.next().await.expect("expected item");
             indexer
@@ -1031,7 +1019,7 @@ mod tests {
         }
 
         blocks_mock.assert_async().await;
-        receipts_mock.assert_async().await;
+        logs_mock.assert_async().await;
     }
 
     #[tokio::test]
@@ -1055,19 +1043,13 @@ mod tests {
             .create_async()
             .await;
 
-        let receipts_mock = server
+        let logs_mock = server
             .mock("POST", "/")
-            .match_body(Matcher::Regex("eth_getBlockReceipts".to_string()))
+            .match_body(Matcher::Regex("eth_getLogs".to_string()))
+            .expect(0)
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(
-                json!([
-                    { "jsonrpc": "2.0", "id": 4, "result": [] }, // block 11
-                    { "jsonrpc": "2.0", "id": 3, "result": [] } // block 10
-                ])
-                .to_string(),
-            )
-            .expect(1)
+            .with_body("[]")
             .create_async()
             .await;
 
@@ -1076,7 +1058,12 @@ mod tests {
             .await;
         indexer.catchup_finalized_head.store(100, Ordering::Relaxed);
 
-        let mut iter = crate::client::CatchupIter::new(indexer.client.clone(), 10, 12);
+        let mut iter = crate::client::CatchupIter::new(
+            indexer.client.clone(),
+            10,
+            12,
+            indexer.contract_address,
+        );
 
         let item1 = iter.next().await.unwrap();
         indexer.process_catchup(&item1).await.unwrap();
@@ -1093,11 +1080,11 @@ mod tests {
         ));
 
         blocks_mock.assert_async().await;
-        receipts_mock.assert_async().await;
+        logs_mock.assert_async().await;
     }
 
     #[tokio::test]
-    async fn catchup_missing_block_falls_back_to_single_receipt_fetch() {
+    async fn catchup_missing_block_falls_back_to_single_logs_fetch() {
         let mut server = Server::new_async().await;
         let block_number = 12;
 
@@ -1116,23 +1103,13 @@ mod tests {
             .create_async()
             .await;
 
-        let receipts_mock = server
+        let logs_mock = server
             .mock("POST", "/")
-            .match_body(Matcher::PartialJson(json!({
-                "method": "eth_getBlockReceipts",
-                "params": [format!("0x{block_number:x}")]
-            })))
+            .match_body(Matcher::Regex("eth_getLogs".to_string()))
+            .expect(0)
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(
-                json!({
-                    "jsonrpc": "2.0",
-                    "id": 2,
-                    "result": []
-                })
-                .to_string(),
-            )
-            .expect(1)
+            .with_body("[]")
             .create_async()
             .await;
 
@@ -1155,7 +1132,7 @@ mod tests {
         ));
 
         block_mock.assert_async().await;
-        receipts_mock.assert_async().await;
+        logs_mock.assert_async().await;
     }
 
     #[tokio::test]
@@ -1174,13 +1151,13 @@ mod tests {
             .create_async()
             .await;
 
-        let receipts_mock = server
+        let logs_mock = server
             .mock("POST", "/")
-            .match_body(Matcher::Regex("eth_getBlockReceipts".to_string()))
+            .match_body(Matcher::Regex("eth_getLogs".to_string()))
+            .expect(0)
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(test_utils::receipts_batch_response(&[(2, None)]).to_string())
-            .expect(1)
+            .with_body("[]")
             .create_async()
             .await;
 
@@ -1190,7 +1167,12 @@ mod tests {
         // Ensure block is considered finalized to avoid the reorg-check refetch
         indexer.catchup_finalized_head.store(100, Ordering::Relaxed);
 
-        let mut iter = crate::client::CatchupIter::new(indexer.client.clone(), 42, 43);
+        let mut iter = crate::client::CatchupIter::new(
+            indexer.client.clone(),
+            42,
+            43,
+            indexer.contract_address,
+        );
         let item = iter.next().await.unwrap();
 
         indexer
@@ -1204,11 +1186,11 @@ mod tests {
         ));
 
         blocks_mock.assert_async().await;
-        receipts_mock.assert_async().await;
+        logs_mock.assert_async().await;
     }
 
     #[tokio::test]
-    async fn live_process_fetches_receipts_singly() {
+    async fn live_process_fetches_logs_singly() {
         let mut server = Server::new_async().await;
         let block_number = 42;
         let item = test_utils::live_block(block_number);
@@ -1216,24 +1198,15 @@ mod tests {
             unreachable!()
         };
 
-        // Live path: assert exactly 1 single eth_getBlockReceipts
-        let receipts_mock = server
+        // Live path with an empty-bloom block: the bloom gate skips the
+        // eth_getLogs fetch entirely.
+        let logs_mock = server
             .mock("POST", "/")
-            .match_body(Matcher::PartialJson(json!({
-                "method": "eth_getBlockReceipts",
-                "params": [format!("0x{block_number:x}")]
-            })))
+            .match_body(Matcher::Regex("eth_getLogs".to_string()))
+            .expect(0)
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(
-                json!({
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "result": []
-                })
-                .to_string(),
-            )
-            .expect(1)
+            .with_body("[]")
             .create_async()
             .await;
 
@@ -1262,7 +1235,7 @@ mod tests {
             Some(ChainEvent::Block(n)) if n == block_number
         ));
 
-        receipts_mock.assert_async().await;
+        logs_mock.assert_async().await;
         reorg_mock.assert_async().await;
     }
 
@@ -1388,23 +1361,13 @@ mod tests {
         };
         let block_number = block.header.number;
 
-        let receipts_mock = server
+        let logs_mock = server
             .mock("POST", "/")
-            .match_body(Matcher::PartialJson(json!({
-                "method": "eth_getBlockReceipts",
-                "params": [format!("0x{block_number:x}")]
-            })))
+            .match_body(Matcher::Regex("eth_getLogs".to_string()))
+            .expect(0)
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(
-                json!({
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "result": []
-                })
-                .to_string(),
-            )
-            .expect(1)
+            .with_body("[]")
             .create_async()
             .await;
 
@@ -1437,7 +1400,7 @@ mod tests {
             Some(ChainEvent::Block(n)) if n == block_number
         ));
 
-        receipts_mock.assert_async().await;
+        logs_mock.assert_async().await;
         reorg_mock.assert_async().await;
     }
 
@@ -1451,23 +1414,13 @@ mod tests {
         };
         let block_number = block.header.number;
 
-        let receipts_mock = server
+        let logs_mock = server
             .mock("POST", "/")
-            .match_body(Matcher::PartialJson(json!({
-                "method": "eth_getBlockReceipts",
-                "params": [format!("0x{block_number:x}")]
-            })))
+            .match_body(Matcher::Regex("eth_getLogs".to_string()))
+            .expect(0)
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(
-                json!({
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "result": []
-                })
-                .to_string(),
-            )
-            .expect(1)
+            .with_body("[]")
             .create_async()
             .await;
 
@@ -1501,7 +1454,7 @@ mod tests {
             "no events should be emitted for a reorged live block"
         );
 
-        receipts_mock.assert_async().await;
+        logs_mock.assert_async().await;
         reorg_mock.assert_async().await;
     }
 

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -4,7 +4,7 @@ use crate::event_parsing::{emit_respond_events, is_contract_call, parse_filtered
 use crate::EthConfig;
 use alloy::consensus::Transaction;
 use alloy::eips::BlockNumberOrTag;
-use alloy::primitives::{Address, B256};
+use alloy::primitives::Address;
 use alloy::rpc::types::{Block, BlockId, Log, TransactionReceipt};
 use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
@@ -16,7 +16,7 @@ use mpc_primitives::{
     BidirectionalTx, BidirectionalTxId, Chain, ChainEvent, ExecutionOutcome, IndexedSignRequest,
     SignId,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -209,16 +209,33 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     ) -> anyhow::Result<()> {
         // Emit telemetry for the indexed block number
         self.telemetry.block_indexed(block.header.number);
-        let processed = self.parse_block(block, receipts).await?;
+
+        // Temporary
+        let relevant_logs: Vec<Log> = receipts
+            .iter()
+            .flat_map(|receipt| {
+                receipt
+                    .inner
+                    .logs()
+                    .iter()
+                    .filter(|log| log.address() == self.contract_address)
+                    .cloned()
+            })
+            .collect();
+
+        let processed = self.parse_block(block, &relevant_logs).await?;
         self.emit_processed_block(processed, is_finalized).await?;
 
         Ok(())
     }
 
+    /// Parse already-filtered contract logs out of a block and assemble the
+    /// [`BlockAndRequests`] (sign requests, respond logs, execution
+    /// confirmations).
     async fn parse_block(
         &self,
         block: &Block,
-        block_receipts: &[TransactionReceipt],
+        relevant_logs: &[Log],
     ) -> anyhow::Result<BlockAndRequests> {
         let block_number = block.header.number;
         let block_hash = block.header.hash;
@@ -231,20 +248,8 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
 
         let mut sign_requests = Vec::new();
 
-        let relevant_logs: Vec<Log> = block_receipts
-            .iter()
-            .flat_map(|receipt| {
-                receipt
-                    .inner
-                    .logs()
-                    .iter()
-                    .filter(|log| log.address() == self.contract_address)
-                    .cloned()
-            })
-            .collect();
-
         let (respond_logs, potential_request_logs): (Vec<Log>, Vec<Log>) =
-            relevant_logs.into_iter().partition(|log| {
+            relevant_logs.iter().cloned().partition(|log| {
                 log.topic0().is_some_and(|topic| {
                     *topic == ChainSignatures::SignatureResponded::SIGNATURE_HASH
                 })
@@ -264,9 +269,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         }
 
         // Collect execution confirmations (if any) and emit ExecutionConfirmed events
-        let exec_events = self
-            .collect_execution_confirmations(block_number, block_receipts)
-            .await?;
+        let exec_events = self.collect_execution_confirmations(block_number).await?;
 
         // Always forward the processed block to the "finalization" stage so it can emit
         // `ChainEvent::Block` even when there are no relevant contract logs.
@@ -379,11 +382,17 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         pending_tx: &BidirectionalTx,
         current_block_number: u64,
     ) -> anyhow::Result<BackfillOutcome> {
-        let Some(tx) = self.client.get_transaction_by_hash(tx_id.0.into()).await? else {
+        // Fetch this single watcher tx's receipt
+        let Some(receipt) = self.client.get_transaction_receipt(tx_id.0.into()).await? else {
             return Ok(BackfillOutcome::NotObserved);
         };
 
-        let Some(mined_block_number) = tx.block_number else {
+        let Some(mined_block_number) = receipt.block_number else {
+            tracing::debug!(
+                ?tx_id,
+                ?sign_id,
+                "late watcher backfill: transaction receipt has no block number"
+            );
             return Ok(BackfillOutcome::NotObserved);
         };
 
@@ -398,33 +407,6 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
 
             return Ok(BackfillOutcome::NotObserved);
         }
-
-        let Some(block_receipts) = self
-            .client
-            .get_block_receipts(mined_block_number.into())
-            .await?
-        else {
-            tracing::debug!(
-                ?tx_id,
-                ?sign_id,
-                mined_block_number,
-                "late watcher backfill found mined transaction without block receipts"
-            );
-            return Ok(BackfillOutcome::NotObserved);
-        };
-
-        let Some(receipt) = block_receipts
-            .into_iter()
-            .find(|receipt| receipt.transaction_hash == tx_id.0)
-        else {
-            tracing::warn!(
-                ?tx_id,
-                ?sign_id,
-                mined_block_number,
-                "late watcher backfill could not find transaction receipt in mined block"
-            );
-            return Ok(BackfillOutcome::NotObserved);
-        };
 
         tracing::info!(
             ?tx_id,
@@ -443,13 +425,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     async fn collect_execution_confirmations(
         &self,
         block_number: u64,
-        block_receipts: &[TransactionReceipt],
     ) -> anyhow::Result<Vec<ChainEvent>> {
-        let block_receipts: HashMap<B256, TransactionReceipt> = block_receipts
-            .iter()
-            .map(|receipt| (receipt.transaction_hash, receipt.clone()))
-            .collect::<HashMap<_, _>>();
-
         let mut events = Vec::new();
         let mut resolved_tx_ids = HashSet::new();
 
@@ -468,22 +444,9 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         // a failed extraction stays pending for retry, not flagged Failed.
         let mut observed_tx_ids = HashSet::new();
 
+        // Per-watcher `eth_getTransactionReceipt`
         for (tx_id, (sign_id, pending_tx)) in watchers {
             tracing::info!(?tx_id, ?sign_id, "querying receipt for bidirectional tx");
-            if let Some(receipt) = block_receipts.get(&pending_tx.id.0) {
-                observed_tx_ids.insert(tx_id);
-                if let Some(event) = self
-                    .execution_confirmed_event(tx_id, sign_id, &pending_tx, block_number, receipt)
-                    .await
-                {
-                    events.push(event);
-                    resolved_tx_ids.insert(tx_id);
-                }
-                // `None` means extraction failed — leave pending for retry.
-                // `observed_tx_ids` above exempts it from the staleness check.
-                continue;
-            }
-
             match self
                 .backfill_execution_confirmation(tx_id, sign_id, &pending_tx, block_number)
                 .await?
@@ -494,6 +457,8 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
                         events.push(event);
                         resolved_tx_ids.insert(tx_id);
                     }
+                    // `None` means extraction failed — leave pending for retry.
+                    // `observed_tx_ids` above exempts it from the staleness check.
                 }
                 BackfillOutcome::NotObserved => {}
             }
@@ -1582,29 +1547,6 @@ mod tests {
         let from_address = address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266");
         let to_address = address!("5fbdb2315678afecb367f032d93f642f64180aa3");
 
-        let tx_response = json!({
-            "hash": format!("{tx_hash:#x}"),
-            "nonce": "0x1",
-            "blockHash": format!("{block_hash:#x}"),
-            "blockNumber": "0x2",
-            "transactionIndex": "0x0",
-            "from": format!("{from_address:#x}"),
-            "to": format!("{to_address:#x}"),
-            "value": "0x0",
-            "gasPrice": "0x3a29f0f8",
-            "gas": "0x5208",
-            "maxFeePerGas": "0xba43b7400",
-            "maxPriorityFeePerGas": "0x5f5e100",
-            "input": "0x",
-            "r": "0xd309309a59a49021281cb6bb41d164c96eab4e50f0c1bd24c03ca336e7bc2bb7",
-            "s": "0x28a7f089143d0a1355ebeb2a1b9f0e5ad9eca4303021c1400d61bc23c9ac5319",
-            "v": "0x0",
-            "yParity": "0x0",
-            "chainId": "0x7a69",
-            "accessList": [],
-            "type": "0x2"
-        });
-
         let receipt_response = json!({
             "transactionHash": format!("{tx_hash:#x}"),
             "blockHash": format!("{block_hash:#x}"),
@@ -1625,7 +1567,7 @@ mod tests {
         server
             .mock("POST", "/")
             .match_body(Matcher::PartialJson(json!({
-                "method": "eth_getTransactionByHash",
+                "method": "eth_getTransactionReceipt",
                 "params": [format!("{tx_hash:#x}")]
             })))
             .with_status(200)
@@ -1634,26 +1576,7 @@ mod tests {
                 json!({
                     "jsonrpc": "2.0",
                     "id": 1,
-                    "result": tx_response,
-                })
-                .to_string(),
-            )
-            .create_async()
-            .await;
-
-        server
-            .mock("POST", "/")
-            .match_body(Matcher::PartialJson(json!({
-                "method": "eth_getBlockReceipts",
-                "params": ["0x2"]
-            })))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                json!({
-                    "jsonrpc": "2.0",
-                    "id": 2,
-                    "result": [receipt_response],
+                    "result": receipt_response,
                 })
                 .to_string(),
             )
@@ -1689,7 +1612,7 @@ mod tests {
         let indexer = builder.build().await;
 
         let events = indexer
-            .collect_execution_confirmations(5, &[])
+            .collect_execution_confirmations(5)
             .await
             .expect("late watcher backfill should succeed");
 

--- a/chain-signatures/chain-ethereum/src/indexer_eth_direct_rpc.rs
+++ b/chain-signatures/chain-ethereum/src/indexer_eth_direct_rpc.rs
@@ -102,16 +102,6 @@ impl RpcEthereumClient {
             .collect())
     }
 
-    pub async fn get_block_receipts(
-        &self,
-        block_id: BlockId,
-    ) -> anyhow::Result<Option<Vec<TransactionReceipt>>> {
-        #[cfg(feature = "bench")]
-        bench::rpc_inc("eth_getBlockReceipts");
-
-        self.block_receipts(block_id).await
-    }
-
     /// Fetch a single transaction's receipt via `eth_getTransactionReceipt`.
     ///
     /// Returns `None` if the tx is unknown or not yet mined (pending).
@@ -123,40 +113,6 @@ impl RpcEthereumClient {
         bench::rpc_inc("eth_getTransactionReceipt");
 
         self.transaction_receipt(tx_hash).await
-    }
-
-    /// Fetch receipts for multiple blocks in batch.
-    /// Order-preserving: result `i` corresponds to `block_ids[i]`, regardless
-    /// of response ordering (uses response `id` mapping, mirroring `get_blocks`).
-    /// A `null` result maps to `None` (block has no transactions).
-    pub async fn get_block_receipts_batch(
-        &self,
-        block_ids: &[BlockId],
-    ) -> anyhow::Result<Vec<Option<Vec<TransactionReceipt>>>> {
-        if block_ids.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        #[cfg(feature = "bench")]
-        bench::rpc_inc_n("eth_getBlockReceipts(batch)", block_ids.len() as u64);
-
-        let requests = block_ids
-            .iter()
-            .map(|block_id| {
-                let request_id = self.next_id();
-                (
-                    request_id,
-                    json!({
-                        "jsonrpc": "2.0",
-                        "id": request_id,
-                        "method": "eth_getBlockReceipts",
-                        "params": [to_hex_block_id(*block_id)],
-                    }),
-                )
-            })
-            .collect::<Vec<_>>();
-
-        self.batch_execute(requests).await
     }
 
     /// Fetch all logs emitted by `address` within `block_id` via a single
@@ -378,17 +334,6 @@ impl RpcEthereumClient {
                 .await
             }
         }
-    }
-
-    async fn block_receipts(
-        &self,
-        block_id: BlockId,
-    ) -> anyhow::Result<Option<Vec<TransactionReceipt>>> {
-        self.rpc_call(
-            "eth_getBlockReceipts",
-            vec![json!(to_hex_block_id(block_id))],
-        )
-        .await
     }
 
     /// Issue `eth_getTransactionReceipt` and deserialize the result as an

--- a/chain-signatures/chain-ethereum/src/indexer_eth_direct_rpc.rs
+++ b/chain-signatures/chain-ethereum/src/indexer_eth_direct_rpc.rs
@@ -112,6 +112,19 @@ impl RpcEthereumClient {
         self.block_receipts(block_id).await
     }
 
+    /// Fetch a single transaction's receipt via `eth_getTransactionReceipt`.
+    ///
+    /// Returns `None` if the tx is unknown or not yet mined (pending).
+    pub async fn get_transaction_receipt(
+        &self,
+        tx_hash: B256,
+    ) -> anyhow::Result<Option<TransactionReceipt>> {
+        #[cfg(feature = "bench")]
+        bench::rpc_inc("eth_getTransactionReceipt");
+
+        self.transaction_receipt(tx_hash).await
+    }
+
     /// Fetch receipts for multiple blocks in batch.
     /// Order-preserving: result `i` corresponds to `block_ids[i]`, regardless
     /// of response ordering (uses response `id` mapping, mirroring `get_blocks`).
@@ -374,6 +387,19 @@ impl RpcEthereumClient {
         self.rpc_call(
             "eth_getBlockReceipts",
             vec![json!(to_hex_block_id(block_id))],
+        )
+        .await
+    }
+
+    /// Issue `eth_getTransactionReceipt` and deserialize the result as an
+    /// optional `TransactionReceipt`. `null` (pending / unknown tx) → `None`.
+    async fn transaction_receipt(
+        &self,
+        tx_hash: B256,
+    ) -> anyhow::Result<Option<TransactionReceipt>> {
+        self.rpc_call(
+            "eth_getTransactionReceipt",
+            vec![json!(format!("{:#x}", tx_hash))],
         )
         .await
     }
@@ -743,6 +769,63 @@ mod tests {
         // block 12 → id 3 → 1 log
         assert_eq!(results[2].len(), 1);
         assert_eq!(results[2][0].address(), addr);
+    }
+
+    #[tokio::test]
+    async fn get_transaction_receipt_returns_receipt_for_mined_tx() {
+        let mut server = Server::new_async().await;
+        let client = RpcEthereumClient::new(&server.url());
+        let tx_hash = B256::with_last_byte(0x42);
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex(r#"eth_getTransactionReceipt"#.to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": crate::test_utils::receipt_value(
+                        &format!("{:#x}", tx_hash),
+                        7,
+                    ),
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let receipt = client
+            .get_transaction_receipt(tx_hash)
+            .await
+            .expect("get_transaction_receipt should succeed");
+
+        let receipt = receipt.expect("mined tx should yield Some(receipt)");
+        assert_eq!(receipt.transaction_hash, tx_hash);
+    }
+
+    #[tokio::test]
+    async fn get_transaction_receipt_returns_none_on_null_result() {
+        let mut server = Server::new_async().await;
+        let client = RpcEthereumClient::new(&server.url());
+        let tx_hash = B256::with_last_byte(0x07);
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex(r#"eth_getTransactionReceipt"#.to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": null }).to_string())
+            .create_async()
+            .await;
+
+        let receipt = client
+            .get_transaction_receipt(tx_hash)
+            .await
+            .expect("get_transaction_receipt should succeed");
+
+        assert!(receipt.is_none(), "null result should map to None");
     }
 
     #[test]

--- a/chain-signatures/chain-ethereum/src/indexer_eth_direct_rpc.rs
+++ b/chain-signatures/chain-ethereum/src/indexer_eth_direct_rpc.rs
@@ -1,7 +1,7 @@
 use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::hex::{self, ToHexExt};
 use alloy::primitives::{Address, Bytes, B256};
-use alloy::rpc::types::{Block, BlockId, Transaction, TransactionReceipt};
+use alloy::rpc::types::{Block, BlockId, Log, Transaction, TransactionReceipt};
 use serde::de::DeserializeOwned;
 use serde_json::json;
 
@@ -144,6 +144,60 @@ impl RpcEthereumClient {
             .collect::<Vec<_>>();
 
         self.batch_execute(requests).await
+    }
+
+    /// Fetch all logs emitted by `address` within `block_id` via a single
+    /// `eth_getLogs` call, server-filtered to that address.
+    ///
+    /// A block with no logs at `address` returns an empty `Vec`.
+    pub async fn get_logs(&self, address: Address, block_id: BlockId) -> anyhow::Result<Vec<Log>> {
+        #[cfg(feature = "bench")]
+        bench::rpc_inc("eth_getLogs");
+
+        self.logs(address, block_id).await
+    }
+
+    /// Fetch `eth_getLogs` for multiple blocks in a single JSON-RPC batch POST,
+    /// returning one `Vec<Log>` per input `block_id`, in input order.
+    ///
+    /// All requests share the same `address`. Each entry corresponds to the
+    /// request at the same index. A server-returned `null` result (or a
+    /// missing response) maps to an empty `Vec` (no logs from `address` in
+    /// that block).
+    pub async fn get_logs_batch(
+        &self,
+        address: Address,
+        block_ids: &[BlockId],
+    ) -> anyhow::Result<Vec<Vec<Log>>> {
+        if block_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        #[cfg(feature = "bench")]
+        bench::rpc_inc_n("eth_getLogs(batch)", block_ids.len() as u64);
+
+        let requests = block_ids
+            .iter()
+            .map(|block_id| {
+                let request_id = self.next_id();
+                (
+                    request_id,
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "method": "eth_getLogs",
+                        "params": [logs_filter_object(address, *block_id)],
+                    }),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let results: Vec<Option<Vec<Log>>> = self.batch_execute(requests).await?;
+
+        Ok(results
+            .into_iter()
+            .map(|opt| opt.unwrap_or_default())
+            .collect())
     }
 
     pub async fn get_nonce(&self, address: Address, block_id: BlockId) -> anyhow::Result<u64> {
@@ -324,6 +378,13 @@ impl RpcEthereumClient {
         .await
     }
 
+    /// Issue a single-block `eth_getLogs` address filter via the raw RPC
+    /// path and deserialize the result array as `Vec<Log>`.
+    async fn logs(&self, address: Address, block_id: BlockId) -> anyhow::Result<Vec<Log>> {
+        self.rpc_call::<Vec<Log>>("eth_getLogs", vec![logs_filter_object(address, block_id)])
+            .await
+    }
+
     async fn transaction_by_hash(&self, tx_hash: B256) -> anyhow::Result<Option<Transaction>> {
         self.rpc_call(
             "eth_getTransactionByHash",
@@ -434,6 +495,27 @@ fn hex_to_u64(value: &str) -> anyhow::Result<u64> {
         .map_err(|err| anyhow::anyhow!("failed to parse hex value '{value}': {err}"))
 }
 
+/// Build the `eth_getLogs` filter object for a single `address` scoped to one
+/// block.
+///
+/// - `BlockId::Hash` → `{ "blockHash": "0x..", "address": "0x.." }` (pins to
+///   the exact block, immune to reorgs).
+/// - `BlockId::Number(tag)` → `{ "fromBlock": tag, "toBlock": tag,
+///   "address": "0x.." }` (request by number/tag).
+fn logs_filter_object(address: Address, block_id: BlockId) -> serde_json::Value {
+    match block_id {
+        BlockId::Hash(hash) => json!({
+            "blockHash": format!("{:#x}", hash.block_hash),
+            "address": format_address(address),
+        }),
+        BlockId::Number(_) => json!({
+            "fromBlock": to_hex_block_id(block_id),
+            "toBlock": to_hex_block_id(block_id),
+            "address": format_address(address),
+        }),
+    }
+}
+
 fn to_hex_block_id(block_id: BlockId) -> String {
     match block_id {
         BlockId::Number(BlockNumberOrTag::Number(number)) => to_hex_u64(number),
@@ -519,6 +601,148 @@ mod tests {
             &blocks[1],
             MaybeBlock::Missing(BlockId::Number(BlockNumberOrTag::Number(8)))
         ));
+    }
+
+    /// Helper: a fully-populated `eth_getLogs` log entry
+    fn log_value(addr: Address, block_number: u64, log_index: u64) -> serde_json::Value {
+        let block_hash = format!("0x{:064x}", block_number);
+        let tx_hash = format!("0x{:064x}", block_number);
+        json!({
+            "logIndex": format!("0x{log_index:x}"),
+            "blockNumber": format!("0x{block_number:x}"),
+            "blockHash": block_hash,
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x0",
+            "address": format!("{:#x}", addr),
+            "topics": [],
+            "data": "0x",
+        })
+    }
+
+    fn filter_response(id: u64, logs: Vec<serde_json::Value>) -> serde_json::Value {
+        json!({ "jsonrpc": "2.0", "id": id, "result": logs })
+    }
+
+    #[tokio::test]
+    async fn get_logs_issues_address_filtered_eth_getlogs_for_number() {
+        let mut server = Server::new_async().await;
+        let client = RpcEthereumClient::new(&server.url());
+        let addr = Address::with_last_byte(0x42);
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex(r#"eth_getLogs"#.to_string()))
+            .match_body(Matcher::Regex(
+                // "0x42" appears at the end of a checksummed address
+                r#"42"#.to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(filter_response(1, vec![log_value(addr, 7, 0)]).to_string())
+            .create_async()
+            .await;
+
+        let logs = client
+            .get_logs(addr, BlockId::Number(BlockNumberOrTag::Number(7)))
+            .await
+            .expect("get_logs should succeed");
+
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].address(), addr);
+    }
+
+    #[tokio::test]
+    async fn get_logs_empty_array_maps_to_empty_vec() {
+        let mut server = Server::new_async().await;
+        let client = RpcEthereumClient::new(&server.url());
+        let addr = Address::with_last_byte(0x07);
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex(r#"eth_getLogs"#.to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(filter_response(1, vec![]).to_string())
+            .create_async()
+            .await;
+
+        let logs = client
+            .get_logs(addr, BlockId::Number(BlockNumberOrTag::Number(11215038)))
+            .await
+            .expect("get_logs should succeed");
+
+        assert!(logs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_logs_uses_block_hash_filter_for_hash_block_id() {
+        let mut server = Server::new_async().await;
+        let client = RpcEthereumClient::new(&server.url());
+        let addr = Address::with_last_byte(0x99);
+        let block_hash = B256::with_last_byte(0xab);
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex(r#"eth_getLogs"#.to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                filter_response(1, vec![log_value(addr, 0xab, 0), log_value(addr, 0xab, 1)])
+                    .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let logs = client
+            .get_logs(addr, BlockId::Hash(block_hash.into()))
+            .await
+            .expect("get_logs should succeed");
+
+        assert_eq!(logs.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn get_logs_batch_preserves_request_order_when_responses_reordered() {
+        let mut server = Server::new_async().await;
+        let client = RpcEthereumClient::new(&server.url());
+        let addr = Address::with_last_byte(0x42);
+        let block_ids = vec![
+            BlockId::Number(BlockNumberOrTag::Number(10)),
+            BlockId::Number(BlockNumberOrTag::Number(11)),
+            BlockId::Number(BlockNumberOrTag::Number(12)),
+        ];
+
+        // Match any eth_getLogs batch POST; respond with 2 results in
+        // reversed order: id 3 first, then 1, then 2 (note: id 2 returns null).
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex(r#"eth_getLogs"#.to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!([
+                    filter_response(3, vec![log_value(addr, 12, 0)]),
+                    filter_response(1, vec![]),          // empty for block 10
+                    { "jsonrpc": "2.0", "id": 2, "result": null }, // null → empty vec for block 11
+                ])
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let results = client
+            .get_logs_batch(addr, &block_ids)
+            .await
+            .expect("batch fetch should succeed");
+
+        assert_eq!(results.len(), 3);
+        // block 10 → id 1 → empty array
+        assert!(results[0].is_empty());
+        // block 11 → id 2 → null → empty vec
+        assert!(results[1].is_empty());
+        // block 12 → id 3 → 1 log
+        assert_eq!(results[2].len(), 1);
+        assert_eq!(results[2][0].address(), addr);
     }
 
     #[test]

--- a/chain-signatures/chain-ethereum/src/indexer_eth_helios.rs
+++ b/chain-signatures/chain-ethereum/src/indexer_eth_helios.rs
@@ -2,7 +2,7 @@ use crate::{EthConfig, MaybeBlock};
 use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::primitives::Address;
 use alloy::primitives::Bytes;
-use alloy::rpc::types::TransactionRequest;
+use alloy::rpc::types::{Filter, Log, TransactionRequest};
 use futures_util::future::join_all;
 use helios::ethereum::{config::networks::Network, EthereumClient, EthereumClientBuilder};
 use std::path::PathBuf;
@@ -93,6 +93,44 @@ impl HeliosEthereumClient {
         results.into_iter().collect()
     }
 
+    /// Fetch all logs emitted by `address` within `block_id` 
+    pub async fn get_logs(
+        &self,
+        address: Address,
+        block_id: alloy::rpc::types::BlockId,
+    ) -> anyhow::Result<Vec<Log>> {
+        self.client
+            .get_logs(&logs_filter(address, block_id))
+            .await
+            .map_err(|err| {
+                anyhow::anyhow!(
+                    "Failed to get logs for address {address:?} block {block_id:?}: {:?}",
+                    err
+                )
+            })
+    }
+
+    /// Fetch `eth_getLogs` for multiple blocks in parallel
+    pub async fn get_logs_batch(
+        &self,
+        address: Address,
+        block_ids: &[alloy::rpc::types::BlockId],
+    ) -> anyhow::Result<Vec<Vec<Log>>> {
+        if block_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let results = join_all(
+            block_ids
+                .iter()
+                .copied()
+                .map(|block_id| async move { self.get_logs(address, block_id).await }),
+        )
+        .await;
+
+        results.into_iter().collect()
+    }
+
     pub async fn get_nonce(
         &self,
         address: Address,
@@ -176,6 +214,20 @@ impl HeliosEthereumClient {
             anyhow::anyhow!("Failed to fetch block for block id {block_id:?}: {:?}", err)
         })
     }
+}
+
+/// Build an alloy [`Filter`] scoped to a single `address` and one block,
+/// mirroring the direct-RPC `logs_filter_object`.
+///
+/// - `BlockId::Hash` → `Filter::AtBlockHash(hash)` (pins to the exact block).
+/// - `BlockId::Number(tag)` → `Filter::Range { from = to = tag }`.
+fn logs_filter(address: Address, block_id: BlockId) -> Filter {
+    let mut filter = Filter::new().address(address);
+    filter = match block_id {
+        BlockId::Hash(hash) => filter.at_block_hash(hash.block_hash),
+        BlockId::Number(tag) => filter.from_block(tag).to_block(tag),
+    };
+    filter
 }
 
 pub async fn build_client(eth: EthConfig) -> anyhow::Result<HeliosEthereumClient> {

--- a/chain-signatures/chain-ethereum/src/indexer_eth_helios.rs
+++ b/chain-signatures/chain-ethereum/src/indexer_eth_helios.rs
@@ -71,6 +71,22 @@ impl HeliosEthereumClient {
             .map_err(|err| anyhow::anyhow!("Failed to get block receipts for block: {:?}", err))
     }
 
+    /// Fetch a single transaction's receipt
+    pub async fn get_transaction_receipt(
+        &self,
+        tx_hash: alloy::primitives::B256,
+    ) -> anyhow::Result<Option<alloy::rpc::types::TransactionReceipt>> {
+        self.client
+            .get_transaction_receipt(tx_hash)
+            .await
+            .map_err(|err| {
+                anyhow::anyhow!(
+                    "Failed to get transaction receipt for {tx_hash:?}: {:?}",
+                    err
+                )
+            })
+    }
+
     /// Helios has no native JSON-RPC batch, so batch = `join_all` of single
     /// `get_block_receipts` calls (mirrors `get_blocks`). Order-preserving via
     /// the input index ordering of `join_all`.
@@ -93,7 +109,7 @@ impl HeliosEthereumClient {
         results.into_iter().collect()
     }
 
-    /// Fetch all logs emitted by `address` within `block_id` 
+    /// Fetch all logs emitted by `address` within `block_id`
     pub async fn get_logs(
         &self,
         address: Address,

--- a/chain-signatures/chain-ethereum/src/test_utils.rs
+++ b/chain-signatures/chain-ethereum/src/test_utils.rs
@@ -1,7 +1,7 @@
 use crate::client::{CatchupItem, EthereumClient};
 use crate::indexer::EthereumIndexer;
 use crate::EthConfig;
-use alloy::primitives::Address;
+use alloy::primitives::{Address, Bloom};
 use mpc_chain_integration_core::utils::retry::RetryConfig;
 use mpc_chain_integration_core::{MockStateManager, NoopChainTelemetry};
 use std::sync::Arc;
@@ -196,17 +196,75 @@ pub fn live_block(number: u64) -> CatchupItem {
     CatchupItem::LiveBlock(block)
 }
 
-pub fn batch_block(
-    number: u64,
-    receipts: Vec<alloy::rpc::types::TransactionReceipt>,
-) -> CatchupItem {
+pub fn batch_block(number: u64, logs: Vec<alloy::rpc::types::Log>) -> CatchupItem {
     let value = block_response(1, number)
         .get("result")
         .expect("block_response has a result envelope")
         .clone();
     let block: alloy::rpc::types::Block =
         serde_json::from_value(value).expect("block fixture should deserialize");
-    CatchupItem::BatchBlock { block, receipts }
+    CatchupItem::BatchBlock { block, logs }
+}
+
+/// Build a `Bloom` marked as potentially containing logs from `address`.
+pub fn bloom_containing_address(address: Address) -> Bloom {
+    let mut bloom = Bloom::default();
+    bloom.accrue_raw_log(address, &[]);
+    bloom
+}
+
+fn bloom_hex(bloom: &Bloom) -> String {
+    use alloy::primitives::hex::encode;
+    format!("0x{}", encode(bloom.as_slice()))
+}
+
+/// Like [`block_response`] but with the `logsBloom` set to a bloom that
+/// marks `address` as potentially present.
+pub fn block_response_with_bloom(request_id: u64, number: u64, bloom: &Bloom) -> serde_json::Value {
+    let mut value = block_response(request_id, number);
+    value
+        .get_mut("result")
+        .expect("block_response has a result envelope")
+        .as_object_mut()
+        .expect("result is an object")
+        .insert(
+            "logsBloom".to_string(),
+            serde_json::Value::String(bloom_hex(bloom)),
+        );
+    value
+}
+
+/// A minimal `eth_getLogs` result entry for `address` in `block_number`,
+/// suitable for `eth_getLogs` batch responses consumed by `get_logs_batch`.
+pub fn log_value(address: Address, block_number: u64, log_index: u64) -> serde_json::Value {
+    let block_hash = format!("0x{:064x}", block_number);
+    let tx_hash = format!("0x{:064x}", block_number);
+    serde_json::json!({
+        "logIndex": format!("0x{log_index:x}"),
+        "blockNumber": format!("0x{block_number:x}"),
+        "blockHash": block_hash,
+        "transactionHash": tx_hash,
+        "transactionIndex": "0x0",
+        "address": format!("{:#x}", address),
+        "topics": [],
+        "data": "0x",
+    })
+}
+
+/// Build a JSON array of `eth_getLogs` batch responses (one per input
+/// `(request_id, logs)` pair)
+pub fn logs_batch_response(ids_and_logs: &[(u64, Vec<serde_json::Value>)]) -> serde_json::Value {
+    let items: Vec<serde_json::Value> = ids_and_logs
+        .iter()
+        .map(|(id, logs)| {
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": logs,
+            })
+        })
+        .collect();
+    serde_json::Value::Array(items)
 }
 
 pub fn receipt_value(tx_hash: &str, block_number: u64) -> serde_json::Value {
@@ -226,20 +284,4 @@ pub fn receipt_value(tx_hash: &str, block_number: u64) -> serde_json::Value {
         "type": "0x2",
         "effectiveGasPrice": "0x1"
     })
-}
-
-pub fn receipts_batch_response(
-    ids_and_receipts: &[(u64, Option<serde_json::Value>)],
-) -> serde_json::Value {
-    let items: Vec<serde_json::Value> = ids_and_receipts
-        .iter()
-        .map(|(id, result)| {
-            serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "result": result
-            })
-        })
-        .collect();
-    serde_json::Value::Array(items)
 }


### PR DESCRIPTION
Moving away from fetching `eth_getBlockReceipts` for every single block:

- **Introduce bloom filter gating**: indexer now completely skips fetching logs for blocks that do not contain `contract_address`
- **Switch to `eth_getLogs`**: Replaced the heavier `eth_getBlockReceipts` fetches with targeted `eth_getLogs` requests (based on positive bloom filter matches)
- **Targeted Execution Confirmations**: instead of fetching and processing all receipts, indexer only issues `eth_getTransactionReceipt` for specific pending transactions currently tracked by the `StateManager`

Benchmark changes (100 blocks range against local eRPC with warm cache):
catchup_progress: 0.68s [-81.5%]
blocks_per_sec: 146.4 [+438.2%]
total_rpc: 110 [-45.3%]
batch_fetch_ms: 590 [-83.0%]
process_ms: 4 [-85.7%]


