### PR TITLE
feat: implement nonce-gated execution confirmation polling

### DIFF
--- a/chain-signatures/chain-ethereum/README.md
+++ b/chain-signatures/chain-ethereum/README.md
@@ -72,6 +72,22 @@ RUST_LOG=mpc_chain_ethereum::bench=info \
 cargo run --example bench_catchup --features bench
 ```
 
+### Watchers benchmark
+
+`examples/bench_watchers.rs` drives `EthereumIndexer` over a fixed historical
+block range with a simulated load of pending cross-chain execution watchers.
+This exercises the nonce-gated polling logic to ensure receipt requests don't
+rate-limit the RPC. Dummy watchers (with `nonce = u64::MAX`, i.e. never
+executable) are injected into a `MockStateManager` before catchup starts.
+
+```sh
+RPC_URL=http://localhost:4000/sepolia/evm/11155111 \
+CONTRACT_ADDRESS=0x69C6b28Fdc74618817fa380De29a653060e14009 \
+START=11214938 END=11215038 WATCHERS=100 \
+RUST_LOG=mpc_chain_ethereum::bench=info \
+cargo run --example bench_watchers --features bench
+```
+
 ### Environment variables
 
 | var              | required? | description |
@@ -82,11 +98,12 @@ cargo run --example bench_catchup --features bench
 | `START`          | no        | inclusive start; if omitted only `END-1` is processed |
 | `NETWORK`        | no        | default `sepolia` |
 | `OPTIMISTIC`     | no        | `1` (default) enables optimistic requests; `0` exercises finality polling |
+| `WATCHERS`       | no        | `bench_watchers` only — number of pending dummy watchers to simulate (default `50`) |
 | `RUST_LOG`       | no        | tracing filter — `mpc_chain_ethereum::bench=info` for just the report |
 
 ## Features
 
 | feature   | what it enables |
 |-----------|-----------------|
-| `bench`   | the `bench` module + RPC/timing counters in the direct-RPC indexer; required by `examples/bench_catchup.rs` |
+| `bench`   | the `bench` module + RPC/timing counters in the direct-RPC indexer; required by `examples/bench_catchup.rs` and `examples/bench_watchers.rs` |
 | `helios`  | the `indexer_eth_helios` light-client |

--- a/chain-signatures/chain-ethereum/README.md
+++ b/chain-signatures/chain-ethereum/README.md
@@ -83,7 +83,7 @@ executable) are injected into a `MockStateManager` before catchup starts.
 ```sh
 RPC_URL=http://localhost:4000/sepolia/evm/11155111 \
 CONTRACT_ADDRESS=0x69C6b28Fdc74618817fa380De29a653060e14009 \
-START=11214938 END=11215038 WATCHERS=100 \
+START=11214938 END=11215038 WATCHERS=1000 \
 RUST_LOG=mpc_chain_ethereum::bench=info \
 cargo run --example bench_watchers --features bench
 ```

--- a/chain-signatures/chain-ethereum/examples/bench_catchup.rs
+++ b/chain-signatures/chain-ethereum/examples/bench_catchup.rs
@@ -29,126 +29,22 @@
 //! Filter logs with `RUST_LOG=mpc_chain_ethereum::bench=info` to see just the
 //! final report; otherwise the full `tracing` log is emitted
 
-use anyhow::anyhow;
-use futures_util::StreamExt;
-use mpc_chain_ethereum::{EthConfig, EthereumStream};
-use mpc_chain_integration_core::{
-    ChainIndexer, ChainStream, MockStateManager, NoopChainTelemetry, StateManager,
-};
+#[path = "helpers/mod.rs"]
+mod helpers;
+use helpers::{init_tracing, make_config, parse_start_end, run_catchup};
+use mpc_chain_integration_core::{MockStateManager, StateManager};
 use mpc_primitives::Chain;
-
-/// Helper to read an environment variable and return an error if it's not set.
-fn opt_env(name: &str) -> anyhow::Result<String> {
-    std::env::var(name).map_err(|_| anyhow!("{name} is required"))
-}
-
-/// Helper to read an environment variable and parse it as a `u64`.
-fn env_u64(name: &str) -> anyhow::Result<u64> {
-    let raw = opt_env(name)?;
-    raw.parse().map_err(|e| anyhow!("invalid {name}: {e}"))
-}
-
-/// Helper to read an environment variable and parse it as a `bool`.
-fn env_bool(name: &str, default: bool) -> anyhow::Result<bool> {
-    match std::env::var(name) {
-        Ok(v) => match v.as_str() {
-            "1" | "true" | "yes" => Ok(true),
-            "0" | "false" | "no" => Ok(false),
-            other => Err(anyhow!("invalid {name}: {other:?}, expected 0/1")),
-        },
-        Err(std::env::VarError::NotPresent) => Ok(default),
-        Err(std::env::VarError::NotUnicode(_)) => Err(anyhow!("invalid {name}: not valid UTF-8")),
-    }
-}
-
-fn make_config() -> anyhow::Result<EthConfig> {
-    Ok(EthConfig {
-        account_sk: String::new(),
-        consensus_rpc_http_url: String::new(),
-        execution_rpc_http_url: opt_env("RPC_URL")?,
-        contract_address: opt_env("CONTRACT_ADDRESS")?
-            .trim_start_matches("0x")
-            .to_string(),
-        network: std::env::var("NETWORK").unwrap_or_else(|_| "sepolia".to_string()),
-        helios_data_path: "/tmp/helios-bench".to_string(),
-        refresh_finalized_interval: 1,
-        optimistic_requests: env_bool("OPTIMISTIC", true)?,
-        light_client: false,
-    })
-}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Enable tracing logs
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .with_target(false)
-        .init();
+    init_tracing();
 
     let config = make_config()?;
-    let end = env_u64("END")?;
-
-    // `catchup_range(end)` derives `current_block = processed_block + 1` and
-    // clamps to `clamp_oldest_supported(current_block, end)`. To process
-    // `[start, end)` we set `processed_block = start - 1`. If `START` is
-    // unset we still set `processed_block = end - 1` so the (empty) range
-    // `[end, end)` is processed — useful as a "live-anchor" smoke test only;
-    // supply both `START` and `END` for a real historical range.
-    let start = match std::env::var("START") {
-        Ok(s) => {
-            let s: u64 = s.parse().map_err(|e| anyhow!("invalid START: {e}"))?;
-            if s == 0 {
-                return Err(anyhow!("START must be >= 1"));
-            }
-            if s >= end {
-                return Err(anyhow!("START must be < END"));
-            }
-            s
-        }
-        Err(std::env::VarError::NotPresent) => end,
-        Err(std::env::VarError::NotUnicode(_)) => {
-            return Err(anyhow!("invalid START: not valid UTF-8"));
-        }
-    };
+    let (start, end) = parse_start_end()?;
 
     let state = MockStateManager::new();
     state.set_processed_block(Chain::Ethereum, start - 1).await;
 
-    // Build the stream. `EthereumStream` creates the bounded event channel
-    // internally
-    let mut stream = EthereumStream::new(config, state, NoopChainTelemetry).await?;
-    let mut indexer = stream.start().await?;
-
-    tracing::info!("bench_catchup: starting catchup over [{start}..{end})");
-
-    // Drain emitted events in parallel so process_catchup never blocks on a
-    // full channel.
-    let drain = tokio::spawn(async move {
-        loop {
-            match stream.next_event().await {
-                Some(ev) => tracing::debug!(?ev, "bench_catchup drained event"),
-                None => {
-                    tracing::warn!("bench_catchup: event channel closed during catchup");
-                    return;
-                }
-            }
-        }
-    });
-
-    let blocks_stream = indexer.catchup_range(end).await;
-    let mut blocks = std::pin::pin!(blocks_stream);
-    let mut count: u64 = 0;
-    while let Some(block) = blocks.next().await {
-        indexer.process_catchup(&block).await?;
-        count += 1;
-    }
-
-    // Fires the final `report_metrics("catchup_completed")` log under `bench`.
-    indexer.notify_catchup_completed().await?;
-
-    drain.abort();
-    let _ = drain.await;
-
-    tracing::info!("bench_catchup: processed {count} blocks; final report above");
+    run_catchup(config, state, end, "bench_catchup").await?;
     Ok(())
 }

--- a/chain-signatures/chain-ethereum/examples/bench_watchers.rs
+++ b/chain-signatures/chain-ethereum/examples/bench_watchers.rs
@@ -42,7 +42,7 @@ async fn main() -> anyhow::Result<()> {
         return Err(anyhow!("START must be >= 1 and < END"));
     }
 
-    let watchers_count = env_u64("WATCHERS", Some(50))?;
+    let watchers_count = env_u64("WATCHERS", Some(1000))?;
 
     let state = MockStateManager::new();
     state.set_processed_block(Chain::Ethereum, start - 1).await;

--- a/chain-signatures/chain-ethereum/examples/bench_watchers.rs
+++ b/chain-signatures/chain-ethereum/examples/bench_watchers.rs
@@ -1,0 +1,83 @@
+//! Standalone watcher benchmark for the Ethereum indexer.
+//!
+//! Drives `EthereumIndexer` over a fixed historical block range with a simulated
+//! load of pending cross-chain execution watchers. This exercises the nonce-gated
+//! polling logic to ensure we do not rate-limit the RPC with receipt requests.
+//!
+//! # Configuration (env vars only)
+//!
+//! - `RPC_URL` (required) — execution-layer RPC endpoint, e.g. an Alchemy URL.
+//! - `CONTRACT_ADDRESS` (required) — contract address to watch.
+//! - `END` (required) — exclusive end of the catchup range.
+//! - `START` (optional) — inclusive start of the range.
+//! - `WATCHERS` (optional, default `50`) — number of pending dummy watchers to simulate.
+//! - `NETWORK` (optional, default `sepolia`).
+//!
+//! # Usage
+//!
+//! ```sh
+//! RPC_URL=http://localhost:4000/sepolia/evm/11155111 \
+//! CONTRACT_ADDRESS=0x69C6b28Fdc74618817fa380De29a653060e14009 \
+//! START=11214938 END=11215038 WATCHERS=100 \
+//! RUST_LOG=mpc_chain_ethereum::bench=info \
+//! cargo run --example bench_watchers --features bench
+//! ```
+
+#[path = "helpers/mod.rs"]
+mod helpers;
+use anyhow::anyhow;
+use helpers::{env_u64, init_tracing, make_config, run_catchup};
+use mpc_chain_integration_core::{MockStateManager, StateManager};
+use mpc_primitives::{BidirectionalTx, BidirectionalTxId, Chain, SignId, LATEST_MPC_KEY_VERSION};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    init_tracing();
+
+    let config = make_config()?;
+    let end = env_u64("END", None)?;
+    let start = env_u64("START", Some(end))?;
+
+    if start == 0 || start >= end {
+        return Err(anyhow!("START must be >= 1 and < END"));
+    }
+
+    let watchers_count = env_u64("WATCHERS", Some(50))?;
+
+    let state = MockStateManager::new();
+    state.set_processed_block(Chain::Ethereum, start - 1).await;
+
+    let dummy_address = alloy::primitives::address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+    for i in 0..watchers_count {
+        let mut hash = [0u8; 32];
+        hash[24..].copy_from_slice(&i.to_be_bytes());
+
+        let tx = BidirectionalTx {
+            id: BidirectionalTxId(hash),
+            sender: [0u8; 32],
+            serialized_transaction: vec![],
+            source_chain: Chain::Solana,
+            target_chain: Chain::Ethereum,
+            caip2_id: "eip155:11155111".to_string(),
+            key_version: LATEST_MPC_KEY_VERSION,
+            deposit: 0,
+            path: "m/44'/60'/0'/0/0".to_string(),
+            algo: "secp256k1".to_string(),
+            dest: Chain::Ethereum.to_string(),
+            params: "{}".to_string(),
+            output_deserialization_schema: vec![],
+            respond_serialization_schema: vec![],
+            request_id: hash,
+            from_address: **dummy_address,
+            nonce: u64::MAX,
+        };
+
+        state
+            .watch_execution(Chain::Ethereum, SignId::new(hash), tx)
+            .await;
+    }
+    tracing::info!("bench_watchers: injected {watchers_count} dummy watchers");
+
+    run_catchup(config, state, end, "bench_watchers").await?;
+    Ok(())
+}

--- a/chain-signatures/chain-ethereum/examples/helpers/mod.rs
+++ b/chain-signatures/chain-ethereum/examples/helpers/mod.rs
@@ -2,8 +2,10 @@
 
 use anyhow::anyhow;
 use futures_util::StreamExt;
-use mpc_chain_ethereum::{EthConfig, EthereumStream};
-use mpc_chain_integration_core::{ChainIndexer, ChainStream, MockStateManager, NoopChainTelemetry};
+use mpc_chain_ethereum::{EthConfig, EthereumIndexer};
+use mpc_chain_integration_core::{
+    utils::stream::chain_event_channel, MockStateManager, NoopChainTelemetry,
+};
 
 /// Read a required environment variable, erroring if it's not set.
 pub fn opt_env(name: &str) -> anyhow::Result<String> {
@@ -37,19 +39,24 @@ pub fn env_bool(name: &str, default: bool) -> anyhow::Result<bool> {
 /// (`RPC_URL`, `CONTRACT_ADDRESS`, `NETWORK`, `OPTIMISTIC`).
 pub fn make_config() -> anyhow::Result<EthConfig> {
     Ok(EthConfig {
-        account_sk: String::new(),
+        // The bench only indexes; the signer is never used.
+        account_sk: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            .parse()
+            .unwrap(),
         consensus_rpc_http_url: String::new(),
-        execution_rpc_http_url: opt_env("RPC_URL")?,
+        execution_rpc_http_url: opt_env("RPC_URL")?
+            .parse()
+            .map_err(|e| anyhow!("invalid RPC_URL: {e}"))?,
         contract_address: opt_env("CONTRACT_ADDRESS")?
-            .trim_start_matches("0x")
-            .to_string(),
+            .parse()
+            .map_err(|e| anyhow!("invalid CONTRACT_ADDRESS: {e}"))?,
         network: std::env::var("NETWORK").unwrap_or_else(|_| "sepolia".to_string()),
         helios_data_path: "/tmp/helios-bench".to_string(),
         refresh_finalized_interval: 1,
         optimistic_requests: env_bool("OPTIMISTIC", true)?,
         light_client: false,
-        gas: Default::default(),
         rpc: Default::default(),
+        gas: Default::default(),
         publisher: Default::default(),
         indexer: Default::default(),
     })
@@ -76,32 +83,28 @@ pub async fn run_catchup(
     end: u64,
     label: &'static str,
 ) -> anyhow::Result<u64> {
-    let mut stream = EthereumStream::new(config, state, NoopChainTelemetry).await?;
-    let mut indexer = stream.start().await?;
+    let indexer = EthereumIndexer::new(config, state, NoopChainTelemetry).await?;
+    let (events_tx, mut events_rx) = chain_event_channel();
 
     tracing::info!("{label}: starting catchup ending at {end}");
 
     let drain = tokio::spawn(async move {
-        loop {
-            match stream.next_event().await {
-                Some(ev) => tracing::debug!(?ev, "{label} drained event"),
-                None => {
-                    tracing::warn!("{label}: event channel closed during catchup");
-                    return;
-                }
-            }
+        while let Some(ev) = events_rx.recv().await {
+            tracing::debug!(?ev, "bench_catchup drained event");
         }
     });
 
-    let blocks_stream = indexer.catchup_range(end).await;
+    let blocks_stream = indexer.catchup_blocks(end).await;
     let mut blocks = std::pin::pin!(blocks_stream);
     let mut count: u64 = 0;
     while let Some(block) = blocks.next().await {
-        indexer.process_catchup(&block).await?;
+        indexer.process_catchup_item(&events_tx, &block).await?;
         count += 1;
     }
 
-    indexer.notify_catchup_completed().await?;
+    // Fires the final `report_metrics("catchup_completed")` log under `bench`.
+    #[cfg(feature = "bench")]
+    mpc_chain_ethereum::bench::report_metrics("catchup_completed");
 
     drain.abort();
     let _ = drain.await;

--- a/chain-signatures/chain-ethereum/examples/helpers/mod.rs
+++ b/chain-signatures/chain-ethereum/examples/helpers/mod.rs
@@ -1,0 +1,134 @@
+//! Shared helpers for the Ethereum benchmark examples.
+
+use anyhow::anyhow;
+use futures_util::StreamExt;
+use mpc_chain_ethereum::{EthConfig, EthereumStream};
+use mpc_chain_integration_core::{ChainIndexer, ChainStream, MockStateManager, NoopChainTelemetry};
+
+/// Read a required environment variable, erroring if it's not set.
+pub fn opt_env(name: &str) -> anyhow::Result<String> {
+    std::env::var(name).map_err(|_| anyhow!("{name} is required"))
+}
+
+/// Read an environment variable and parse it as a `u64`, falling back to
+/// `default` if unset. Pass `None` to make the variable required.
+pub fn env_u64(name: &str, default: Option<u64>) -> anyhow::Result<u64> {
+    match std::env::var(name) {
+        Ok(v) => v.parse().map_err(|e| anyhow!("invalid {name}: {e}")),
+        Err(std::env::VarError::NotPresent) => default.ok_or_else(|| anyhow!("{name} is required")),
+        Err(std::env::VarError::NotUnicode(_)) => Err(anyhow!("invalid {name}: not valid UTF-8")),
+    }
+}
+
+/// Read an environment variable and parse it as a `bool` (`0/1/true/false/yes/no`).
+pub fn env_bool(name: &str, default: bool) -> anyhow::Result<bool> {
+    match std::env::var(name) {
+        Ok(v) => match v.as_str() {
+            "1" | "true" | "yes" => Ok(true),
+            "0" | "false" | "no" => Ok(false),
+            other => Err(anyhow!("invalid {name}: {other:?}, expected 0/1")),
+        },
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(std::env::VarError::NotUnicode(_)) => Err(anyhow!("invalid {name}: not valid UTF-8")),
+    }
+}
+
+/// Build an [`EthConfig`] from the standard set of benchmark env vars
+/// (`RPC_URL`, `CONTRACT_ADDRESS`, `NETWORK`, `OPTIMISTIC`).
+pub fn make_config() -> anyhow::Result<EthConfig> {
+    Ok(EthConfig {
+        account_sk: String::new(),
+        consensus_rpc_http_url: String::new(),
+        execution_rpc_http_url: opt_env("RPC_URL")?,
+        contract_address: opt_env("CONTRACT_ADDRESS")?
+            .trim_start_matches("0x")
+            .to_string(),
+        network: std::env::var("NETWORK").unwrap_or_else(|_| "sepolia".to_string()),
+        helios_data_path: "/tmp/helios-bench".to_string(),
+        refresh_finalized_interval: 1,
+        optimistic_requests: env_bool("OPTIMISTIC", true)?,
+        light_client: false,
+    })
+}
+
+/// Initialize the `tracing` subscriber the same way in every bench binary.
+pub fn init_tracing() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_target(false)
+        .init();
+}
+
+/// Spin up an [`EthereumStream`]/[`ChainIndexer`] pair, spawn a background
+/// task that drains emitted events (so `process_catchup` never blocks on a
+/// full channel), then drive `catchup_range(end)` -> `process_catchup` to
+/// completion, firing `notify_catchup_completed` (and the resulting
+/// `Catchup Benchmark Report`) at the end.
+///
+/// Returns the number of blocks processed.
+pub async fn run_catchup(
+    config: EthConfig,
+    state: MockStateManager,
+    end: u64,
+    label: &'static str,
+) -> anyhow::Result<u64> {
+    let mut stream = EthereumStream::new(config, state, NoopChainTelemetry).await?;
+    let mut indexer = stream.start().await?;
+
+    tracing::info!("{label}: starting catchup ending at {end}");
+
+    let drain = tokio::spawn(async move {
+        loop {
+            match stream.next_event().await {
+                Some(ev) => tracing::debug!(?ev, "{label} drained event"),
+                None => {
+                    tracing::warn!("{label}: event channel closed during catchup");
+                    return;
+                }
+            }
+        }
+    });
+
+    let blocks_stream = indexer.catchup_range(end).await;
+    let mut blocks = std::pin::pin!(blocks_stream);
+    let mut count: u64 = 0;
+    while let Some(block) = blocks.next().await {
+        indexer.process_catchup(&block).await?;
+        count += 1;
+    }
+
+    indexer.notify_catchup_completed().await?;
+
+    drain.abort();
+    let _ = drain.await;
+
+    tracing::info!("{label}: processed {count} blocks; final report above");
+    Ok(count)
+}
+
+/// Parse the standard `START`/`END` pair into `(start, processed_block)`.
+///
+/// `processed_block = start - 1` so that `catchup_range(end)` covers
+/// `[start, end)`. If `START` is unset, `start` defaults to `end` (an
+/// empty/"live-anchor" range — mainly useful as a smoke test).
+#[allow(dead_code)] // `bench_watchers` doesn't use this, but `bench_catchup` does.
+pub fn parse_start_end() -> anyhow::Result<(u64, u64)> {
+    let end = env_u64("END", None)?;
+    let start = match std::env::var("START") {
+        Ok(s) => {
+            let s: u64 = s.parse().map_err(|e| anyhow!("invalid START: {e}"))?;
+            if s == 0 {
+                return Err(anyhow!("START must be >= 1"));
+            }
+            if s >= end {
+                return Err(anyhow!("START must be < END"));
+            }
+            s
+        }
+        Err(std::env::VarError::NotPresent) => end,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            return Err(anyhow!("invalid START: not valid UTF-8"));
+        }
+    };
+    Ok((start, end))
+}

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -2234,4 +2234,503 @@ mod tests {
         nonce_mock.assert_async().await;
         receipt_mock.assert_async().await;
     }
+
+    #[tokio::test]
+    async fn new_watcher_resolves_at_appearance_block() {
+        let mut server = Server::new_async().await;
+
+        let from_address = address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+        let tx_hash = b256!("4444444444444444444444444444444444444444444444444444444444444444");
+        let block_hash = b256!("6e4e53d1de650d5a5ebed19b38321db369ef1dc357904284ecf4d89b8834969c");
+        let receipt_response = json!({
+            "transactionHash": format!("{tx_hash:#x}"),
+            "blockHash": format!("{block_hash:#x}"),
+            "blockNumber": "0x3",
+            "transactionIndex": "0x0",
+            "from": format!("{from_address:#x}"),
+            "to": format!("{from_address:#x}"),
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x3a29f0f8",
+            "contractAddress": null,
+            "logsBloom": format!("0x{}", "0".repeat(512)),
+            "cumulativeGasUsed": "0x5208",
+            "type": "0x2",
+            "logs": [],
+            "status": "0x0"
+        });
+
+        // Nonce check pinned at block 5 (NOT a tick): one-shot
+        // appearance gate fires immediately for newly seen watchers
+        let nonce_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionCount",
+                "params": [format!("{from_address:#x}"), "0x5"]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": "0x1" }).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        // Receipt shows the tx already mined at block 3 (before registration)
+        let receipt_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionReceipt",
+                "params": [format!("{tx_hash:#x}")]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": receipt_response }).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let builder = test_utils::TestIndexerBuilder::new(server.url());
+        builder
+            .state_manager
+            .watch_execution(
+                Chain::Ethereum,
+                SignId::new([4; 32]),
+                BidirectionalTx {
+                    id: BidirectionalTxId(tx_hash.0),
+                    sender: [0u8; 32],
+                    serialized_transaction: vec![],
+                    source_chain: Chain::Solana,
+                    target_chain: Chain::Ethereum,
+                    caip2_id: "eip155:31337".to_string(),
+                    key_version: LATEST_MPC_KEY_VERSION,
+                    deposit: 0,
+                    path: "m/44'/60'/0'/0/0".to_string(),
+                    algo: "secp256k1".to_string(),
+                    dest: Chain::Ethereum.to_string(),
+                    params: "{}".to_string(),
+                    output_deserialization_schema: vec![],
+                    respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
+                    request_id: tx_hash.0,
+                    from_address: **from_address,
+                    nonce: 0,
+                },
+            )
+            .await;
+        let indexer = builder.build().await;
+
+        let mut block: Block = Block::default();
+        block.header.number = 5;
+        block.transactions = BlockTransactions::Hashes(Vec::new());
+
+        let events = indexer
+            .collect_execution_confirmations(&block)
+            .await
+            .expect("should succeed");
+
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ChainEvent::ExecutionConfirmed {
+                tx_id,
+                block_height,
+                result,
+                ..
+            } => {
+                assert_eq!(tx_id.0, tx_hash.0);
+                assert_eq!(*block_height, 3, "event height is the mined block");
+                assert!(matches!(result, ExecutionOutcome::Failed));
+            }
+            other => panic!("expected ExecutionConfirmed, got {other:?}"),
+        }
+
+        nonce_mock.assert_async().await;
+        receipt_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn failed_mined_receipt_retried_next_block() {
+        let mut server = Server::new_async().await;
+
+        let from_address = address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+        let tx_hash = b256!("5555555555555555555555555555555555555555555555555555555555555555");
+        let block_hash = b256!("6e4e53d1de650d5a5ebed19b38321db369ef1dc357904284ecf4d89b8834969c");
+        let receipt_response = json!({
+            "transactionHash": format!("{tx_hash:#x}"),
+            "blockHash": format!("{block_hash:#x}"),
+            "blockNumber": "0x5",
+            "transactionIndex": "0x0",
+            "from": format!("{from_address:#x}"),
+            "to": format!("{from_address:#x}"),
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x3a29f0f8",
+            "contractAddress": null,
+            "logsBloom": format!("0x{}", "0".repeat(512)),
+            "cumulativeGasUsed": "0x5208",
+            "type": "0x2",
+            "logs": [],
+            "status": "0x0"
+        });
+
+        // Phase 1 (block 5): receipt RPC fails
+        let failing_receipt_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionReceipt",
+                "params": [format!("{tx_hash:#x}")]
+            })))
+            .with_status(500)
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        let builder = test_utils::TestIndexerBuilder::new(server.url());
+        builder
+            .state_manager
+            .watch_execution(
+                Chain::Ethereum,
+                SignId::new([5; 32]),
+                BidirectionalTx {
+                    id: BidirectionalTxId(tx_hash.0),
+                    sender: [0u8; 32],
+                    serialized_transaction: vec![],
+                    source_chain: Chain::Solana,
+                    target_chain: Chain::Ethereum,
+                    caip2_id: "eip155:31337".to_string(),
+                    key_version: LATEST_MPC_KEY_VERSION,
+                    deposit: 0,
+                    path: "m/44'/60'/0'/0/0".to_string(),
+                    algo: "secp256k1".to_string(),
+                    dest: Chain::Ethereum.to_string(),
+                    params: "{}".to_string(),
+                    output_deserialization_schema: vec![],
+                    respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
+                    request_id: tx_hash.0,
+                    from_address: **from_address,
+                    nonce: 0,
+                },
+            )
+            .await;
+        let indexer = builder.build().await;
+
+        let mut block5: Block = Block::default();
+        block5.header.number = 5;
+        block5.transactions = BlockTransactions::Hashes(vec![tx_hash]);
+
+        let events = indexer
+            .collect_execution_confirmations(&block5)
+            .await
+            .expect("receipt failure should not fail block processing");
+        assert!(events.is_empty());
+        failing_receipt_mock.assert_async().await;
+        failing_receipt_mock.remove_async().await;
+
+        // Phase 2 (block 6, NOT a tick): the failed watcher is retried via the
+        // nonce gate without waiting for the next sweep
+        let nonce_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionCount",
+                "params": [format!("{from_address:#x}"), "0x6"]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": "0x1" }).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let receipt_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionReceipt",
+                "params": [format!("{tx_hash:#x}")]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": receipt_response }).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut block6: Block = Block::default();
+        block6.header.number = 6;
+        block6.transactions = BlockTransactions::Hashes(Vec::new());
+
+        let events = indexer
+            .collect_execution_confirmations(&block6)
+            .await
+            .expect("should succeed");
+
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ChainEvent::ExecutionConfirmed {
+                tx_id,
+                block_height,
+                ..
+            } => {
+                assert_eq!(tx_id.0, tx_hash.0);
+                assert_eq!(*block_height, 5, "event height is the mined block");
+            }
+            other => panic!("expected ExecutionConfirmed, got {other:?}"),
+        }
+
+        nonce_mock.assert_async().await;
+        receipt_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn failed_nonce_fetch_retried_next_block() {
+        let mut server = Server::new_async().await;
+
+        let from_address = address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+        let tx_hash = b256!("6666666666666666666666666666666666666666666666666666666666666666");
+
+        // Phase 1 (block 10, tick): nonce fetch fails
+        let failing_nonce_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionCount",
+            })))
+            .with_status(500)
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        let builder = test_utils::TestIndexerBuilder::new(server.url());
+        builder
+            .state_manager
+            .watch_execution(
+                Chain::Ethereum,
+                SignId::new([6; 32]),
+                BidirectionalTx {
+                    id: BidirectionalTxId(tx_hash.0),
+                    sender: [0u8; 32],
+                    serialized_transaction: vec![],
+                    source_chain: Chain::Solana,
+                    target_chain: Chain::Ethereum,
+                    caip2_id: "eip155:31337".to_string(),
+                    key_version: LATEST_MPC_KEY_VERSION,
+                    deposit: 0,
+                    path: "m/44'/60'/0'/0/0".to_string(),
+                    algo: "secp256k1".to_string(),
+                    dest: Chain::Ethereum.to_string(),
+                    params: "{}".to_string(),
+                    output_deserialization_schema: vec![],
+                    respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
+                    request_id: tx_hash.0,
+                    from_address: **from_address,
+                    nonce: 0,
+                },
+            )
+            .await;
+        let indexer = builder.build().await;
+
+        let mut block10: Block = Block::default();
+        block10.header.number = 10;
+        block10.transactions = BlockTransactions::Hashes(Vec::new());
+
+        let events = indexer
+            .collect_execution_confirmations(&block10)
+            .await
+            .expect("nonce failure should not fail block processing");
+        assert!(events.is_empty());
+        failing_nonce_mock.assert_async().await;
+        failing_nonce_mock.remove_async().await;
+
+        // Phase 2 (block 11, NOT a tick): retried via the nonce gate; nonce
+        // consumed, no receipt -> Failed at block 11
+        let nonce_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionCount",
+                "params": [format!("{from_address:#x}"), "0xb"]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": "0x1" }).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let receipt_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionReceipt",
+                "params": [format!("{tx_hash:#x}")]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": null }).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut block11: Block = Block::default();
+        block11.header.number = 11;
+        block11.transactions = BlockTransactions::Hashes(Vec::new());
+
+        let events = indexer
+            .collect_execution_confirmations(&block11)
+            .await
+            .expect("should succeed");
+
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ChainEvent::ExecutionConfirmed {
+                tx_id,
+                block_height,
+                result,
+                ..
+            } => {
+                assert_eq!(tx_id.0, tx_hash.0);
+                assert_eq!(*block_height, 11);
+                assert!(matches!(result, ExecutionOutcome::Failed));
+            }
+            other => panic!("expected ExecutionConfirmed, got {other:?}"),
+        }
+
+        nonce_mock.assert_async().await;
+        receipt_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn replaced_sibling_fails_at_replacement_block_without_rpc() {
+        let mut server = Server::new_async().await;
+
+        let from_address = address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+        let tx_hash_a = b256!("7777777777777777777777777777777777777777777777777777777777777777");
+        let tx_hash_b = b256!("8888888888888888888888888888888888888888888888888888888888888888");
+        let block_hash = b256!("6e4e53d1de650d5a5ebed19b38321db369ef1dc357904284ecf4d89b8834969c");
+        let receipt_response = json!({
+            "transactionHash": format!("{tx_hash_a:#x}"),
+            "blockHash": format!("{block_hash:#x}"),
+            "blockNumber": "0x5",
+            "transactionIndex": "0x0",
+            "from": format!("{from_address:#x}"),
+            "to": format!("{from_address:#x}"),
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x3a29f0f8",
+            "contractAddress": null,
+            "logsBloom": format!("0x{}", "0".repeat(512)),
+            "cumulativeGasUsed": "0x5208",
+            "type": "0x2",
+            "logs": [],
+            "status": "0x0"
+        });
+
+        // Phase 1 (block 4): both watchers appear; one-shot gate checks the
+        // (deduped) sender once, nonce not yet consumed
+        let nonce_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionCount",
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": "0x0" }).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let receipt_a_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionReceipt",
+                "params": [format!("{tx_hash_a:#x}")]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": receipt_response }).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        // The replaced sibling must never be queried over RPC
+        let receipt_b_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionReceipt",
+                "params": [format!("{tx_hash_b:#x}")]
+            })))
+            .expect(0)
+            .create_async()
+            .await;
+
+        let builder = test_utils::TestIndexerBuilder::new(server.url());
+        let create_tx = |hash: alloy::primitives::B256| BidirectionalTx {
+            id: BidirectionalTxId(hash.0),
+            sender: [0u8; 32],
+            serialized_transaction: vec![],
+            source_chain: Chain::Solana,
+            target_chain: Chain::Ethereum,
+            caip2_id: "eip155:31337".to_string(),
+            key_version: LATEST_MPC_KEY_VERSION,
+            deposit: 0,
+            path: "m/44'/60'/0'/0/0".to_string(),
+            algo: "secp256k1".to_string(),
+            dest: Chain::Ethereum.to_string(),
+            params: "{}".to_string(),
+            output_deserialization_schema: vec![],
+            respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
+            request_id: hash.0,
+            from_address: **from_address,
+            nonce: 0,
+        };
+
+        builder
+            .state_manager
+            .watch_execution(Chain::Ethereum, SignId::new([7; 32]), create_tx(tx_hash_a))
+            .await;
+        builder
+            .state_manager
+            .watch_execution(Chain::Ethereum, SignId::new([8; 32]), create_tx(tx_hash_b))
+            .await;
+        let indexer = builder.build().await;
+
+        let mut block4: Block = Block::default();
+        block4.header.number = 4;
+        block4.transactions = BlockTransactions::Hashes(Vec::new());
+
+        let events = indexer
+            .collect_execution_confirmations(&block4)
+            .await
+            .expect("should succeed");
+        assert!(events.is_empty());
+        nonce_mock.assert_async().await;
+        nonce_mock.remove_async().await;
+
+        // Phase 2 (block 5, NOT a tick): tx A mines; sibling B is failed
+        // purely from local watcher state, no nonce RPC
+        let mut block5: Block = Block::default();
+        block5.header.number = 5;
+        block5.transactions = BlockTransactions::Hashes(vec![tx_hash_a]);
+
+        let events = indexer
+            .collect_execution_confirmations(&block5)
+            .await
+            .expect("should succeed");
+
+        assert_eq!(events.len(), 2);
+        let mut resolved: Vec<_> = events
+            .iter()
+            .map(|e| match e {
+                ChainEvent::ExecutionConfirmed {
+                    tx_id,
+                    block_height,
+                    result,
+                    ..
+                } => {
+                    assert_eq!(*block_height, 5, "both events at the replacement block");
+                    assert!(matches!(result, ExecutionOutcome::Failed));
+                    tx_id.0
+                }
+                other => panic!("expected ExecutionConfirmed, got {other:?}"),
+            })
+            .collect();
+        resolved.sort();
+        let mut expected = vec![tx_hash_a.0, tx_hash_b.0];
+        expected.sort();
+        assert_eq!(resolved, expected);
+
+        receipt_a_mock.assert_async().await;
+        receipt_b_mock.assert_async().await;
+    }
 }

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -12,14 +12,14 @@ use alloy::rpc::types::{Block, BlockId, BlockTransactions, Log};
 use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use async_trait::async_trait;
-use futures_util::{future, stream};
+use futures_util::{stream, StreamExt};
 use mpc_chain_integration_core::utils::stream::chain_event_channel;
 use mpc_chain_integration_core::{ChainIndexer, ChainStream, ChainTelemetry, StateManager};
 use mpc_primitives::{
     BidirectionalTx, BidirectionalTxId, Chain, ChainEvent, ExecutionOutcome, IndexedSignRequest,
     SignId,
 };
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -27,6 +27,8 @@ use tokio::sync::{mpsc, Notify};
 use tokio::time::{sleep, Duration, Instant};
 
 const MAX_LIVE_BLOCK_BUFFER: usize = 16384;
+/// Max concurrent JSON-RPC calls when resolving watcher receipts/nonces.
+const MAX_CONCURRENT_WATCHER_RPCS: usize = 8;
 /// Limit of consecutive `get_block(Finalized)` total failures allowed before `wait_for_finalized_block` gives up.
 const MAX_FINALIZED_FAILURES: u32 = 20;
 
@@ -454,59 +456,73 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             .into_iter()
             .partition(|(tx_id, _)| block_tx_hashes.contains(&B256::from(tx_id.0)));
 
-        // Fetch receipts for transactions mined in this block
-        let mut events = if mined_in_block.is_empty() {
-            Vec::new()
-        } else {
-            let futures =
-                mined_in_block
-                    .into_iter()
-                    .map(|(tx_id, (sign_id, pending_tx))| async move {
-                        let outcome = self
-                            .backfill_execution_confirmation(
-                                tx_id,
-                                sign_id,
-                                &pending_tx,
-                                block_number,
-                            )
-                            .await?;
-                        Ok::<_, anyhow::Error>(outcome)
-                    });
-
-            future::try_join_all(futures)
-                .await?
-                .into_iter()
-                .filter_map(|outcome| match outcome {
-                    BackfillOutcome::Observed { event } => event,
-                    BackfillOutcome::NotObserved => None,
-                })
-                .collect()
-        };
+        // Fetch receipts for transactions mined in this block, failures are
+        // logged and skipped: the watcher stays pending and the nonce gate
+        // picks it up again.
+        let mut events: Vec<ChainEvent> = stream::iter(mined_in_block.into_iter().map(
+            |(tx_id, (sign_id, pending_tx))| async move {
+                let result = self
+                    .backfill_execution_confirmation(tx_id, sign_id, &pending_tx, block_number)
+                    .await;
+                (tx_id, sign_id, result)
+            },
+        ))
+        .buffer_unordered(MAX_CONCURRENT_WATCHER_RPCS)
+        .filter_map(|(tx_id, sign_id, result)| async move {
+            match result {
+                Ok(BackfillOutcome::Observed { event }) => event,
+                Ok(BackfillOutcome::NotObserved) => None,
+                Err(err) => {
+                    tracing::warn!(
+                        ?tx_id,
+                        ?sign_id,
+                        ?err,
+                        "failed to fetch receipt for bidirectional tx mined in block"
+                    );
+                    None
+                }
+            }
+        })
+        .collect()
+        .await;
 
         // Throttle the nonce check to every 10 blocks (Detects replaced/dropped txs)
         if block_number % 10 == 0 && !unmined_watchers.is_empty() {
             // Extract unique senders functionally
-            let unique_senders: std::collections::HashSet<_> = unmined_watchers
+            let unique_senders: HashSet<_> = unmined_watchers
                 .iter()
                 .map(|(_, (_, tx))| Address::from(tx.from_address))
                 .collect();
 
-            // Fetch nonces concurrently
-            let nonce_futures = unique_senders.into_iter().map(|sender| async move {
-                let nonce = self
-                    .client
-                    .get_nonce(
-                        sender,
-                        BlockId::Number(BlockNumberOrTag::Number(block_number)),
-                    )
-                    .await?;
-                Ok::<_, anyhow::Error>((sender, nonce))
-            });
-
-            let nonces: std::collections::HashMap<_, _> = future::try_join_all(nonce_futures)
-                .await?
-                .into_iter()
-                .collect();
+            // Fetch nonces, failed senders are skipped, leaving
+            // their watchers pending for the next throttled check.
+            let nonces: HashMap<_, _> =
+                stream::iter(unique_senders.into_iter().map(|sender| async move {
+                    let result = self
+                        .client
+                        .get_nonce(
+                            sender,
+                            BlockId::Number(BlockNumberOrTag::Number(block_number)),
+                        )
+                        .await;
+                    (sender, result)
+                }))
+                .buffer_unordered(MAX_CONCURRENT_WATCHER_RPCS)
+                .filter_map(|(sender, result)| async move {
+                    match result {
+                        Ok(nonce) => Some((sender, nonce)),
+                        Err(err) => {
+                            tracing::warn!(
+                                ?sender,
+                                ?err,
+                                "failed to fetch nonce for bidirectional tx"
+                            );
+                            None
+                        }
+                    }
+                })
+                .collect()
+                .await;
 
             // Filter unmined watchers down to ONLY those whose nonces were consumed
             let consumed_txs: Vec<_> = unmined_watchers
@@ -518,47 +534,51 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
                 })
                 .collect();
 
-            // Fetch receipts for consumed txs concurrently
-            if !consumed_txs.is_empty() {
-                let consumed_futures =
-                    consumed_txs
-                        .into_iter()
-                        .map(|(tx_id, (sign_id, pending_tx))| async move {
-                            let outcome = self
-                                .backfill_execution_confirmation(
-                                    tx_id,
-                                    sign_id,
-                                    &pending_tx,
-                                    block_number,
-                                )
-                                .await?;
-                            Ok::<_, anyhow::Error>((tx_id, sign_id, pending_tx, outcome))
-                        });
+            // Fetch receipts for consumed txs, failures are
+            // logged and skipped: the watcher stays pending for the next
+            // throttled check.
+            let consumed_events: Vec<_> = stream::iter(consumed_txs.into_iter().map(
+                |(tx_id, (sign_id, pending_tx))| async move {
+                    let result = self
+                        .backfill_execution_confirmation(tx_id, sign_id, &pending_tx, block_number)
+                        .await;
+                    (tx_id, sign_id, pending_tx, result)
+                },
+            ))
+            .buffer_unordered(MAX_CONCURRENT_WATCHER_RPCS)
+            .filter_map(|(tx_id, sign_id, pending_tx, result)| async move {
+                match result {
+                    Ok(BackfillOutcome::Observed { event }) => event, // Late watcher pickup
+                    Ok(BackfillOutcome::NotObserved) => {
+                        tracing::warn!(
+                            ?tx_id,
+                            ?sign_id,
+                            expected_nonce = pending_tx.nonce,
+                            "transaction replaced or dropped (nonce consumed by another tx)"
+                        );
+                        Some(ChainEvent::ExecutionConfirmed {
+                            tx_id,
+                            sign_id,
+                            source_chain: pending_tx.source_chain,
+                            block_height: block_number,
+                            result: ExecutionOutcome::Failed,
+                        })
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            ?tx_id,
+                            ?sign_id,
+                            ?err,
+                            "failed to fetch receipt for nonce-consumed bidirectional tx"
+                        );
+                        None
+                    }
+                }
+            })
+            .collect()
+            .await;
 
-                let consumed_events = future::try_join_all(consumed_futures)
-                    .await?
-                    .into_iter()
-                    .filter_map(|(tx_id, sign_id, pending_tx, outcome)| match outcome {
-                        BackfillOutcome::Observed { event } => event, // Late watcher pickup
-                        BackfillOutcome::NotObserved => {
-                            tracing::warn!(
-                                ?tx_id,
-                                ?sign_id,
-                                expected_nonce = pending_tx.nonce,
-                                "transaction replaced or dropped (nonce consumed by another tx)"
-                            );
-                            Some(ChainEvent::ExecutionConfirmed {
-                                tx_id,
-                                sign_id,
-                                source_chain: pending_tx.source_chain,
-                                block_height: block_number,
-                                result: ExecutionOutcome::Failed,
-                            })
-                        }
-                    });
-
-                events.extend(consumed_events);
-            }
+            events.extend(consumed_events);
         }
 
         Ok(events)
@@ -960,7 +980,7 @@ mod tests {
     use alloy::primitives::{address, b256};
     use alloy::rpc::types::{Block, BlockId, BlockTransactions};
     use mockito::{Matcher, Server};
-    use mpc_chain_integration_core::ChainIndexer;
+    use mpc_chain_integration_core::{ChainIndexer, StateManager};
     use mpc_primitives::{
         BidirectionalTx, BidirectionalTxId, Chain, ChainEvent, ExecutionOutcome, SignId,
         LATEST_MPC_KEY_VERSION,
@@ -1862,5 +1882,199 @@ mod tests {
         assert_eq!(events.len(), 1);
         receipt_mock.assert_async().await;
         nonce_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn watcher_resolution_tolerates_single_receipt_failure() {
+        let mut server = Server::new_async().await;
+
+        let from_address = address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+        let tx_hash_ok = b256!("1111111111111111111111111111111111111111111111111111111111111111");
+        let tx_hash_err = b256!("2222222222222222222222222222222222222222222222222222222222222222");
+        let block_hash = b256!("6e4e53d1de650d5a5ebed19b38321db369ef1dc357904284ecf4d89b8834969c");
+
+        let receipt_response = json!({
+            "transactionHash": format!("{tx_hash_ok:#x}"),
+            "blockHash": format!("{block_hash:#x}"),
+            "blockNumber": "0x5",
+            "transactionIndex": "0x0",
+            "from": format!("{from_address:#x}"),
+            "to": format!("{from_address:#x}"),
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x3a29f0f8",
+            "contractAddress": null,
+            "logsBloom": format!("0x{}", "0".repeat(512)),
+            "cumulativeGasUsed": "0x5208",
+            "type": "0x2",
+            "logs": [],
+            "status": "0x0"
+        });
+
+        let receipt_ok_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionReceipt",
+                "params": [format!("{tx_hash_ok:#x}")]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": receipt_response }).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        // Always fail; the test client retries, so assert it was hit at least once
+        let receipt_err_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionReceipt",
+                "params": [format!("{tx_hash_err:#x}")]
+            })))
+            .with_status(500)
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        let builder = test_utils::TestIndexerBuilder::new(server.url());
+
+        let create_tx = |hash: alloy::primitives::B256| BidirectionalTx {
+            id: BidirectionalTxId(hash.0),
+            sender: [0u8; 32],
+            serialized_transaction: vec![],
+            source_chain: Chain::Solana,
+            target_chain: Chain::Ethereum,
+            caip2_id: "eip155:31337".to_string(),
+            key_version: LATEST_MPC_KEY_VERSION,
+            deposit: 0,
+            path: "m/44'/60'/0'/0/0".to_string(),
+            algo: "secp256k1".to_string(),
+            dest: Chain::Ethereum.to_string(),
+            params: "{}".to_string(),
+            output_deserialization_schema: vec![],
+            respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
+            request_id: hash.0,
+            from_address: **from_address,
+            nonce: 0,
+        };
+
+        builder
+            .state_manager
+            .watch_execution(Chain::Ethereum, SignId::new([1; 32]), create_tx(tx_hash_ok))
+            .await;
+        builder
+            .state_manager
+            .watch_execution(
+                Chain::Ethereum,
+                SignId::new([2; 32]),
+                create_tx(tx_hash_err),
+            )
+            .await;
+
+        let state_manager = builder.state_manager.clone();
+        let indexer = builder.build().await;
+
+        let mut block: Block = Block::default();
+        block.header.number = 5;
+        block.transactions = BlockTransactions::Hashes(vec![tx_hash_ok, tx_hash_err]);
+
+        // One failing receipt must not fail the whole block
+        let events = indexer
+            .collect_execution_confirmations(&block)
+            .await
+            .expect("block processing should tolerate a single receipt failure");
+
+        assert_eq!(
+            events.len(),
+            1,
+            "only the successful receipt emits an event"
+        );
+        match &events[0] {
+            ChainEvent::ExecutionConfirmed { tx_id, .. } => {
+                assert_eq!(tx_id.0, tx_hash_ok.0);
+            }
+            other => panic!("expected ExecutionConfirmed, got {other:?}"),
+        }
+
+        // The failed watcher stays pending for a later retry
+        let pending = state_manager.get_execution_watchers(Chain::Ethereum).await;
+        assert!(
+            pending.contains_key(&BidirectionalTxId(tx_hash_err.0)),
+            "failed watcher should remain pending"
+        );
+
+        receipt_ok_mock.assert_async().await;
+        receipt_err_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn watcher_resolution_tolerates_nonce_fetch_failure() {
+        let mut server = Server::new_async().await;
+
+        let from_address = address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+        let tx_hash = b256!("3333333333333333333333333333333333333333333333333333333333333333");
+
+        // Nonce fetch always fails; watcher must stay pending without events
+        let nonce_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionCount",
+            })))
+            .with_status(500)
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        // No receipt fetch should happen for an unmined tx whose nonce is unknown
+        let receipt_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex("eth_getTransactionReceipt".to_string()))
+            .expect(0)
+            .create_async()
+            .await;
+
+        let tx = BidirectionalTx {
+            id: BidirectionalTxId(tx_hash.0),
+            sender: [0u8; 32],
+            serialized_transaction: vec![],
+            source_chain: Chain::Solana,
+            target_chain: Chain::Ethereum,
+            caip2_id: "eip155:31337".to_string(),
+            key_version: LATEST_MPC_KEY_VERSION,
+            deposit: 0,
+            path: "m/44'/60'/0'/0/0".to_string(),
+            algo: "secp256k1".to_string(),
+            dest: Chain::Ethereum.to_string(),
+            params: "{}".to_string(),
+            output_deserialization_schema: vec![],
+            respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
+            request_id: tx_hash.0,
+            from_address: **from_address,
+            nonce: 0,
+        };
+
+        let builder = test_utils::TestIndexerBuilder::new(server.url());
+        builder
+            .state_manager
+            .watch_execution(Chain::Ethereum, SignId::new([3; 32]), tx)
+            .await;
+        let state_manager = builder.state_manager.clone();
+        let indexer = builder.build().await;
+
+        // Block height 10 triggers the throttled nonce check
+        let mut block: Block = Block::default();
+        block.header.number = 10;
+        block.transactions = BlockTransactions::Hashes(Vec::new());
+
+        let events = indexer
+            .collect_execution_confirmations(&block)
+            .await
+            .expect("nonce fetch failure should not fail block processing");
+
+        assert!(events.is_empty());
+        let pending = state_manager.get_execution_watchers(Chain::Ethereum).await;
+        assert!(pending.contains_key(&BidirectionalTxId(tx_hash.0)));
+
+        nonce_mock.assert_async().await;
+        receipt_mock.assert_async().await;
     }
 }

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -20,7 +20,7 @@ use mpc_primitives::{
 };
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration, Instant};
 use tokio_util::sync::CancellationToken;
@@ -483,9 +483,16 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         failed.extend(gated_failed);
 
         // Failed watchers are retried on the next block.
-        self.watcher_gate.lock().unwrap().retry = failed;
+        self.lock_watcher_gate().retry = failed;
 
         Ok(events)
+    }
+
+    /// Locks the watcher gate Mutex, recovering the guard if poisoned.
+    fn lock_watcher_gate(&self) -> MutexGuard<'_, WatcherGateState> {
+        self.watcher_gate
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
     }
 
     /// Updates gate scheduling state, returning the watchers to nonce-check
@@ -495,7 +502,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         &self,
         watchers: &HashMap<BidirectionalTxId, (SignId, BidirectionalTx)>,
     ) -> (HashSet<BidirectionalTxId>, HashSet<BidirectionalTxId>) {
-        let mut gate = self.watcher_gate.lock().unwrap();
+        let mut gate = self.lock_watcher_gate();
         gate.retry.retain(|id| watchers.contains_key(id));
         let new_watchers = watchers
             .keys()

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -22,13 +22,16 @@ use mpc_primitives::{
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tokio::sync::{mpsc, Notify};
 use tokio::time::{sleep, Duration, Instant};
 
 const MAX_LIVE_BLOCK_BUFFER: usize = 16384;
 /// Max concurrent JSON-RPC calls when resolving watcher receipts/nonces.
 const MAX_CONCURRENT_WATCHER_RPCS: usize = 8;
+/// Cadence (in blocks) of the full nonce sweep over long-pending watchers.
+/// Backstop only: consumption by a tx with no local watcher shouldn't happen.
+const WATCHER_SLOW_SWEEP_INTERVAL: u64 = 10;
 /// Limit of consecutive `get_block(Finalized)` total failures allowed before `wait_for_finalized_block` gives up.
 const MAX_FINALIZED_FAILURES: u32 = 20;
 
@@ -79,7 +82,29 @@ pub struct EthereumIndexer<S: StateManager, T: ChainTelemetry> {
     live_blocks_rx: Option<mpsc::Receiver<MaybeBlock>>,
     /// The block number of the latest finalized block at the time catchup started. Used to determine which blocks are finalized during catchup.
     catchup_finalized_head: AtomicU64,
+    /// Watcher nonce-gate scheduling state (first-appearance checks + retries).
+    watcher_gate: Mutex<WatcherGateState>,
 }
+
+/// Scheduling state for the watcher nonce gate
+#[derive(Default)]
+struct WatcherGateState {
+    /// Watchers present at the previous block, for first-appearance detection.
+    prev: HashSet<BidirectionalTxId>,
+    /// Watchers whose last RPC resolution attempt failed; retried every block.
+    retry: HashSet<BidirectionalTxId>,
+}
+
+/// A pending execution watcher entry from the state manager.
+type WatcherEntry = (BidirectionalTxId, (SignId, BidirectionalTx));
+
+/// Per-watcher receipt resolution result.
+type WatcherReceipt = (
+    BidirectionalTxId,
+    SignId,
+    BidirectionalTx,
+    anyhow::Result<BackfillOutcome>,
+);
 
 /// Result of a `backfill_execution_confirmation`. `Observed` carries an
 /// optional event; the staleness check skips observed watchers so a mined tx
@@ -114,6 +139,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             catchup_complete: Arc::new(Notify::new()),
             live_blocks_rx: None,
             catchup_finalized_head: AtomicU64::new(0),
+            watcher_gate: Mutex::new(WatcherGateState::default()),
         })
     }
 
@@ -141,6 +167,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             catchup_complete: Arc::new(Notify::new()),
             live_blocks_rx: None,
             catchup_finalized_head: AtomicU64::new(0),
+            watcher_gate: Mutex::new(WatcherGateState::default()),
         }
     }
 
@@ -423,7 +450,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         Ok(BackfillOutcome::Observed { event })
     }
 
-    /// Collects execution confirmations for all watchers at the given block number.
+    /// Collects execution confirmations for all watchers at the given block
     async fn collect_execution_confirmations(
         &self,
         block: &Block,
@@ -444,6 +471,8 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             "collect_execution_confirmations checking watchers"
         );
 
+        let (new_watchers, retry) = self.schedule_watcher_gates(&watchers);
+
         // Extract hashes from the block
         let block_tx_hashes: HashSet<_> = match &block.transactions {
             BlockTransactions::Hashes(hashes) => hashes.iter().copied().collect(),
@@ -456,22 +485,124 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             .into_iter()
             .partition(|(tx_id, _)| block_tx_hashes.contains(&B256::from(tx_id.0)));
 
-        // Fetch receipts for transactions mined in this block, failures are
-        // logged and skipped: the watcher stays pending and the nonce gate
-        // picks it up again.
-        let mut events: Vec<ChainEvent> = stream::iter(mined_in_block.into_iter().map(
-            |(tx_id, (sign_id, pending_tx))| async move {
-                let result = self
-                    .backfill_execution_confirmation(tx_id, sign_id, &pending_tx, block_number)
-                    .await;
-                (tx_id, sign_id, result)
-            },
-        ))
+        // Receipts for watched txs mined in this block
+        let (mut events, consumed_slots, mut failed) = self
+            .resolve_mined_watchers(mined_in_block, block_number)
+            .await;
+
+        // Fail pending watchers replaced by a sibling tx mined in this block
+        let (sibling_events, unmined_watchers) =
+            Self::resolve_replaced_siblings(unmined_watchers, &consumed_slots, block_number);
+
+        events.extend(sibling_events);
+
+        // Nonce gate: one-shot for new watchers, every block for retries,
+        // every WATCHER_SLOW_SWEEP_INTERVAL blocks for edge-case consumption by a tx with no local watcher.
+        let sweep_all = block_number % WATCHER_SLOW_SWEEP_INTERVAL == 0;
+        let gated: Vec<_> = unmined_watchers
+            .into_iter()
+            .filter(|(tx_id, _)| sweep_all || new_watchers.contains(tx_id) || retry.contains(tx_id))
+            .collect();
+
+        let (gated_events, gated_failed) = self.resolve_gated_watchers(gated, block_number).await;
+        events.extend(gated_events);
+        failed.extend(gated_failed);
+
+        // Failed watchers are retried on the next block.
+        self.watcher_gate.lock().unwrap().retry = failed;
+
+        Ok(events)
+    }
+
+    /// Updates gate scheduling state, returning the watchers to nonce-check
+    /// this block: newly appeared ones (one-shot) and previously failed ones
+    /// (retried every block).
+    fn schedule_watcher_gates(
+        &self,
+        watchers: &HashMap<BidirectionalTxId, (SignId, BidirectionalTx)>,
+    ) -> (HashSet<BidirectionalTxId>, HashSet<BidirectionalTxId>) {
+        let mut gate = self.watcher_gate.lock().unwrap();
+        gate.retry.retain(|id| watchers.contains_key(id));
+        let new_watchers = watchers
+            .keys()
+            .filter(|id| !gate.prev.contains(*id))
+            .copied()
+            .collect();
+        gate.prev = watchers.keys().copied().collect();
+        (new_watchers, gate.retry.clone())
+    }
+
+    /// Fetches receipts for a batch of watchers with bounded concurrency,
+    /// keeping per-watcher results so one failure doesn't abort the batch.
+    async fn fetch_watcher_receipts(
+        &self,
+        watchers: Vec<WatcherEntry>,
+        block_number: u64,
+    ) -> Vec<WatcherReceipt> {
+        stream::iter(
+            watchers
+                .into_iter()
+                .map(|(tx_id, (sign_id, pending_tx))| async move {
+                    let result = self
+                        .backfill_execution_confirmation(tx_id, sign_id, &pending_tx, block_number)
+                        .await;
+                    (tx_id, sign_id, pending_tx, result)
+                }),
+        )
         .buffer_unordered(MAX_CONCURRENT_WATCHER_RPCS)
-        .filter_map(|(tx_id, sign_id, result)| async move {
+        .collect()
+        .await
+    }
+
+    /// Fetches nonces for the given senders with bounded concurrency.
+    async fn fetch_sender_nonces(
+        &self,
+        senders: HashSet<Address>,
+        block_number: u64,
+    ) -> Vec<(Address, anyhow::Result<u64>)> {
+        stream::iter(senders.into_iter().map(|sender| async move {
+            let result = self
+                .client
+                .get_nonce(
+                    sender,
+                    BlockId::Number(BlockNumberOrTag::Number(block_number)),
+                )
+                .await;
+            (sender, result)
+        }))
+        .buffer_unordered(MAX_CONCURRENT_WATCHER_RPCS)
+        .collect()
+        .await
+    }
+
+    /// Resolves watched txs whose hash appears in this block. Returns emitted
+    /// events, the (sender, nonce) slots consumed by observed txs (input to
+    /// sibling correlation), and watchers whose RPC attempt failed.
+    async fn resolve_mined_watchers(
+        &self,
+        mined: Vec<WatcherEntry>,
+        block_number: u64,
+    ) -> (
+        Vec<ChainEvent>,
+        HashSet<(Address, u64)>,
+        HashSet<BidirectionalTxId>,
+    ) {
+        let mut events = Vec::new();
+        let mut consumed_slots = HashSet::new();
+        let mut failed = HashSet::new();
+
+        for (tx_id, sign_id, pending_tx, result) in
+            self.fetch_watcher_receipts(mined, block_number).await
+        {
             match result {
-                Ok(BackfillOutcome::Observed { event }) => event,
-                Ok(BackfillOutcome::NotObserved) => None,
+                Ok(BackfillOutcome::Observed { event }) => {
+                    consumed_slots
+                        .insert((Address::from(pending_tx.from_address), pending_tx.nonce));
+                    if let Some(event) = event {
+                        events.push(event);
+                    }
+                }
+                Ok(BackfillOutcome::NotObserved) => {}
                 Err(err) => {
                     tracing::warn!(
                         ?tx_id,
@@ -479,109 +610,135 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
                         ?err,
                         "failed to fetch receipt for bidirectional tx mined in block"
                     );
-                    None
+                    failed.insert(tx_id);
                 }
             }
-        })
-        .collect()
-        .await;
-
-        // Throttle the nonce check to every 10 blocks (Detects replaced/dropped txs)
-        if block_number % 10 == 0 && !unmined_watchers.is_empty() {
-            // Extract unique senders functionally
-            let unique_senders: HashSet<_> = unmined_watchers
-                .iter()
-                .map(|(_, (_, tx))| Address::from(tx.from_address))
-                .collect();
-
-            // Fetch nonces, failed senders are skipped, leaving
-            // their watchers pending for the next throttled check.
-            let nonces: HashMap<_, _> =
-                stream::iter(unique_senders.into_iter().map(|sender| async move {
-                    let result = self
-                        .client
-                        .get_nonce(
-                            sender,
-                            BlockId::Number(BlockNumberOrTag::Number(block_number)),
-                        )
-                        .await;
-                    (sender, result)
-                }))
-                .buffer_unordered(MAX_CONCURRENT_WATCHER_RPCS)
-                .filter_map(|(sender, result)| async move {
-                    match result {
-                        Ok(nonce) => Some((sender, nonce)),
-                        Err(err) => {
-                            tracing::warn!(
-                                ?sender,
-                                ?err,
-                                "failed to fetch nonce for bidirectional tx"
-                            );
-                            None
-                        }
-                    }
-                })
-                .collect()
-                .await;
-
-            // Filter unmined watchers down to ONLY those whose nonces were consumed
-            let consumed_txs: Vec<_> = unmined_watchers
-                .into_iter()
-                .filter(|(_, (_, tx))| {
-                    nonces
-                        .get(&Address::from(tx.from_address))
-                        .is_some_and(|&current_nonce| tx.nonce < current_nonce)
-                })
-                .collect();
-
-            // Fetch receipts for consumed txs, failures are
-            // logged and skipped: the watcher stays pending for the next
-            // throttled check.
-            let consumed_events: Vec<_> = stream::iter(consumed_txs.into_iter().map(
-                |(tx_id, (sign_id, pending_tx))| async move {
-                    let result = self
-                        .backfill_execution_confirmation(tx_id, sign_id, &pending_tx, block_number)
-                        .await;
-                    (tx_id, sign_id, pending_tx, result)
-                },
-            ))
-            .buffer_unordered(MAX_CONCURRENT_WATCHER_RPCS)
-            .filter_map(|(tx_id, sign_id, pending_tx, result)| async move {
-                match result {
-                    Ok(BackfillOutcome::Observed { event }) => event, // Late watcher pickup
-                    Ok(BackfillOutcome::NotObserved) => {
-                        tracing::warn!(
-                            ?tx_id,
-                            ?sign_id,
-                            expected_nonce = pending_tx.nonce,
-                            "transaction replaced or dropped (nonce consumed by another tx)"
-                        );
-                        Some(ChainEvent::ExecutionConfirmed {
-                            tx_id,
-                            sign_id,
-                            source_chain: pending_tx.source_chain,
-                            block_height: block_number,
-                            result: ExecutionOutcome::Failed,
-                        })
-                    }
-                    Err(err) => {
-                        tracing::warn!(
-                            ?tx_id,
-                            ?sign_id,
-                            ?err,
-                            "failed to fetch receipt for nonce-consumed bidirectional tx"
-                        );
-                        None
-                    }
-                }
-            })
-            .collect()
-            .await;
-
-            events.extend(consumed_events);
         }
 
-        Ok(events)
+        (events, consumed_slots, failed)
+    }
+
+    /// Fails pending watchers whose (sender, nonce) slot was consumed by a
+    /// different tx mined in this block: since only the network can sign for
+    /// these sender addresses, the consuming tx is necessarily another
+    /// watcher, making replacement a pure function of block content + local
+    /// watcher state (no RPC, deterministic `block_height` across nodes).
+    /// Returns the events and the remaining unmined watchers.
+    fn resolve_replaced_siblings(
+        unmined: Vec<WatcherEntry>,
+        consumed_slots: &HashSet<(Address, u64)>,
+        block_number: u64,
+    ) -> (Vec<ChainEvent>, Vec<WatcherEntry>) {
+        let (replaced, remaining): (Vec<_>, Vec<_>) =
+            unmined.into_iter().partition(|(_, (_, tx))| {
+                consumed_slots.contains(&(Address::from(tx.from_address), tx.nonce))
+            });
+
+        let events = replaced
+            .into_iter()
+            .map(|(tx_id, (sign_id, tx))| {
+                tracing::warn!(
+                    ?tx_id,
+                    ?sign_id,
+                    nonce = tx.nonce,
+                    "transaction replaced by sibling tx mined in this block"
+                );
+                ChainEvent::ExecutionConfirmed {
+                    tx_id,
+                    sign_id,
+                    source_chain: tx.source_chain,
+                    block_height: block_number,
+                    result: ExecutionOutcome::Failed,
+                }
+            })
+            .collect();
+
+        (events, remaining)
+    }
+
+    /// Nonce-gates unmined watchers: fetches deduped sender nonces, then
+    /// resolves watchers whose nonce was consumed. Returns emitted events and
+    /// watchers whose RPC attempt failed.
+    async fn resolve_gated_watchers(
+        &self,
+        gated: Vec<WatcherEntry>,
+        block_number: u64,
+    ) -> (Vec<ChainEvent>, HashSet<BidirectionalTxId>) {
+        let unique_senders: HashSet<_> = gated
+            .iter()
+            .map(|(_, (_, tx))| Address::from(tx.from_address))
+            .collect();
+
+        // Failed senders are skipped: their watchers stay pending and are
+        // retried on the next block.
+        let mut nonces = HashMap::new();
+        let mut failed = HashSet::new();
+        for (sender, result) in self.fetch_sender_nonces(unique_senders, block_number).await {
+            match result {
+                Ok(nonce) => {
+                    nonces.insert(sender, nonce);
+                }
+                Err(err) => {
+                    tracing::warn!(?sender, ?err, "failed to fetch nonce for bidirectional tx");
+                    failed.extend(
+                        gated
+                            .iter()
+                            .filter(|(_, (_, tx))| Address::from(tx.from_address) == sender)
+                            .map(|(tx_id, _)| *tx_id),
+                    );
+                }
+            }
+        }
+
+        // Keep ONLY watchers whose nonces were consumed
+        let consumed_txs: Vec<_> = gated
+            .into_iter()
+            .filter(|(_, (_, tx))| {
+                nonces
+                    .get(&Address::from(tx.from_address))
+                    .is_some_and(|&current_nonce| tx.nonce < current_nonce)
+            })
+            .collect();
+
+        let mut events = Vec::new();
+        for (tx_id, sign_id, pending_tx, result) in self
+            .fetch_watcher_receipts(consumed_txs, block_number)
+            .await
+        {
+            match result {
+                Ok(BackfillOutcome::Observed { event }) => {
+                    if let Some(event) = event {
+                        events.push(event); // Late watcher pickup
+                    }
+                }
+                Ok(BackfillOutcome::NotObserved) => {
+                    tracing::warn!(
+                        ?tx_id,
+                        ?sign_id,
+                        expected_nonce = pending_tx.nonce,
+                        "transaction replaced or dropped (nonce consumed by another tx)"
+                    );
+                    events.push(ChainEvent::ExecutionConfirmed {
+                        tx_id,
+                        sign_id,
+                        source_chain: pending_tx.source_chain,
+                        block_height: block_number,
+                        result: ExecutionOutcome::Failed,
+                    });
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        ?tx_id,
+                        ?sign_id,
+                        ?err,
+                        "failed to fetch receipt for nonce-consumed bidirectional tx"
+                    );
+                    failed.insert(tx_id);
+                }
+            }
+        }
+
+        (events, failed)
     }
 
     /// Emits the processed block in-order once we reach finality for it.

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -6,19 +6,20 @@ use crate::event_parsing::{emit_respond_events, is_contract_call, parse_filtered
 use crate::EthConfig;
 use alloy::consensus::Transaction;
 use alloy::eips::BlockNumberOrTag;
-use alloy::primitives::Address;
-use alloy::rpc::types::{Block, BlockId, Log};
+use alloy::network::TransactionResponse;
+use alloy::primitives::{Address, B256};
+use alloy::rpc::types::{Block, BlockId, BlockTransactions, Log};
 use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use async_trait::async_trait;
-use futures_util::{future::try_join_all, stream};
+use futures_util::{future, stream};
 use mpc_chain_integration_core::utils::stream::chain_event_channel;
 use mpc_chain_integration_core::{ChainIndexer, ChainStream, ChainTelemetry, StateManager};
 use mpc_primitives::{
     BidirectionalTx, BidirectionalTxId, Chain, ChainEvent, ExecutionOutcome, IndexedSignRequest,
     SignId,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -267,7 +268,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         }
 
         // Collect execution confirmations (if any) and emit ExecutionConfirmed events
-        let exec_events = self.collect_execution_confirmations(block_number).await?;
+        let exec_events = self.collect_execution_confirmations(block).await?;
 
         // Always forward the processed block to the "finalization" stage so it can emit
         // `ChainEvent::Block` even when there are no relevant contract logs.
@@ -423,7 +424,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     /// Collects execution confirmations for all watchers at the given block number.
     async fn collect_execution_confirmations(
         &self,
-        block_number: u64,
+        block: &Block,
     ) -> anyhow::Result<Vec<ChainEvent>> {
         let watchers = self
             .state_manager
@@ -434,85 +435,131 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             return Ok(Vec::new());
         }
 
+        let block_number = block.header.number;
         tracing::info!(
             watchers_count = watchers.len(),
             block_number,
             "collect_execution_confirmations checking watchers"
         );
 
-        // Group watchers by from_address
-        let mut unique_senders = HashSet::new();
-        for (_, tx) in watchers.values() {
-            unique_senders.insert(Address::from(tx.from_address));
-        }
+        // Extract hashes from the block
+        let block_tx_hashes: HashSet<_> = match &block.transactions {
+            BlockTransactions::Hashes(hashes) => hashes.iter().copied().collect(),
+            BlockTransactions::Full(txs) => txs.iter().map(|tx| tx.tx_hash()).collect(),
+            _ => HashSet::new(),
+        };
 
-        // Fetch the current nonce for each unique sender
-        let nonce_futures = unique_senders.into_iter().map(|sender| async move {
-            let current_nonce = self
-                .client
-                .get_nonce(
-                    sender,
-                    BlockId::Number(BlockNumberOrTag::Number(block_number)),
-                )
-                .await?;
-            Ok::<_, anyhow::Error>((sender, current_nonce))
-        });
-
-        // Collect the nonces into a HashMap for easy lookup
-        let nonces: HashMap<Address, u64> =
-            try_join_all(nonce_futures).await?.into_iter().collect();
-
-        // Filter transactions down to ONLY those whose nonce has been consumed
-        let ready_txs: Vec<_> = watchers
+        // Partition watchers into those that mined in this block and those that did not
+        let (mined_in_block, unmined_watchers): (Vec<_>, Vec<_>) = watchers
             .into_iter()
-            .filter(|(_, (_, tx))| {
-                let sender = Address::from(tx.from_address);
-                if let Some(&current_nonce) = nonces.get(&sender) {
-                    tx.nonce < current_nonce
-                } else {
-                    false
-                }
-            })
-            .collect();
+            .partition(|(tx_id, _)| block_tx_hashes.contains(&B256::from(tx_id.0)));
 
-        if ready_txs.is_empty() {
-            return Ok(Vec::new());
-        }
+        // Fetch receipts for transactions mined in this block
+        let mut events = if mined_in_block.is_empty() {
+            Vec::new()
+        } else {
+            let futures =
+                mined_in_block
+                    .into_iter()
+                    .map(|(tx_id, (sign_id, pending_tx))| async move {
+                        let outcome = self
+                            .backfill_execution_confirmation(
+                                tx_id,
+                                sign_id,
+                                &pending_tx,
+                                block_number,
+                            )
+                            .await?;
+                        Ok::<_, anyhow::Error>(outcome)
+                    });
 
-        // Fetch receipts for the ready transactions
-        let receipt_futures =
-            ready_txs
+            future::try_join_all(futures)
+                .await?
                 .into_iter()
-                .map(|(tx_id, (sign_id, pending_tx))| async move {
-                    let outcome = self
-                        .backfill_execution_confirmation(tx_id, sign_id, &pending_tx, block_number)
-                        .await?;
-                    Ok::<_, anyhow::Error>((tx_id, sign_id, pending_tx, outcome))
-                });
+                .filter_map(|outcome| match outcome {
+                    BackfillOutcome::Observed { event } => event,
+                    BackfillOutcome::NotObserved => None,
+                })
+                .collect()
+        };
 
-        let receipt_results = try_join_all(receipt_futures).await?;
+        // Throttle the nonce check to every 10 blocks (Detects replaced/dropped txs)
+        if block_number % 10 == 0 && !unmined_watchers.is_empty() {
+            // Extract unique senders functionally
+            let unique_senders: std::collections::HashSet<_> = unmined_watchers
+                .iter()
+                .map(|(_, (_, tx))| Address::from(tx.from_address))
+                .collect();
 
-        // Process the receipt results into events
-        let events = receipt_results
-            .into_iter()
-            .filter_map(|(tx_id, sign_id, pending_tx, outcome)| match outcome {
-                BackfillOutcome::Observed { event } => event, // Return event if Some, skip if None (extraction failed)
-                BackfillOutcome::NotObserved => {
-                    tracing::warn!(
-                        ?tx_id,
-                        ?sign_id,
-                        "transaction replaced or dropped (nonce consumed by another tx)"
-                    );
-                    Some(ChainEvent::ExecutionConfirmed {
-                        tx_id,
-                        sign_id,
-                        source_chain: pending_tx.source_chain,
-                        block_height: block_number,
-                        result: ExecutionOutcome::Failed,
-                    })
-                }
-            })
-            .collect();
+            // Fetch nonces concurrently
+            let nonce_futures = unique_senders.into_iter().map(|sender| async move {
+                let nonce = self
+                    .client
+                    .get_nonce(
+                        sender,
+                        BlockId::Number(BlockNumberOrTag::Number(block_number)),
+                    )
+                    .await?;
+                Ok::<_, anyhow::Error>((sender, nonce))
+            });
+
+            let nonces: std::collections::HashMap<_, _> = future::try_join_all(nonce_futures)
+                .await?
+                .into_iter()
+                .collect();
+
+            // Filter unmined watchers down to ONLY those whose nonces were consumed
+            let consumed_txs: Vec<_> = unmined_watchers
+                .into_iter()
+                .filter(|(_, (_, tx))| {
+                    nonces
+                        .get(&Address::from(tx.from_address))
+                        .is_some_and(|&current_nonce| tx.nonce < current_nonce)
+                })
+                .collect();
+
+            // Fetch receipts for consumed txs concurrently
+            if !consumed_txs.is_empty() {
+                let consumed_futures =
+                    consumed_txs
+                        .into_iter()
+                        .map(|(tx_id, (sign_id, pending_tx))| async move {
+                            let outcome = self
+                                .backfill_execution_confirmation(
+                                    tx_id,
+                                    sign_id,
+                                    &pending_tx,
+                                    block_number,
+                                )
+                                .await?;
+                            Ok::<_, anyhow::Error>((tx_id, sign_id, pending_tx, outcome))
+                        });
+
+                let consumed_events = future::try_join_all(consumed_futures)
+                    .await?
+                    .into_iter()
+                    .filter_map(|(tx_id, sign_id, pending_tx, outcome)| match outcome {
+                        BackfillOutcome::Observed { event } => event, // Late watcher pickup
+                        BackfillOutcome::NotObserved => {
+                            tracing::warn!(
+                                ?tx_id,
+                                ?sign_id,
+                                expected_nonce = pending_tx.nonce,
+                                "transaction replaced or dropped (nonce consumed by another tx)"
+                            );
+                            Some(ChainEvent::ExecutionConfirmed {
+                                tx_id,
+                                sign_id,
+                                source_chain: pending_tx.source_chain,
+                                block_height: block_number,
+                                result: ExecutionOutcome::Failed,
+                            })
+                        }
+                    });
+
+                events.extend(consumed_events);
+            }
+        }
 
         Ok(events)
     }
@@ -910,8 +957,8 @@ mod tests {
     use crate::client::CatchupItem;
     use crate::test_utils;
     use alloy::eips::BlockNumberOrTag;
-    use alloy::primitives::{address, b256, B256};
-    use alloy::rpc::types::BlockId;
+    use alloy::primitives::{address, b256};
+    use alloy::rpc::types::{Block, BlockId, BlockTransactions};
     use mockito::{Matcher, Server};
     use mpc_chain_integration_core::ChainIndexer;
     use mpc_primitives::{
@@ -1517,12 +1564,12 @@ mod tests {
             "status": "0x0"
         });
 
-        // Mock the eth_getTransactionCount
+        // Mock Nonce Call: Block height 10 ("0xa"), returning current nonce 1
         server
             .mock("POST", "/")
             .match_body(Matcher::PartialJson(json!({
                 "method": "eth_getTransactionCount",
-                "params": [format!("{from_address:#x}"), "0x5"]
+                "params": [format!("{from_address:#x}"), "0xa"]
             })))
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -1530,7 +1577,7 @@ mod tests {
             .create_async()
             .await;
 
-        // Mock the eth_getTransactionReceipt
+        // Mock Receipt Call
         server
             .mock("POST", "/")
             .match_body(Matcher::PartialJson(json!({
@@ -1578,8 +1625,13 @@ mod tests {
             .await;
         let indexer = builder.build().await;
 
+        // Construct mock block at height 10 (triggers modulo 10 check)
+        let mut block: Block = Block::default();
+        block.header.number = 10;
+        block.transactions = BlockTransactions::Hashes(Vec::new());
+
         let events = indexer
-            .collect_execution_confirmations(5)
+            .collect_execution_confirmations(&block)
             .await
             .expect("late watcher backfill should succeed");
 
@@ -1611,12 +1663,12 @@ mod tests {
         let tx_hash_1 = b256!("1111111111111111111111111111111111111111111111111111111111111111");
         let tx_hash_2 = b256!("2222222222222222222222222222222222222222222222222222222222222222");
 
-        // Mock Nonce Call: Expect exactly 1 call (deduplicated), returning nonce 2
+        // Mock Nonce Call: Expect exactly 1 call (deduplicated) for height 10 ("0xa"), returning nonce 2
         let nonce_mock = server
             .mock("POST", "/")
             .match_body(Matcher::PartialJson(json!({
                 "method": "eth_getTransactionCount",
-                "params": [format!("{from_address:#x}"), "0x5"] // block height 5
+                "params": [format!("{from_address:#x}"), "0xa"]
             })))
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -1647,32 +1699,30 @@ mod tests {
             .match_body(Matcher::PartialJson(json!({ "method": "eth_getTransactionReceipt", "params": [format!("{tx_hash_2:#x}")] })))
             .with_status(200)
             .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": null }).to_string())
-            .expect(0) // STRICT ASSERT: Must NOT be called because nonce < current_nonce is false
+            .expect(0) // Nonce < current_nonce is false
             .create_async().await;
 
         // Setup Indexer & Watchers
         let builder = test_utils::TestIndexerBuilder::new(server.url());
 
-        let create_tx = |hash: B256, nonce: u64| {
-            BidirectionalTx {
-                id: BidirectionalTxId(hash.0),
-                sender: [0u8; 32],
-                serialized_transaction: vec![],
-                source_chain: Chain::Solana,
-                target_chain: Chain::Ethereum,
-                caip2_id: "eip155:31337".to_string(),
-                key_version: LATEST_MPC_KEY_VERSION,
-                deposit: 0,
-                path: "m/44'/60'/0'/0/0".to_string(),
-                algo: "secp256k1".to_string(),
-                dest: Chain::Ethereum.to_string(),
-                params: "{}".to_string(),
-                output_deserialization_schema: vec![],
-                respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
-                request_id: hash.0,
-                from_address: **from_address,
-                nonce, // nonce is the key differentiator for this test
-            }
+        let create_tx = |hash: alloy::primitives::B256, nonce: u64| BidirectionalTx {
+            id: BidirectionalTxId(hash.0),
+            sender: [0u8; 32],
+            serialized_transaction: vec![],
+            source_chain: Chain::Solana,
+            target_chain: Chain::Ethereum,
+            caip2_id: "eip155:31337".to_string(),
+            key_version: LATEST_MPC_KEY_VERSION,
+            deposit: 0,
+            path: "m/44'/60'/0'/0/0".to_string(),
+            algo: "secp256k1".to_string(),
+            dest: Chain::Ethereum.to_string(),
+            params: "{}".to_string(),
+            output_deserialization_schema: vec![],
+            respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
+            request_id: hash.0,
+            from_address: **from_address,
+            nonce,
         };
 
         builder
@@ -1702,22 +1752,115 @@ mod tests {
 
         let indexer = builder.build().await;
 
-        // Run Execution Confirmations
+        // Mock block at height 10
+        let mut block: Block = Block::default();
+        block.header.number = 10;
+        block.transactions = BlockTransactions::Hashes(Vec::new());
+
         let events = indexer
-            .collect_execution_confirmations(5)
+            .collect_execution_confirmations(&block)
             .await
             .expect("should succeed");
 
-        // We returned null for the receipts, so it assumes they were dropped/replaced.
         assert_eq!(
             events.len(),
             2,
-            "Should emit 2 Failed events for the 2 consumed nonces"
+            "Should emit 2 Failed events for consumed nonces"
         );
 
         nonce_mock.assert_async().await;
         receipt_mock_0.assert_async().await;
         receipt_mock_1.assert_async().await;
         receipt_mock_2.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn watcher_resolution_uses_block_transactions_without_nonce_rpc() {
+        let mut server = Server::new_async().await;
+
+        let from_address = address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+        let tx_hash = b256!("018b2331d461a4aeedf6a1f9cc37463377578244e6a35216057a8370714e798f");
+        let block_hash = b256!("6e4e53d1de650d5a5ebed19b38321db369ef1dc357904284ecf4d89b8834969c");
+
+        let receipt_response = json!({
+            "transactionHash": format!("{tx_hash:#x}"),
+            "blockHash": format!("{block_hash:#x}"),
+            "blockNumber": "0x5",
+            "transactionIndex": "0x0",
+            "from": format!("{from_address:#x}"),
+            "to": format!("{from_address:#x}"),
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x3a29f0f8",
+            "contractAddress": null,
+            "logsBloom": format!("0x{}", "0".repeat(512)),
+            "cumulativeGasUsed": "0x5208",
+            "type": "0x2",
+            "logs": [],
+            "status": "0x0"
+        });
+
+        // Mock Receipt: EXPECT 1 call
+        let receipt_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionReceipt",
+                "params": [format!("{tx_hash:#x}")]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": receipt_response }).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        // Mock Nonce: EXPECT 0 calls (because the hash was found directly in the block!)
+        let nonce_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex("eth_getTransactionCount".to_string()))
+            .expect(0)
+            .create_async()
+            .await;
+
+        let sign_id = SignId::new([0x55; 32]);
+        let tx = BidirectionalTx {
+            id: BidirectionalTxId(tx_hash.0),
+            sender: [0u8; 32],
+            serialized_transaction: vec![],
+            source_chain: Chain::Solana,
+            target_chain: Chain::Ethereum,
+            caip2_id: "eip155:31337".to_string(),
+            key_version: LATEST_MPC_KEY_VERSION,
+            deposit: 0,
+            path: "m/44'/60'/0'/0/0".to_string(),
+            algo: "secp256k1".to_string(),
+            dest: Chain::Ethereum.to_string(),
+            params: "{}".to_string(),
+            output_deserialization_schema: vec![],
+            respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
+            request_id: sign_id.request_id,
+            from_address: **from_address,
+            nonce: 0,
+        };
+
+        let builder = test_utils::TestIndexerBuilder::new(server.url());
+        builder
+            .state_manager
+            .watch_execution(Chain::Ethereum, sign_id, tx)
+            .await;
+        let indexer = builder.build().await;
+
+        // Block height 5 (NOT a modulo 10 block), but contains tx_hash in block.transactions
+        let mut block: Block = Block::default();
+        block.header.number = 5;
+        block.transactions = BlockTransactions::Hashes(vec![tx_hash]);
+
+        let events = indexer
+            .collect_execution_confirmations(&block)
+            .await
+            .expect("should succeed");
+
+        assert_eq!(events.len(), 1);
+        receipt_mock.assert_async().await;
+        nonce_mock.assert_async().await;
     }
 }

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -11,7 +11,10 @@ use alloy::rpc::types::{Block, BlockId, Log};
 use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use async_trait::async_trait;
-use futures_util::stream;
+use futures_util::{
+    future::{join_all, try_join_all},
+    stream,
+};
 use mpc_chain_integration_core::utils::stream::chain_event_channel;
 use mpc_chain_integration_core::{ChainIndexer, ChainStream, ChainTelemetry, StateManager};
 use mpc_primitives::{
@@ -420,21 +423,18 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         Ok(BackfillOutcome::Observed { event })
     }
 
+    /// Collects execution confirmations for all watchers at the given block number.
     async fn collect_execution_confirmations(
         &self,
         block_number: u64,
     ) -> anyhow::Result<Vec<ChainEvent>> {
-        let mut events = Vec::new();
-        // let mut resolved_tx_ids = HashSet::new();
-
         let watchers = self
             .state_manager
             .get_execution_watchers(Chain::Ethereum)
             .await;
 
-        // If there are no watchers return early.
         if watchers.is_empty() {
-            return Ok(events);
+            return Ok(Vec::new());
         }
 
         tracing::info!(
@@ -443,7 +443,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             "collect_execution_confirmations checking watchers"
         );
 
-        // Group watchers by from_address to deduplicate nonce fetching
+        // Group watchers by from_address
         let mut watchers_by_sender: HashMap<Address, Vec<_>> = HashMap::new();
         for (tx_id, (sign_id, pending_tx)) in watchers {
             watchers_by_sender
@@ -452,64 +452,72 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
                 .push((tx_id, sign_id, pending_tx));
         }
 
-        for (sender, pending_txs) in watchers_by_sender {
-            // Fetch the nonce for this sender at the exact current block
-            let current_nonce = match self
-                .client
-                .get_nonce(
-                    sender,
-                    BlockId::Number(BlockNumberOrTag::Number(block_number)),
-                )
-                .await
-            {
-                Ok(nonce) => nonce,
+        // Fetch the current nonce for each unique sender
+        let nonce_futures = watchers_by_sender
+            .into_iter()
+            .map(|(sender, txs)| async move {
+                // Fetch the nonce for this sender at the exact current block
+                let current_nonce = self
+                    .client
+                    .get_nonce(
+                        sender.into(),
+                        BlockId::Number(BlockNumberOrTag::Number(block_number)),
+                    )
+                    .await;
+                (sender, txs, current_nonce)
+            });
+        let senders_with_nonces = join_all(nonce_futures).await;
+
+        // Filter transactions down to ONLY those whose nonce has been consumed
+        let ready_txs: Vec<_> = senders_with_nonces
+            .into_iter()
+            .filter_map(|(sender, txs, nonce_res)| match nonce_res {
+                Ok(current_nonce) => Some(
+                    txs.into_iter()
+                        .filter(move |(_, _, tx)| tx.nonce < current_nonce),
+                ),
                 Err(err) => {
                     tracing::warn!(?sender, ?err, "Failed to fetch nonce for sender");
-                    continue;
+                    None
                 }
-            };
+            })
+            .flatten()
+            .collect();
 
-            // Iterate over the pending transactions for this sender and check if their nonce has been consumed
-            for (tx_id, sign_id, pending_tx) in pending_txs {
-                if current_nonce <= pending_tx.nonce {
-                    // Nonce hasn't been reached yet. Still pending. 0 RPC calls needed!
-                    continue;
-                }
+        // Fetch receipts for the ready transactions
+        let receipt_futures =
+            ready_txs
+                .into_iter()
+                .map(|(tx_id, sign_id, pending_tx)| async move {
+                    let outcome = self
+                        .backfill_execution_confirmation(tx_id, sign_id, &pending_tx, block_number)
+                        .await?;
+                    Ok::<_, anyhow::Error>((tx_id, sign_id, pending_tx, outcome))
+                });
 
-                // TODO: submit as batch or parallelize the per-watcher `eth_getTransactionReceipt` calls once
-                // we have a way to track rate-limits and backoff for all requests (right now we just retry individually on failure)
-                // The nonce has been consumed by the network. The tx was either mined or replaced.
-                match self
-                    .backfill_execution_confirmation(tx_id, sign_id, &pending_tx, block_number)
-                    .await?
-                {
-                    BackfillOutcome::Observed { event } => {
-                        if let Some(event) = event {
-                            events.push(event);
-                        }
-                        // If event is None, extraction failed — leave pending for retry
-                    }
-                    BackfillOutcome::NotObserved => {
-                        // Nonce consumed, but our specific tx_hash isn't mined.
-                        // This means the transaction was replaced or dropped.
-                        tracing::warn!(
-                            ?tx_id,
-                            ?sign_id,
-                            expected_nonce = pending_tx.nonce,
-                            current_nonce,
-                            "transaction replaced or dropped (nonce consumed by another tx)"
-                        );
-                        events.push(ChainEvent::ExecutionConfirmed {
-                            tx_id,
-                            sign_id,
-                            source_chain: pending_tx.source_chain,
-                            block_height: block_number,
-                            result: ExecutionOutcome::Failed,
-                        });
-                    }
+        let receipt_results = try_join_all(receipt_futures).await?;
+
+        // Process the receipt results into events
+        let events = receipt_results
+            .into_iter()
+            .filter_map(|(tx_id, sign_id, pending_tx, outcome)| match outcome {
+                BackfillOutcome::Observed { event } => event, // Return event if Some, skip if None (extraction failed)
+                BackfillOutcome::NotObserved => {
+                    tracing::warn!(
+                        ?tx_id,
+                        ?sign_id,
+                        "transaction replaced or dropped (nonce consumed by another tx)"
+                    );
+                    Some(ChainEvent::ExecutionConfirmed {
+                        tx_id,
+                        sign_id,
+                        source_chain: pending_tx.source_chain,
+                        block_height: block_number,
+                        result: ExecutionOutcome::Failed,
+                    })
                 }
-            }
-        }
+            })
+            .collect();
 
         Ok(events)
     }

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -18,7 +18,7 @@ use mpc_primitives::{
     BidirectionalTx, BidirectionalTxId, Chain, ChainEvent, ExecutionOutcome, IndexedSignRequest,
     SignId,
 };
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -425,92 +425,89 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         block_number: u64,
     ) -> anyhow::Result<Vec<ChainEvent>> {
         let mut events = Vec::new();
-        let mut resolved_tx_ids = HashSet::new();
+        // let mut resolved_tx_ids = HashSet::new();
 
         let watchers = self
             .state_manager
             .get_execution_watchers(Chain::Ethereum)
             .await;
+
+        // If there are no watchers return early.
+        if watchers.is_empty() {
+            return Ok(events);
+        }
+
         tracing::info!(
             watchers_count = watchers.len(),
             block_number,
             "collect_execution_confirmations checking watchers"
         );
 
-        // Watchers whose receipt we saw this call, even if no event was
-        // emitted. The staleness check below skips these so a mined tx with
-        // a failed extraction stays pending for retry, not flagged Failed.
-        let mut observed_tx_ids = HashSet::new();
-
-        // TODO: submit as batch or parallelize the per-watcher `eth_getTransactionReceipt` calls once
-        // we have a way to track rate-limits and backoff for all requests (right now we just retry individually on failure)
-        // Per-watcher `eth_getTransactionReceipt`
+        // Group watchers by from_address to deduplicate nonce fetching
+        let mut watchers_by_sender: HashMap<Address, Vec<_>> = HashMap::new();
         for (tx_id, (sign_id, pending_tx)) in watchers {
-            tracing::info!(?tx_id, ?sign_id, "querying receipt for bidirectional tx");
-            match self
-                .backfill_execution_confirmation(tx_id, sign_id, &pending_tx, block_number)
-                .await?
-            {
-                BackfillOutcome::Observed { event } => {
-                    observed_tx_ids.insert(tx_id);
-                    if let Some(event) = event {
-                        events.push(event);
-                        resolved_tx_ids.insert(tx_id);
-                    }
-                    // `None` means extraction failed — leave pending for retry.
-                    // `observed_tx_ids` above exempts it from the staleness check.
-                }
-                BackfillOutcome::NotObserved => {}
-            }
+            watchers_by_sender
+                .entry(pending_tx.from_address.into())
+                .or_default()
+                .push((tx_id, sign_id, pending_tx));
         }
 
-        // Staleness checks (nonce too low)
-        let remaining_pending = self
-            .state_manager
-            .get_execution_watchers(Chain::Ethereum)
-            .await;
-
-        for (tx_id, (sign_id, tx)) in remaining_pending {
-            if resolved_tx_ids.contains(&tx_id) || observed_tx_ids.contains(&tx_id) {
-                continue;
-            }
-
+        for (sender, pending_txs) in watchers_by_sender {
+            // Fetch the nonce for this sender at the exact current block
             let current_nonce = match self
                 .client
-                .as_ref()
                 .get_nonce(
-                    tx.from_address.into(),
+                    sender,
                     BlockId::Number(BlockNumberOrTag::Number(block_number)),
                 )
                 .await
             {
                 Ok(nonce) => nonce,
                 Err(err) => {
-                    tracing::warn!(
-                        ?tx_id,
-                        ?sign_id,
-                        ?err,
-                        "Failed to fetch nonce for bidirectional tx"
-                    );
+                    tracing::warn!(?sender, ?err, "Failed to fetch nonce for sender");
                     continue;
                 }
             };
 
-            if tx.nonce < current_nonce {
-                tracing::warn!(
-                    ?sign_id,
-                    "Nonce too low for tx {:?}: expected {}, got {}",
-                    tx_id,
-                    tx.nonce,
-                    current_nonce
-                );
-                events.push(ChainEvent::ExecutionConfirmed {
-                    tx_id,
-                    sign_id,
-                    source_chain: tx.source_chain,
-                    block_height: block_number,
-                    result: ExecutionOutcome::Failed,
-                });
+            // Iterate over the pending transactions for this sender and check if their nonce has been consumed
+            for (tx_id, sign_id, pending_tx) in pending_txs {
+                if current_nonce <= pending_tx.nonce {
+                    // Nonce hasn't been reached yet. Still pending. 0 RPC calls needed!
+                    continue;
+                }
+
+                // TODO: submit as batch or parallelize the per-watcher `eth_getTransactionReceipt` calls once
+                // we have a way to track rate-limits and backoff for all requests (right now we just retry individually on failure)
+                // The nonce has been consumed by the network. The tx was either mined or replaced.
+                match self
+                    .backfill_execution_confirmation(tx_id, sign_id, &pending_tx, block_number)
+                    .await?
+                {
+                    BackfillOutcome::Observed { event } => {
+                        if let Some(event) = event {
+                            events.push(event);
+                        }
+                        // If event is None, extraction failed — leave pending for retry
+                    }
+                    BackfillOutcome::NotObserved => {
+                        // Nonce consumed, but our specific tx_hash isn't mined.
+                        // This means the transaction was replaced or dropped.
+                        tracing::warn!(
+                            ?tx_id,
+                            ?sign_id,
+                            expected_nonce = pending_tx.nonce,
+                            current_nonce,
+                            "transaction replaced or dropped (nonce consumed by another tx)"
+                        );
+                        events.push(ChainEvent::ExecutionConfirmed {
+                            tx_id,
+                            sign_id,
+                            source_chain: pending_tx.source_chain,
+                            block_height: block_number,
+                            result: ExecutionOutcome::Failed,
+                        });
+                    }
+                }
             }
         }
 
@@ -1517,6 +1514,20 @@ mod tests {
             "status": "0x0"
         });
 
+        // Mock the eth_getTransactionCount
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionCount",
+                "params": [format!("{from_address:#x}"), "0x5"]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": "0x1" }).to_string())
+            .create_async()
+            .await;
+
+        // Mock the eth_getTransactionReceipt
         server
             .mock("POST", "/")
             .match_body(Matcher::PartialJson(json!({

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -11,17 +11,14 @@ use alloy::rpc::types::{Block, BlockId, Log};
 use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use async_trait::async_trait;
-use futures_util::{
-    future::{join_all, try_join_all},
-    stream,
-};
+use futures_util::{future::try_join_all, stream};
 use mpc_chain_integration_core::utils::stream::chain_event_channel;
 use mpc_chain_integration_core::{ChainIndexer, ChainStream, ChainTelemetry, StateManager};
 use mpc_primitives::{
     BidirectionalTx, BidirectionalTxId, Chain, ChainEvent, ExecutionOutcome, IndexedSignRequest,
     SignId,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -444,51 +441,49 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         );
 
         // Group watchers by from_address
-        let mut watchers_by_sender: HashMap<Address, Vec<_>> = HashMap::new();
-        for (tx_id, (sign_id, pending_tx)) in watchers {
-            watchers_by_sender
-                .entry(pending_tx.from_address.into())
-                .or_default()
-                .push((tx_id, sign_id, pending_tx));
+        let mut unique_senders = HashSet::new();
+        for (_, tx) in watchers.values() {
+            unique_senders.insert(Address::from(tx.from_address));
         }
 
         // Fetch the current nonce for each unique sender
-        let nonce_futures = watchers_by_sender
-            .into_iter()
-            .map(|(sender, txs)| async move {
-                // Fetch the nonce for this sender at the exact current block
-                let current_nonce = self
-                    .client
-                    .get_nonce(
-                        sender,
-                        BlockId::Number(BlockNumberOrTag::Number(block_number)),
-                    )
-                    .await;
-                (sender, txs, current_nonce)
-            });
-        let senders_with_nonces = join_all(nonce_futures).await;
+        let nonce_futures = unique_senders.into_iter().map(|sender| async move {
+            let current_nonce = self
+                .client
+                .get_nonce(
+                    sender,
+                    BlockId::Number(BlockNumberOrTag::Number(block_number)),
+                )
+                .await?;
+            Ok::<_, anyhow::Error>((sender, current_nonce))
+        });
+
+        // Collect the nonces into a HashMap for easy lookup
+        let nonces: HashMap<Address, u64> =
+            try_join_all(nonce_futures).await?.into_iter().collect();
 
         // Filter transactions down to ONLY those whose nonce has been consumed
-        let ready_txs: Vec<_> = senders_with_nonces
+        let ready_txs: Vec<_> = watchers
             .into_iter()
-            .filter_map(|(sender, txs, nonce_res)| match nonce_res {
-                Ok(current_nonce) => Some(
-                    txs.into_iter()
-                        .filter(move |(_, _, tx)| tx.nonce < current_nonce),
-                ),
-                Err(err) => {
-                    tracing::warn!(?sender, ?err, "Failed to fetch nonce for sender");
-                    None
+            .filter(|(_, (_, tx))| {
+                let sender = Address::from(tx.from_address);
+                if let Some(&current_nonce) = nonces.get(&sender) {
+                    tx.nonce < current_nonce
+                } else {
+                    false
                 }
             })
-            .flatten()
             .collect();
+
+        if ready_txs.is_empty() {
+            return Ok(Vec::new());
+        }
 
         // Fetch receipts for the ready transactions
         let receipt_futures =
             ready_txs
                 .into_iter()
-                .map(|(tx_id, sign_id, pending_tx)| async move {
+                .map(|(tx_id, (sign_id, pending_tx))| async move {
                     let outcome = self
                         .backfill_execution_confirmation(tx_id, sign_id, &pending_tx, block_number)
                         .await?;
@@ -915,7 +910,7 @@ mod tests {
     use crate::client::CatchupItem;
     use crate::test_utils;
     use alloy::eips::BlockNumberOrTag;
-    use alloy::primitives::{address, b256};
+    use alloy::primitives::{address, b256, B256};
     use alloy::rpc::types::BlockId;
     use mockito::{Matcher, Server};
     use mpc_chain_integration_core::ChainIndexer;
@@ -1605,5 +1600,124 @@ mod tests {
             }
             other => panic!("expected ExecutionConfirmed, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn watcher_resolution_deduplicates_nonces_and_gates_receipts() {
+        let mut server = Server::new_async().await;
+
+        let from_address = address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+        let tx_hash_0 = b256!("0000000000000000000000000000000000000000000000000000000000000000");
+        let tx_hash_1 = b256!("1111111111111111111111111111111111111111111111111111111111111111");
+        let tx_hash_2 = b256!("2222222222222222222222222222222222222222222222222222222222222222");
+
+        // Mock Nonce Call: Expect exactly 1 call (deduplicated), returning nonce 2
+        let nonce_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionCount",
+                "params": [format!("{from_address:#x}"), "0x5"] // block height 5
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": "0x2" }).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        // Mock Receipts: Expect calls for tx_0 and tx_1. tx_2 should NOT be called.
+        let receipt_mock_0 = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({ "method": "eth_getTransactionReceipt", "params": [format!("{tx_hash_0:#x}")] })))
+            .with_status(200)
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": null }).to_string())
+            .expect(1)
+            .create_async().await;
+
+        let receipt_mock_1 = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({ "method": "eth_getTransactionReceipt", "params": [format!("{tx_hash_1:#x}")] })))
+            .with_status(200)
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": null }).to_string())
+            .expect(1)
+            .create_async().await;
+
+        let receipt_mock_2 = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({ "method": "eth_getTransactionReceipt", "params": [format!("{tx_hash_2:#x}")] })))
+            .with_status(200)
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": null }).to_string())
+            .expect(0) // STRICT ASSERT: Must NOT be called because nonce < current_nonce is false
+            .create_async().await;
+
+        // Setup Indexer & Watchers
+        let builder = test_utils::TestIndexerBuilder::new(server.url());
+
+        let create_tx = |hash: B256, nonce: u64| {
+            BidirectionalTx {
+                id: BidirectionalTxId(hash.0),
+                sender: [0u8; 32],
+                serialized_transaction: vec![],
+                source_chain: Chain::Solana,
+                target_chain: Chain::Ethereum,
+                caip2_id: "eip155:31337".to_string(),
+                key_version: LATEST_MPC_KEY_VERSION,
+                deposit: 0,
+                path: "m/44'/60'/0'/0/0".to_string(),
+                algo: "secp256k1".to_string(),
+                dest: Chain::Ethereum.to_string(),
+                params: "{}".to_string(),
+                output_deserialization_schema: vec![],
+                respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
+                request_id: hash.0,
+                from_address: **from_address,
+                nonce, // nonce is the key differentiator for this test
+            }
+        };
+
+        builder
+            .state_manager
+            .watch_execution(
+                Chain::Ethereum,
+                SignId::new([0; 32]),
+                create_tx(tx_hash_0, 0),
+            )
+            .await;
+        builder
+            .state_manager
+            .watch_execution(
+                Chain::Ethereum,
+                SignId::new([1; 32]),
+                create_tx(tx_hash_1, 1),
+            )
+            .await;
+        builder
+            .state_manager
+            .watch_execution(
+                Chain::Ethereum,
+                SignId::new([2; 32]),
+                create_tx(tx_hash_2, 2),
+            )
+            .await;
+
+        let indexer = builder.build().await;
+
+        // Run Execution Confirmations
+        let events = indexer
+            .collect_execution_confirmations(5)
+            .await
+            .expect("should succeed");
+
+        // We returned null for the receipts, so it assumes they were dropped/replaced.
+        assert_eq!(
+            events.len(),
+            2,
+            "Should emit 2 Failed events for the 2 consumed nonces"
+        );
+
+        nonce_mock.assert_async().await;
+        receipt_mock_0.assert_async().await;
+        receipt_mock_1.assert_async().await;
+        receipt_mock_2.assert_async().await;
     }
 }

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -460,7 +460,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
                 let current_nonce = self
                     .client
                     .get_nonce(
-                        sender.into(),
+                        sender,
                         BlockId::Number(BlockNumberOrTag::Number(block_number)),
                     )
                     .await;

--- a/chain-signatures/chain-ethereum/src/test_utils.rs
+++ b/chain-signatures/chain-ethereum/src/test_utils.rs
@@ -2,6 +2,7 @@ use crate::client::{CatchupItem, EthereumClient};
 use crate::indexer::EthereumIndexer;
 use crate::EthConfig;
 use alloy::primitives::{Address, Bloom};
+use alloy::rpc::types::{Block, Log};
 use mpc_chain_integration_core::utils::retry::RetryConfig;
 use mpc_chain_integration_core::{MockStateManager, NoopChainTelemetry};
 use std::sync::Arc;
@@ -191,18 +192,16 @@ pub fn live_block(number: u64) -> CatchupItem {
         .get("result")
         .expect("block_response has a result envelope")
         .clone();
-    let block: alloy::rpc::types::Block =
-        serde_json::from_value(value).expect("block fixture should deserialize");
+    let block: Block = serde_json::from_value(value).expect("block fixture should deserialize");
     CatchupItem::LiveBlock(block)
 }
 
-pub fn batch_block(number: u64, logs: Vec<alloy::rpc::types::Log>) -> CatchupItem {
+pub fn batch_block(number: u64, logs: Vec<Log>) -> CatchupItem {
     let value = block_response(1, number)
         .get("result")
         .expect("block_response has a result envelope")
         .clone();
-    let block: alloy::rpc::types::Block =
-        serde_json::from_value(value).expect("block fixture should deserialize");
+    let block: Block = serde_json::from_value(value).expect("block fixture should deserialize");
     CatchupItem::BatchBlock { block, logs }
 }
 

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -793,11 +793,17 @@ async fn test_ethereum_stream_execution_confirmation() -> Result<()> {
 
     let mut stream = stream_ethereum(&ctx, backlog.clone()).await?;
 
-    // Send a transaction from the watched address to bump nonce and trigger the staleness check.
-    submit_sign_request(&ctx, [4u8; 32], "execution-path").await?;
+    // Send 10 transactions from the watched address to bump the nonce
+    // AND guarantee the local chain crosses a `block_number % 10 == 0` boundary
+    // to trigger the throttled staleness check.
+    for i in 0..10 {
+        let mut req_id = [0u8; 32];
+        req_id[0] = i as u8;
+        submit_sign_request(&ctx, req_id, "execution-path").await?;
+    }
 
     let mut saw_execution = false;
-    for _ in 0..8 {
+    for _ in 0..20 {
         match next_event_within(&mut stream, Duration::from_secs(10)).await? {
             ChainEvent::ExecutionConfirmed { sign_id: ev_id, .. } if ev_id == sign_id => {
                 saw_execution = true;


### PR DESCRIPTION
Re-architect how Ethereum indexer confirms cross-chain execution requests. 

Original solution involved polling `eth_getTransactionReceipt` for every pending watcher on every block. This was breaking with thousands of watchers (tested 5000 watchers against local eRPC, see new benchmark below).

New solution employs multi-tiered strategy:

1. **In-block transaction list check** (no RPC requests): For every incoming block check if any pending watchers transaction hash is included. Handles majority of successful executions
2. **Nonce-gated polling**: Secondary check for watchers not found in the current block.  `eth_getTransactionReceipt` is performed only if current sender nonce has advanced. Watchers are grouped by sender address ensuring only one `eth_getTransactionCount` RPC call per unique address. This is triggered for every 10th block (waiting for ~120 sec for sad path seems like an acceptable trade-off).
3. **Individual `eth_getTransactionReceipt`**: Receipts are only requested for transaction identified by Tier 1 or Tier 2. Fetching is executed concurrently (using `futures::try_join_all`)

This PR also introduces benchmark for watchers `examples/bench_watchers.rs`:
```bash
RPC_URL=http://localhost:4000/sepolia/evm/11155111 \
CONTRACT_ADDRESS=0x69C6b28Fdc74618817fa380De29a653060e14009 \
START=11214938 END=11215038 WATCHERS=5000 \
RUST_LOG=mpc_chain_ethereum::bench=info \
cargo run --example bench_watchers --features bench
```
