### PR TITLE
refactor: adjust `eth_optimistic_requests` CLI flag

### DIFF
--- a/chain-signatures/chain-ethereum/src/config.rs
+++ b/chain-signatures/chain-ethereum/src/config.rs
@@ -16,7 +16,8 @@ pub struct EthConfig {
     pub helios_data_path: String,
     /// refresh finalized block interval in milliseconds
     pub refresh_finalized_interval: u64,
-    /// Enable the indexer to just send requests optimistically instead waiting for final.
+    /// Emit requests without waiting for block finality. Only for dev chains
+    /// (anvil never reports finalized blocks); unsafe on live networks.
     pub optimistic_requests: bool,
     /// light client is true if using helios, false if using direct rpc
     pub light_client: bool,

--- a/chain-signatures/node/src/cli/args/ethereum.rs
+++ b/chain-signatures/node/src/cli/args/ethereum.rs
@@ -70,6 +70,10 @@ pub struct EthArgs {
         default_value = "10000"
     )]
     pub eth_refresh_finalized_interval: u64,
+    /// Emit requests without waiting for block finality. FOR DEV/DEMO USE ONLY:
+    /// on live networks a reorg can orphan already-emitted sign requests.
+    #[clap(long, env("MPC_ETH_OPTIMISTIC_REQUESTS"), default_value = "false")]
+    pub eth_optimistic_requests: bool,
 }
 
 impl EthArgs {
@@ -106,6 +110,9 @@ impl EthArgs {
             "--eth-refresh-finalized-interval".to_string(),
             self.eth_refresh_finalized_interval.to_string(),
         ]);
+        if self.eth_optimistic_requests {
+            args.push("--eth-optimistic-requests".to_string());
+        }
         if self.eth_light_client {
             args.push("--eth-light-client".to_string());
         }
@@ -121,12 +128,18 @@ impl EthArgs {
         }
 
         let network = self.eth_network.unwrap_or_default();
+        if self.eth_optimistic_requests && network == "mainnet" {
+            tracing::warn!(
+                "eth optimistic requests enabled on mainnet: emitted requests are NOT \
+                 reorg-safe; this flag is intended for dev/demo use only"
+            );
+        }
         Some(EthConfig {
             account_sk: self.eth_account_sk?.expose_secret().to_string(), // this is safe because  EthConfig has custom Debug implementation that redacts the account_sk field
             consensus_rpc_http_url: self.eth_consensus_rpc_http_url.unwrap_or_default(),
             execution_rpc_http_url: self.eth_execution_rpc_http_url?,
             contract_address: self.eth_contract_address?,
-            optimistic_requests: network == "anvil", // anvil never reports finalized blocks
+            optimistic_requests: self.eth_optimistic_requests || network == "anvil", // anvil never reports finalized blocks, so requests are emitted without waiting for finality
             network,
             helios_data_path: self.eth_helios_data_path.unwrap_or_default(),
             refresh_finalized_interval: self.eth_refresh_finalized_interval,
@@ -147,6 +160,7 @@ impl EthArgs {
                 eth_network: Some(config.network),
                 eth_helios_data_path: Some(config.helios_data_path),
                 eth_refresh_finalized_interval: config.refresh_finalized_interval,
+                eth_optimistic_requests: config.optimistic_requests,
                 eth_light_client: config.light_client,
             },
             _ => Self {
@@ -157,6 +171,7 @@ impl EthArgs {
                 eth_network: None,
                 eth_helios_data_path: None,
                 eth_refresh_finalized_interval: 0,
+                eth_optimistic_requests: false,
                 eth_light_client: false,
             },
         }

--- a/chain-signatures/node/src/cli/args/ethereum.rs
+++ b/chain-signatures/node/src/cli/args/ethereum.rs
@@ -42,13 +42,15 @@ pub struct EthArgs {
         requires = "eth_account_sk"
     )]
     pub eth_consensus_rpc_http_url: Option<String>,
-    /// The network that the eth indexer is running on. Either "sepolia"/"mainnet"
+    /// The network that the eth indexer is running on: "sepolia"/"mainnet",
+    /// or "anvil" for local dev chains (anvil never reports finalized blocks,
+    /// so requests are emitted without waiting for finality).
     #[clap(
         long,
         env("MPC_ETH_NETWORK"),
         requires = "eth_account_sk",
         default_value = "sepolia",
-        value_parser = ["sepolia", "mainnet"],
+        value_parser = ["sepolia", "mainnet", "anvil"],
     )]
     pub eth_network: Option<String>,
     /// Helios light client data path
@@ -68,10 +70,6 @@ pub struct EthArgs {
         default_value = "10000"
     )]
     pub eth_refresh_finalized_interval: u64,
-    /// Enable the indexer to just send requests optimistically instead waiting for final.
-    /// Useful for testing where we do not want to reach finality due to how long it takes.
-    #[clap(long, env("MPC_ETH_OPTIMISTIC_REQUESTS"), default_value = "false")]
-    pub eth_optimistic_requests: bool,
 }
 
 impl EthArgs {
@@ -108,9 +106,6 @@ impl EthArgs {
             "--eth-refresh-finalized-interval".to_string(),
             self.eth_refresh_finalized_interval.to_string(),
         ]);
-        if self.eth_optimistic_requests {
-            args.push("--eth-optimistic-requests".to_string());
-        }
         if self.eth_light_client {
             args.push("--eth-light-client".to_string());
         }
@@ -125,15 +120,16 @@ impl EthArgs {
             );
         }
 
+        let network = self.eth_network.unwrap_or_default();
         Some(EthConfig {
             account_sk: self.eth_account_sk?.expose_secret().to_string(), // this is safe because  EthConfig has custom Debug implementation that redacts the account_sk field
             consensus_rpc_http_url: self.eth_consensus_rpc_http_url.unwrap_or_default(),
             execution_rpc_http_url: self.eth_execution_rpc_http_url?,
             contract_address: self.eth_contract_address?,
-            network: self.eth_network.unwrap_or_default(),
+            optimistic_requests: network == "anvil", // anvil never reports finalized blocks
+            network,
             helios_data_path: self.eth_helios_data_path.unwrap_or_default(),
             refresh_finalized_interval: self.eth_refresh_finalized_interval,
-            optimistic_requests: self.eth_optimistic_requests,
             #[cfg(feature = "helios")]
             light_client: self.eth_light_client,
             #[cfg(not(feature = "helios"))]
@@ -151,7 +147,6 @@ impl EthArgs {
                 eth_network: Some(config.network),
                 eth_helios_data_path: Some(config.helios_data_path),
                 eth_refresh_finalized_interval: config.refresh_finalized_interval,
-                eth_optimistic_requests: config.optimistic_requests,
                 eth_light_client: config.light_client,
             },
             _ => Self {
@@ -162,7 +157,6 @@ impl EthArgs {
                 eth_network: None,
                 eth_helios_data_path: None,
                 eth_refresh_finalized_interval: 0,
-                eth_optimistic_requests: false,
                 eth_light_client: false,
             },
         }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -389,7 +389,7 @@ pub async fn setup(spawner: &mut ClusterSpawner) -> anyhow::Result<Context> {
             consensus_rpc_http_url: rpc_endpoint.clone(),
             execution_rpc_http_url: rpc_endpoint,
             contract_address: contract_address_hex.clone(),
-            network: "sepolia".to_string(),
+            network: "anvil".to_string(),
             helios_data_path: format!("/tmp/helios-{}", contract_address_hex),
             refresh_finalized_interval: 1_000,
             optimistic_requests: true,

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -33,7 +33,7 @@ enum Cli {
             default_value = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
         )]
         eth_account_sk: String,
-        #[arg(long, default_value = "sepolia")]
+        #[arg(long, default_value = "anvil")]
         eth_network: String,
         #[arg(long, default_value = "/tmp/data")]
         eth_helios_data_path: String,
@@ -71,10 +71,10 @@ async fn main() -> anyhow::Result<()> {
                     consensus_rpc_http_url: eth_consensus_rpc_http_url,
                     execution_rpc_http_url: eth_execution_rpc_http_url,
                     contract_address: eth_contract_address,
+                    optimistic_requests: eth_network == "anvil",
                     network: eth_network,
                     helios_data_path: eth_helios_data_path,
                     refresh_finalized_interval: eth_refresh_finalized_interval,
-                    optimistic_requests: false,
                     light_client: false,
                 }),
                 ..Default::default()


### PR DESCRIPTION
- Use `anvil` for integration tests, which sets `optimistic_requests: true`
- Update comment for `MPC_ETH_OPTIMISTIC_REQUESTS` / `eth_optimistic_requests` CLI args to clarify demo / dev use
- Add `warn!` if using optimistic path with `mainnet`