### PR TITLE
feat: introduce global 429-aware backoff

### DIFF
--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -243,6 +243,13 @@ impl EthereumClient {
         })
     }
 
+    /// Overrides the shared 429 cooldown gate
+    #[cfg(test)]
+    pub(crate) fn with_shared_backoff(mut self, shared_backoff: SharedBackoff) -> Self {
+        self.shared_backoff = shared_backoff;
+        self
+    }
+
     fn client_name(&self) -> &str {
         match &self.inner {
             #[cfg(feature = "helios")]
@@ -531,6 +538,40 @@ mod tests {
             EthereumClient::clamp_oldest_supported_with(1, anchor_height, max_catchup_blocks),
             expected_oldest,
         );
+    }
+
+    #[tokio::test]
+    async fn shared_backoff_gates_concurrent_calls_on_429() {
+        let mut server = Server::new_async().await;
+        server
+            .mock("POST", "/")
+            // 1 initial + max_times(2) retries per op, 2 concurrent ops.
+            // Ungated, all 6 would fire within ~25ms of local backoff.
+            .expect(6)
+            .with_status(429)
+            .with_body("Too Many Requests")
+            .create_async()
+            .await;
+
+        let client = test_utils::create_test_ethereum_client(&server.url())
+            .await
+            .with_shared_backoff(SharedBackoff::with_cooldowns(
+                Duration::from_millis(50),
+                Duration::from_millis(200),
+            ));
+
+        let start = std::time::Instant::now();
+        let (r1, r2) = tokio::join!(
+            client.get_logs(Address::ZERO, BlockId::Number(BlockNumberOrTag::Number(1))),
+            client.get_logs(Address::ZERO, BlockId::Number(BlockNumberOrTag::Number(2))),
+        );
+
+        // HTTP status surfaces in the error (retry classification relies on
+        // this string match) and retries are exhausted.
+        assert!(r1.is_err() && r2.is_err());
+        assert!(r1.unwrap_err().to_string().contains("429"));
+        // The gate forces retries into separate >= 50ms cooldown windows.
+        assert!(start.elapsed() >= Duration::from_millis(100));
     }
 
     #[tokio::test]

--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use crate::indexer_eth_direct_rpc;
 use crate::EthConfig;
-use mpc_chain_integration_core::utils::retry::{retry_rpc, RetryConfig};
+use mpc_chain_integration_core::utils::retry::{retry_rpc_gated, RetryConfig, SharedBackoff};
 
 #[cfg(feature = "helios")]
 use super::indexer_eth_helios;
@@ -198,6 +198,8 @@ fn default_eth_retry_strategy() -> RetryConfig {
 pub struct EthereumClient {
     inner: EthereumClientInner,
     retry_strategy: RetryConfig,
+    /// Global 429 cooldown gate shared by all RPC calls through this client
+    shared_backoff: SharedBackoff,
 }
 
 #[derive(Clone)]
@@ -237,6 +239,7 @@ impl EthereumClient {
         Ok(Self {
             inner,
             retry_strategy,
+            shared_backoff: SharedBackoff::new(),
         })
     }
 
@@ -250,9 +253,10 @@ impl EthereumClient {
 
     pub async fn get_block(&self, block_id: BlockId) -> Option<Block> {
         let max_attempts = self.retry_strategy.max_times;
-        let res = retry_rpc!(
+        let res = retry_rpc_gated!(
             ETH_RPC_TIMEOUT,
             self.retry_strategy,
+            self.shared_backoff,
             |attempt, err, sleep| {
                 tracing::warn!(
                     client = self.client_name(),
@@ -292,9 +296,10 @@ impl EthereumClient {
         let max_attempts = self.retry_strategy.max_times;
         let num_blocks = block_ids.len();
 
-        let res = retry_rpc!(
+        let res = retry_rpc_gated!(
             ETH_RPC_BATCH_TIMEOUT,
             self.retry_strategy,
+            self.shared_backoff,
             |attempt, err, sleep| {
                 tracing::warn!(
                     client = self.client_name(),
@@ -331,9 +336,10 @@ impl EthereumClient {
         &self,
         tx_hash: B256,
     ) -> anyhow::Result<Option<TransactionReceipt>> {
-        retry_rpc!(
+        retry_rpc_gated!(
             ETH_RPC_TIMEOUT,
             self.retry_strategy,
+            self.shared_backoff,
             "get_transaction_receipt",
             {
                 match &self.inner {
@@ -352,13 +358,21 @@ impl EthereumClient {
     /// Fetch all logs emitted by `address` within `block_id` via a single
     /// server-filtered `eth_getLogs`.
     pub async fn get_logs(&self, address: Address, block_id: BlockId) -> anyhow::Result<Vec<Log>> {
-        retry_rpc!(ETH_RPC_TIMEOUT, self.retry_strategy, "get_logs", {
-            match &self.inner {
-                #[cfg(feature = "helios")]
-                EthereumClientInner::Helios(client) => client.get_logs(address, block_id).await,
-                EthereumClientInner::DirectRpc(client) => client.get_logs(address, block_id).await,
+        retry_rpc_gated!(
+            ETH_RPC_TIMEOUT,
+            self.retry_strategy,
+            self.shared_backoff,
+            "get_logs",
+            {
+                match &self.inner {
+                    #[cfg(feature = "helios")]
+                    EthereumClientInner::Helios(client) => client.get_logs(address, block_id).await,
+                    EthereumClientInner::DirectRpc(client) => {
+                        client.get_logs(address, block_id).await
+                    }
+                }
             }
-        })
+        )
     }
 
     /// Fetch `eth_getLogs` for multiple blocks in a single JSON-RPC batch POST,
@@ -369,9 +383,10 @@ impl EthereumClient {
         address: Address,
         block_ids: &[BlockId],
     ) -> anyhow::Result<Vec<Vec<Log>>> {
-        retry_rpc!(
+        retry_rpc_gated!(
             ETH_RPC_BATCH_TIMEOUT,
             self.retry_strategy,
+            self.shared_backoff,
             "get_logs_batch",
             {
                 match &self.inner {
@@ -388,22 +403,33 @@ impl EthereumClient {
     }
 
     pub async fn get_nonce(&self, address: Address, block_id: BlockId) -> anyhow::Result<u64> {
-        retry_rpc!(ETH_RPC_TIMEOUT, self.retry_strategy, "get_nonce", {
-            match &self.inner {
-                #[cfg(feature = "helios")]
-                EthereumClientInner::Helios(client) => client.get_nonce(address, block_id).await,
-                EthereumClientInner::DirectRpc(client) => client.get_nonce(address, block_id).await,
+        retry_rpc_gated!(
+            ETH_RPC_TIMEOUT,
+            self.retry_strategy,
+            self.shared_backoff,
+            "get_nonce",
+            {
+                match &self.inner {
+                    #[cfg(feature = "helios")]
+                    EthereumClientInner::Helios(client) => {
+                        client.get_nonce(address, block_id).await
+                    }
+                    EthereumClientInner::DirectRpc(client) => {
+                        client.get_nonce(address, block_id).await
+                    }
+                }
             }
-        })
+        )
     }
 
     pub async fn get_transaction_by_hash(
         &self,
         tx_hash: alloy::primitives::B256,
     ) -> anyhow::Result<Option<alloy::rpc::types::Transaction>> {
-        retry_rpc!(
+        retry_rpc_gated!(
             ETH_RPC_TIMEOUT,
             self.retry_strategy,
+            self.shared_backoff,
             "get_transaction_by_hash",
             {
                 match &self.inner {
@@ -424,9 +450,10 @@ impl EthereumClient {
         tx_hash: alloy::primitives::B256,
     ) -> anyhow::Result<alloy::primitives::Bytes> {
         // TODO: trace_transaction_output can be slow, consider a longer timeout than ETH_RPC_TIMEOUT if necessary
-        retry_rpc!(
+        retry_rpc_gated!(
             ETH_RPC_TIMEOUT,
             self.retry_strategy,
+            self.shared_backoff,
             "trace_transaction_output",
             {
                 match &self.inner {

--- a/chain-signatures/chain-ethereum/src/indexer_eth_direct_rpc.rs
+++ b/chain-signatures/chain-ethereum/src/indexer_eth_direct_rpc.rs
@@ -243,6 +243,7 @@ impl RpcEthereumClient {
         });
 
         let response = self.http.post(&self.url).json(&request).send().await?;
+        let response = ensure_http_success(response, &format!("rpc {method}")).await?;
         let value: serde_json::Value = response.json().await?;
 
         if let Some(error) = value.get("error") {
@@ -279,6 +280,7 @@ impl RpcEthereumClient {
 
         // Send the batch request and parse the response. The response is expected to be an array of JSON-RPC response objects.
         let response = self.http.post(&self.url).json(&payload).send().await?;
+        let response = ensure_http_success(response, "batch rpc").await?;
         let value: serde_json::Value = response.json().await?;
         let items = if let serde_json::Value::Array(items) = value {
             items
@@ -447,6 +449,26 @@ fn trace_output_to_bytes(
     }
 
     Ok(Bytes::from(hex::decode(stripped)?))
+}
+
+/// Bails with the HTTP status and a truncated body when the response is not
+/// successful, keeping status codes (e.g. 429) visible to retry classification.
+async fn ensure_http_success(
+    response: reqwest::Response,
+    label: &str,
+) -> anyhow::Result<reqwest::Response> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+    let body: String = response
+        .text()
+        .await
+        .unwrap_or_default()
+        .chars()
+        .take(256)
+        .collect();
+    anyhow::bail!("{label} HTTP error {status}: {body}")
 }
 
 fn format_address(address: Address) -> String {

--- a/chain-signatures/chain-integration-core/src/utils/retry.rs
+++ b/chain-signatures/chain-integration-core/src/utils/retry.rs
@@ -5,8 +5,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use backon::ExponentialBuilder;
 use rand::Rng;
 
-// Re-export the retry_rpc macro
-pub use crate::retry_rpc;
+// Re-export the retry macros
+pub use crate::{retry_rpc, retry_rpc_gated};
 
 const RATE_LIMIT_BASE_COOLDOWN: Duration = Duration::from_secs(1);
 const RATE_LIMIT_MAX_COOLDOWN: Duration = Duration::from_secs(60);
@@ -289,6 +289,106 @@ macro_rules! retry_rpc {
     }};
 }
 
+/// Like [`retry_rpc!`], but gates every attempt on a shared 429 cooldown
+/// ([`SharedBackoff`]): each attempt waits out the global cooldown before
+/// firing, a 429 extends the shared window, and a success resets the penalty.
+/// Prevents retry storms when an endpoint starts rate-limiting. Per-call
+/// backoff still applies on top.
+///
+/// # Forms
+///
+/// ## 1. Standard — named operation, structured [`tracing::warn`] on every retry
+/// ```ignore
+/// retry_rpc_gated!(timeout, strategy, shared, "op_name", { code })
+/// ```
+///
+/// ## 2. Full — custom notify closure
+/// ```ignore
+/// retry_rpc_gated!(timeout, strategy, shared, |attempt, err, sleep| { notify }, { code })
+/// ```
+///
+/// See [`retry_rpc!`] for the other parameters; `shared` is a [`SharedBackoff`]
+/// handle cloned across all call sites hitting the same endpoint.
+#[macro_export]
+macro_rules! retry_rpc_gated {
+    // Standard form: op_name string, default structured logging
+    ($timeout:expr, $strategy:expr, $shared:expr, $op_name:literal, { $($code:tt)* }) => {{
+        let shared = &$shared;
+        let mut attempt_counter: u32 = 0;
+        let op = || async {
+            shared.wait().await;
+            let fut = async { $($code)* };
+            match tokio::time::timeout($timeout, fut).await {
+                Ok(Ok(res)) => {
+                    shared.report_success();
+                    Ok(res)
+                }
+                Ok(Err(e)) => {
+                    if $crate::utils::retry::is_rate_limited(&e) {
+                        let cooldown = shared.report_rate_limited();
+                        tracing::warn!(
+                            operation = $op_name,
+                            ?cooldown,
+                            "rate limited (429), engaging global cooldown"
+                        );
+                    }
+                    Err(e)
+                }
+                Err(_) => Err(anyhow::anyhow!("Operation timed out after {:?}", $timeout)),
+            }
+        };
+        use $crate::backon::Retryable as _;
+        op.retry(&$strategy.build())
+            .when(|e: &anyhow::Error| $crate::utils::retry::is_retryable(e))
+            .notify(|err: &anyhow::Error, sleep: std::time::Duration| {
+                attempt_counter += 1;
+                tracing::warn!(
+                    operation = $op_name,
+                    attempt = attempt_counter,
+                    error = %err,
+                    retry_in = ?sleep,
+                    "RPC call failed, retrying"
+                );
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("{e} (exhausted after {} attempts)", attempt_counter + 1))
+    }};
+
+    // Full form: custom notify closure
+    ($timeout:expr, $strategy:expr, $shared:expr, |$attempt:ident, $err:ident, $sleep:ident| $notify:block, { $($code:tt)* }) => {{
+        let shared = &$shared;
+        let mut attempt_counter: u32 = 0;
+        let op = || async {
+            shared.wait().await;
+            let fut = async { $($code)* };
+            match tokio::time::timeout($timeout, fut).await {
+                Ok(Ok(res)) => {
+                    shared.report_success();
+                    Ok(res)
+                }
+                Ok(Err(e)) => {
+                    if $crate::utils::retry::is_rate_limited(&e) {
+                        let cooldown = shared.report_rate_limited();
+                        tracing::warn!(?cooldown, "rate limited (429), engaging global cooldown");
+                    }
+                    Err(e)
+                }
+                Err(_) => Err(anyhow::anyhow!("Operation timed out after {:?}", $timeout)),
+            }
+        };
+        use $crate::backon::Retryable as _;
+        op.retry(&$strategy.build())
+            .when(|e: &anyhow::Error| $crate::utils::retry::is_retryable(e))
+            .notify(|$err: &anyhow::Error, $sleep: std::time::Duration| {
+                attempt_counter += 1;
+                let $attempt = attempt_counter;
+                $notify
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("{e} (exhausted after {} attempts)", attempt_counter + 1))
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -358,6 +458,83 @@ mod tests {
         let t = std::time::Instant::now();
         sb.wait().await;
         assert!(t.elapsed() >= Duration::from_millis(80));
+    }
+
+    fn gated_test_config() -> RetryConfig {
+        RetryConfig {
+            min_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(5),
+            max_times: 2,
+            jitter: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn macro_engages_global_cooldown_on_429() {
+        let shared =
+            SharedBackoff::with_cooldowns(Duration::from_millis(50), Duration::from_millis(200));
+        let calls = Arc::new(AtomicU32::new(0));
+        let start = std::time::Instant::now();
+
+        // Spawn two concurrent tasks that will each hit the 429 and trigger the shared cooldown.
+        let mut handles = Vec::new();
+        for _ in 0..2 {
+            let shared = shared.clone();
+            let calls = calls.clone();
+            handles.push(tokio::spawn(async move {
+                let attempts = calls.clone();
+                let _: anyhow::Result<()> = retry_rpc_gated!(
+                    Duration::from_secs(5),
+                    gated_test_config(),
+                    shared,
+                    "test_op",
+                    {
+                        attempts.fetch_add(1, Ordering::Relaxed);
+                        Err(anyhow::anyhow!(
+                            "HTTP status client error (429 Too Many Requests)"
+                        ))
+                    }
+                );
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        // (1 initial + max_times retries) per op
+        assert_eq!(calls.load(Ordering::Relaxed), 6); 
+        // Without the gate, 6 calls with 1-5ms backoff finish in ~20ms.
+        assert!(start.elapsed() >= Duration::from_millis(100));
+    }
+
+    #[tokio::test]
+    async fn macro_reports_success_after_429() {
+        let shared =
+            SharedBackoff::with_cooldowns(Duration::from_millis(50), Duration::from_millis(200));
+        let calls = Arc::new(AtomicU32::new(0));
+        let attempts = calls.clone();
+        let start = std::time::Instant::now();
+
+        // The first attempt returns a 429, the second attempt succeeds.
+        let res: anyhow::Result<u32> = retry_rpc_gated!(
+            Duration::from_secs(5),
+            gated_test_config(),
+            shared,
+            "test_op",
+            {
+                if attempts.fetch_add(1, Ordering::Relaxed) == 0 {
+                    Err(anyhow::anyhow!(
+                        "HTTP status client error (429 Too Many Requests)"
+                    ))
+                } else {
+                    Ok(42)
+                }
+            }
+        );
+        assert_eq!(res.unwrap(), 42);
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+        // The retry had to wait out the cooldown window set by the first attempt.
+        assert!(start.elapsed() >= Duration::from_millis(50));
     }
 
     #[test]

--- a/chain-signatures/chain-integration-core/src/utils/retry.rs
+++ b/chain-signatures/chain-integration-core/src/utils/retry.rs
@@ -502,7 +502,7 @@ mod tests {
         }
 
         // (1 initial + max_times retries) per op
-        assert_eq!(calls.load(Ordering::Relaxed), 6); 
+        assert_eq!(calls.load(Ordering::Relaxed), 6);
         // Without the gate, 6 calls with 1-5ms backoff finish in ~20ms.
         assert!(start.elapsed() >= Duration::from_millis(100));
     }

--- a/chain-signatures/chain-integration-core/src/utils/retry.rs
+++ b/chain-signatures/chain-integration-core/src/utils/retry.rs
@@ -1,9 +1,118 @@
-use std::time::Duration;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use backon::ExponentialBuilder;
+use rand::Rng;
 
 // Re-export the retry_rpc macro
 pub use crate::retry_rpc;
+
+const RATE_LIMIT_BASE_COOLDOWN: Duration = Duration::from_secs(1);
+const RATE_LIMIT_MAX_COOLDOWN: Duration = Duration::from_secs(60);
+const RATE_LIMIT_MAX_JITTER: Duration = Duration::from_millis(500);
+const MAX_PENALTY_LEVEL: u32 = 10;
+
+/// Shared, 429-aware cooldown gate.
+#[derive(Clone)]
+pub struct SharedBackoff {
+    /// Inner state is shared across all clones of this instance to avoid per-instance fragmentation
+    inner: Arc<SharedBackoffInner>,
+}
+
+struct SharedBackoffInner {
+    /// Epoch millis until which all requests should wait.
+    limited_until_ms: AtomicU64,
+    /// Exponential penalty level, used to compute the cooldown duration.
+    penalty_level: AtomicU32,
+    /// Base cooldown duration for the first penalty level.
+    base_cooldown: Duration,
+    /// Maximum cooldown duration for the highest penalty level.
+    max_cooldown: Duration,
+}
+
+impl Default for SharedBackoff {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SharedBackoff {
+    pub fn new() -> Self {
+        Self::with_cooldowns(RATE_LIMIT_BASE_COOLDOWN, RATE_LIMIT_MAX_COOLDOWN)
+    }
+
+    pub fn with_cooldowns(base_cooldown: Duration, max_cooldown: Duration) -> Self {
+        Self {
+            inner: Arc::new(SharedBackoffInner {
+                limited_until_ms: AtomicU64::new(0),
+                penalty_level: AtomicU32::new(0),
+                base_cooldown,
+                max_cooldown,
+            }),
+        }
+    }
+
+    /// Extends the global cooldown window after an observed 429. Concurrent
+    /// reports grow the penalty but only ever extend the window, never shorten
+    /// it. Returns the cooldown that was applied.
+    pub fn report_rate_limited(&self) -> Duration {
+        let level = self.inner.penalty_level.fetch_add(1, Ordering::Relaxed);
+        self.inner
+            .penalty_level
+            .fetch_min(MAX_PENALTY_LEVEL, Ordering::Relaxed);
+        let cooldown = self.cooldown_for_level(level);
+        self.inner
+            .limited_until_ms
+            .fetch_max(now_ms() + cooldown.as_millis() as u64, Ordering::Relaxed);
+        cooldown
+    }
+
+    /// Resets the penalty level after a successful call.
+    pub fn report_success(&self) {
+        self.inner.penalty_level.store(0, Ordering::Relaxed);
+    }
+
+    /// Sleeps until the global cooldown window has elapsed, plus random jitter
+    /// so callers parked on the same window don't all fire at once.
+    pub async fn wait(&self) {
+        let remaining = self.remaining();
+        if remaining.is_zero() {
+            return;
+        }
+        let jitter_cap = (remaining / 2).min(RATE_LIMIT_MAX_JITTER);
+        let jitter = rand::thread_rng().gen_range(Duration::ZERO..=jitter_cap);
+        tokio::time::sleep(remaining + jitter).await;
+    }
+
+    /// Time left in the current cooldown window, zero if not limited.
+    pub fn remaining(&self) -> Duration {
+        let ms = self
+            .inner
+            .limited_until_ms
+            .load(Ordering::Relaxed)
+            .saturating_sub(now_ms());
+        Duration::from_millis(ms)
+    }
+
+    fn cooldown_for_level(&self, level: u32) -> Duration {
+        let millis = (self.inner.base_cooldown.as_millis() as u64)
+            .saturating_mul(1u64 << level.min(MAX_PENALTY_LEVEL));
+        Duration::from_millis(millis).min(self.inner.max_cooldown)
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+/// Returns true if the error looks like an HTTP 429 (rate limited).
+pub fn is_rate_limited(e: &anyhow::Error) -> bool {
+    contains_status_code(&e.to_string(), "429")
+}
 
 /// Configuration for retrying RPC calls with exponential backoff.
 #[derive(Clone, Copy)]
@@ -192,6 +301,63 @@ mod tests {
             );
             assert!(!is_retryable(&e), "{code} should not be retryable");
         }
+    }
+
+    #[test]
+    fn shared_backoff_rate_limit_cooldown_grows_and_caps() {
+        let sb =
+            SharedBackoff::with_cooldowns(Duration::from_millis(100), Duration::from_millis(400));
+        assert_eq!(sb.report_rate_limited(), Duration::from_millis(100));
+        assert_eq!(sb.report_rate_limited(), Duration::from_millis(200));
+        assert_eq!(sb.report_rate_limited(), Duration::from_millis(400));
+        assert_eq!(sb.report_rate_limited(), Duration::from_millis(400));
+    }
+
+    #[test]
+    fn shared_backoff_shorter_cooldown_does_not_shorten_window() {
+        let sb = SharedBackoff::with_cooldowns(Duration::from_millis(100), Duration::from_secs(60));
+        sb.report_rate_limited();
+        let long = sb.report_rate_limited();
+        sb.report_success();
+        let short = sb.report_rate_limited();
+        assert!(short < long);
+        assert!(sb.remaining() > short);
+    }
+
+    #[test]
+    fn shared_backoff_success_resets_penalty() {
+        let sb = SharedBackoff::with_cooldowns(Duration::from_millis(100), Duration::from_secs(60));
+        sb.report_rate_limited();
+        sb.report_rate_limited();
+        sb.report_success();
+        assert_eq!(sb.report_rate_limited(), Duration::from_millis(100));
+    }
+
+    #[test]
+    fn detects_rate_limit_errors() {
+        assert!(is_rate_limited(&anyhow::anyhow!(
+            "HTTP status client error (429 Too Many Requests) for url (http://x/)"
+        )));
+        // Port 42900 contains "429"; the 500 must not be mistaken for rate limiting.
+        assert!(!is_rate_limited(&anyhow::anyhow!(
+            "HTTP status server error (500) for url (http://127.0.0.1:42900/)"
+        )));
+        assert!(!is_rate_limited(&anyhow::anyhow!(
+            "HTTP status client error (403 Forbidden)"
+        )));
+    }
+
+    #[tokio::test]
+    async fn wait_blocks_until_cooldown_elapses() {
+        let sb = SharedBackoff::with_cooldowns(Duration::from_millis(80), Duration::from_secs(60));
+        let t = std::time::Instant::now();
+        sb.wait().await;
+        assert!(t.elapsed() < Duration::from_millis(50));
+
+        sb.report_rate_limited();
+        let t = std::time::Instant::now();
+        sb.wait().await;
+        assert!(t.elapsed() >= Duration::from_millis(80));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1014 

- Add `SharedBackoff` in `chain-integration-core/src/utils/retry.rs`. Arc-shared atomic gate
- Add `retry_rpc_gated!` macro, similar to existing `retry_rpc!`, but accepts `SharedBackoff` and includes gate hooks.
- `EthereumClient`: add `shared_backoff` field. Replace all sites using `retry_rpc!` to `retry_rpc_gated!`.