### PR TITLE
Address review comments from #996

### DIFF
--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -45,6 +45,9 @@ use tokio::sync::{mpsc, watch};
 use url::Url;
 
 const DEFAULT_WEB_PORT: u16 = 3000;
+/// Capacity of the SignCommand channel that feeds chain sign events from the
+/// indexers/streams into the SignatureSpawner.
+const MAX_SIGN_COMMANDS: usize = 16384;
 
 #[derive(Parser, Debug)]
 pub enum Cli {
@@ -238,7 +241,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
 
             // SignCommand channel: chain sign events (requests, completions,
             // chain aborts) from the indexers/streams into the SignatureSpawner.
-            let (sign_tx, sign_rx) = mpsc::channel(16384);
+            let (sign_tx, sign_rx) = mpsc::channel(MAX_SIGN_COMMANDS);
 
             let StorageHandles {
                 key_storage,

--- a/chain-signatures/node/src/protocol/message/crypto.rs
+++ b/chain-signatures/node/src/protocol/message/crypto.rs
@@ -25,9 +25,7 @@ pub struct SignedMessage {
 
 impl SignedMessage {
     pub const ASSOCIATED_DATA: &'static [u8] = b"";
-}
 
-impl SignedMessage {
     pub fn encrypt<T: Serialize>(
         msg: &T,
         from: Participant,
@@ -45,9 +43,7 @@ impl SignedMessage {
             })?;
         Ok(ciphered)
     }
-}
 
-impl SignedMessage {
     pub fn decrypt<T: DeserializeOwned>(
         encrypted: &Ciphered,
         cipher_sk: &hpke::SecretKey,
@@ -346,7 +342,7 @@ mod tests {
                 data: vec![128u8; 1024],
                 timestamp: 1,
             }),
-            Message::Triple(crate::protocol::message::TripleMessage {
+            Message::Triple(TripleMessage {
                 id: 2,
                 epoch,
                 from,
@@ -363,18 +359,15 @@ mod tests {
         ];
 
         let batch_bytesize = batch.iter().map(|msg| msg.size()).sum::<usize>();
-        dbg!(batch_bytesize);
 
         let (_cipher_sk, cipher_pk) = hpke::generate();
         let sign_sk =
             near_crypto::SecretKey::from_seed(near_crypto::KeyType::ED25519, "sign-encrypt0");
         let ciphered = SignedMessage::encrypt(&batch, from, &sign_sk, &cipher_pk).unwrap();
         let ciphered_bytesize = ciphered.text.len();
-        dbg!(ciphered_bytesize);
 
         let margin_percent = 0.05;
         let margin_of_err = (batch_bytesize as f64 * margin_percent) as usize;
-        dbg!(margin_of_err);
         assert!(
             ((batch_bytesize - margin_of_err)..(batch_bytesize + margin_of_err))
                 .contains(&ciphered_bytesize),

--- a/chain-signatures/node/src/protocol/message/inbox.rs
+++ b/chain-signatures/node/src/protocol/message/inbox.rs
@@ -421,8 +421,18 @@ mod tests {
     use mpc_keys::hpke;
     use std::time::Duration;
 
-    #[tokio::test]
-    async fn test_inbox() {
+    struct InboxTestSetup {
+        epoch: u64,
+        from: Participant,
+        sign_sk: near_crypto::SecretKey,
+        cipher_pk: hpke::PublicKey,
+        channel: MessageChannel,
+        inbox: tokio::task::JoinHandle<()>,
+        _config_tx: watch::Sender<Config>,
+        _contract_tx: watch::Sender<Option<crate::protocol::ProtocolState>>,
+    }
+
+    fn inbox_setup() -> InboxTestSetup {
         let epoch = 299;
         let from = Participant::from(0);
         let (cipher_sk, cipher_pk) = hpke::generate();
@@ -462,136 +472,159 @@ mod tests {
         let (inbox, _outbox, channel) = MessageChannel::new();
         let inbox = tokio::spawn(inbox.run(config_rx, contract_watcher));
 
-        // Case 1:
-        // Check that the inbox received our messages correctly:
-        {
-            let batch = vec![
-                Message::Triple(TripleMessage {
-                    id: 1,
-                    epoch,
-                    from,
-                    data: vec![128u8; 1024],
-                    timestamp: 1,
-                }),
-                Message::Triple(crate::protocol::message::TripleMessage {
-                    id: 2,
-                    epoch,
-                    from,
-                    data: vec![255u8; 2048],
-                    timestamp: 2,
-                }),
-                Message::Triple(TripleMessage {
-                    id: 3,
-                    epoch,
-                    from,
-                    data: vec![101u8; 1337],
-                    timestamp: 3,
-                }),
-            ];
-            let encrypted = SignedMessage::encrypt(&batch, from, &sign_sk, &cipher_pk).unwrap();
-            channel.send_inbox(encrypted).await;
-
-            let mut recv1 = channel.subscribe_triple(1).await;
-            let mut recv2 = channel.subscribe_triple(2).await;
-            let mut recv3 = channel.subscribe_triple(3).await;
-
-            let (m1, m2, m3) = match tokio::join!(recv1.recv(), recv2.recv(), recv3.recv()) {
-                (Some(m1), Some(m2), Some(m3)) => (m1, m2, m3),
-                _ => panic!("failed to join on inbox"),
-            };
-
-            assert_eq!(m1.id, 1);
-            assert_eq!(m2.id, 2);
-            assert_eq!(m3.id, 3);
-
-            channel.unsubscribe_triple(1).await;
-            channel.unsubscribe_triple(2).await;
-            channel.unsubscribe_triple(3).await;
+        InboxTestSetup {
+            epoch,
+            from,
+            sign_sk,
+            cipher_pk,
+            channel,
+            inbox,
+            _config_tx,
+            _contract_tx,
         }
+    }
 
-        // Case 2:
-        // Check that inbox filters work correctly, and that the first message did not make it through:
-        let filter_id = 2;
-        let batch = vec![
+    fn triple_batch(epoch: u64, from: Participant) -> Vec<Message> {
+        vec![
             Message::Triple(TripleMessage {
                 id: 1,
                 epoch,
                 from,
-                data: vec![129u8; 1024],
+                data: vec![128u8; 1024],
                 timestamp: 1,
             }),
             Message::Triple(TripleMessage {
-                id: filter_id,
+                id: 2,
                 epoch,
                 from,
-                data: vec![229u8; 2048],
+                data: vec![255u8; 2048],
                 timestamp: 2,
             }),
             Message::Triple(TripleMessage {
                 id: 3,
                 epoch,
                 from,
-                data: vec![121u8; 1337],
+                data: vec![101u8; 1337],
                 timestamp: 3,
             }),
-        ];
-        {
-            let encrypted = SignedMessage::encrypt(&batch, from, &sign_sk, &cipher_pk).unwrap();
+        ]
+    }
 
-            let mut recv1 = channel.subscribe_triple(1).await;
-            let mut recv2 = channel.subscribe_triple(filter_id).await;
-            let mut recv3 = channel.subscribe_triple(3).await;
+    /// Check that the inbox receives our messages correctly.
+    #[tokio::test]
+    async fn test_inbox_receives_messages() {
+        let setup = inbox_setup();
+        let batch = triple_batch(setup.epoch, setup.from);
+        let encrypted =
+            SignedMessage::encrypt(&batch, setup.from, &setup.sign_sk, &setup.cipher_pk).unwrap();
+        setup.channel.send_inbox(encrypted).await;
 
-            channel.filter_triple(filter_id).await;
-            channel.send_inbox(encrypted).await;
+        let mut recv1 = setup.channel.subscribe_triple(1).await;
+        let mut recv2 = setup.channel.subscribe_triple(2).await;
+        let mut recv3 = setup.channel.subscribe_triple(3).await;
 
-            let (m1, m3) = match tokio::join!(recv1.recv(), recv3.recv()) {
-                (Some(m1), Some(m3)) => (m1, m3),
-                _ => panic!("failed to join on inbox"),
-            };
+        let (m1, m2, m3) = match tokio::join!(recv1.recv(), recv2.recv(), recv3.recv()) {
+            (Some(m1), Some(m2), Some(m3)) => (m1, m2, m3),
+            _ => panic!("failed to join on inbox"),
+        };
 
-            assert_eq!(m1.id, 1);
-            assert_eq!(m3.id, 3);
+        assert_eq!(m1.id, 1);
+        assert_eq!(m2.id, 2);
+        assert_eq!(m3.id, 3);
 
-            // Expect to timeout here since the message gets filtered out.
-            let result = tokio::time::timeout(Duration::from_millis(100), recv2.recv()).await;
-            assert!(result.is_err());
+        setup.inbox.abort();
+    }
 
-            channel.unsubscribe_triple(1).await;
-            channel.unsubscribe_triple(2).await;
-            channel.unsubscribe_triple(3).await;
+    /// Check that inbox filters work correctly, and that the filtered message
+    /// does not make it through.
+    #[tokio::test]
+    async fn test_inbox_filters_messages() {
+        let setup = inbox_setup();
+        let filter_id = 2;
+        let batch = triple_batch(setup.epoch, setup.from);
+        let encrypted =
+            SignedMessage::encrypt(&batch, setup.from, &setup.sign_sk, &setup.cipher_pk).unwrap();
+
+        let mut recv1 = setup.channel.subscribe_triple(1).await;
+        let mut recv2 = setup.channel.subscribe_triple(filter_id).await;
+        let mut recv3 = setup.channel.subscribe_triple(3).await;
+
+        setup.channel.filter_triple(filter_id).await;
+        setup.channel.send_inbox(encrypted).await;
+
+        let (m1, m3) = match tokio::join!(recv1.recv(), recv3.recv()) {
+            (Some(m1), Some(m3)) => (m1, m3),
+            _ => panic!("failed to join on inbox"),
+        };
+
+        assert_eq!(m1.id, 1);
+        assert_eq!(m3.id, 3);
+
+        // Expect to timeout here since the message gets filtered out.
+        let result = tokio::time::timeout(Duration::from_millis(100), recv2.recv()).await;
+        assert!(result.is_err());
+
+        setup.inbox.abort();
+    }
+
+    /// Check idempotency. The same set of messages encrypted and signed again
+    /// should produce the same signature. Thus sending the same encrypted
+    /// message should be idempotent and no new messages should be received by
+    /// the subscribers.
+    #[tokio::test]
+    async fn test_inbox_idempotency() {
+        let setup = inbox_setup();
+        let batch = triple_batch(setup.epoch, setup.from);
+        let encrypted =
+            SignedMessage::encrypt(&batch, setup.from, &setup.sign_sk, &setup.cipher_pk).unwrap();
+        setup.channel.send_inbox(encrypted).await;
+
+        let mut recv1 = setup.channel.subscribe_triple(1).await;
+        let mut recv2 = setup.channel.subscribe_triple(2).await;
+        let mut recv3 = setup.channel.subscribe_triple(3).await;
+
+        match tokio::join!(recv1.recv(), recv2.recv(), recv3.recv()) {
+            (Some(_), Some(_), Some(_)) => {}
+            _ => panic!("failed to join on inbox"),
         }
 
-        // Case 3:
-        // Check idempotentcy. The same set of messages (from case 2) encrypted and signed again should produce
-        // the same signature. Thus sending the same encrypted message should be idempotent and no new messages
-        // should be received by the subscribers.
-        {
-            let encrypted = SignedMessage::encrypt(&batch, from, &sign_sk, &cipher_pk).unwrap();
-            channel.send_inbox(encrypted).await;
-            let mut recv1 =
-                tokio::time::timeout(Duration::from_millis(300), channel.subscribe_triple(1))
-                    .await
-                    .unwrap();
-            let mut recv2 =
-                tokio::time::timeout(Duration::from_millis(300), channel.subscribe_triple(2))
-                    .await
-                    .unwrap();
-            let mut recv3 =
-                tokio::time::timeout(Duration::from_millis(300), channel.subscribe_triple(3))
-                    .await
-                    .unwrap();
+        setup.channel.unsubscribe_triple(1).await;
+        setup.channel.unsubscribe_triple(2).await;
+        setup.channel.unsubscribe_triple(3).await;
 
-            let result1 = tokio::time::timeout(Duration::from_millis(100), recv1.recv()).await;
-            let result2 = tokio::time::timeout(Duration::from_millis(100), recv2.recv()).await;
-            let result3 = tokio::time::timeout(Duration::from_millis(100), recv3.recv()).await;
+        // Encrypting the same batch again produces the same signature, so the
+        // inbox should drop it as a duplicate.
+        let encrypted =
+            SignedMessage::encrypt(&batch, setup.from, &setup.sign_sk, &setup.cipher_pk).unwrap();
+        setup.channel.send_inbox(encrypted).await;
+        let mut recv1 = tokio::time::timeout(
+            Duration::from_millis(300),
+            setup.channel.subscribe_triple(1),
+        )
+        .await
+        .unwrap();
+        let mut recv2 = tokio::time::timeout(
+            Duration::from_millis(300),
+            setup.channel.subscribe_triple(2),
+        )
+        .await
+        .unwrap();
+        let mut recv3 = tokio::time::timeout(
+            Duration::from_millis(300),
+            setup.channel.subscribe_triple(3),
+        )
+        .await
+        .unwrap();
 
-            assert!(result1.is_err());
-            assert!(result2.is_err());
-            assert!(result3.is_err());
-        }
+        let result1 = tokio::time::timeout(Duration::from_millis(100), recv1.recv()).await;
+        let result2 = tokio::time::timeout(Duration::from_millis(100), recv2.recv()).await;
+        let result3 = tokio::time::timeout(Duration::from_millis(100), recv3.recv()).await;
 
-        inbox.abort();
+        assert!(result1.is_err());
+        assert!(result2.is_err());
+        assert!(result3.is_err());
+
+        setup.inbox.abort();
     }
 
     #[tokio::test]

--- a/chain-signatures/node/src/protocol/message/outbox.rs
+++ b/chain-signatures/node/src/protocol/message/outbox.rs
@@ -276,3 +276,82 @@ fn partition_256kb(outgoing: impl IntoIterator<Item = (Message, Instant)>) -> Ve
 
     partitions
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::message::types::TripleMessage;
+
+    fn triple_message(id: u64, data_size: usize) -> Message {
+        Message::Triple(TripleMessage {
+            id,
+            epoch: 0,
+            from: Participant::from(0),
+            data: vec![0u8; data_size],
+            timestamp: 1,
+        })
+    }
+
+    fn triple_ids(partition: &Partition) -> Vec<u64> {
+        partition
+            .messages
+            .iter()
+            .map(|msg| match msg {
+                Message::Triple(msg) => msg.id,
+                other => panic!("expected triple message, got {}", other.typename()),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_partition_256kb_empty() {
+        let partitions = partition_256kb(Vec::new());
+        assert!(partitions.is_empty());
+    }
+
+    #[test]
+    fn test_partition_256kb_single_partition() {
+        let outgoing = vec![
+            (triple_message(1, 1024), Instant::now()),
+            (triple_message(2, 2048), Instant::now()),
+        ];
+        let partitions = partition_256kb(outgoing);
+
+        assert_eq!(partitions.len(), 1);
+        assert_eq!(triple_ids(&partitions[0]), vec![1, 2]);
+    }
+
+    #[test]
+    fn test_partition_256kb_splits_over_limit() {
+        // Each message is ~100kb, so the first two fit into one 256kb
+        // partition and the third starts a new one.
+        let outgoing = (1..=3)
+            .map(|id| (triple_message(id, 100 * 1024), Instant::now()))
+            .collect::<Vec<_>>();
+        let partitions = partition_256kb(outgoing);
+
+        assert_eq!(partitions.len(), 2);
+        assert_eq!(triple_ids(&partitions[0]), vec![1, 2]);
+        assert_eq!(triple_ids(&partitions[1]), vec![3]);
+        for partition in &partitions {
+            let bytesize = partition
+                .messages
+                .iter()
+                .map(|msg| msg.size())
+                .sum::<usize>();
+            assert!(bytesize <= 256 * 1024);
+        }
+    }
+
+    #[test]
+    fn test_partition_256kb_drops_unknown_messages() {
+        let outgoing = vec![
+            (Message::Unknown(HashMap::new()), Instant::now()),
+            (triple_message(1, 1024), Instant::now()),
+        ];
+        let partitions = partition_256kb(outgoing);
+
+        assert_eq!(partitions.len(), 1);
+        assert_eq!(triple_ids(&partitions[0]), vec![1]);
+    }
+}


### PR DESCRIPTION
Follow-up to #996 addressing @isSerge's review comments:

- `16384` sign channel capacity moved to a `MAX_SIGN_COMMANDS` constant ([comment](https://github.com/sig-net/mpc/pull/996#discussion_r3575956921))
- collapsed the three `impl SignedMessage` blocks into one ([comment](https://github.com/sig-net/mpc/pull/996#discussion_r3576044936))
- removed `dbg!` calls from `test_encrypt_size` ([comment](https://github.com/sig-net/mpc/pull/996#discussion_r3575969877))
- dropped fully-qualified `crate::protocol::message::TripleMessage` paths in tests ([comment](https://github.com/sig-net/mpc/pull/996#discussion_r3575968497), [comment](https://github.com/sig-net/mpc/pull/996#discussion_r3576032225))
- split the `test_inbox` god test into three focused tests (`test_inbox_receives_messages`, `test_inbox_filters_messages`, `test_inbox_idempotency`) with a shared setup helper ([comment](https://github.com/sig-net/mpc/pull/996#discussion_r3575976092))
- added outbox tests covering `partition_256kb` ([comment](https://github.com/sig-net/mpc/pull/996#discussion_r3575987905))

🤖 Generated with [Claude Code](https://claude.com/claude-code)