### PR TITLE
logs: associate tx hash with sign id for eth and solana

### DIFF
--- a/chain-signatures/chain-ethereum/src/event_parsing.rs
+++ b/chain-signatures/chain-ethereum/src/event_parsing.rs
@@ -132,10 +132,11 @@ fn sign_request_from_filtered_log(log: Log) -> Option<IndexedSignRequest> {
     );
 
     // Use transaction hash as entropy
-    let entropy = log.transaction_hash.unwrap_or_default();
+    let tx_hash = log.transaction_hash.unwrap_or_default();
+    let entropy = tx_hash;
 
     let sign_id = SignId::new(event.generate_request_id());
-    tracing::info!(?sign_id, "eth signature requested");
+    tracing::info!(%tx_hash, ?sign_id, "eth signature requested");
 
     Some(IndexedSignRequest::sign(
         sign_id,

--- a/chain-signatures/chain-solana/src/indexer.rs
+++ b/chain-signatures/chain-solana/src/indexer.rs
@@ -893,9 +893,17 @@ async fn emit_events(
 ) -> anyhow::Result<()> {
     match SolanaEvents::parse(tx, program_id, logs)? {
         SolanaEvents::Sign(events) => {
-            let signature = signature.as_ref().to_vec();
+            let sig_bytes = signature.as_ref().to_vec();
             for ev in events {
-                if let Some(request) = ev.build_sign_request(&signature) {
+                if let Some(request) = ev.build_sign_request(&sig_bytes) {
+                    // `signature` is the Solana transaction signature, i.e. the tx hash
+                    // shown in explorers and used as the getTransaction lookup key. Log it
+                    // next to the sign_id so a given tx can be matched to its request.
+                    tracing::info!(
+                        tx_hash = %signature,
+                        sign_id = ?request.id,
+                        "solana sign request parsed",
+                    );
                     events_tx
                         .send(ChainEvent::SignRequest {
                             request,


### PR DESCRIPTION
Currently if we look at a sign request from solana or eth explorer, there's no way for us to associate that with a sign id quickly. Adding this log will make it very easy.

Don't want to enforce this on every chain because many chains don't have such explorer and they likely do not start debugging from a tx on their network. I'd want to align with applications team so we can make sure whatever they keep for record for the tx will be associated with a sign id easily.

helps visibility in https://github.com/sig-net/mpc/issues/1021