### PR TITLE
refactor: Ethereum indexer migration to a new design

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7364,6 +7364,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber 0.3.20",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7384,6 +7384,7 @@ dependencies = [
  "mpc-primitives",
  "rand 0.8.5",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -7562,6 +7563,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "tracing-opentelemetry",
  "tracing-stackdriver",
@@ -15639,9 +15641,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6056,6 +6056,7 @@ dependencies = [
  "testcontainers",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber 0.3.20",
  "url 2.5.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ serde_json = "1"
 sha3 = "0.10.8"
 thiserror = "1"
 tokio = { version = "1.45.1", features = ["full"] }
+tokio-util = { version = "0.7.16", default-features = false }
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.20", default-features = false, features = [
     "env-filter",

--- a/chain-signatures/chain-ethereum/Cargo.toml
+++ b/chain-signatures/chain-ethereum/Cargo.toml
@@ -24,6 +24,7 @@ mpc-primitives.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 reqwest.workspace = true
 tracing.workspace = true
 

--- a/chain-signatures/chain-ethereum/examples/bench_catchup.rs
+++ b/chain-signatures/chain-ethereum/examples/bench_catchup.rs
@@ -31,9 +31,9 @@
 
 use anyhow::anyhow;
 use futures_util::StreamExt;
-use mpc_chain_ethereum::{EthConfig, EthereumStream};
+use mpc_chain_ethereum::{EthConfig, EthereumIndexer};
 use mpc_chain_integration_core::{
-    ChainIndexer, ChainStream, MockStateManager, NoopChainTelemetry, StateManager,
+    utils::stream::chain_event_channel, MockStateManager, NoopChainTelemetry, StateManager,
 };
 use mpc_primitives::Chain;
 
@@ -114,37 +114,29 @@ async fn main() -> anyhow::Result<()> {
     let state = MockStateManager::new();
     state.set_processed_block(Chain::Ethereum, start - 1).await;
 
-    // Build the stream. `EthereumStream` creates the bounded event channel
-    // internally
-    let mut stream = EthereumStream::new(config, state, NoopChainTelemetry).await?;
-    let mut indexer = stream.start().await?;
+    let indexer = EthereumIndexer::new(config, state, NoopChainTelemetry).await?;
+    let (events_tx, mut events_rx) = chain_event_channel();
 
     tracing::info!("bench_catchup: starting catchup over [{start}..{end})");
 
-    // Drain emitted events in parallel so process_catchup never blocks on a
-    // full channel.
+    // Drain emitted events in parallel so processing never blocks on a full channel.
     let drain = tokio::spawn(async move {
-        loop {
-            match stream.next_event().await {
-                Some(ev) => tracing::debug!(?ev, "bench_catchup drained event"),
-                None => {
-                    tracing::warn!("bench_catchup: event channel closed during catchup");
-                    return;
-                }
-            }
+        while let Some(ev) = events_rx.recv().await {
+            tracing::debug!(?ev, "bench_catchup drained event");
         }
     });
 
-    let blocks_stream = indexer.catchup_range(end).await;
+    let blocks_stream = indexer.catchup_blocks(end).await;
     let mut blocks = std::pin::pin!(blocks_stream);
     let mut count: u64 = 0;
     while let Some(block) = blocks.next().await {
-        indexer.process_catchup(&block).await?;
+        indexer.process_catchup_item(&events_tx, &block).await?;
         count += 1;
     }
 
     // Fires the final `report_metrics("catchup_completed")` log under `bench`.
-    indexer.notify_catchup_completed().await?;
+    #[cfg(feature = "bench")]
+    mpc_chain_ethereum::bench::report_metrics("catchup_completed");
 
     drain.abort();
     let _ = drain.await;

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -33,6 +33,7 @@ fn live_blocks_channel() -> (mpsc::Sender<MaybeBlock>, mpsc::Receiver<MaybeBlock
     mpsc::channel(MAX_LIVE_BLOCK_BUFFER)
 }
 
+// TODO: Move this to some common crate so it can be shared across workspace
 /// Aborts the wrapped task on drop, prevents leaking a background task
 /// if the indexer is dropped while the live block fetcher is still running.
 struct AbortOnDrop(tokio::task::JoinHandle<()>);

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -634,7 +634,6 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     /// Catchup blocks in `[processed + 1, anchor_height)` fetched in batches.
     /// Samples the finalized head once at catchup start, so blocks at or below
     /// it can skip the per-block re-fetch + reorg hash check.
-
     pub async fn catchup_blocks(
         &self,
         anchor_height: u64,

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -761,7 +761,8 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         Ok(())
     }
 
-    /// Shared body of the legacy `process` and the `run()` live loop.
+    /// Process a single live item and emit its events, keeping the reorg hash
+    /// check (live blocks are not yet finalized).
     async fn process_live_item(
         &self,
         events_tx: &mpsc::Sender<ChainEvent>,

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -966,8 +966,13 @@ mod tests {
         BidirectionalTx, BidirectionalTxId, Chain, ChainEvent, ExecutionOutcome, SignId,
         LATEST_MPC_KEY_VERSION,
     };
+    use mpc_chain_integration_core::StateManager;
     use serde_json::json;
-    use std::sync::atomic::Ordering;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+    use tokio::time::Duration;
+    use tokio_util::sync::CancellationToken;
 
     #[tokio::test]
     async fn missing_catchup_block_is_refetched() {
@@ -1665,158 +1670,233 @@ mod tests {
             .into_bytes()
     }
 
-    #[tokio::test]
-    async fn run_processes_catchup_then_goes_live_and_stops_on_cancel() {
-        use mpc_chain_integration_core::StateManager;
-        use std::sync::atomic::AtomicU64;
-        use std::sync::Arc;
-        use tokio::time::Duration;
-        use tokio_util::sync::CancellationToken;
+    /// Fixture for running the indexer in a test with a mock JSON-RPC server.
+    /// Holds the mock server, latest block, and other state for running the indexer in tests.
+    struct RunFixture {
+        _server: mockito::ServerGuard,
+        latest: Arc<AtomicU64>,
+        /// Highest block number fetched by number, used to detect producer
+        /// activity after cancellation.
+        max_requested_block: Arc<AtomicU64>,
+        cancel: CancellationToken,
+        run_handle: tokio::task::JoinHandle<anyhow::Result<()>>,
+        events_rx: mpsc::Receiver<ChainEvent>,
+    }
 
-        let mut server = Server::new_async().await;
-        let latest = Arc::new(AtomicU64::new(9));
+    impl RunFixture {
+        async fn spawn(processed: u64, latest: u64) -> Self {
+            let mut server = Server::new_async().await;
+            let latest = Arc::new(AtomicU64::new(latest));
+            let max_requested_block = Arc::new(AtomicU64::new(0));
 
-        // Anchor sampling + live head polling.
-        server
-            .mock("POST", "/")
-            .match_body(Matcher::PartialJson(json!({
-                "method": "eth_getBlockByNumber",
-                "params": ["latest", false]
-            })))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body_from_request({
-                let latest = latest.clone();
-                move |req| block_reply(req, latest.load(Ordering::Relaxed))
-            })
-            .create_async()
-            .await;
+            // Anchor sampling + live head polling.
+            server
+                .mock("POST", "/")
+                .match_body(Matcher::PartialJson(json!({
+                    "method": "eth_getBlockByNumber",
+                    "params": ["latest", false]
+                })))
+                .with_status(200)
+                .with_header("content-type", "application/json")
+                .with_body_from_request({
+                    let latest = latest.clone();
+                    move |req| block_reply(req, latest.load(Ordering::Relaxed))
+                })
+                .create_async()
+                .await;
 
-        // Finalized head sampled once at catchup start; blocks <= 9 skip the
-        // catchup reorg refetch.
-        server
-            .mock("POST", "/")
-            .match_body(Matcher::PartialJson(json!({
-                "method": "eth_getBlockByNumber",
-                "params": ["finalized", false]
-            })))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body_from_request(|req| block_reply(req, 9))
-            .create_async()
-            .await;
+            // Finalized head sampled once at catchup start; tracking `latest`
+            // means catchup blocks skip the reorg refetch.
+            server
+                .mock("POST", "/")
+                .match_body(Matcher::PartialJson(json!({
+                    "method": "eth_getBlockByNumber",
+                    "params": ["finalized", false]
+                })))
+                .with_status(200)
+                .with_header("content-type", "application/json")
+                .with_body_from_request({
+                    let latest = latest.clone();
+                    move |req| block_reply(req, latest.load(Ordering::Relaxed))
+                })
+                .create_async()
+                .await;
 
-        // Catchup batch for blocks 6..=9 (processed block seeded at 5). Derive
-        // ids and block numbers from the request so alloy's id assignment and
-        // response pairing don't matter.
-        server
-            .mock("POST", "/")
-            .match_body(Matcher::Regex(r"^\[".to_string()))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body_from_request(|req| {
-                let body: serde_json::Value =
-                    serde_json::from_slice(req.body().expect("request body")).expect("json body");
-                let items = body
-                    .as_array()
-                    .expect("batch body")
-                    .iter()
-                    .map(|r| {
-                        let id = r["id"].as_u64().expect("request id");
-                        let hex = r["params"][0].as_str().expect("block number param");
+            // Catchup batches (JSON-RPC array body): derive ids and block
+            // numbers from the request.
+            server
+                .mock("POST", "/")
+                .match_body(Matcher::Regex(r"^\[".to_string()))
+                .with_status(200)
+                .with_header("content-type", "application/json")
+                .with_body_from_request(|req| {
+                    let body: serde_json::Value =
+                        serde_json::from_slice(req.body().expect("request body"))
+                            .expect("json body");
+                    let items = body
+                        .as_array()
+                        .expect("batch body")
+                        .iter()
+                        .map(|r| {
+                            let id = r["id"].as_u64().expect("request id");
+                            let hex = r["params"][0].as_str().expect("block number param");
+                            let number = u64::from_str_radix(hex.trim_start_matches("0x"), 16)
+                                .expect("hex block number");
+                            test_utils::block_response(id, number)
+                        })
+                        .collect();
+                    serde_json::Value::Array(items).to_string().into_bytes()
+                })
+                .create_async()
+                .await;
+
+            // Single-block fetches by number (live fetch + reorg refetch).
+            server
+                .mock("POST", "/")
+                .match_body(Matcher::Regex(
+                    r#"^\{.*"params":\["0x"#.to_string(),
+                ))
+                .with_status(200)
+                .with_header("content-type", "application/json")
+                .with_body_from_request({
+                    let max_requested_block = max_requested_block.clone();
+                    move |req| {
+                        let body: serde_json::Value =
+                            serde_json::from_slice(req.body().expect("request body"))
+                                .expect("json body");
+                        let id = body["id"].as_u64().expect("request id");
+                        let hex = body["params"][0].as_str().expect("block number param");
                         let number = u64::from_str_radix(hex.trim_start_matches("0x"), 16)
                             .expect("hex block number");
+                        max_requested_block.fetch_max(number, Ordering::Relaxed);
                         test_utils::block_response(id, number)
-                    })
-                    .collect();
-                serde_json::Value::Array(items).to_string().into_bytes()
-            })
-            .create_async()
-            .await;
+                            .to_string()
+                            .into_bytes()
+                    }
+                })
+                .create_async()
+                .await;
 
-        // Live block 10: fetched by the live task and re-fetched for the reorg check.
-        server
-            .mock("POST", "/")
-            .match_body(Matcher::PartialJson(json!({
-                "method": "eth_getBlockByNumber",
-                "params": ["0xa", false]
-            })))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body_from_request(|req| block_reply(req, 10))
-            .create_async()
-            .await;
+            let builder = test_utils::TestIndexerBuilder::new(server.url());
+            builder
+                .state_manager
+                .set_processed_block(Chain::Ethereum, processed)
+                .await;
+            let indexer = builder.build().await;
 
-        // Post-cancel leak check: block 11 must never be requested.
-        let block_11_mock = server
-            .mock("POST", "/")
-            .match_body(Matcher::PartialJson(json!({
-                "method": "eth_getBlockByNumber",
-                "params": ["0xb", false]
-            })))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(test_utils::block_response(1, 11).to_string())
-            .expect(0)
-            .create_async()
-            .await;
+            let (events_tx, events_rx) = chain_event_channel();
+            let cancel = CancellationToken::new();
+            let run_handle = tokio::spawn({
+                let cancel = cancel.clone();
+                async move { indexer.run(events_tx, cancel).await }
+            });
 
-        let builder = test_utils::TestIndexerBuilder::new(server.url());
-        builder
-            .state_manager
-            .set_processed_block(Chain::Ethereum, 5)
-            .await;
-        let indexer = builder.build().await;
+            Self {
+                _server: server,
+                latest,
+                max_requested_block,
+                cancel,
+                run_handle,
+                events_rx,
+            }
+        }
 
-        let (events_tx, mut events_rx) = chain_event_channel();
-        let cancel = CancellationToken::new();
-        let run_handle = tokio::spawn({
-            let cancel = cancel.clone();
-            async move { indexer.run(events_tx, cancel).await }
-        });
+        async fn next_event(&mut self) -> ChainEvent {
+            tokio::time::timeout(Duration::from_secs(5), self.events_rx.recv())
+                .await
+                .expect("timed out waiting for chain event")
+                .expect("events channel closed")
+        }
+
+        async fn cancel_and_join(&mut self) {
+            self.cancel.cancel();
+            tokio::time::timeout(Duration::from_secs(5), &mut self.run_handle)
+                .await
+                .expect("run() should stop promptly after cancel")
+                .expect("run task panicked")
+                .expect("run() should exit Ok on cancel");
+        }
+    }
+
+    #[tokio::test]
+    async fn run_processes_catchup_range_in_order() {
+        let mut f = RunFixture::spawn(5, 9).await;
 
         for n in 6..=9 {
-            let event = tokio::time::timeout(Duration::from_secs(5), events_rx.recv())
-                .await
-                .expect("catchup block event timed out")
-                .expect("events channel closed");
+            let event = f.next_event().await;
             assert!(
                 matches!(event, ChainEvent::Block(b) if b == n),
                 "expected Block({n}), got {event:?}"
             );
         }
-        let event = tokio::time::timeout(Duration::from_secs(5), events_rx.recv())
-            .await
-            .expect("catchup completed event timed out")
-            .expect("events channel closed");
+        let event = f.next_event().await;
         assert!(
             matches!(event, ChainEvent::CatchupCompleted),
             "expected CatchupCompleted, got {event:?}"
         );
 
-        // Advance the head; the live task should pick up block 10.
-        latest.store(10, Ordering::Relaxed);
-        let event = tokio::time::timeout(Duration::from_secs(5), events_rx.recv())
-            .await
-            .expect("live block event timed out")
-            .expect("events channel closed");
+        f.cancel_and_join().await;
+    }
+
+    #[tokio::test]
+    async fn run_emits_live_blocks_after_catchup_completed() {
+        let mut f = RunFixture::spawn(9, 9).await;
+        assert!(matches!(
+            f.next_event().await,
+            ChainEvent::CatchupCompleted
+        ));
+
+        f.latest.store(10, Ordering::Relaxed);
+        let event = f.next_event().await;
         assert!(
             matches!(event, ChainEvent::Block(10)),
             "expected Block(10), got {event:?}"
         );
 
-        cancel.cancel();
-        tokio::time::timeout(Duration::from_secs(5), run_handle)
-            .await
-            .expect("run() should stop promptly after cancel")
-            .expect("run task panicked")
-            .expect("run() should exit Ok on cancel");
+        f.cancel_and_join().await;
+    }
 
-        // The cancelled run must take its live producer down with it: the live
-        // task ticks every RETRY_DELAY (500ms), so it would request block 11
-        // well within this window if it were still alive.
-        latest.store(11, Ordering::Relaxed);
+    #[tokio::test]
+    async fn run_stops_promptly_on_cancel_while_live() {
+        let mut f = RunFixture::spawn(9, 9).await;
+        assert!(matches!(
+            f.next_event().await,
+            ChainEvent::CatchupCompleted
+        ));
+        f.cancel_and_join().await;
+    }
+
+    #[tokio::test]
+    async fn run_stops_promptly_on_cancel_during_catchup() {
+        let mut f = RunFixture::spawn(0, 500).await;
+        f.cancel_and_join().await;
+    }
+
+    #[tokio::test]
+    async fn cancel_aborts_live_block_producer() {
+        let mut f = RunFixture::spawn(9, 9).await;
+        assert!(matches!(
+            f.next_event().await,
+            ChainEvent::CatchupCompleted
+        ));
+
+        f.latest.store(10, Ordering::Relaxed);
+        assert!(matches!(
+            f.next_event().await,
+            ChainEvent::Block(10)
+        ));
+
+        f.cancel_and_join().await;
+
+        // The live producer ticks every RETRY_DELAY (500ms); if it survived
+        // run() it would fetch block 11 well within this window.
+        let max_at_cancel = f.max_requested_block.load(Ordering::Relaxed);
+        f.latest.store(11, Ordering::Relaxed);
         tokio::time::sleep(Duration::from_millis(1200)).await;
-        block_11_mock.assert_async().await;
+        assert_eq!(
+            f.max_requested_block.load(Ordering::Relaxed),
+            max_at_cancel,
+            "live block producer survived run() cancellation"
+        );
     }
 }

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -11,9 +11,8 @@ use alloy::rpc::types::{Block, BlockId, Log};
 use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use async_trait::async_trait;
-use futures_util::{stream, StreamExt};
-use mpc_chain_integration_core::utils::stream::chain_event_channel;
-use mpc_chain_integration_core::{ChainIndexer, ChainStream, ChainTelemetry, StateManager};
+use futures_util::{stream, Stream, StreamExt};
+use mpc_chain_integration_core::{ChainIndexer, ChainTelemetry, StateManager};
 use mpc_primitives::{
     BidirectionalTx, BidirectionalTxId, Chain, ChainEvent, ExecutionOutcome, IndexedSignRequest,
     SignId,
@@ -22,7 +21,7 @@ use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use tokio::sync::{mpsc, Notify};
+use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
@@ -81,12 +80,7 @@ pub struct EthereumIndexer<S: StateManager, T: ChainTelemetry> {
     state_manager: S,
     telemetry: T,
     client: Arc<EthereumClient>,
-    /// Legacy `ChainStream` path only: `run()` receives the sender from the
-    /// supervisor on every spawn instead.
-    events_tx: mpsc::Sender<ChainEvent>,
     contract_address: Address,
-    catchup_complete: Arc<Notify>,
-    live_blocks_rx: Option<mpsc::Receiver<MaybeBlock>>,
     /// The block number of the latest finalized block at the time catchup started. Used to determine which blocks are finalized during catchup.
     catchup_finalized_head: AtomicU64,
 }
@@ -102,12 +96,7 @@ enum BackfillOutcome {
 }
 
 impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
-    pub async fn new(
-        eth: EthConfig,
-        state_manager: S,
-        telemetry: T,
-        events_tx: mpsc::Sender<ChainEvent>,
-    ) -> anyhow::Result<Self> {
+    pub async fn new(eth: EthConfig, state_manager: S, telemetry: T) -> anyhow::Result<Self> {
         let client = Arc::new(EthereumClient::new(eth.clone()).await?);
         let contract_address = format!("0x{}", eth.contract_address);
         let contract_address = Address::from_str(&contract_address).with_context(|| {
@@ -119,38 +108,19 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             state_manager,
             telemetry,
             client,
-            events_tx,
             contract_address,
-            catchup_complete: Arc::new(Notify::new()),
-            live_blocks_rx: None,
             catchup_finalized_head: AtomicU64::new(0),
         })
     }
 
-    /// Construct an indexer for the supervised `run()` path. The construction-time
-    /// events channel is a placeholder: `run()` receives the real sender from
-    /// the supervisor on every spawn.
-    pub async fn new_supervised(
-        eth: EthConfig,
-        state_manager: S,
-        telemetry: T,
-    ) -> anyhow::Result<Self> {
-        let (events_tx, _events_rx) = chain_event_channel();
-        Self::new(eth, state_manager, telemetry, events_tx).await
-    }
-
     /// Construct an `EthereumIndexer` for tests with a pre-built `EthereumClient`
     /// (so a mockito URL can be injected) and a parsed `contract_address`.
-    ///
-    /// All other fields take sensible test defaults: a fresh `Notify` for
-    /// `catchup_complete` and `None` for `live_blocks_rx`.
     #[cfg(test)]
     pub(crate) fn new_for_test(
         eth: EthConfig,
         state_manager: S,
         telemetry: T,
         client: Arc<EthereumClient>,
-        events_tx: mpsc::Sender<ChainEvent>,
         contract_address: Address,
     ) -> Self {
         Self {
@@ -158,10 +128,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             state_manager,
             telemetry,
             client,
-            events_tx,
             contract_address,
-            catchup_complete: Arc::new(Notify::new()),
-            live_blocks_rx: None,
             catchup_finalized_head: AtomicU64::new(0),
         }
     }
@@ -610,8 +577,123 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         Ok(())
     }
 
-    /// Shared body of the legacy `process_catchup` and the `run()` catchup loop.
-    async fn process_catchup_item(
+    /// Retries `process_catchup_item` with `RETRY_DELAY` backoff until it
+    /// succeeds or `cancel` fires.
+    async fn process_catchup_retrying(
+        &self,
+        events_tx: &mpsc::Sender<ChainEvent>,
+        item: &CatchupItem,
+        cancel: &CancellationToken,
+    ) {
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => return,
+                result = self.process_catchup_item(events_tx, item) => {
+                    match result {
+                        Ok(()) => return,
+                        Err(err) => {
+                            tracing::warn!(?err, "ethereum catchup block processing failed; retrying");
+                        }
+                    }
+                }
+            }
+            tokio::select! {
+                _ = cancel.cancelled() => return,
+                _ = sleep(Self::RETRY_DELAY) => {}
+            }
+        }
+    }
+
+    /// Retries `process_live_item` with `RETRY_DELAY` backoff until it
+    /// succeeds or `cancel` fires.
+    async fn process_live_retrying(
+        &self,
+        events_tx: &mpsc::Sender<ChainEvent>,
+        item: &CatchupItem,
+        cancel: &CancellationToken,
+    ) {
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => return,
+                result = self.process_live_item(events_tx, item) => {
+                    match result {
+                        Ok(()) => return,
+                        Err(err) => {
+                            tracing::warn!(?err, "ethereum live block processing failed; retrying");
+                        }
+                    }
+                }
+            }
+            tokio::select! {
+                _ = cancel.cancelled() => return,
+                _ = sleep(Self::RETRY_DELAY) => {}
+            }
+        }
+    }
+
+    /// Catchup blocks in `[processed + 1, anchor_height)` fetched in batches.
+    /// Samples the finalized head once at catchup start, so blocks at or below
+    /// it can skip the per-block re-fetch + reorg hash check.
+    // TODO: start from genesis block of contract deployment instead of
+    // anchor_height so that we can start from the very beginning of
+    // the history of the network in case where we do not have a checkpoint.
+    // https://github.com/sig-net/mpc/issues/777
+    pub async fn catchup_blocks(
+        &self,
+        anchor_height: u64,
+    ) -> std::pin::Pin<Box<dyn Stream<Item = CatchupItem> + Send + 'static>> {
+        #[cfg(feature = "bench")]
+        crate::bench::rpc_reset();
+
+        let current_block = self
+            .state_manager
+            .get_processed_block(Chain::Ethereum)
+            .await
+            .map(|n| n.saturating_add(1))
+            .unwrap_or(anchor_height);
+        let catchup_start = self
+            .client
+            .clamp_oldest_supported(current_block, anchor_height);
+
+        let catchup_iter = CatchupIter::new(
+            self.client.clone(),
+            catchup_start,
+            anchor_height,
+            self.contract_address,
+        );
+
+        // Sample the finalized head once at catchup start, so that blocks at or below it can skip the per-block re-fetch + reorg hash check.
+        if let Some(finalized_block) = self
+            .client
+            .get_block(BlockId::Number(BlockNumberOrTag::Finalized))
+            .await
+        {
+            self.catchup_finalized_head
+                .store(finalized_block.header.number, Ordering::Relaxed);
+            tracing::info!(
+                finalized_head = finalized_block.header.number,
+                catchup_start,
+                anchor_height,
+                "sampled finalized head for catchup reorg-check gating"
+            );
+        } else {
+            tracing::warn!(
+                "could not sample finalized head for catchup; keeping reorg check for all blocks"
+            );
+        }
+
+        // Convert the async state machine into a Stream
+        let stream = stream::unfold(catchup_iter, |mut state| async move {
+            let item = state.next().await;
+            item.map(|block| (block, state))
+        });
+
+        Box::pin(stream)
+    }
+
+    /// Process a single catchup item (batch block, missing-block refetch, or
+    /// live block) and emit its events.
+    pub async fn process_catchup_item(
         &self,
         events_tx: &mpsc::Sender<ChainEvent>,
         item: &CatchupItem,
@@ -808,109 +890,6 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
     type Block = CatchupItem;
     type Iter = std::pin::Pin<Box<dyn stream::Stream<Item = Self::Block> + Send + 'static>>;
 
-    async fn livestream(&mut self) -> anyhow::Result<Option<u64>> {
-        let start_block_number = loop {
-            if let Some(block_number) = self.client.get_latest_block_number().await {
-                break block_number.saturating_add(1);
-            };
-            sleep(Self::RETRY_DELAY).await;
-        };
-
-        let (live_blocks_tx, live_blocks_rx) = live_blocks_channel();
-        let client = self.client.clone();
-        let catchup_complete = self.catchup_complete.clone();
-        tokio::spawn(async move {
-            // Wait for catchup to complete before starting to index live blocks
-            catchup_complete.notified().await;
-            Self::index_live_blocks(client, start_block_number, live_blocks_tx).await;
-        });
-
-        self.live_blocks_rx = Some(live_blocks_rx);
-        Ok(Some(start_block_number))
-    }
-
-    async fn next(&mut self) -> Option<Self::Block> {
-        let rx = self.live_blocks_rx.as_mut()?;
-        rx.recv().await.map(|maybe| match maybe {
-            MaybeBlock::Block(block) => CatchupItem::LiveBlock(block),
-            MaybeBlock::Missing(id) => CatchupItem::Missing(id),
-        })
-    }
-
-    async fn catchup_range(&self, anchor_height: u64) -> Self::Iter {
-        #[cfg(feature = "bench")]
-        crate::bench::rpc_reset();
-
-        // TODO: start from genesis block of contract deployment instead of
-        // anchor_height so that we can start from the very beginning of
-        // the history of the network in case where we do not have a checkpoint.
-        // https://github.com/sig-net/mpc/issues/777
-        let current_block = self
-            .state_manager
-            .get_processed_block(Chain::Ethereum)
-            .await
-            .map(|n| n.saturating_add(1))
-            .unwrap_or(anchor_height);
-        let catchup_start = self
-            .client
-            .clamp_oldest_supported(current_block, anchor_height);
-
-        let catchup_iter = CatchupIter::new(
-            self.client.clone(),
-            catchup_start,
-            anchor_height,
-            self.contract_address,
-        );
-
-        // Sample the finalized head once at catchup start, so that blocks at or below it can skip the per-block re-fetch + reorg hash check.
-        if let Some(finalized_block) = self
-            .client
-            .get_block(BlockId::Number(BlockNumberOrTag::Finalized))
-            .await
-        {
-            self.catchup_finalized_head
-                .store(finalized_block.header.number, Ordering::Relaxed);
-            tracing::info!(
-                finalized_head = finalized_block.header.number,
-                catchup_start,
-                anchor_height,
-                "sampled finalized head for catchup reorg-check gating"
-            );
-        } else {
-            tracing::warn!(
-                "could not sample finalized head for catchup; keeping reorg check for all blocks"
-            );
-        }
-
-        // Convert the async state machine into a Stream
-        let stream = stream::unfold(catchup_iter, |mut state| async move {
-            let item = state.next().await;
-            item.map(|block| (block, state))
-        });
-
-        Box::pin(stream)
-    }
-
-    async fn process_catchup(&mut self, item: &Self::Block) -> anyhow::Result<()> {
-        self.process_catchup_item(&self.events_tx, item).await
-    }
-
-    async fn process(&mut self, item: &Self::Block) -> anyhow::Result<()> {
-        self.process_live_item(&self.events_tx, item).await
-    }
-
-    async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {
-        #[cfg(feature = "bench")]
-        crate::bench::report_metrics("catchup_completed");
-
-        self.events_tx
-            .send(ChainEvent::CatchupCompleted)
-            .await
-            .context("failed to send catchup completed event")?;
-        self.catchup_complete.notify_one();
-        Ok(())
-    }
-
     async fn run(
         &self,
         events_tx: mpsc::Sender<ChainEvent>,
@@ -930,30 +909,15 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
             }
         };
 
-        let mut catchup_iter = self.catchup_range(anchor_height).await;
+        let mut catchup_iter = self.catchup_blocks(anchor_height).await;
         loop {
             let item = tokio::select! {
                 _ = cancel.cancelled() => return Ok(()),
                 item = catchup_iter.next() => item,
             };
             let Some(item) = item else { break };
-            loop {
-                tokio::select! {
-                    _ = cancel.cancelled() => return Ok(()),
-                    result = self.process_catchup_item(&events_tx, &item) => {
-                        match result {
-                            Ok(()) => break,
-                            Err(err) => {
-                                tracing::warn!(?err, "ethereum catchup block processing failed; retrying");
-                            }
-                        }
-                    }
-                }
-                tokio::select! {
-                    _ = cancel.cancelled() => return Ok(()),
-                    _ = sleep(Self::RETRY_DELAY) => {}
-                }
-            }
+            self.process_catchup_retrying(&events_tx, &item, &cancel)
+                .await;
         }
 
         events_tx
@@ -982,64 +946,11 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
                 MaybeBlock::Block(block) => CatchupItem::LiveBlock(block),
                 MaybeBlock::Missing(id) => CatchupItem::Missing(id),
             };
-            loop {
-                tokio::select! {
-                    _ = cancel.cancelled() => return Ok(()),
-                    result = self.process_live_item(&events_tx, &item) => {
-                        match result {
-                            Ok(()) => break,
-                            Err(err) => {
-                                tracing::warn!(?err, "ethereum live block processing failed; retrying");
-                            }
-                        }
-                    }
-                }
-                tokio::select! {
-                    _ = cancel.cancelled() => return Ok(()),
-                    _ = sleep(Self::RETRY_DELAY) => {}
-                }
-            }
+            self.process_live_retrying(&events_tx, &item, &cancel).await;
         }
     }
 }
 
-/// Ethereum indexer stream implementing the `ChainStream` trait.
-/// Construction is side-effect free; the shared `run_stream()` loop calls
-/// `start()` after recovery has completed.
-pub struct EthereumStream<S: StateManager, T: ChainTelemetry> {
-    events_rx: Option<mpsc::Receiver<ChainEvent>>,
-    start_state: Option<EthereumIndexer<S, T>>,
-}
-
-impl<S: StateManager, T: ChainTelemetry> EthereumStream<S, T> {
-    pub async fn new(eth: EthConfig, state_manager: S, telemetry: T) -> anyhow::Result<Self> {
-        tracing::info!(eth_config = ?eth, "creating ethereum indexer stream");
-        let (events_tx, events_rx) = chain_event_channel();
-        let indexer = EthereumIndexer::new(eth, state_manager, telemetry, events_tx).await?;
-        Ok(Self {
-            events_rx: Some(events_rx),
-            start_state: Some(indexer),
-        })
-    }
-}
-
-#[async_trait]
-impl<S: StateManager, T: ChainTelemetry> ChainStream for EthereumStream<S, T> {
-    type Indexer = EthereumIndexer<S, T>;
-
-    async fn start(&mut self) -> anyhow::Result<Self::Indexer> {
-        self.start_state
-            .take()
-            .context("ethereum stream already started")
-    }
-
-    async fn next_event(&mut self) -> Option<ChainEvent> {
-        match self.events_rx.as_mut() {
-            Some(rx) => rx.recv().await,
-            None => None,
-        }
-    }
-}
 #[cfg(test)]
 mod tests {
     use crate::client::CatchupItem;
@@ -1048,6 +959,7 @@ mod tests {
     use alloy::primitives::{address, b256};
     use alloy::rpc::types::BlockId;
     use mockito::{Matcher, Server};
+    use mpc_chain_integration_core::utils::stream::chain_event_channel;
     use mpc_chain_integration_core::ChainIndexer;
     use mpc_primitives::{
         BidirectionalTx, BidirectionalTxId, Chain, ChainEvent, ExecutionOutcome, SignId,
@@ -1082,14 +994,16 @@ mod tests {
             .create_async()
             .await;
 
-        let (mut indexer, mut events_rx) = test_utils::TestIndexerBuilder::new(server.url())
-            .build_with_rx()
+        let indexer = test_utils::TestIndexerBuilder::new(server.url())
+            .build()
             .await;
+        let (events_tx, mut events_rx) = chain_event_channel();
 
         indexer
-            .process_catchup(&CatchupItem::Missing(BlockId::Number(
-                BlockNumberOrTag::Number(12),
-            )))
+            .process_catchup_item(
+                &events_tx,
+                &CatchupItem::Missing(BlockId::Number(BlockNumberOrTag::Number(12))),
+            )
             .await
             .expect("missing catchup block should be refetched successfully");
 
@@ -1128,9 +1042,10 @@ mod tests {
             .create_async()
             .await;
 
-        let (mut indexer, mut events_rx) = test_utils::TestIndexerBuilder::new(server.url())
-            .build_with_rx()
+        let indexer = test_utils::TestIndexerBuilder::new(server.url())
+            .build()
             .await;
+        let (events_tx, mut events_rx) = chain_event_channel();
         // Ensure blocks are considered finalized to avoid reorg-check refetches in process_catchup
         indexer.catchup_finalized_head.store(100, Ordering::Relaxed);
 
@@ -1143,7 +1058,7 @@ mod tests {
         for n in 1..=32 {
             let item = iter.next().await.expect("expected item");
             indexer
-                .process_catchup(&item)
+                .process_catchup_item(&events_tx, &item)
                 .await
                 .expect("processing batch block should succeed");
 
@@ -1188,9 +1103,10 @@ mod tests {
             .create_async()
             .await;
 
-        let (mut indexer, mut events_rx) = test_utils::TestIndexerBuilder::new(server.url())
-            .build_with_rx()
+        let indexer = test_utils::TestIndexerBuilder::new(server.url())
+            .build()
             .await;
+        let (events_tx, mut events_rx) = chain_event_channel();
         indexer.catchup_finalized_head.store(100, Ordering::Relaxed);
 
         let mut iter = crate::client::CatchupIter::new(
@@ -1201,14 +1117,20 @@ mod tests {
         );
 
         let item1 = iter.next().await.unwrap();
-        indexer.process_catchup(&item1).await.unwrap();
+        indexer
+            .process_catchup_item(&events_tx, &item1)
+            .await
+            .unwrap();
         assert!(matches!(
             events_rx.recv().await,
             Some(ChainEvent::Block(10))
         ));
 
         let item2 = iter.next().await.unwrap();
-        indexer.process_catchup(&item2).await.unwrap();
+        indexer
+            .process_catchup_item(&events_tx, &item2)
+            .await
+            .unwrap();
         assert!(matches!(
             events_rx.recv().await,
             Some(ChainEvent::Block(11))
@@ -1248,16 +1170,17 @@ mod tests {
             .create_async()
             .await;
 
-        let (mut indexer, mut events_rx) = test_utils::TestIndexerBuilder::new(server.url())
-            .build_with_rx()
+        let indexer = test_utils::TestIndexerBuilder::new(server.url())
+            .build()
             .await;
+        let (events_tx, mut events_rx) = chain_event_channel();
 
         // Ensure block is considered finalized to avoid the reorg-check refetch
         indexer.catchup_finalized_head.store(100, Ordering::Relaxed);
 
         let item = CatchupItem::Missing(BlockId::Number(BlockNumberOrTag::Number(block_number)));
         indexer
-            .process_catchup(&item)
+            .process_catchup_item(&events_tx, &item)
             .await
             .expect("processing missing block should succeed with refetch");
 
@@ -1296,9 +1219,10 @@ mod tests {
             .create_async()
             .await;
 
-        let (mut indexer, mut events_rx) = test_utils::TestIndexerBuilder::new(server.url())
-            .build_with_rx()
+        let indexer = test_utils::TestIndexerBuilder::new(server.url())
+            .build()
             .await;
+        let (events_tx, mut events_rx) = chain_event_channel();
         // Ensure block is considered finalized to avoid the reorg-check refetch
         indexer.catchup_finalized_head.store(100, Ordering::Relaxed);
 
@@ -1311,7 +1235,7 @@ mod tests {
         let item = iter.next().await.unwrap();
 
         indexer
-            .process_catchup(&item)
+            .process_catchup_item(&events_tx, &item)
             .await
             .expect("processing batch block with null receipts (normalized) should succeed");
 
@@ -1356,12 +1280,13 @@ mod tests {
             .create_async()
             .await;
 
-        let (mut indexer, mut events_rx) = test_utils::TestIndexerBuilder::new(server.url())
-            .build_with_rx()
+        let indexer = test_utils::TestIndexerBuilder::new(server.url())
+            .build()
             .await;
+        let (events_tx, mut events_rx) = chain_event_channel();
 
         indexer
-            .process(&item)
+            .process_live_item(&events_tx, &item)
             .await
             .expect("live process should succeed");
 
@@ -1376,17 +1301,18 @@ mod tests {
 
     #[tokio::test]
     async fn missing_catchup_block_returns_error_when_refetch_fails() {
-        let (mut indexer, mut events_rx) =
-            test_utils::TestIndexerBuilder::new("http://127.0.0.1:1")
-                .client_url("http://127.0.0.1:1")
-                .rpc_urls("", "")
-                .build_with_rx()
-                .await;
+        let indexer = test_utils::TestIndexerBuilder::new("http://127.0.0.1:1")
+            .client_url("http://127.0.0.1:1")
+            .rpc_urls("", "")
+            .build()
+            .await;
+        let (events_tx, mut events_rx) = chain_event_channel();
 
         let err = indexer
-            .process_catchup(&CatchupItem::Missing(BlockId::Number(
-                BlockNumberOrTag::Number(12),
-            )))
+            .process_catchup_item(
+                &events_tx,
+                &CatchupItem::Missing(BlockId::Number(BlockNumberOrTag::Number(12))),
+            )
             .await
             .expect_err("missing catchup block should fail when refetch cannot recover it");
 
@@ -1421,15 +1347,16 @@ mod tests {
             .await;
 
         // Optimistic mode (default) so `wait_for_finalized_block` is skipped.
-        let (mut indexer, mut events_rx) = test_utils::TestIndexerBuilder::new(server.url())
-            .build_with_rx()
+        let indexer = test_utils::TestIndexerBuilder::new(server.url())
+            .build()
             .await;
+        let (events_tx, mut events_rx) = chain_event_channel();
         // Block 42 was finalized at fetch time (head sampled at 100), so the
         // re-fetch + reorg check is skipped.
         indexer.catchup_finalized_head.store(100, Ordering::Relaxed);
 
         indexer
-            .process_catchup(&item)
+            .process_catchup_item(&events_tx, &item)
             .await
             .expect("catchup over a present finalized block should succeed");
 
@@ -1467,14 +1394,15 @@ mod tests {
             .create_async()
             .await;
 
-        let (mut indexer, mut events_rx) = test_utils::TestIndexerBuilder::new(server.url())
-            .build_with_rx()
+        let indexer = test_utils::TestIndexerBuilder::new(server.url())
+            .build()
             .await;
+        let (events_tx, mut events_rx) = chain_event_channel();
         // Finalized head sampled at 10 → block 42 is unfinalized at fetch time.
         indexer.catchup_finalized_head.store(10, Ordering::Relaxed);
 
         indexer
-            .process_catchup(&item)
+            .process_catchup_item(&events_tx, &item)
             .await
             .expect("catchup over an unfinalized block should succeed");
 
@@ -1521,12 +1449,13 @@ mod tests {
             .create_async()
             .await;
 
-        let (mut indexer, mut events_rx) = test_utils::TestIndexerBuilder::new(server.url())
-            .build_with_rx()
+        let indexer = test_utils::TestIndexerBuilder::new(server.url())
+            .build()
             .await;
+        let (events_tx, mut events_rx) = chain_event_channel();
 
         indexer
-            .process(&item)
+            .process_live_item(&events_tx, &item)
             .await
             .expect("live process over a block should succeed");
 
@@ -1574,12 +1503,13 @@ mod tests {
             .create_async()
             .await;
 
-        let (mut indexer, mut events_rx) = test_utils::TestIndexerBuilder::new(server.url())
-            .build_with_rx()
+        let indexer = test_utils::TestIndexerBuilder::new(server.url())
+            .build()
             .await;
+        let (events_tx, mut events_rx) = chain_event_channel();
 
         indexer
-            .process(&item)
+            .process_live_item(&events_tx, &item)
             .await
             .expect("reorged live block should not error");
 
@@ -1736,7 +1666,6 @@ mod tests {
 
     #[tokio::test]
     async fn run_processes_catchup_then_goes_live_and_stops_on_cancel() {
-        use mpc_chain_integration_core::utils::stream::chain_event_channel;
         use mpc_chain_integration_core::StateManager;
         use std::sync::atomic::AtomicU64;
         use std::sync::Arc;

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -33,8 +33,8 @@ fn live_blocks_channel() -> (mpsc::Sender<MaybeBlock>, mpsc::Receiver<MaybeBlock
     mpsc::channel(MAX_LIVE_BLOCK_BUFFER)
 }
 
-/// Aborts the wrapped task on drop, so a cancelled `run()` takes its live
-/// block producer down with it instead of leaking it across restarts.
+/// Aborts the wrapped task on drop, prevents leaking a background task
+/// if the indexer is dropped while the live block fetcher is still running.
 struct AbortOnDrop(tokio::task::JoinHandle<()>);
 
 impl Drop for AbortOnDrop {
@@ -634,10 +634,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     /// Catchup blocks in `[processed + 1, anchor_height)` fetched in batches.
     /// Samples the finalized head once at catchup start, so blocks at or below
     /// it can skip the per-block re-fetch + reorg hash check.
-    // TODO: start from genesis block of contract deployment instead of
-    // anchor_height so that we can start from the very beginning of
-    // the history of the network in case where we do not have a checkpoint.
-    // https://github.com/sig-net/mpc/issues/777
+
     pub async fn catchup_blocks(
         &self,
         anchor_height: u64,
@@ -645,6 +642,10 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         #[cfg(feature = "bench")]
         crate::bench::rpc_reset();
 
+        // TODO: start from genesis block of contract deployment instead of
+        // anchor_height so that we can start from the very beginning of
+        // the history of the network in case where we do not have a checkpoint.
+        // https://github.com/sig-net/mpc/issues/777
         let current_block = self
             .state_manager
             .get_processed_block(Chain::Ethereum)
@@ -962,11 +963,11 @@ mod tests {
     use mockito::{Matcher, Server};
     use mpc_chain_integration_core::utils::stream::chain_event_channel;
     use mpc_chain_integration_core::ChainIndexer;
+    use mpc_chain_integration_core::StateManager;
     use mpc_primitives::{
         BidirectionalTx, BidirectionalTxId, Chain, ChainEvent, ExecutionOutcome, SignId,
         LATEST_MPC_KEY_VERSION,
     };
-    use mpc_chain_integration_core::StateManager;
     use serde_json::json;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::Arc;
@@ -1753,9 +1754,7 @@ mod tests {
             // Single-block fetches by number (live fetch + reorg refetch).
             server
                 .mock("POST", "/")
-                .match_body(Matcher::Regex(
-                    r#"^\{.*"params":\["0x"#.to_string(),
-                ))
+                .match_body(Matcher::Regex(r#"^\{.*"params":\["0x"#.to_string()))
                 .with_status(200)
                 .with_header("content-type", "application/json")
                 .with_body_from_request({
@@ -1841,10 +1840,7 @@ mod tests {
     #[tokio::test]
     async fn run_emits_live_blocks_after_catchup_completed() {
         let mut f = RunFixture::spawn(9, 9).await;
-        assert!(matches!(
-            f.next_event().await,
-            ChainEvent::CatchupCompleted
-        ));
+        assert!(matches!(f.next_event().await, ChainEvent::CatchupCompleted));
 
         f.latest.store(10, Ordering::Relaxed);
         let event = f.next_event().await;
@@ -1859,10 +1855,7 @@ mod tests {
     #[tokio::test]
     async fn run_stops_promptly_on_cancel_while_live() {
         let mut f = RunFixture::spawn(9, 9).await;
-        assert!(matches!(
-            f.next_event().await,
-            ChainEvent::CatchupCompleted
-        ));
+        assert!(matches!(f.next_event().await, ChainEvent::CatchupCompleted));
         f.cancel_and_join().await;
     }
 
@@ -1875,16 +1868,10 @@ mod tests {
     #[tokio::test]
     async fn cancel_aborts_live_block_producer() {
         let mut f = RunFixture::spawn(9, 9).await;
-        assert!(matches!(
-            f.next_event().await,
-            ChainEvent::CatchupCompleted
-        ));
+        assert!(matches!(f.next_event().await, ChainEvent::CatchupCompleted));
 
         f.latest.store(10, Ordering::Relaxed);
-        assert!(matches!(
-            f.next_event().await,
-            ChainEvent::Block(10)
-        ));
+        assert!(matches!(f.next_event().await, ChainEvent::Block(10)));
 
         f.cancel_and_join().await;
 

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -11,7 +11,7 @@ use alloy::rpc::types::{Block, BlockId, Log};
 use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use async_trait::async_trait;
-use futures_util::stream;
+use futures_util::{stream, StreamExt};
 use mpc_chain_integration_core::utils::stream::chain_event_channel;
 use mpc_chain_integration_core::{ChainIndexer, ChainStream, ChainTelemetry, StateManager};
 use mpc_primitives::{
@@ -24,6 +24,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Notify};
 use tokio::time::{sleep, Duration, Instant};
+use tokio_util::sync::CancellationToken;
 
 const MAX_LIVE_BLOCK_BUFFER: usize = 16384;
 /// Limit of consecutive `get_block(Finalized)` total failures allowed before `wait_for_finalized_block` gives up.
@@ -31,6 +32,16 @@ const MAX_FINALIZED_FAILURES: u32 = 20;
 
 fn live_blocks_channel() -> (mpsc::Sender<MaybeBlock>, mpsc::Receiver<MaybeBlock>) {
     mpsc::channel(MAX_LIVE_BLOCK_BUFFER)
+}
+
+/// Aborts the wrapped task on drop, so a cancelled `run()` takes its live
+/// block producer down with it instead of leaking it across restarts.
+struct AbortOnDrop(tokio::task::JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
 }
 
 pub struct BlockAndRequests {
@@ -70,6 +81,8 @@ pub struct EthereumIndexer<S: StateManager, T: ChainTelemetry> {
     state_manager: S,
     telemetry: T,
     client: Arc<EthereumClient>,
+    /// Legacy `ChainStream` path only: `run()` receives the sender from the
+    /// supervisor on every spawn instead.
     events_tx: mpsc::Sender<ChainEvent>,
     contract_address: Address,
     catchup_complete: Arc<Notify>,
@@ -114,6 +127,18 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         })
     }
 
+    /// Construct an indexer for the supervised `run()` path. The construction-time
+    /// events channel is a placeholder: `run()` receives the real sender from
+    /// the supervisor on every spawn.
+    pub async fn new_supervised(
+        eth: EthConfig,
+        state_manager: S,
+        telemetry: T,
+    ) -> anyhow::Result<Self> {
+        let (events_tx, _events_rx) = chain_event_channel();
+        Self::new(eth, state_manager, telemetry, events_tx).await
+    }
+
     /// Construct an `EthereumIndexer` for tests with a pre-built `EthereumClient`
     /// (so a mockito URL can be injected) and a parsed `contract_address`.
     ///
@@ -143,14 +168,10 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
 
     async fn index_live_blocks(
         client: Arc<EthereumClient>,
-        catchup_complete: Arc<Notify>,
         start_block_number: u64,
         live_blocks: mpsc::Sender<MaybeBlock>,
     ) {
         tracing::info!("indexing ethereum live blocks");
-
-        // Wait for catchup to complete before starting to index live blocks
-        catchup_complete.notified().await;
 
         let mut current_block_number = start_block_number;
 
@@ -216,6 +237,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     /// For the live path, `is_finalized` is always `false`
     async fn process_block(
         &self,
+        events_tx: &mpsc::Sender<ChainEvent>,
         block: &Block,
         relevant_logs: &[Log],
         is_finalized: bool,
@@ -224,7 +246,8 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         self.telemetry.block_indexed(block.header.number);
 
         let processed = self.parse_block(block, relevant_logs).await?;
-        self.emit_processed_block(processed, is_finalized).await?;
+        self.emit_processed_block(events_tx, processed, is_finalized)
+            .await?;
 
         Ok(())
     }
@@ -523,6 +546,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     /// (see `process_block`).
     async fn emit_processed_block(
         &self,
+        events_tx: &mpsc::Sender<ChainEvent>,
         BlockAndRequests {
             block_number,
             block_hash,
@@ -558,14 +582,14 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         }
 
         for event in execution_events {
-            self.events_tx
+            events_tx
                 .send(event)
                 .await
                 .context("failed to emit ExecutionConfirmed event")?;
         }
 
         for request in indexed_requests {
-            self.events_tx
+            events_tx
                 .send(ChainEvent::SignRequest {
                     request,
                     block_timestamp: Some(block_timestamp),
@@ -575,14 +599,115 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         }
 
         if !respond_logs.is_empty() {
-            emit_respond_events(&respond_logs, self.events_tx.clone()).await;
+            emit_respond_events(&respond_logs, events_tx.clone()).await;
         }
 
-        self.events_tx
+        events_tx
             .send(ChainEvent::Block(block_number))
             .await
             .context("failed to emit block event")?;
 
+        Ok(())
+    }
+
+    /// Shared body of the legacy `process_catchup` and the `run()` catchup loop.
+    async fn process_catchup_item(
+        &self,
+        events_tx: &mpsc::Sender<ChainEvent>,
+        item: &CatchupItem,
+    ) -> anyhow::Result<()> {
+        // NOTE: oh rust: needed otherwise the block gets dropped before we can use
+        // it, since it `block` is of reference type. Maybe the language will let
+        // us elide this in the future, but for now we need to introduce a new var.
+        let _block;
+        let _logs;
+
+        let (block, logs) = match item {
+            CatchupItem::BatchBlock { block, logs } => (block, logs.as_slice()),
+            CatchupItem::Missing(block_id) => {
+                tracing::warn!(
+                    ?block_id,
+                    "ethereum catchup block missing from batch; refetching"
+                );
+
+                #[cfg(feature = "bench")]
+                let start = std::time::Instant::now();
+
+                // Refetch the block, then bloom-gate a single-block `eth_getLogs`.
+                let Some(block) = self.client.get_block(*block_id).await else {
+                    anyhow::bail!(
+                        "ethereum catchup block {block_id:?} is still unavailable after refetch"
+                    )
+                };
+                let l = self.fetch_block_logs(&block).await?;
+
+                #[cfg(feature = "bench")]
+                crate::bench::add_refetch_time(start.elapsed());
+
+                _block = block;
+                _logs = l;
+                (&_block, _logs.as_slice())
+            }
+            CatchupItem::LiveBlock(block) => {
+                _logs = self.fetch_block_logs(block).await?;
+                (block, _logs.as_slice())
+            }
+        };
+
+        let height = block.header.number;
+        if height.is_multiple_of(10) {
+            tracing::info!(height, "processed ethereum catchup block attempt");
+        }
+
+        #[cfg(feature = "bench")]
+        let start_process = std::time::Instant::now();
+
+        // Determine if the block is finalized based on the sampled finalized head at catchup start
+        let f0 = self.catchup_finalized_head.load(Ordering::Relaxed);
+        let is_finalized = block.header.number <= f0;
+        self.process_block(events_tx, block, logs, is_finalized)
+            .await?;
+
+        #[cfg(feature = "bench")]
+        {
+            crate::bench::add_process_time(start_process.elapsed());
+            if crate::bench::inc_block() % 100 == 0 {
+                crate::bench::report_metrics("catchup_progress");
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Shared body of the legacy `process` and the `run()` live loop.
+    async fn process_live_item(
+        &self,
+        events_tx: &mpsc::Sender<ChainEvent>,
+        item: &CatchupItem,
+    ) -> anyhow::Result<()> {
+        let _block;
+        let _logs;
+
+        let (block, logs) = match item {
+            CatchupItem::LiveBlock(block) => {
+                _logs = self.fetch_block_logs(block).await?;
+                (block, _logs.as_slice())
+            }
+            CatchupItem::BatchBlock { block, logs } => (block, logs.as_slice()),
+            CatchupItem::Missing(block_id) => {
+                let Some(b) = self.client.get_block(*block_id).await else {
+                    anyhow::bail!(
+                        "ethereum live stream yielded missing block {block_id:?} and refetch failed"
+                    )
+                };
+                _logs = self.fetch_block_logs(&b).await?;
+                _block = b;
+                (&_block, _logs.as_slice())
+            }
+        };
+
+        // Live blocks are not yet finalized, so keep the reorg hash check
+        self.process_block(events_tx, block, logs, false).await?;
         Ok(())
     }
 
@@ -692,12 +817,13 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
         };
 
         let (live_blocks_tx, live_blocks_rx) = live_blocks_channel();
-        tokio::spawn(Self::index_live_blocks(
-            self.client.clone(),
-            self.catchup_complete.clone(),
-            start_block_number,
-            live_blocks_tx,
-        ));
+        let client = self.client.clone();
+        let catchup_complete = self.catchup_complete.clone();
+        tokio::spawn(async move {
+            // Wait for catchup to complete before starting to index live blocks
+            catchup_complete.notified().await;
+            Self::index_live_blocks(client, start_block_number, live_blocks_tx).await;
+        });
 
         self.live_blocks_rx = Some(live_blocks_rx);
         Ok(Some(start_block_number))
@@ -766,93 +892,11 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
     }
 
     async fn process_catchup(&mut self, item: &Self::Block) -> anyhow::Result<()> {
-        // NOTE: oh rust: needed otherwise the block gets dropped before we can use
-        // it, since it `block` is of reference type. Maybe the language will let
-        // us elide this in the future, but for now we need to introduce a new var.
-        let _block;
-        let _logs;
-
-        let (block, logs) = match item {
-            CatchupItem::BatchBlock { block, logs } => (block, logs.as_slice()),
-            CatchupItem::Missing(block_id) => {
-                tracing::warn!(
-                    ?block_id,
-                    "ethereum catchup block missing from batch; refetching"
-                );
-
-                #[cfg(feature = "bench")]
-                let start = std::time::Instant::now();
-
-                // Refetch the block, then bloom-gate a single-block `eth_getLogs`.
-                let Some(block) = self.client.get_block(*block_id).await else {
-                    anyhow::bail!(
-                        "ethereum catchup block {block_id:?} is still unavailable after refetch"
-                    )
-                };
-                let l = self.fetch_block_logs(&block).await?;
-
-                #[cfg(feature = "bench")]
-                crate::bench::add_refetch_time(start.elapsed());
-
-                _block = block;
-                _logs = l;
-                (&_block, _logs.as_slice())
-            }
-            CatchupItem::LiveBlock(block) => {
-                _logs = self.fetch_block_logs(block).await?;
-                (block, _logs.as_slice())
-            }
-        };
-
-        let height = block.header.number;
-        if height.is_multiple_of(10) {
-            tracing::info!(height, "processed ethereum catchup block attempt");
-        }
-
-        #[cfg(feature = "bench")]
-        let start_process = std::time::Instant::now();
-
-        // Determine if the block is finalized based on the sampled finalized head at catchup start
-        let f0 = self.catchup_finalized_head.load(Ordering::Relaxed);
-        let is_finalized = block.header.number <= f0;
-        self.process_block(block, logs, is_finalized).await?;
-
-        #[cfg(feature = "bench")]
-        {
-            crate::bench::add_process_time(start_process.elapsed());
-            if crate::bench::inc_block() % 100 == 0 {
-                crate::bench::report_metrics("catchup_progress");
-            }
-        }
-
-        Ok(())
+        self.process_catchup_item(&self.events_tx, item).await
     }
 
     async fn process(&mut self, item: &Self::Block) -> anyhow::Result<()> {
-        let _block;
-        let _logs;
-
-        let (block, logs) = match item {
-            CatchupItem::LiveBlock(block) => {
-                _logs = self.fetch_block_logs(block).await?;
-                (block, _logs.as_slice())
-            }
-            CatchupItem::BatchBlock { block, logs } => (block, logs.as_slice()),
-            CatchupItem::Missing(block_id) => {
-                let Some(b) = self.client.get_block(*block_id).await else {
-                    anyhow::bail!(
-                        "ethereum live stream yielded missing block {block_id:?} and refetch failed"
-                    )
-                };
-                _logs = self.fetch_block_logs(&b).await?;
-                _block = b;
-                (&_block, _logs.as_slice())
-            }
-        };
-
-        // Live blocks are not yet finalized, so keep the reorg hash check
-        self.process_block(block, logs, false).await?;
-        Ok(())
+        self.process_live_item(&self.events_tx, item).await
     }
 
     async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {
@@ -865,6 +909,97 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
             .context("failed to send catchup completed event")?;
         self.catchup_complete.notify_one();
         Ok(())
+    }
+
+    async fn run(
+        &self,
+        events_tx: mpsc::Sender<ChainEvent>,
+        cancel: CancellationToken,
+    ) -> anyhow::Result<()> {
+        // Anchor: the live task starts here once catchup reaches it.
+        let anchor_height = loop {
+            if cancel.is_cancelled() {
+                return Ok(());
+            }
+            if let Some(latest) = self.client.get_latest_block_number().await {
+                break latest.saturating_add(1);
+            }
+            tokio::select! {
+                _ = cancel.cancelled() => return Ok(()),
+                _ = sleep(Self::RETRY_DELAY) => {}
+            }
+        };
+
+        let mut catchup_iter = self.catchup_range(anchor_height).await;
+        loop {
+            let item = tokio::select! {
+                _ = cancel.cancelled() => return Ok(()),
+                item = catchup_iter.next() => item,
+            };
+            let Some(item) = item else { break };
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => return Ok(()),
+                    result = self.process_catchup_item(&events_tx, &item) => {
+                        match result {
+                            Ok(()) => break,
+                            Err(err) => {
+                                tracing::warn!(?err, "ethereum catchup block processing failed; retrying");
+                            }
+                        }
+                    }
+                }
+                tokio::select! {
+                    _ = cancel.cancelled() => return Ok(()),
+                    _ = sleep(Self::RETRY_DELAY) => {}
+                }
+            }
+        }
+
+        events_tx
+            .send(ChainEvent::CatchupCompleted)
+            .await
+            .context("failed to send catchup completed event")?;
+
+        // Spawned only after catchup: no catchup/live coordination needed, and
+        // the abort-on-drop guard ties the task's lifetime to this `run()`.
+        let (live_blocks_tx, mut live_blocks_rx) = live_blocks_channel();
+        let _live_task = AbortOnDrop(tokio::spawn(Self::index_live_blocks(
+            self.client.clone(),
+            anchor_height,
+            live_blocks_tx,
+        )));
+
+        loop {
+            let maybe = tokio::select! {
+                _ = cancel.cancelled() => return Ok(()),
+                maybe = live_blocks_rx.recv() => maybe,
+            };
+            let Some(maybe) = maybe else {
+                anyhow::bail!("ethereum live block producer terminated");
+            };
+            let item = match maybe {
+                MaybeBlock::Block(block) => CatchupItem::LiveBlock(block),
+                MaybeBlock::Missing(id) => CatchupItem::Missing(id),
+            };
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => return Ok(()),
+                    result = self.process_live_item(&events_tx, &item) => {
+                        match result {
+                            Ok(()) => break,
+                            Err(err) => {
+                                tracing::warn!(?err, "ethereum live block processing failed; retrying");
+                            }
+                        }
+                    }
+                }
+                tokio::select! {
+                    _ = cancel.cancelled() => return Ok(()),
+                    _ = sleep(Self::RETRY_DELAY) => {}
+                }
+            }
+        }
     }
 }
 
@@ -1586,5 +1721,172 @@ mod tests {
             }
             other => panic!("expected ExecutionConfirmed, got {other:?}"),
         }
+    }
+
+    /// JSON-RPC response for a single `eth_getBlockByNumber` request, echoing
+    /// the request id.
+    fn block_reply(req: &mockito::Request, number: u64) -> Vec<u8> {
+        let body: serde_json::Value =
+            serde_json::from_slice(req.body().expect("request body")).expect("json body");
+        let id = body["id"].as_u64().expect("request id");
+        test_utils::block_response(id, number)
+            .to_string()
+            .into_bytes()
+    }
+
+    #[tokio::test]
+    async fn run_processes_catchup_then_goes_live_and_stops_on_cancel() {
+        use mpc_chain_integration_core::utils::stream::chain_event_channel;
+        use mpc_chain_integration_core::StateManager;
+        use std::sync::atomic::AtomicU64;
+        use std::sync::Arc;
+        use tokio::time::Duration;
+        use tokio_util::sync::CancellationToken;
+
+        let mut server = Server::new_async().await;
+        let latest = Arc::new(AtomicU64::new(9));
+
+        // Anchor sampling + live head polling.
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockByNumber",
+                "params": ["latest", false]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body_from_request({
+                let latest = latest.clone();
+                move |req| block_reply(req, latest.load(Ordering::Relaxed))
+            })
+            .create_async()
+            .await;
+
+        // Finalized head sampled once at catchup start; blocks <= 9 skip the
+        // catchup reorg refetch.
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockByNumber",
+                "params": ["finalized", false]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body_from_request(|req| block_reply(req, 9))
+            .create_async()
+            .await;
+
+        // Catchup batch for blocks 6..=9 (processed block seeded at 5). Derive
+        // ids and block numbers from the request so alloy's id assignment and
+        // response pairing don't matter.
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::Regex(r"^\[".to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body_from_request(|req| {
+                let body: serde_json::Value =
+                    serde_json::from_slice(req.body().expect("request body")).expect("json body");
+                let items = body
+                    .as_array()
+                    .expect("batch body")
+                    .iter()
+                    .map(|r| {
+                        let id = r["id"].as_u64().expect("request id");
+                        let hex = r["params"][0].as_str().expect("block number param");
+                        let number = u64::from_str_radix(hex.trim_start_matches("0x"), 16)
+                            .expect("hex block number");
+                        test_utils::block_response(id, number)
+                    })
+                    .collect();
+                serde_json::Value::Array(items).to_string().into_bytes()
+            })
+            .create_async()
+            .await;
+
+        // Live block 10: fetched by the live task and re-fetched for the reorg check.
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockByNumber",
+                "params": ["0xa", false]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body_from_request(|req| block_reply(req, 10))
+            .create_async()
+            .await;
+
+        // Post-cancel leak check: block 11 must never be requested.
+        let block_11_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockByNumber",
+                "params": ["0xb", false]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(test_utils::block_response(1, 11).to_string())
+            .expect(0)
+            .create_async()
+            .await;
+
+        let builder = test_utils::TestIndexerBuilder::new(server.url());
+        builder
+            .state_manager
+            .set_processed_block(Chain::Ethereum, 5)
+            .await;
+        let indexer = builder.build().await;
+
+        let (events_tx, mut events_rx) = chain_event_channel();
+        let cancel = CancellationToken::new();
+        let run_handle = tokio::spawn({
+            let cancel = cancel.clone();
+            async move { indexer.run(events_tx, cancel).await }
+        });
+
+        for n in 6..=9 {
+            let event = tokio::time::timeout(Duration::from_secs(5), events_rx.recv())
+                .await
+                .expect("catchup block event timed out")
+                .expect("events channel closed");
+            assert!(
+                matches!(event, ChainEvent::Block(b) if b == n),
+                "expected Block({n}), got {event:?}"
+            );
+        }
+        let event = tokio::time::timeout(Duration::from_secs(5), events_rx.recv())
+            .await
+            .expect("catchup completed event timed out")
+            .expect("events channel closed");
+        assert!(
+            matches!(event, ChainEvent::CatchupCompleted),
+            "expected CatchupCompleted, got {event:?}"
+        );
+
+        // Advance the head; the live task should pick up block 10.
+        latest.store(10, Ordering::Relaxed);
+        let event = tokio::time::timeout(Duration::from_secs(5), events_rx.recv())
+            .await
+            .expect("live block event timed out")
+            .expect("events channel closed");
+        assert!(
+            matches!(event, ChainEvent::Block(10)),
+            "expected Block(10), got {event:?}"
+        );
+
+        cancel.cancel();
+        tokio::time::timeout(Duration::from_secs(5), run_handle)
+            .await
+            .expect("run() should stop promptly after cancel")
+            .expect("run task panicked")
+            .expect("run() should exit Ok on cancel");
+
+        // The cancelled run must take its live producer down with it: the live
+        // task ticks every RETRY_DELAY (500ms), so it would request block 11
+        // well within this window if it were still alive.
+        latest.store(11, Ordering::Relaxed);
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+        block_11_mock.assert_async().await;
     }
 }

--- a/chain-signatures/chain-ethereum/src/lib.rs
+++ b/chain-signatures/chain-ethereum/src/lib.rs
@@ -16,6 +16,6 @@ mod respond_bidirectional;
 mod test_utils;
 mod util;
 
-pub use client::MaybeBlock;
+pub use client::{CatchupItem, MaybeBlock};
 pub use config::EthConfig;
-pub use indexer::{EthereumIndexer, EthereumStream};
+pub use indexer::EthereumIndexer;

--- a/chain-signatures/chain-ethereum/src/lib.rs
+++ b/chain-signatures/chain-ethereum/src/lib.rs
@@ -18,4 +18,4 @@ mod util;
 
 pub use client::MaybeBlock;
 pub use config::EthConfig;
-pub use indexer::EthereumStream;
+pub use indexer::{EthereumIndexer, EthereumStream};

--- a/chain-signatures/chain-ethereum/src/test_utils.rs
+++ b/chain-signatures/chain-ethereum/src/test_utils.rs
@@ -6,7 +6,6 @@ use mpc_chain_integration_core::utils::retry::RetryConfig;
 use mpc_chain_integration_core::{MockStateManager, NoopChainTelemetry};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::mpsc;
 
 /// Default refresh interval (ms) used by `IndexerBuilder` unless overridden.
 const DEFAULT_REFRESH_FINALIZED_INTERVAL: u64 = 100;
@@ -39,10 +38,8 @@ pub async fn create_test_ethereum_client(url: &str) -> EthereumClient {
 }
 
 /// Builder for constructing an `EthereumIndexer<MockStateManager, NoopChainTelemetry>`
-/// in tests against a mockito server.
-///
-/// Use [`TestIndexerBuilder::build()`] when you don't need the event receiver, or [`TestIndexerBuilder::build_with_rx()`] when
-/// you do.
+/// in tests against a mockito server. Tests supply their own events channel to
+/// the processing methods they drive.
 pub struct TestIndexerBuilder {
     server_url: String,
     pub eth: EthConfig,
@@ -102,46 +99,16 @@ impl TestIndexerBuilder {
         self
     }
 
-    async fn build_inner(self) -> EthereumIndexer<MockStateManager, NoopChainTelemetry> {
+    /// Build the indexer.
+    pub async fn build(self) -> EthereumIndexer<MockStateManager, NoopChainTelemetry> {
         let client = Arc::new(create_test_ethereum_client(&self.server_url).await);
-        let (events_tx, events_rx) = mpsc::channel::<mpc_primitives::ChainEvent>(1);
-        // events_rx is dropped by `.build()`; returned by `.build_with_rx()`.
-        let _ = events_rx;
         EthereumIndexer::new_for_test(
             self.eth,
             self.state_manager,
             NoopChainTelemetry,
             client,
-            events_tx,
             Address::ZERO,
         )
-    }
-
-    /// Build the indexer without exposing its event receiver. The receiver
-    /// is dropped.
-    pub async fn build(self) -> EthereumIndexer<MockStateManager, NoopChainTelemetry> {
-        self.build_inner().await
-    }
-
-    /// Build the indexer and return it together with a receiver for the events
-    /// channel wired into it.
-    pub async fn build_with_rx(
-        self,
-    ) -> (
-        EthereumIndexer<MockStateManager, NoopChainTelemetry>,
-        mpsc::Receiver<mpc_primitives::ChainEvent>,
-    ) {
-        let client = Arc::new(create_test_ethereum_client(&self.server_url).await);
-        let (events_tx, events_rx) = mpsc::channel::<mpc_primitives::ChainEvent>(1);
-        let indexer = EthereumIndexer::new_for_test(
-            self.eth,
-            self.state_manager,
-            NoopChainTelemetry,
-            client,
-            events_tx,
-            Address::ZERO,
-        );
-        (indexer, events_rx)
     }
 }
 

--- a/chain-signatures/chain-integration-core/Cargo.toml
+++ b/chain-signatures/chain-integration-core/Cargo.toml
@@ -19,3 +19,4 @@ mpc-primitives.workspace = true
 rand.workspace = true
 tracing.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true

--- a/chain-signatures/chain-integration-core/src/indexer.rs
+++ b/chain-signatures/chain-integration-core/src/indexer.rs
@@ -3,11 +3,13 @@ use std::time::Duration;
 
 use futures_util::Stream;
 use mpc_primitives::{Chain, ChainEvent};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 
 // TODO: Consider removing default implementations from the trait and force to implement (also removes dependency for `tokio` and `tracing` in this crate)
 /// Interface for a chain indexer that can catch up and livestream events from a specific chain.
 #[async_trait::async_trait]
-pub trait ChainIndexer: Send + 'static {
+pub trait ChainIndexer: Send + Sync + 'static {
     const CHAIN: Chain;
     type Block: Send;
     type Iter: Stream<Item = Self::Block> + Send + Unpin + 'static;
@@ -36,6 +38,24 @@ pub trait ChainIndexer: Send + 'static {
     async fn process(&mut self, block: &Self::Block) -> anyhow::Result<()> {
         let _ = block;
         Ok(())
+    }
+
+    /// Owns the full catchup + live loop: emits catchup events, then
+    /// [`ChainEvent::CatchupCompleted`], then live events on `events_tx`, resuming
+    /// from the chain's persisted progress and its own current tip. Must honour
+    /// `cancel` — the supervisor cancels and respawns `run()` on regression or
+    /// watchdog stall. Returning `Err` triggers a supervised restart; returning
+    /// `Ok(())` shuts the chain down.
+    async fn run(
+        &self,
+        events_tx: mpsc::Sender<ChainEvent>,
+        cancel: CancellationToken,
+    ) -> anyhow::Result<()> {
+        let _ = (events_tx, cancel);
+        Err(anyhow::anyhow!(
+            "run() not implemented for {}",
+            Self::CHAIN.as_str()
+        ))
     }
 
     /// Process the next block, return true for success, false for shutdown.

--- a/chain-signatures/chain-integration-core/src/indexer.rs
+++ b/chain-signatures/chain-integration-core/src/indexer.rs
@@ -1,3 +1,4 @@
+use std::ops::AsyncFnMut;
 use std::time::Duration;
 
 use futures_util::Stream;
@@ -48,6 +49,17 @@ pub trait ChainIndexer: Send + 'static {
             tokio::time::sleep(Self::RETRY_DELAY).await;
         }
         true
+    }
+}
+
+/// Retries `process` indefinitely with a fixed delay between attempts.
+pub async fn process_with_retry<F>(mut process: F, retry_delay: Duration)
+where
+    F: AsyncFnMut() -> anyhow::Result<()>,
+{
+    while let Err(err) = process().await {
+        tracing::warn!(?err, "block processing failed; retrying");
+        tokio::time::sleep(retry_delay).await;
     }
 }
 

--- a/chain-signatures/chain-integration-core/src/indexer.rs
+++ b/chain-signatures/chain-integration-core/src/indexer.rs
@@ -23,7 +23,10 @@ pub trait ChainIndexer: Send + Sync + 'static {
         Ok(())
     }
 
-    async fn catchup_range(&self, anchor_height: u64) -> Self::Iter;
+    async fn catchup_range(&self, anchor_height: u64) -> Self::Iter {
+        let _ = anchor_height;
+        unimplemented!("catchup_range is only driven by the legacy ChainStream pipeline")
+    }
 
     async fn process_catchup(&mut self, item: &Self::Block) -> anyhow::Result<()> {
         let _ = item;

--- a/chain-signatures/chain-integration-core/src/indexer.rs
+++ b/chain-signatures/chain-integration-core/src/indexer.rs
@@ -23,6 +23,7 @@ pub trait ChainIndexer: Send + Sync + 'static {
         Ok(())
     }
 
+    // TODO: this is only used in the legacy ChainStream pipeline, remove it once possible
     async fn catchup_range(&self, anchor_height: u64) -> Self::Iter {
         let _ = anchor_height;
         unimplemented!("catchup_range is only driven by the legacy ChainStream pipeline")
@@ -42,12 +43,10 @@ pub trait ChainIndexer: Send + Sync + 'static {
         Ok(())
     }
 
+    // TODO: remove default method implementation once all indexers implement it
     /// Owns the full catchup + live loop: emits catchup events, then
     /// [`ChainEvent::CatchupCompleted`], then live events on `events_tx`, resuming
-    /// from the chain's persisted progress and its own current tip. Must honour
-    /// `cancel` — the supervisor cancels and respawns `run()` on regression or
-    /// watchdog stall. Returning `Err` triggers a supervised restart; returning
-    /// `Ok(())` shuts the chain down.
+    /// from the chain's persisted progress and its own current tip.
     async fn run(
         &self,
         events_tx: mpsc::Sender<ChainEvent>,

--- a/chain-signatures/chain-integration-core/src/indexer.rs
+++ b/chain-signatures/chain-integration-core/src/indexer.rs
@@ -1,4 +1,3 @@
-use std::ops::AsyncFnMut;
 use std::time::Duration;
 
 use futures_util::Stream;
@@ -69,17 +68,6 @@ pub trait ChainIndexer: Send + Sync + 'static {
             tokio::time::sleep(Self::RETRY_DELAY).await;
         }
         true
-    }
-}
-
-/// Retries `process` indefinitely with a fixed delay between attempts.
-pub async fn process_with_retry<F>(mut process: F, retry_delay: Duration)
-where
-    F: AsyncFnMut() -> anyhow::Result<()>,
-{
-    while let Err(err) = process().await {
-        tracing::warn!(?err, "block processing failed; retrying");
-        tokio::time::sleep(retry_delay).await;
     }
 }
 

--- a/chain-signatures/chain-integration-core/src/lib.rs
+++ b/chain-signatures/chain-integration-core/src/lib.rs
@@ -6,7 +6,7 @@ mod state;
 mod telemetry;
 pub mod utils;
 
-pub use indexer::{ChainIndexer, ChainStream};
+pub use indexer::{process_with_retry, ChainIndexer, ChainStream};
 pub use publish::{ChainPublisher, PublishAction};
 pub use state::{MockStateManager, StateManager};
 pub use telemetry::{

--- a/chain-signatures/chain-integration-core/src/lib.rs
+++ b/chain-signatures/chain-integration-core/src/lib.rs
@@ -6,7 +6,7 @@ mod state;
 mod telemetry;
 pub mod utils;
 
-pub use indexer::{process_with_retry, ChainIndexer, ChainStream};
+pub use indexer::{ChainIndexer, ChainStream};
 pub use publish::{ChainPublisher, PublishAction};
 pub use state::{MockStateManager, StateManager};
 pub use telemetry::{

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -64,6 +64,7 @@ serde_json.workspace = true
 sha3.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true

--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -21,7 +21,7 @@ use crate::storage::checkpoint_storage::CheckpointStorage;
 use crate::storage::presignature_storage::PresignatureStorage;
 use crate::storage::secret_storage::SecretNodeStorageVariant;
 use crate::storage::triple_storage::{TriplePair, TripleStorage};
-use crate::stream::{run_stream, StreamContext};
+use crate::stream::{run_stream, supervisor::run_supervised, StreamContext};
 use crate::{logs, storage, web};
 pub use args::{canton::CantonArgs, ethereum::EthArgs, hydration::HydrationArgs, solana::SolArgs};
 
@@ -32,7 +32,7 @@ use enum_map::EnumMap;
 use k256::sha2::Sha256;
 use local_ip_address::local_ip;
 use mpc_chain_canton::{CantonClient, CantonConfig, CantonStream};
-use mpc_chain_ethereum::{publisher, EthConfig, EthereumStream};
+use mpc_chain_ethereum::{publisher, EthConfig, EthereumIndexer};
 use mpc_chain_integration_core::ChainPublisher;
 use mpc_chain_near::NearClient;
 use mpc_chain_solana::{SolConfig, SolanaClient, SolanaStream};
@@ -788,11 +788,13 @@ async fn spawn_indexers(
 
     if let Some(eth_config) = eth {
         let eth_telemetry = NodeTelemetry::new(Chain::Ethereum);
-        match EthereumStream::new(eth_config, backlog.clone(), eth_telemetry.clone()).await {
-            Ok(eth_stream) => {
-                tracing::info!("ethereum indexer stream created successfully");
-                tokio::spawn(run_stream(
-                    eth_stream,
+        match EthereumIndexer::new_supervised(eth_config, backlog.clone(), eth_telemetry.clone())
+            .await
+        {
+            Ok(eth_indexer) => {
+                tracing::info!("ethereum indexer created successfully");
+                tokio::spawn(run_supervised(
+                    eth_indexer,
                     StreamContext::new(
                         backlog.clone(),
                         sign_tx.clone(),
@@ -806,7 +808,7 @@ async fn spawn_indexers(
                 ));
             }
             Err(err) => {
-                tracing::error!(?err, "failed to create ethereum indexer stream");
+                tracing::error!(?err, "failed to create ethereum indexer");
             }
         }
     }

--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -788,9 +788,7 @@ async fn spawn_indexers(
 
     if let Some(eth_config) = eth {
         let eth_telemetry = NodeTelemetry::new(Chain::Ethereum);
-        match EthereumIndexer::new_supervised(eth_config, backlog.clone(), eth_telemetry.clone())
-            .await
-        {
+        match EthereumIndexer::new(eth_config, backlog.clone(), eth_telemetry.clone()).await {
             Ok(eth_indexer) => {
                 tracing::info!("ethereum indexer created successfully");
                 tokio::spawn(run_supervised(

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -1,6 +1,7 @@
 pub mod ops;
 pub mod pipeline;
 pub(crate) mod recovery;
+pub mod supervisor;
 
 use crate::backlog::Backlog;
 use crate::mesh::MeshState;

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -1,5 +1,6 @@
 pub mod ops;
 pub mod pipeline;
+pub(crate) mod recovery;
 
 use crate::backlog::Backlog;
 use crate::mesh::MeshState;

--- a/chain-signatures/node/src/stream/pipeline.rs
+++ b/chain-signatures/node/src/stream/pipeline.rs
@@ -20,7 +20,7 @@ use tokio::time::Duration;
 /// RPC rate-limiting is handled separately by `MAX_FINALIZED_FAILURES` in
 /// `wait_for_finalized_block`, which bails after ~200s — faster than this
 /// watchdog for any chain.
-fn live_block_timeout(chain: Chain) -> Duration {
+pub(crate) fn live_block_timeout(chain: Chain) -> Duration {
     const FLOOR_SECS: u64 = 300;
     const BUFFER_SECS: u64 = 300;
     Duration::from_secs(
@@ -289,7 +289,7 @@ impl<I: ChainIndexer> ChainPipeline<I> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RegressionOutcome {
+pub(crate) enum RegressionOutcome {
     /// Consensus digest mismatches local backlog — transition to Recovery.
     Recovery,
     /// Local backlog is aligned with consensus, continue current state.
@@ -299,7 +299,7 @@ enum RegressionOutcome {
 }
 
 /// Waits for a consensus checkpoint digest change, then checks for regression.
-async fn wait_detected_regression(
+pub(crate) async fn wait_detected_regression(
     checkpoints_rx: &mut CheckpointWatcher,
     backlog: &Backlog,
     chain: Chain,

--- a/chain-signatures/node/src/stream/pipeline.rs
+++ b/chain-signatures/node/src/stream/pipeline.rs
@@ -1,3 +1,4 @@
+use super::recovery::recover_backlog;
 use super::ChainStreaming;
 use crate::backlog::Backlog;
 use crate::mesh::MeshState;
@@ -164,49 +165,18 @@ impl<I: ChainIndexer> ChainPipeline<I> {
 
     async fn handle_recovery(&mut self, load_local: bool) -> Option<ChainStreaming> {
         let chain = I::CHAIN;
-        tracing::info!(%chain, load_local, "starting checkpoint recovery or regression");
-        crate::mesh::wait_threshold_active(&mut self.mesh_state.clone(), self.threshold).await;
-
-        if load_local {
-            // Load local checkpoint from storage first
-            match self.backlog.storage.load_latest(chain).await {
-                Ok(Some(checkpoint)) => {
-                    tracing::info!(
-                        ?chain,
-                        height = checkpoint.block_height,
-                        "loaded local checkpoint"
-                    );
-                    if let Err(err) = self.backlog.recover_by_checkpoint(checkpoint).await {
-                        tracing::warn!(?chain, %err, "failed to recover from local checkpoint");
-                    }
-                }
-                Ok(None) => {
-                    tracing::info!(?chain, "no local checkpoint found");
-                }
-                Err(err) => {
-                    tracing::warn!(?chain, %err, "failed to load local checkpoint");
-                }
-            }
-        }
-
-        // Perform consensus checkpoint alignment. Returns None when no alignment is
-        // needed (the normal case); returns Some(height) when the backlog was regressed.
-        // When regression occurs, abort all in-flight signature tasks for this chain
-        // so stale tasks don't complete and publish abandoned signatures/checkpoints.
-        if crate::backlog::consensus::align_backlog_with_consensus(
+        recover_backlog(
             chain,
+            load_local,
             &self.backlog,
             &mut self.checkpoints_rx,
             &mut self.mesh_state,
             &self.node_client,
+            &self.sign_tx,
+            self.threshold,
             &self.my_account_id,
         )
-        .await
-        .is_some()
-        {
-            tracing::warn!(%chain, "backlog regressed via consensus checkpoint; aborting in-flight tasks");
-            let _ = self.sign_tx.send(SignCommand::AbortChain(chain)).await;
-        }
+        .await;
 
         // Determine anchor height
         let anchor_height = loop {

--- a/chain-signatures/node/src/stream/recovery.rs
+++ b/chain-signatures/node/src/stream/recovery.rs
@@ -1,0 +1,68 @@
+use crate::backlog::{Backlog, consensus};
+use crate::mesh::{self, MeshState};
+use crate::node_client::NodeClient;
+use crate::types::CheckpointWatcher;
+
+use mpc_primitives::{Chain, SignCommand};
+use near_account_id::AccountId;
+use tokio::sync::{mpsc, watch};
+
+/// Node-side checkpoint recovery:
+/// waits for an active mesh, optionally loads the latest local checkpoint into the
+/// backlog, then aligns the backlog with the consensus checkpoint feed, aborting
+/// in-flight signature tasks for this chain if a regression occurred.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn recover_backlog(
+    chain: Chain,
+    load_local: bool,
+    backlog: &Backlog,
+    checkpoints_rx: &mut CheckpointWatcher,
+    mesh_state: &mut watch::Receiver<MeshState>,
+    node_client: &NodeClient,
+    sign_tx: &mpsc::Sender<SignCommand>,
+    threshold: usize,
+    my_account_id: &AccountId,
+) {
+    tracing::info!(%chain, load_local, "starting checkpoint recovery or regression");
+    mesh::wait_threshold_active(&mut mesh_state.clone(), threshold).await;
+
+    if load_local {
+        match backlog.storage.load_latest(chain).await {
+            Ok(Some(checkpoint)) => {
+                tracing::info!(
+                    ?chain,
+                    height = checkpoint.block_height,
+                    "loaded local checkpoint"
+                );
+                if let Err(err) = backlog.recover_by_checkpoint(checkpoint).await {
+                    tracing::warn!(?chain, %err, "failed to recover from local checkpoint");
+                }
+            }
+            Ok(None) => {
+                tracing::info!(?chain, "no local checkpoint found");
+            }
+            Err(err) => {
+                tracing::warn!(?chain, %err, "failed to load local checkpoint");
+            }
+        }
+    }
+
+    // Returns None when no alignment is needed (the normal case); Some(height) when
+    // the backlog was regressed. On regression, abort all in-flight signature tasks
+    // for this chain so stale tasks don't complete and publish abandoned
+    // signatures/checkpoints.
+    if consensus::align_backlog_with_consensus(
+        chain,
+        backlog,
+        checkpoints_rx,
+        mesh_state,
+        node_client,
+        my_account_id,
+    )
+    .await
+    .is_some()
+    {
+        tracing::warn!(%chain, "backlog regressed via consensus checkpoint; aborting in-flight tasks");
+        let _ = sign_tx.send(SignCommand::AbortChain(chain)).await;
+    }
+}

--- a/chain-signatures/node/src/stream/recovery.rs
+++ b/chain-signatures/node/src/stream/recovery.rs
@@ -1,4 +1,4 @@
-use crate::backlog::{Backlog, consensus};
+use crate::backlog::{consensus, Backlog};
 use crate::mesh::{self, MeshState};
 use crate::node_client::NodeClient;
 use crate::types::CheckpointWatcher;

--- a/chain-signatures/node/src/stream/supervisor.rs
+++ b/chain-signatures/node/src/stream/supervisor.rs
@@ -1,0 +1,436 @@
+use super::pipeline::{live_block_timeout, wait_detected_regression, RegressionOutcome};
+use super::recovery::recover_backlog;
+use super::{handle_chain_event, StreamContext};
+
+use mpc_chain_integration_core::utils::stream::chain_event_channel;
+use mpc_chain_integration_core::{ChainIndexer, ChainTelemetry};
+use mpc_primitives::ChainEvent;
+use std::sync::Arc;
+use tokio::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
+
+/// Delay before respawning a `run()` that returned an error.
+const ERROR_RESTART_DELAY: Duration = Duration::from_secs(1);
+/// How long a cancelled `run()` gets to drain before it is aborted.
+const RUN_DRAIN_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Supervised indexer loop: node-side recovery, then spawn the chain's `run()`
+/// loop and dispatch its events. Regression or a watchdog stall cancels `run()`
+/// and restarts it, re-running light recovery (`load_local: false`) first.
+pub async fn run_supervised<I: ChainIndexer, T: ChainTelemetry>(
+    indexer: I,
+    ctx: StreamContext,
+    telemetry: T,
+) {
+    run_supervised_with_watchdog(indexer, ctx, telemetry, live_block_timeout(I::CHAIN)).await
+}
+
+async fn run_supervised_with_watchdog<I: ChainIndexer, T: ChainTelemetry>(
+    indexer: I,
+    mut ctx: StreamContext,
+    telemetry: T,
+    watchdog_timeout: Duration,
+) {
+    let chain = I::CHAIN;
+    tracing::info!(%chain, "starting supervised chain indexer");
+
+    let threshold = ctx.contract_watcher.wait_threshold().await;
+    let my_account_id = ctx.contract_watcher.account_id().clone();
+    let root_pk = ctx.contract_watcher.wait_public_key().await;
+    let indexer = Arc::new(indexer);
+
+    enum Exit {
+        Restart,
+        Shutdown,
+    }
+
+    let mut load_local = true;
+    loop {
+        recover_backlog(
+            chain,
+            load_local,
+            &ctx.backlog,
+            &mut ctx.checkpoints_rx,
+            &mut ctx.mesh_state,
+            &ctx.node_client,
+            &ctx.sign_tx,
+            threshold,
+            &my_account_id,
+        )
+        .await;
+        load_local = false;
+
+        let (events_tx, mut events_rx) = chain_event_channel();
+        let cancel = CancellationToken::new();
+        let mut run_handle = tokio::spawn({
+            let indexer = indexer.clone();
+            let cancel = cancel.clone();
+            async move { indexer.run(events_tx, cancel).await }
+        });
+
+        ctx.caught_up = false;
+        let mut last_block_event = Instant::now();
+        let mut run_finished = false;
+
+        let exit = loop {
+            tokio::select! {
+                // Gate dispatch on checkpoint capacity: when the cap is full the
+                // channel backs up and pauses the chain's `send().await`.
+                event = events_rx.recv(), if ctx.backlog.has_checkpoint_slot(chain).await => {
+                    let Some(event) = event else {
+                        run_finished = true;
+                        // `run()` exited on its own: Ok shuts the chain down,
+                        // Err (or panic) is treated as a crash and restarted.
+                        break match (&mut run_handle).await {
+                            Ok(Ok(())) => Exit::Shutdown,
+                            Ok(Err(err)) => {
+                                tracing::warn!(?err, %chain, "chain run() failed; restarting");
+                                tokio::time::sleep(ERROR_RESTART_DELAY).await;
+                                Exit::Restart
+                            }
+                            Err(err) => {
+                                tracing::warn!(?err, %chain, "chain run() panicked; restarting");
+                                Exit::Restart
+                            }
+                        };
+                    };
+                    if matches!(event, ChainEvent::Block(_)) {
+                        last_block_event = Instant::now();
+                    }
+                    if let Err(err) =
+                        handle_chain_event(event, &mut ctx, &telemetry, root_pk, chain).await
+                    {
+                        tracing::error!(?err, %chain, "failed to process chain event");
+                    }
+                }
+                result = wait_detected_regression(&mut ctx.checkpoints_rx, &ctx.backlog, chain) => {
+                    match result {
+                        RegressionOutcome::Recovery => {
+                            break Exit::Restart;
+                        }
+                        RegressionOutcome::Aligned => {}
+                        RegressionOutcome::Shutdown => break Exit::Shutdown,
+                    }
+                }
+                // Watchdog: restart when no `ChainEvent::Block` was observed within
+                // the per-chain timeout (other event kinds do not count).
+                _ = tokio::time::sleep_until(last_block_event + watchdog_timeout) => {
+                    tracing::warn!(
+                        %chain, ?watchdog_timeout,
+                        "no block event within watchdog timeout; restarting chain indexer"
+                    );
+                    break Exit::Restart;
+                }
+            }
+        };
+
+        if !run_finished {
+            cancel.cancel();
+            if tokio::time::timeout(RUN_DRAIN_TIMEOUT, &mut run_handle)
+                .await
+                .is_err()
+            {
+                tracing::warn!(%chain, "run() did not drain after cancellation; aborting");
+                run_handle.abort();
+            }
+        }
+
+        if matches!(exit, Exit::Shutdown) {
+            tracing::warn!(%chain, "supervised chain indexer shutting down");
+            return;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backlog::Backlog;
+    use crate::mesh::MeshState;
+    use crate::node_client::NodeClient;
+    use crate::rpc::ContractStateWatcher;
+    use crate::stream::test_utils::test_rpc_channel;
+
+    use k256::ProjectivePoint;
+    use mpc_chain_integration_core::{NoopChainTelemetry, StateManager};
+    use mpc_primitives::{Chain, CheckpointDigest, SignCommand};
+    use near_account_id::AccountId;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::{mpsc, watch, Notify};
+
+    /// Creates a test `StreamContext` along with channels for checkpoint and mesh state updates.
+    fn test_ctx(
+        backlog: Backlog,
+        sign_tx: mpsc::Sender<SignCommand>,
+    ) -> (
+        StreamContext,
+        watch::Sender<Option<CheckpointDigest>>,
+        watch::Sender<MeshState>,
+    ) {
+        let account_id: AccountId = "test.near".parse().unwrap();
+        let (contract_watcher, _tx) = ContractStateWatcher::with_running(
+            &account_id,
+            ProjectivePoint::GENERATOR.to_affine(),
+            0,
+            Default::default(),
+        );
+        let (mesh_tx, mesh_rx) = watch::channel(MeshState::default());
+        let (cp_tx, cp_rx) = watch::channel(None);
+        let (rpc, _rpc_rx) = test_rpc_channel(8);
+        let ctx = StreamContext::new(
+            backlog,
+            sign_tx,
+            rpc,
+            contract_watcher,
+            mesh_rx,
+            NodeClient::new(&Default::default()),
+            cp_rx,
+        );
+        (ctx, cp_tx, mesh_tx)
+    }
+
+    /// Emits CatchupCompleted + Block(100), then exits Ok.
+    struct EventsThenExitIndexer;
+
+    #[async_trait::async_trait]
+    impl ChainIndexer for EventsThenExitIndexer {
+        const CHAIN: Chain = Chain::Ethereum;
+        type Block = u64;
+        type Iter = futures_util::stream::Empty<u64>;
+
+        async fn catchup_range(&self, _anchor_height: u64) -> Self::Iter {
+            futures_util::stream::empty()
+        }
+
+        async fn run(
+            &self,
+            events_tx: mpsc::Sender<ChainEvent>,
+            _cancel: CancellationToken,
+        ) -> anyhow::Result<()> {
+            events_tx.send(ChainEvent::CatchupCompleted).await.unwrap();
+            events_tx.send(ChainEvent::Block(100)).await.unwrap();
+            Ok(())
+        }
+    }
+
+    /// First `run()` stalls until cancelled; subsequent runs exit Ok.
+    struct StalledRunIndexer {
+        attempts: Arc<AtomicUsize>,
+        first_cancel: Arc<Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl ChainIndexer for StalledRunIndexer {
+        const CHAIN: Chain = Chain::Ethereum;
+        type Block = u64;
+        type Iter = futures_util::stream::Empty<u64>;
+
+        async fn catchup_range(&self, _anchor_height: u64) -> Self::Iter {
+            futures_util::stream::empty()
+        }
+
+        async fn run(
+            &self,
+            _events_tx: mpsc::Sender<ChainEvent>,
+            cancel: CancellationToken,
+        ) -> anyhow::Result<()> {
+            if self.attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                cancel.cancelled().await;
+                self.first_cancel.notify_one();
+            }
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatches_events_and_shuts_down_when_run_exits() {
+        let backlog = Backlog::new();
+        let (sign_tx, _sign_rx) = mpsc::channel(8);
+        let (ctx, _cp_tx, _mesh_tx) = test_ctx(backlog.clone(), sign_tx);
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            run_supervised_with_watchdog(
+                EventsThenExitIndexer,
+                ctx,
+                NoopChainTelemetry,
+                Duration::from_secs(60),
+            ),
+        )
+        .await
+        .expect("supervisor should shut down after run() exits");
+
+        assert_eq!(
+            backlog.get_processed_block(Chain::Ethereum).await,
+            Some(100)
+        );
+    }
+
+    #[tokio::test]
+    async fn watchdog_cancels_and_restarts_stalled_run() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let first_cancel = Arc::new(Notify::new());
+        let indexer = StalledRunIndexer {
+            attempts: attempts.clone(),
+            first_cancel: first_cancel.clone(),
+        };
+        let (sign_tx, _sign_rx) = mpsc::channel(8);
+        let (ctx, _cp_tx, _mesh_tx) = test_ctx(Backlog::new(), sign_tx);
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            run_supervised_with_watchdog(
+                indexer,
+                ctx,
+                NoopChainTelemetry,
+                Duration::from_millis(50),
+            ),
+        )
+        .await
+        .expect("supervisor should shut down after second run() exits");
+
+        first_cancel.notified().await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn regression_cancels_and_restarts_run() {
+        let chain = Chain::Ethereum;
+        let backlog = Backlog::new();
+        backlog.set_processed_block(chain, 100).await;
+        backlog.checkpoint(chain).await.unwrap();
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let first_cancel = Arc::new(Notify::new());
+        let indexer = StalledRunIndexer {
+            attempts: attempts.clone(),
+            first_cancel: first_cancel.clone(),
+        };
+        let (sign_tx, _sign_rx) = mpsc::channel(8);
+        let (ctx, cp_tx, _mesh_tx) = test_ctx(backlog, sign_tx);
+
+        let task = tokio::spawn(run_supervised_with_watchdog(
+            indexer,
+            ctx,
+            NoopChainTelemetry,
+            Duration::from_secs(60),
+        ));
+
+        while attempts.load(Ordering::SeqCst) == 0 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        cp_tx
+            .send(Some(CheckpointDigest {
+                height: 200,
+                digest: [0xab; 32],
+            }))
+            .unwrap();
+        first_cancel.notified().await;
+        // Unblock the restart's consensus alignment (no peers serve the digest).
+        cp_tx.send(None).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(10), task)
+            .await
+            .expect("supervisor should shut down after second run() exits")
+            .expect("supervisor task should not panic");
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn block_events_reset_watchdog() {
+        struct TrickleIndexer {
+            attempts: Arc<AtomicUsize>,
+        }
+
+        #[async_trait::async_trait]
+        impl ChainIndexer for TrickleIndexer {
+            const CHAIN: Chain = Chain::Ethereum;
+            type Block = u64;
+            type Iter = futures_util::stream::Empty<u64>;
+
+            async fn catchup_range(&self, _anchor_height: u64) -> Self::Iter {
+                futures_util::stream::empty()
+            }
+
+            async fn run(
+                &self,
+                events_tx: mpsc::Sender<ChainEvent>,
+                _cancel: CancellationToken,
+            ) -> anyhow::Result<()> {
+                self.attempts.fetch_add(1, Ordering::SeqCst);
+                for _ in 0..5 {
+                    events_tx.send(ChainEvent::Block(1)).await.unwrap();
+                    tokio::time::sleep(Duration::from_millis(30)).await;
+                }
+                Ok(())
+            }
+        }
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let indexer = TrickleIndexer {
+            attempts: attempts.clone(),
+        };
+        let (sign_tx, _sign_rx) = mpsc::channel(8);
+        let (ctx, _cp_tx, _mesh_tx) = test_ctx(Backlog::new(), sign_tx);
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            run_supervised_with_watchdog(
+                indexer,
+                ctx,
+                NoopChainTelemetry,
+                Duration::from_millis(100),
+            ),
+        )
+        .await
+        .expect("supervisor should shut down after run() exits");
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn full_checkpoint_cap_pauses_exit_and_watchdog_restarts() {
+        let chain = Chain::Ethereum;
+        let backlog = Backlog::new();
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let indexer = StalledRunIndexer {
+            attempts: attempts.clone(),
+            first_cancel: Arc::new(Notify::new()),
+        };
+        let (sign_tx, _sign_rx) = mpsc::channel(8);
+        let (ctx, _cp_tx, _mesh_tx) = test_ctx(backlog.clone(), sign_tx);
+
+        let task = tokio::spawn(run_supervised_with_watchdog(
+            indexer,
+            ctx,
+            NoopChainTelemetry,
+            Duration::from_millis(50),
+        ));
+
+        while attempts.load(Ordering::SeqCst) == 0 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        // Fill the pending-checkpoint cap so `has_checkpoint_slot` returns false.
+        let interval = chain.checkpoint_interval().unwrap();
+        for i in 1..=crate::backlog::MAX_PENDING_CHECKPOINTS {
+            let h = (i as u64) * interval;
+            assert!(backlog.set_processed_block(chain, h).await.is_some());
+        }
+        assert!(!backlog.has_checkpoint_slot(chain).await);
+
+        // The first (stalled) run is restarted by the watchdog; afterwards the
+        // instant-Ok exits cannot be observed while the cap is full, so the
+        // supervisor must keep restarting instead of shutting down.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(
+            !task.is_finished(),
+            "supervisor must not shut down while the checkpoint cap is full"
+        );
+        assert!(
+            attempts.load(Ordering::SeqCst) >= 2,
+            "watchdog should have restarted run()"
+        );
+        task.abort();
+    }
+}

--- a/chain-signatures/node/src/stream/supervisor.rs
+++ b/chain-signatures/node/src/stream/supervisor.rs
@@ -84,13 +84,11 @@ async fn run_supervised_with_watchdog<I: ChainIndexer, T: ChainTelemetry>(
                         // Err (or panic) is treated as a crash and restarted.
                         break match (&mut run_handle).await {
                             Ok(Ok(())) => Exit::Shutdown,
-                            Ok(Err(err)) => {
-                                tracing::warn!(?err, %chain, "chain run() failed; restarting");
+                            result => {
+                                // anyhow error or JoinError::Panic — both can
+                                // hot-loop, so back off before restarting.
+                                tracing::warn!(?result, %chain, "chain run() failed; restarting");
                                 tokio::time::sleep(ERROR_RESTART_DELAY).await;
-                                Exit::Restart
-                            }
-                            Err(err) => {
-                                tracing::warn!(?err, %chain, "chain run() panicked; restarting");
                                 Exit::Restart
                             }
                         };

--- a/chain-signatures/node/src/stream/supervisor.rs
+++ b/chain-signatures/node/src/stream/supervisor.rs
@@ -1,3 +1,4 @@
+// TODO: this should eventually become part of ChainPipeline, keep separate for now to avoid breaking the existing ChainStream pipeline
 use super::pipeline::{live_block_timeout, wait_detected_regression, RegressionOutcome};
 use super::recovery::recover_backlog;
 use super::{handle_chain_event, StreamContext};
@@ -338,6 +339,7 @@ mod tests {
 
     #[tokio::test]
     async fn block_events_reset_watchdog() {
+        /// Emits 5 block events, then exits Ok.
         struct TrickleIndexer {
             attempts: Arc<AtomicUsize>,
         }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -30,6 +30,7 @@ semver.workspace = true
 shell-escape = "0.1.5"
 testcontainers = "0.23.1"
 tokio = { version = "1.45.1", features = ["full", "test-util"] }
+tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 thiserror.workspace = true

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -10,8 +10,9 @@ use integration_tests::eth;
 use k256::elliptic_curve::sec1::ToEncodedPoint as _;
 use k256::{AffinePoint, Scalar};
 use mpc_chain_ethereum::abi::ChainSignatures::{self, SignRequest};
-use mpc_chain_ethereum::{EthConfig, EthereumStream};
-use mpc_chain_integration_core::{ChainStream, ChainTelemetry, NoopChainTelemetry, StateManager};
+use mpc_chain_ethereum::{EthConfig, EthereumIndexer};
+use mpc_chain_integration_core::utils::stream::chain_event_channel;
+use mpc_chain_integration_core::{ChainIndexer, NoopChainTelemetry, StateManager};
 use mpc_crypto::kdf::generate_signature;
 use mpc_node::backlog::Backlog;
 use mpc_node::mesh::{connection::NodeStatus, MeshState};
@@ -20,10 +21,10 @@ use mpc_node::protocol::ParticipantInfo;
 use mpc_node::rpc::{ContractStateWatcher, RpcChannel};
 use mpc_node::sign_bidirectional::{PublishState, SignStatus};
 use mpc_node::storage::checkpoint_storage::CheckpointStorage;
-use mpc_node::stream::{run_stream, ChainPipeline, ChainStreaming, StreamContext};
+use mpc_node::stream::{supervisor::run_supervised, StreamContext};
 use mpc_node::util::current_unix_timestamp;
 use mpc_primitives::{
-    Chain, ChainEvent, CheckpointDigest, IndexedSignRequest, SignArgs,
+    Chain, ChainEvent, IndexedSignRequest, SignArgs,
     SignBidirectionalEvent as NodeSignBidirectionalEvent, SignCommand, SignId, SignKind,
     LATEST_MPC_KEY_VERSION,
 };
@@ -31,6 +32,7 @@ use near_primitives::types::AccountId;
 use std::time::Duration;
 use tokio::sync::{mpsc, watch};
 use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
 
 fn signature_deposit() -> U256 {
     U256::from(1u64)
@@ -41,7 +43,7 @@ fn test_rpc_channel(buffer: usize) -> (RpcChannel, mpsc::Receiver<mpc_node::rpc:
     (RpcChannel { tx }, rx)
 }
 
-// Integration tests for EthereumStream
+// Integration tests for the Ethereum indexer
 //
 // These tests spin up Anvil, deploy the ChainSignatures contract, and exercise the
 // Ethereum indexer stream in isolation (no MPC cluster required).
@@ -341,28 +343,33 @@ fn test_bidirectional_event() -> NodeSignBidirectionalEvent {
     }
 }
 
-struct StartedEthereumStream<S: StateManager, T: ChainTelemetry> {
-    stream: EthereumStream<S, T>,
-    _indexer_task: tokio::task::JoinHandle<()>,
-    _cp_tx: watch::Sender<Option<CheckpointDigest>>,
+struct StartedEthereumIndexer {
+    events_rx: mpsc::Receiver<ChainEvent>,
+    /// Events observed while waiting for catchup to complete, replayed first so
+    /// tests see the full event stream.
+    pending: std::collections::VecDeque<ChainEvent>,
+    cancel: CancellationToken,
+    run_task: tokio::task::JoinHandle<anyhow::Result<()>>,
 }
 
-impl<S: StateManager, T: ChainTelemetry> std::ops::Deref for StartedEthereumStream<S, T> {
-    type Target = EthereumStream<S, T>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.stream
+impl StartedEthereumIndexer {
+    async fn next_event(&mut self) -> Option<ChainEvent> {
+        if let Some(event) = self.pending.pop_front() {
+            return Some(event);
+        }
+        self.events_rx.recv().await
     }
 }
 
-impl<S: StateManager, T: ChainTelemetry> std::ops::DerefMut for StartedEthereumStream<S, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.stream
+impl Drop for StartedEthereumIndexer {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        self.run_task.abort();
     }
 }
 
-async fn next_event_within<S: StateManager, T: ChainTelemetry>(
-    client: &mut StartedEthereumStream<S, T>,
+async fn next_event_within(
+    client: &mut StartedEthereumIndexer,
     duration: Duration,
 ) -> Result<ChainEvent> {
     timeout(duration, async {
@@ -376,50 +383,41 @@ async fn next_event_within<S: StateManager, T: ChainTelemetry>(
     .context("timed out waiting for chain event")
 }
 
-/// Helper for starting the ethereum stream, especially in cases where we do not want
-/// to call into run_stream where we want to directly call `next_event` on each test.
+/// Helper for starting the ethereum indexer, especially in cases where we do not want
+/// to call into run_supervised where we want to directly call `next_event` on each test.
 async fn stream_ethereum(
     ctx: &EthereumTestEnvironment,
     backlog: Backlog,
-) -> Result<StartedEthereumStream<impl StateManager, NoopChainTelemetry>> {
-    let mut stream =
-        EthereumStream::new(ctx.config(true), backlog.clone(), NoopChainTelemetry).await?;
-    let indexer = stream.start().await?;
-    let (cp_tx, cp_rx) = watch::channel(None);
-    let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
-    let node_client = NodeClient::new(&Default::default());
-    let (sign_tx, _sign_rx) = tokio::sync::mpsc::channel(1);
-    let (pipeline, mut state_rx) = ChainPipeline::new(
-        indexer,
-        cp_rx,
-        backlog,
-        sign_tx,
-        mesh_rx,
-        node_client,
-        0,
-        "test.near".parse().unwrap(),
-    );
-    let indexer_task = tokio::spawn(pipeline.run());
+) -> Result<StartedEthereumIndexer> {
+    let indexer =
+        EthereumIndexer::new(ctx.config(true), backlog.clone(), NoopChainTelemetry).await?;
+    let (events_tx, mut events_rx) = chain_event_channel();
+    let cancel = CancellationToken::new();
+    let run_task = tokio::spawn({
+        let cancel = cancel.clone();
+        async move { indexer.run(events_tx, cancel).await }
+    });
 
-    // Wait until the pipeline is live so the subscription and anchor are established
+    // Wait until catchup completes so the live task and anchor are established
     // before callers begin submitting transactions.
+    let mut pending = std::collections::VecDeque::new();
     timeout(Duration::from_secs(30), async {
         loop {
-            if *state_rx.borrow() == ChainStreaming::Live {
-                return Ok(());
-            }
-            if state_rx.changed().await.is_err() {
-                anyhow::bail!("pipeline shut down before reaching Live state");
+            match events_rx.recv().await {
+                Some(ChainEvent::CatchupCompleted) => return Ok(()),
+                Some(event) => pending.push_back(event),
+                None => anyhow::bail!("indexer run() exited before completing catchup"),
             }
         }
     })
     .await
-    .context("timed out waiting for pipeline to reach Live state")??;
+    .context("timed out waiting for indexer to complete catchup")??;
 
-    Ok(StartedEthereumStream {
-        stream,
-        _indexer_task: indexer_task,
-        _cp_tx: cp_tx,
+    Ok(StartedEthereumIndexer {
+        events_rx,
+        pending,
+        cancel,
+        run_task,
     })
 }
 
@@ -453,7 +451,8 @@ async fn test_ethereum_stream_resume_starts_after_checkpoint_height() -> Result<
     }
 
     let backlog = Backlog::persisted(storage);
-    let stream = EthereumStream::new(ctx.config(true), backlog.clone(), NoopChainTelemetry).await?;
+    let indexer =
+        EthereumIndexer::new(ctx.config(true), backlog.clone(), NoopChainTelemetry).await?;
     let (sign_tx, mut sign_rx) = mpsc::channel(16);
     let (contract_watcher, _contract_tx) = ContractStateWatcher::with_running(
         &"test.near".parse::<AccountId>().unwrap(),
@@ -470,8 +469,8 @@ async fn test_ethereum_stream_resume_starts_after_checkpoint_height() -> Result<
     let (rpc, _rpc_rx) = test_rpc_channel(16);
 
     let (_cp_tx, checkpoints_rx) = watch::channel(None);
-    let run_handle = tokio::spawn(run_stream(
-        stream,
+    let run_handle = tokio::spawn(run_supervised(
+        indexer,
         StreamContext::new(
             backlog.clone(),
             sign_tx.clone(),
@@ -636,7 +635,8 @@ async fn test_ethereum_stream_linear_catchup_from_checkpoint() -> Result<()> {
     let catchup_payload = [0x55; 32];
     submit_sign_request(&ctx, catchup_payload, "catchup-linear-path").await?;
 
-    let stream = EthereumStream::new(ctx.config(true), backlog.clone(), NoopChainTelemetry).await?;
+    let indexer =
+        EthereumIndexer::new(ctx.config(true), backlog.clone(), NoopChainTelemetry).await?;
     let (sign_tx, mut sign_rx) = mpsc::channel(16);
     let (contract_watcher, _contract_tx) = ContractStateWatcher::with_running(
         &"test.near".parse::<AccountId>().unwrap(),
@@ -653,8 +653,8 @@ async fn test_ethereum_stream_linear_catchup_from_checkpoint() -> Result<()> {
     let (rpc, _rpc_rx) = test_rpc_channel(16);
 
     let (_cp_tx, checkpoints_rx) = watch::channel(None);
-    let run_handle = tokio::spawn(run_stream(
-        stream,
+    let run_handle = tokio::spawn(run_supervised(
+        indexer,
         StreamContext::new(
             backlog.clone(),
             sign_tx.clone(),
@@ -826,7 +826,8 @@ async fn test_ethereum_stream_backfills_late_execution_watcher_after_catchup() -
         ))
         .await;
 
-    let stream = EthereumStream::new(ctx.config(true), backlog.clone(), NoopChainTelemetry).await?;
+    let indexer =
+        EthereumIndexer::new(ctx.config(true), backlog.clone(), NoopChainTelemetry).await?;
     let (sign_tx, mut sign_rx) = mpsc::channel(16);
     let (contract_watcher, _contract_tx) = ContractStateWatcher::with_running(
         &"test.near".parse::<AccountId>().unwrap(),
@@ -843,8 +844,8 @@ async fn test_ethereum_stream_backfills_late_execution_watcher_after_catchup() -
     let (rpc, _rpc_rx) = test_rpc_channel(16);
 
     let (_cp_tx, checkpoints_rx) = watch::channel(None);
-    let run_handle = tokio::spawn(run_stream(
-        stream,
+    let run_handle = tokio::spawn(run_supervised(
+        indexer,
         StreamContext::new(
             backlog.clone(),
             sign_tx.clone(),


### PR DESCRIPTION
This PR focuses on migration of Ethereum indexer to a new trait design and creates shared supervision logic on the node side. 

Main changes:
- `ChainIndexer` trait: add default implementation for `run()` - returns `Err` so an unmigrated chain can't be silently
   supervised (After migration all default implementations will be removed)
- Create `stream/supervisor.rs` - includes all node-side logic: recovery, regression detection, watchdog, etc. (chain-specific logic has been moved to `run()` method - see  `EthereumIndexer` changes below). Should probably become part of `ChainPipeline` eventually, but for now keep separate, because original `ChainPipeline` is still used by Canton and Solana (TODO added)
- Update `cli/mod.rs` to use `supervisor::run_supervised` instead of `run_stream` for Ethereum
- Create `stream/recovery.rs` - extract backlog recovery logic from `stream/pipeline.rs`
- Update `EthereumIndexer`:
  - add `run` method: anchor retry-loop -> `catchup_blocks()` -> `CatchupCompleted` -> spawns `index_live_blocks` -> `process_live_retrying`. All retry loops are cancel-aware
  - add `AbortOnDrop` wrapper to prevent task leaking
  - remove `livestream/next/catchup_range/process_catchup/process/notify_catchup_completed` methods (currently covered by default trait implementations, but none is used)
  - remove struct fields: `catchup_complete`, `events_tx`, `live_blocks_rx`
  - deleted `EthereumStream` struct
  