### PR TITLE
refactor: consolidate constants into config structs

### DIFF
--- a/chain-signatures/chain-ethereum/examples/bench_catchup.rs
+++ b/chain-signatures/chain-ethereum/examples/bench_catchup.rs
@@ -74,6 +74,10 @@ fn make_config() -> anyhow::Result<EthConfig> {
         refresh_finalized_interval: 1,
         optimistic_requests: env_bool("OPTIMISTIC", true)?,
         light_client: false,
+        rpc: Default::default(),
+        gas: Default::default(),
+        publisher: Default::default(),
+        indexer: Default::default(),
     })
 }
 

--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -2,17 +2,16 @@ use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::{Address, B256};
 use alloy::rpc::types::{Block, BlockId, Log, TransactionReceipt};
 use std::sync::Arc;
-use std::time::Duration;
 
+use crate::config::RpcConfig;
 use crate::indexer_eth_direct_rpc;
 use crate::EthConfig;
-use mpc_chain_integration_core::utils::retry::{retry_rpc_gated, RetryConfig, SharedBackoff};
+#[cfg(test)]
+use mpc_chain_integration_core::utils::retry::RetryConfig;
+use mpc_chain_integration_core::utils::retry::{retry_rpc_gated, SharedBackoff};
 
 #[cfg(feature = "helios")]
 use super::indexer_eth_helios;
-
-/// Catchup batch size for [`CatchupIter`]
-pub const CATCHUP_BLOCK_BATCH_SIZE: u64 = 32;
 
 /// Block number alias shared by the client and indexer.
 pub type BlockNumber = u64;
@@ -56,6 +55,7 @@ enum BlockSlot {
 pub struct CatchupIter {
     client: Arc<EthereumClient>,
     contract_address: Address,
+    batch_size: u64,
     next_block: BlockNumber,
     end_block: BlockNumber,
     buffered_blocks: std::vec::IntoIter<CatchupItem>,
@@ -67,10 +67,12 @@ impl CatchupIter {
         start_block: BlockNumber,
         end_block: BlockNumber,
         contract_address: Address,
+        batch_size: u64,
     ) -> Self {
         Self {
             client,
             contract_address,
+            batch_size,
             next_block: start_block,
             end_block,
             buffered_blocks: Vec::new().into_iter(),
@@ -84,7 +86,7 @@ impl CatchupIter {
 
         let batch_end = self
             .next_block
-            .saturating_add(CATCHUP_BLOCK_BATCH_SIZE)
+            .saturating_add(self.batch_size)
             .min(self.end_block);
 
         let batch_block_ids: Vec<BlockId> = (self.next_block..batch_end)
@@ -177,27 +179,10 @@ impl CatchupIter {
     }
 }
 
-// Constants for Ethereum RPC client retry behavior
-const ETH_RPC_TIMEOUT: Duration = Duration::from_secs(2);
-const ETH_RPC_BATCH_TIMEOUT: Duration = Duration::from_secs(5);
-const ETH_RPC_MIN_DELAY: Duration = Duration::from_millis(500);
-const ETH_RPC_MAX_DELAY: Duration = Duration::from_secs(10);
-const ETH_RPC_MAX_RETRIES: usize = 5;
-
-/// Helper for consistent config
-fn default_eth_retry_strategy() -> RetryConfig {
-    RetryConfig {
-        min_delay: ETH_RPC_MIN_DELAY,
-        max_delay: ETH_RPC_MAX_DELAY,
-        max_times: ETH_RPC_MAX_RETRIES,
-        jitter: true,
-    }
-}
-
 #[derive(Clone)]
 pub struct EthereumClient {
     inner: EthereumClientInner,
-    retry_strategy: RetryConfig,
+    rpc: RpcConfig,
     /// Global 429 cooldown gate shared by all RPC calls through this client
     shared_backoff: SharedBackoff,
 }
@@ -211,14 +196,6 @@ pub enum EthereumClientInner {
 
 impl EthereumClient {
     pub async fn new(eth: EthConfig) -> anyhow::Result<EthereumClient> {
-        Self::new_with_strategy(eth, default_eth_retry_strategy()).await
-    }
-
-    /// Creates a new Ethereum client with the specified retry strategy.
-    pub async fn new_with_strategy(
-        eth: EthConfig,
-        retry_strategy: RetryConfig,
-    ) -> anyhow::Result<Self> {
         let inner = if eth.light_client {
             #[cfg(feature = "helios")]
             {
@@ -238,9 +215,20 @@ impl EthereumClient {
 
         Ok(Self {
             inner,
-            retry_strategy,
+            rpc: eth.rpc.clone(),
             shared_backoff: SharedBackoff::new(),
         })
+    }
+
+    /// Overrides the RPC retry strategy
+    #[cfg(test)]
+    pub(crate) async fn new_with_strategy(
+        eth: EthConfig,
+        retry_strategy: RetryConfig,
+    ) -> anyhow::Result<Self> {
+        let mut client = Self::new(eth).await?;
+        client.rpc.retry = retry_strategy;
+        Ok(client)
     }
 
     /// Overrides the shared 429 cooldown gate
@@ -259,10 +247,10 @@ impl EthereumClient {
     }
 
     pub async fn get_block(&self, block_id: BlockId) -> Option<Block> {
-        let max_attempts = self.retry_strategy.max_times;
+        let max_attempts = self.rpc.retry.max_times;
         let res = retry_rpc_gated!(
-            ETH_RPC_TIMEOUT,
-            self.retry_strategy,
+            self.rpc.timeout,
+            self.rpc.retry,
             self.shared_backoff,
             |attempt, err, sleep| {
                 tracing::warn!(
@@ -300,12 +288,12 @@ impl EthereumClient {
             return Vec::new();
         }
 
-        let max_attempts = self.retry_strategy.max_times;
+        let max_attempts = self.rpc.retry.max_times;
         let num_blocks = block_ids.len();
 
         let res = retry_rpc_gated!(
-            ETH_RPC_BATCH_TIMEOUT,
-            self.retry_strategy,
+            self.rpc.batch_timeout,
+            self.rpc.retry,
             self.shared_backoff,
             |attempt, err, sleep| {
                 tracing::warn!(
@@ -344,8 +332,8 @@ impl EthereumClient {
         tx_hash: B256,
     ) -> anyhow::Result<Option<TransactionReceipt>> {
         retry_rpc_gated!(
-            ETH_RPC_TIMEOUT,
-            self.retry_strategy,
+            self.rpc.timeout,
+            self.rpc.retry,
             self.shared_backoff,
             "get_transaction_receipt",
             {
@@ -366,8 +354,8 @@ impl EthereumClient {
     /// server-filtered `eth_getLogs`.
     pub async fn get_logs(&self, address: Address, block_id: BlockId) -> anyhow::Result<Vec<Log>> {
         retry_rpc_gated!(
-            ETH_RPC_TIMEOUT,
-            self.retry_strategy,
+            self.rpc.timeout,
+            self.rpc.retry,
             self.shared_backoff,
             "get_logs",
             {
@@ -391,8 +379,8 @@ impl EthereumClient {
         block_ids: &[BlockId],
     ) -> anyhow::Result<Vec<Vec<Log>>> {
         retry_rpc_gated!(
-            ETH_RPC_BATCH_TIMEOUT,
-            self.retry_strategy,
+            self.rpc.batch_timeout,
+            self.rpc.retry,
             self.shared_backoff,
             "get_logs_batch",
             {
@@ -411,8 +399,8 @@ impl EthereumClient {
 
     pub async fn get_nonce(&self, address: Address, block_id: BlockId) -> anyhow::Result<u64> {
         retry_rpc_gated!(
-            ETH_RPC_TIMEOUT,
-            self.retry_strategy,
+            self.rpc.timeout,
+            self.rpc.retry,
             self.shared_backoff,
             "get_nonce",
             {
@@ -434,8 +422,8 @@ impl EthereumClient {
         tx_hash: alloy::primitives::B256,
     ) -> anyhow::Result<Option<alloy::rpc::types::Transaction>> {
         retry_rpc_gated!(
-            ETH_RPC_TIMEOUT,
-            self.retry_strategy,
+            self.rpc.timeout,
+            self.rpc.retry,
             self.shared_backoff,
             "get_transaction_by_hash",
             {
@@ -456,10 +444,10 @@ impl EthereumClient {
         &self,
         tx_hash: alloy::primitives::B256,
     ) -> anyhow::Result<alloy::primitives::Bytes> {
-        // TODO: trace_transaction_output can be slow, consider a longer timeout than ETH_RPC_TIMEOUT if necessary
+        // TODO: trace_transaction_output can be slow, consider a longer timeout than the configured RPC timeout if necessary
         retry_rpc_gated!(
-            ETH_RPC_TIMEOUT,
-            self.retry_strategy,
+            self.rpc.timeout,
+            self.rpc.retry,
             self.shared_backoff,
             "trace_transaction_output",
             {
@@ -524,6 +512,7 @@ mod tests {
     use alloy::primitives::Bloom;
     use mockito::{Matcher, Server};
     use serde_json::json;
+    use std::time::Duration;
 
     // TODO: add more tests for non HTTP-related functionality, e.g. clamp_oldest_supported_with
 
@@ -699,7 +688,7 @@ mod tests {
         let contract_address = Address::with_last_byte(0x42);
 
         let client = Arc::new(test_utils::create_test_ethereum_client(&server.url()).await);
-        let mut iter = CatchupIter::new(client, 10, 43, contract_address);
+        let mut iter = CatchupIter::new(client, 10, 43, contract_address, 32);
 
         for expected_number in 10..42 {
             let next = iter.next().await;
@@ -785,7 +774,7 @@ mod tests {
         let contract_address = Address::with_last_byte(0x42);
 
         let client = Arc::new(test_utils::create_test_ethereum_client(&server.url()).await);
-        let mut iter = CatchupIter::new(client, 0, 65, contract_address);
+        let mut iter = CatchupIter::new(client, 0, 65, contract_address, 32);
 
         for expected_number in 0..65 {
             let next = iter.next().await;
@@ -961,7 +950,7 @@ mod tests {
             .await;
 
         let client = Arc::new(test_utils::create_test_ethereum_client(&server.url()).await);
-        let mut iter = CatchupIter::new(client, 10, 12, contract_address);
+        let mut iter = CatchupIter::new(client, 10, 12, contract_address, 32);
 
         let item1 = iter.next().await.unwrap();
         let item2 = iter.next().await.unwrap();
@@ -1017,7 +1006,7 @@ mod tests {
             .await;
 
         let client = Arc::new(test_utils::create_test_ethereum_client(&server.url()).await);
-        let mut iter = CatchupIter::new(client, 10, 12, contract_address);
+        let mut iter = CatchupIter::new(client, 10, 12, contract_address, 32);
 
         for expected_number in [10u64, 11] {
             let item = iter.next().await.expect("expected item");

--- a/chain-signatures/chain-ethereum/src/config.rs
+++ b/chain-signatures/chain-ethereum/src/config.rs
@@ -1,4 +1,150 @@
+use mpc_chain_integration_core::utils::retry::RetryConfig;
 use std::fmt;
+use std::time::Duration;
+
+/// Timeouts and retry budget for the read-side Ethereum RPC client.
+#[derive(Clone, Debug)]
+pub struct RpcConfig {
+    /// Timeout for single-call RPC requests
+    pub timeout: Duration,
+    /// Timeout for batched RPC requests
+    pub batch_timeout: Duration,
+    /// Retry strategy shared by all RPC calls
+    pub retry: RetryConfig,
+}
+
+impl Default for RpcConfig {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(2),
+            batch_timeout: Duration::from_secs(5),
+            retry: RetryConfig {
+                min_delay: Duration::from_millis(500),
+                max_delay: Duration::from_secs(10),
+                max_times: 5,
+                jitter: true,
+            },
+        }
+    }
+}
+
+/// Gas limits for `respond` transactions. Chain-specific: other EVM chains
+/// need their own values.
+#[derive(Clone, Debug)]
+pub struct GasConfig {
+    /// Minimum gas limit; estimated gas is never clamped below this
+    pub base_gas_limit: u64,
+    /// Per-request gas used by the static fallback heuristic
+    pub batch_gas_per_request: u64,
+    /// Maximum gas limit per transaction
+    pub max_gas_limit: u64,
+    /// Fractional buffer applied on top of the dynamically estimated gas.
+    /// Absorbs variance between estimation and execution so transactions
+    /// don't revert on chain.
+    pub estimation_buffer_percent: u64,
+}
+
+impl Default for GasConfig {
+    fn default() -> Self {
+        Self {
+            base_gas_limit: 40_000,
+            batch_gas_per_request: 20_000,
+            max_gas_limit: 16_777_216,
+            estimation_buffer_percent: 20,
+        }
+    }
+}
+
+impl GasConfig {
+    /// Gas limit from a dynamic `eth_estimateGas` result: buffered, then
+    /// clamped to `[base_gas_limit, max_gas_limit]`.
+    pub fn clamp_estimate(&self, estimate: u64) -> u64 {
+        let buffered = estimate + (estimate / 100).saturating_mul(self.estimation_buffer_percent);
+        buffered.min(self.max_gas_limit).max(self.base_gas_limit)
+    }
+
+    /// Static fallback heuristic when dynamic estimation fails.
+    pub fn fallback_gas(&self, num_requests: u64) -> u64 {
+        self.base_gas_limit
+            .max(self.batch_gas_per_request * num_requests)
+    }
+}
+
+/// Batching behavior and retry budgets for the publish path.
+#[derive(Clone, Debug)]
+pub struct PublisherConfig {
+    /// Maximum number of responses per `respond` transaction
+    pub max_batch_size: usize,
+    /// Flush pending responses after this long even if the batch isn't full
+    pub batch_flush_interval: Duration,
+    /// Capacity of the channel feeding the background batching task
+    pub channel_capacity: usize,
+    /// Timeout for a single transaction send attempt
+    pub send_timeout: Duration,
+    /// Retry strategy for sending the `respond` transaction
+    pub send_retry: RetryConfig,
+    /// Timeout for a single receipt poll attempt
+    pub receipt_timeout: Duration,
+    /// Retry strategy for polling the transaction receipt
+    pub receipt_retry: RetryConfig,
+    /// Retry strategy for the whole batch publish (retries indefinitely)
+    pub batch_publish_retry: RetryConfig,
+}
+
+impl Default for PublisherConfig {
+    fn default() -> Self {
+        Self {
+            max_batch_size: 10,
+            batch_flush_interval: Duration::from_millis(2000),
+            channel_capacity: 1024,
+            send_timeout: Duration::from_secs(5),
+            send_retry: RetryConfig {
+                min_delay: Duration::from_millis(500),
+                max_delay: Duration::from_secs(10),
+                max_times: 3,
+                jitter: true,
+            },
+            receipt_timeout: Duration::from_secs(2),
+            receipt_retry: RetryConfig {
+                min_delay: Duration::from_secs(1),
+                max_delay: Duration::from_secs(20),
+                max_times: 6,
+                jitter: true,
+            },
+            batch_publish_retry: RetryConfig {
+                min_delay: Duration::from_secs(1),
+                max_delay: Duration::from_secs(10),
+                max_times: usize::MAX,
+                jitter: true,
+            },
+        }
+    }
+}
+
+/// Tuning for the indexing pipeline (catchup, live stream, finality waits).
+#[derive(Clone, Debug)]
+pub struct IndexerConfig {
+    /// Blocks per catchup batch (`eth_getBlockByNumber` JSON-RPC batch)
+    pub catchup_block_batch_size: u64,
+    /// Capacity of the live-block channel
+    pub live_block_buffer: usize,
+    /// Consecutive `get_block(Finalized)` failures tolerated before
+    /// `wait_for_finalized_block` gives up
+    pub max_finalized_failures: u32,
+    /// Re-warn interval (seconds) while the finalized head is stalled
+    pub stall_rewarn_secs: u64,
+}
+
+impl Default for IndexerConfig {
+    fn default() -> Self {
+        Self {
+            catchup_block_batch_size: 32,
+            live_block_buffer: 16384,
+            max_finalized_failures: 20,
+            stall_rewarn_secs: 300,
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct EthConfig {
@@ -21,6 +167,10 @@ pub struct EthConfig {
     pub optimistic_requests: bool,
     /// light client is true if using helios, false if using direct rpc
     pub light_client: bool,
+    pub rpc: RpcConfig,
+    pub gas: GasConfig,
+    pub publisher: PublisherConfig,
+    pub indexer: IndexerConfig,
 }
 
 impl EthConfig {
@@ -49,6 +199,10 @@ impl fmt::Debug for EthConfig {
             )
             .field("optimistic_requests", &self.optimistic_requests)
             .field("light_client", &self.light_client)
+            .field("rpc", &self.rpc)
+            .field("gas", &self.gas)
+            .field("publisher", &self.publisher)
+            .field("indexer", &self.indexer)
             .finish()
     }
 }

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -25,14 +25,6 @@ use std::sync::Arc;
 use tokio::sync::{mpsc, Notify};
 use tokio::time::{sleep, Duration, Instant};
 
-const MAX_LIVE_BLOCK_BUFFER: usize = 16384;
-/// Limit of consecutive `get_block(Finalized)` total failures allowed before `wait_for_finalized_block` gives up.
-const MAX_FINALIZED_FAILURES: u32 = 20;
-
-fn live_blocks_channel() -> (mpsc::Sender<MaybeBlock>, mpsc::Receiver<MaybeBlock>) {
-    mpsc::channel(MAX_LIVE_BLOCK_BUFFER)
-}
-
 pub struct BlockAndRequests {
     block_number: u64,
     block_hash: alloy::primitives::B256,
@@ -589,13 +581,14 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     /// Blocks until the specified block number has been finalized on the Ethereum chain.
     async fn wait_for_finalized_block(&self, block_number: BlockNumber) -> anyhow::Result<()> {
         let retry_interval = Duration::from_millis(self.eth.refresh_finalized_interval);
+        let max_finalized_failures = self.eth.indexer.max_finalized_failures;
         let mut last_final_block_number: Option<BlockNumber> = None;
         let mut consecutive_failures = 0u32;
 
         // Warn if the finalized block number has not advanced for this long
         let stall_warn_secs = Chain::Ethereum.expected_finality_time_secs();
         // Re-warn on this heartbeat interval if the finalized block number has not advanced
-        const STALL_REWARN_SECS: u64 = 300;
+        let stall_rewarn_secs = self.eth.indexer.stall_rewarn_secs;
         let mut last_advanced_at = Instant::now();
         let mut last_stall_warn_at = Instant::now();
 
@@ -607,16 +600,16 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
                 .await
             else {
                 consecutive_failures += 1;
-                if consecutive_failures >= MAX_FINALIZED_FAILURES {
+                if consecutive_failures >= max_finalized_failures {
                     // Propagate error to the outer ChainIndexer loop to catch it,
                     // sleep for RETRY_DELAY, and attempt the entire block process again.
                     anyhow::bail!(
-                        "get_block(Finalized) failed {MAX_FINALIZED_FAILURES} times consecutively; aborting wait"
+                        "get_block(Finalized) failed {max_finalized_failures} times consecutively; aborting wait"
                     );
                 }
                 tracing::warn!(
                     block_number,
-                    "finalized ethereum block not found (failure {consecutive_failures}/{MAX_FINALIZED_FAILURES}); retrying"
+                    "finalized ethereum block not found (failure {consecutive_failures}/{max_finalized_failures}); retrying"
                 );
                 sleep(retry_interval).await;
                 continue;
@@ -649,7 +642,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
                     let now = Instant::now();
                     let secs_since_advance = now.duration_since(last_advanced_at).as_secs();
                     if secs_since_advance >= stall_warn_secs
-                        && now.duration_since(last_stall_warn_at).as_secs() >= STALL_REWARN_SECS
+                        && now.duration_since(last_stall_warn_at).as_secs() >= stall_rewarn_secs
                     {
                         tracing::warn!(
                             block_number,
@@ -691,7 +684,7 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
             sleep(Self::RETRY_DELAY).await;
         };
 
-        let (live_blocks_tx, live_blocks_rx) = live_blocks_channel();
+        let (live_blocks_tx, live_blocks_rx) = mpsc::channel(self.eth.indexer.live_block_buffer);
         tokio::spawn(Self::index_live_blocks(
             self.client.clone(),
             self.catchup_complete.clone(),
@@ -909,7 +902,7 @@ impl<S: StateManager, T: ChainTelemetry> ChainStream for EthereumStream<S, T> {
 #[cfg(test)]
 mod tests {
     use crate::client::CatchupItem;
-    use crate::test_utils;
+    use crate::{test_utils, IndexerConfig};
     use alloy::eips::BlockNumberOrTag;
     use alloy::primitives::{address, b256};
     use alloy::rpc::types::BlockId;
@@ -1467,7 +1460,7 @@ mod tests {
         let mut server = Server::new_async().await;
 
         // Mock eth_getBlockByNumber(finalized) to always return null (simulating repeated 429/failure)
-        // Should be called MAX_FINALIZED_FAILURES times
+        // Should be called max_finalized_failures times
         server
             .mock("POST", "/")
             .match_body(Matcher::PartialJson(json!({
@@ -1477,7 +1470,7 @@ mod tests {
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(test_utils::missing_block_response(1).to_string())
-            .expect(super::MAX_FINALIZED_FAILURES as usize)
+            .expect(IndexerConfig::default().max_finalized_failures as usize)
             .create_async()
             .await;
 

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -734,6 +734,7 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
             catchup_start,
             anchor_height,
             self.contract_address,
+            self.eth.indexer.catchup_block_batch_size,
         );
 
         // Sample the finalized head once at catchup start, so that blocks at or below it can skip the per-block re-fetch + reorg hash check.
@@ -1004,6 +1005,7 @@ mod tests {
             1,
             33,
             indexer.contract_address,
+            indexer.eth.indexer.catchup_block_batch_size,
         );
         for n in 1..=32 {
             let item = iter.next().await.expect("expected item");
@@ -1063,6 +1065,7 @@ mod tests {
             10,
             12,
             indexer.contract_address,
+            indexer.eth.indexer.catchup_block_batch_size,
         );
 
         let item1 = iter.next().await.unwrap();
@@ -1172,6 +1175,7 @@ mod tests {
             42,
             43,
             indexer.contract_address,
+            indexer.eth.indexer.catchup_block_batch_size,
         );
         let item = iter.next().await.unwrap();
 

--- a/chain-signatures/chain-ethereum/src/lib.rs
+++ b/chain-signatures/chain-ethereum/src/lib.rs
@@ -17,5 +17,5 @@ mod test_utils;
 mod util;
 
 pub use client::MaybeBlock;
-pub use config::EthConfig;
+pub use config::{EthConfig, GasConfig, IndexerConfig, PublisherConfig, RpcConfig};
 pub use indexer::EthereumStream;

--- a/chain-signatures/chain-ethereum/src/publisher.rs
+++ b/chain-signatures/chain-ethereum/src/publisher.rs
@@ -707,7 +707,7 @@ mod tests {
         let mut server = Server::new_async().await;
         mock_alloy_background_rpcs(&mut server).await;
 
-        // A suspiciously tiny estimate (well below ETH_BASE_GAS_LIMIT) should be
+        // A suspiciously tiny estimate (well below the configured base gas limit) should be
         // lifted to the base limit so the tx is never under-funded.
         server
             .mock("POST", "/")

--- a/chain-signatures/chain-ethereum/src/publisher.rs
+++ b/chain-signatures/chain-ethereum/src/publisher.rs
@@ -406,6 +406,10 @@ mod tests {
             refresh_finalized_interval: 1000,
             optimistic_requests: false,
             light_client: false,
+            rpc: Default::default(),
+            gas: Default::default(),
+            publisher: Default::default(),
+            indexer: Default::default(),
         }
     }
 

--- a/chain-signatures/chain-ethereum/src/publisher.rs
+++ b/chain-signatures/chain-ethereum/src/publisher.rs
@@ -1,4 +1,5 @@
 use crate::abi::ChainSignatures;
+use crate::config::{GasConfig, PublisherConfig};
 use crate::EthConfig;
 use alloy::network::EthereumWallet;
 use alloy::primitives::{Address, B256, U256};
@@ -12,8 +13,7 @@ use alloy::rpc::types::TransactionReceipt;
 use alloy_signer_local::PrivateKeySigner;
 use k256::elliptic_curve::{point::AffineCoordinates, sec1::ToEncodedPoint};
 use mpc_chain_integration_core::{
-    utils::retry::{retry_rpc, RetryConfig},
-    ChainPublisher, PublishAction, PublisherTelemetry,
+    utils::retry::retry_rpc, ChainPublisher, PublishAction, PublisherTelemetry,
 };
 use mpc_primitives::{SignId, Signature};
 use std::collections::HashMap;
@@ -32,42 +32,6 @@ type EthContractFillProvider = FillProvider<
     >,
     RootProvider,
 >;
-
-// Send Ethereum tx retry constants
-const ETH_SEND_MAX_ATTEMPTS: usize = 3;
-const ETH_SEND_TIMEOUT: Duration = Duration::from_secs(5);
-const ETH_SEND_MIN_DELAY: Duration = Duration::from_millis(500);
-const ETH_SEND_MAX_DELAY: Duration = Duration::from_secs(10);
-
-// Polling Receipt
-const ETH_RECEIPT_TIMEOUT: Duration = Duration::from_secs(2);
-const ETH_RECEIPT_MIN_DELAY: Duration = Duration::from_secs(1);
-const ETH_RECEIPT_MAX_DELAY: Duration = Duration::from_secs(20);
-
-// TODO: these should be configurable (create GasConfig struct) if we add other EVM chains in the future
-// Ethereum gas limits
-const ETH_BASE_GAS_LIMIT: u64 = 40_000;
-const ETH_BATCH_GAS_PER_REQUEST: u64 = 20_000;
-/// The maximum gas limit per transaction.
-const ETH_MAX_GAS_LIMIT: u64 = 16_777_216;
-/// Fractional buffer applied on top of the dynamically estimated gas.
-/// Absorbs variance between estimation and execution so transactions
-/// don't revert on chain.
-const ETH_GAS_ESTIMATION_BUFFER_PERCENT: u64 = 20;
-
-/// The maximum number of attempts to fetch eth tx and its receipt
-const ETH_TX_RECEIPT_MAX_ATTEMPTS: usize = 6;
-
-/// The interval to batch send Ethereum responses
-const ETH_RESPOND_BATCH_INTERVAL: Duration = Duration::from_millis(2000);
-/// The batch size for Ethereum responses
-const ETH_RESPOND_BATCH_SIZE: usize = 10;
-
-const BATCH_PUBLISH_MIN_DELAY: Duration = Duration::from_secs(1);
-const BATCH_PUBLISH_MAX_DELAY: Duration = Duration::from_secs(10);
-
-/// The maximum number of concurrent RPC requests the system can make
-const MAX_CONCURRENT_RPC_REQUESTS: usize = 1024;
 
 /// Convert MPC Signature to ChainSignatures::Signature
 impl From<&Signature> for ChainSignatures::Signature {
@@ -93,6 +57,10 @@ pub struct EthClient {
     batch_tx: mpsc::Sender<PublishAction>,
     /// Telemetry interface for recording metrics related to publishing signatures
     telemetry: Arc<dyn PublisherTelemetry>,
+    /// Gas configuration for estimating and clamping gas limits
+    gas: GasConfig,
+    /// Publisher configuration for controlling batching and retry behavior
+    publisher: PublisherConfig,
 }
 
 impl EthClient {
@@ -110,12 +78,14 @@ impl EthClient {
         let address = Address::from_str(&format!("0x{}", eth.contract_address)).unwrap();
         let contract = ChainSignatures::new(address, provider);
 
-        let (batch_tx, batch_rx) = mpsc::channel(MAX_CONCURRENT_RPC_REQUESTS);
+        let (batch_tx, batch_rx) = mpsc::channel(eth.publisher.channel_capacity);
 
         let client = Self {
             contract,
             batch_tx,
             telemetry,
+            gas: eth.gas.clone(),
+            publisher: eth.publisher.clone(),
         };
 
         // Spawn the background batching loop
@@ -134,8 +104,8 @@ impl EthClient {
         let mut interval = tokio::time::interval(Duration::from_millis(100));
         loop {
             interval.tick().await;
-            if (start.elapsed() > ETH_RESPOND_BATCH_INTERVAL
-                || actions_batch.len() >= ETH_RESPOND_BATCH_SIZE)
+            if (start.elapsed() > self.publisher.batch_flush_interval
+                || actions_batch.len() >= self.publisher.max_batch_size)
                 && !actions_batch.is_empty()
             {
                 tracing::info!(
@@ -158,16 +128,9 @@ impl EthClient {
             .map(|action| (action.request.id, action.signature))
             .collect();
 
-        let retry_config = RetryConfig {
-            max_times: usize::MAX,
-            min_delay: BATCH_PUBLISH_MIN_DELAY,
-            max_delay: BATCH_PUBLISH_MAX_DELAY,
-            jitter: true,
-        };
-
         let res = retry_rpc!(
             Duration::MAX, // Prevent from timing out
-            retry_config,
+            self.publisher.batch_publish_retry,
             |attempt, err, sleep| {
                 tracing::warn!(
                     "batch publish failed (attempt {attempt}): {err}, retrying in {sleep:?}"
@@ -188,22 +151,15 @@ impl EthClient {
         actions.clear();
     }
 
-    /// Wait for transaction receipt with max_attempts and exponential delay backoff starting at 5s
+    /// Wait for transaction receipt with the configured attempts and exponential delay backoff
     async fn wait_for_transaction_receipt(
         &self,
         tx_hash: B256,
         sign_ids: &[SignId],
     ) -> anyhow::Result<TransactionReceipt> {
-        let retry_config = RetryConfig {
-            max_times: ETH_TX_RECEIPT_MAX_ATTEMPTS,
-            min_delay: ETH_RECEIPT_MIN_DELAY,
-            max_delay: ETH_RECEIPT_MAX_DELAY,
-            jitter: true,
-        };
-
         retry_rpc!(
-            ETH_RECEIPT_TIMEOUT,
-            retry_config,
+            self.publisher.receipt_timeout,
+            self.publisher.receipt_retry,
             // Log the error and retry attempt
             |attempt, err, sleep| {
                 tracing::error!(
@@ -240,16 +196,9 @@ impl EthClient {
         gas: u64,
         sign_ids: &[SignId],
     ) -> anyhow::Result<B256> {
-        let send_retry = RetryConfig {
-            max_times: ETH_SEND_MAX_ATTEMPTS,
-            min_delay: ETH_SEND_MIN_DELAY,
-            max_delay: ETH_SEND_MAX_DELAY,
-            jitter: true,
-        };
-
         retry_rpc!(
-            ETH_SEND_TIMEOUT,
-            send_retry,
+            self.publisher.send_timeout,
+            self.publisher.send_retry,
             |attempt, err, sleep| {
                 tracing::warn!(
                     ?sign_ids,
@@ -311,9 +260,9 @@ impl EthClient {
 
     /// Estimate the gas limit for a batch of responses.
     ///
-    /// Uses the node's `eth_estimateGas` then applies a 20% buffer to absorb variance.
-    ///
-    /// On failure fallsback to a conservative static heuristic based on the batch size.
+    /// Uses the node's `eth_estimateGas` then applies the configured buffer to
+    /// absorb variance. On failure falls back to a conservative static
+    /// heuristic based on the batch size.
     async fn estimate_batch_gas(
         &self,
         responses: &[ChainSignatures::Response],
@@ -321,19 +270,14 @@ impl EthClient {
     ) -> u64 {
         let call = self.contract.respond(responses.to_vec());
         match call.estimate_gas().await {
-            Ok(est) => {
-                // Add a buffer, capped at the per-tx block gas limit, never below the configured base limit
-                let buffered = est + (est / 100).saturating_mul(ETH_GAS_ESTIMATION_BUFFER_PERCENT);
-                let capped = buffered.min(ETH_MAX_GAS_LIMIT);
-                std::cmp::max(capped, ETH_BASE_GAS_LIMIT)
-            }
+            Ok(est) => self.gas.clamp_estimate(est),
             Err(e) => {
                 tracing::warn!(
                     error = %e,
                     num_requests,
                     "dynamic gas estimation failed, falling back to static heuristic"
                 );
-                std::cmp::max(ETH_BASE_GAS_LIMIT, ETH_BATCH_GAS_PER_REQUEST * num_requests)
+                self.gas.fallback_gas(num_requests)
             }
         }
     }
@@ -780,7 +724,7 @@ mod tests {
         );
 
         let gas = client.estimate_batch_gas(&[], 1).await;
-        assert_eq!(gas, ETH_BASE_GAS_LIMIT);
+        assert_eq!(gas, GasConfig::default().base_gas_limit);
     }
 
     #[tokio::test]

--- a/chain-signatures/chain-ethereum/src/test_utils.rs
+++ b/chain-signatures/chain-ethereum/src/test_utils.rs
@@ -31,6 +31,10 @@ pub async fn create_test_ethereum_client(url: &str) -> EthereumClient {
         helios_data_path: "".to_string(),
         refresh_finalized_interval: 0,
         optimistic_requests: false,
+        rpc: Default::default(),
+        gas: Default::default(),
+        publisher: Default::default(),
+        indexer: Default::default(),
     };
 
     EthereumClient::new_with_strategy(eth, retry_strategy)
@@ -66,6 +70,10 @@ impl TestIndexerBuilder {
                 refresh_finalized_interval: DEFAULT_REFRESH_FINALIZED_INTERVAL,
                 optimistic_requests: true,
                 light_client: false,
+                rpc: Default::default(),
+                gas: Default::default(),
+                publisher: Default::default(),
+                indexer: Default::default(),
             },
             state_manager: MockStateManager::new(),
             optimistic_requests: true,

--- a/chain-signatures/chain-integration-core/src/utils/retry.rs
+++ b/chain-signatures/chain-integration-core/src/utils/retry.rs
@@ -115,7 +115,7 @@ pub fn is_rate_limited(e: &anyhow::Error) -> bool {
 }
 
 /// Configuration for retrying RPC calls with exponential backoff.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct RetryConfig {
     pub min_delay: Duration,
     pub max_delay: Duration,

--- a/chain-signatures/chain-integration-core/src/utils/retry.rs
+++ b/chain-signatures/chain-integration-core/src/utils/retry.rs
@@ -220,7 +220,7 @@ pub fn is_retryable(e: &anyhow::Error) -> bool {
 /// ## Full form (custom retry logging)
 /// ```ignore
 /// let block = retry_rpc!(
-///     ETH_RPC_TIMEOUT,
+///     RPC_TIMEOUT,
 ///     self.retry_strategy,
 ///     "get_block",
 ///     |attempt, err, sleep| {

--- a/chain-signatures/node/src/cli/args/ethereum.rs
+++ b/chain-signatures/node/src/cli/args/ethereum.rs
@@ -147,6 +147,12 @@ impl EthArgs {
             light_client: self.eth_light_client,
             #[cfg(not(feature = "helios"))]
             light_client: false,
+            // TODO: currently we only have Ethereum and Sepolia, so defaults
+            // are fine. Make these configurable when we add more chains.
+            rpc: Default::default(),
+            gas: Default::default(),
+            publisher: Default::default(),
+            indexer: Default::default(),
         })
     }
 

--- a/chain-signatures/node/src/stream/pipeline.rs
+++ b/chain-signatures/node/src/stream/pipeline.rs
@@ -16,9 +16,9 @@ use tokio::time::Duration;
 /// their finality cadence to avoid false restarts. We derive it from the chain's
 /// `expected_finality_time_secs` with a buffer, flooring at 300s for fast chains.
 ///
-/// RPC rate-limiting is handled separately by `MAX_FINALIZED_FAILURES` in
-/// `wait_for_finalized_block`, which bails after ~200s — faster than this
-/// watchdog for any chain.
+/// RPC rate-limiting is handled separately by the `max_finalized_failures`
+/// budget in `wait_for_finalized_block`, which bails after ~200s — faster
+/// than this watchdog for any chain.
 fn live_block_timeout(chain: Chain) -> Duration {
     const FLOOR_SECS: u64 = 300;
     const BUFFER_SECS: u64 = 300;

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -20,7 +20,7 @@ use alloy::primitives::{Address, U256};
 use anyhow::Context as _;
 use cluster::spawner::ClusterSpawner;
 use mpc_chain_canton::CantonConfig;
-use mpc_chain_ethereum::{EthConfig, GasConfig, IndexerConfig, PublisherConfig, RpcConfig};
+use mpc_chain_ethereum::EthConfig;
 use mpc_chain_solana::SolConfig;
 use mpc_contract::config::{PresignatureConfig, ProtocolConfig, TripleConfig};
 use mpc_contract::primitives::CandidateInfo;
@@ -394,10 +394,10 @@ pub async fn setup(spawner: &mut ClusterSpawner) -> anyhow::Result<Context> {
             refresh_finalized_interval: 1_000,
             optimistic_requests: true,
             light_client: false,
-            gas: GasConfig::default(),
-            indexer: IndexerConfig::default(),
-            publisher: PublisherConfig::default(),
-            rpc: RpcConfig::default(),
+            gas: Default::default(),
+            indexer: Default::default(),
+            publisher: Default::default(),
+            rpc: Default::default(),
         });
 
         ethereum = Some(EthereumContext {

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -20,7 +20,7 @@ use alloy::primitives::{Address, U256};
 use anyhow::Context as _;
 use cluster::spawner::ClusterSpawner;
 use mpc_chain_canton::CantonConfig;
-use mpc_chain_ethereum::EthConfig;
+use mpc_chain_ethereum::{EthConfig, GasConfig, IndexerConfig, PublisherConfig, RpcConfig};
 use mpc_chain_solana::SolConfig;
 use mpc_contract::config::{PresignatureConfig, ProtocolConfig, TripleConfig};
 use mpc_contract::primitives::CandidateInfo;
@@ -394,6 +394,10 @@ pub async fn setup(spawner: &mut ClusterSpawner) -> anyhow::Result<Context> {
             refresh_finalized_interval: 1_000,
             optimistic_requests: true,
             light_client: false,
+            gas: GasConfig::default(),
+            indexer: IndexerConfig::default(),
+            publisher: PublisherConfig::default(),
+            rpc: RpcConfig::default(),
         });
 
         ethereum = Some(EthereumContext {

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -6,7 +6,7 @@ use std::vec;
 use clap::Parser;
 use integration_tests::cluster::spawner::ClusterSpawner;
 use integration_tests::NodeConfig;
-use mpc_chain_ethereum::{EthConfig, GasConfig, IndexerConfig, PublisherConfig, RpcConfig};
+use mpc_chain_ethereum::EthConfig;
 use near_account_id::AccountId;
 use near_crypto::PublicKey;
 use serde_json::json;
@@ -76,10 +76,10 @@ async fn main() -> anyhow::Result<()> {
                     helios_data_path: eth_helios_data_path,
                     refresh_finalized_interval: eth_refresh_finalized_interval,
                     light_client: false,
-                    gas: GasConfig::default(),
-                    indexer: IndexerConfig::default(),
-                    publisher: PublisherConfig::default(),
-                    rpc: RpcConfig::default(),
+                    gas: Default::default(),
+                    indexer: Default::default(),
+                    publisher: Default::default(),
+                    rpc: Default::default(),
                 }),
                 ..Default::default()
             };

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -6,7 +6,7 @@ use std::vec;
 use clap::Parser;
 use integration_tests::cluster::spawner::ClusterSpawner;
 use integration_tests::NodeConfig;
-use mpc_chain_ethereum::EthConfig;
+use mpc_chain_ethereum::{EthConfig, GasConfig, IndexerConfig, PublisherConfig, RpcConfig};
 use near_account_id::AccountId;
 use near_crypto::PublicKey;
 use serde_json::json;
@@ -76,6 +76,10 @@ async fn main() -> anyhow::Result<()> {
                     helios_data_path: eth_helios_data_path,
                     refresh_finalized_interval: eth_refresh_finalized_interval,
                     light_client: false,
+                    gas: GasConfig::default(),
+                    indexer: IndexerConfig::default(),
+                    publisher: PublisherConfig::default(),
+                    rpc: RpcConfig::default(),
                 }),
                 ..Default::default()
             };

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -10,9 +10,7 @@ use integration_tests::eth;
 use k256::elliptic_curve::sec1::ToEncodedPoint as _;
 use k256::{AffinePoint, Scalar};
 use mpc_chain_ethereum::abi::ChainSignatures::{self, SignRequest};
-use mpc_chain_ethereum::{
-    EthConfig, EthereumStream, GasConfig, IndexerConfig, PublisherConfig, RpcConfig,
-};
+use mpc_chain_ethereum::{EthConfig, EthereumStream};
 use mpc_chain_integration_core::{ChainStream, ChainTelemetry, NoopChainTelemetry, StateManager};
 use mpc_crypto::kdf::generate_signature;
 use mpc_node::backlog::Backlog;
@@ -164,10 +162,10 @@ impl EthereumTestEnvironment {
             refresh_finalized_interval: 500,
             optimistic_requests,
             light_client: false,
-            gas: GasConfig::default(),
-            indexer: IndexerConfig::default(),
-            publisher: PublisherConfig::default(),
-            rpc: RpcConfig::default(),
+            gas: Default::default(),
+            indexer: Default::default(),
+            publisher: Default::default(),
+            rpc: Default::default(),
         }
     }
 

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -10,7 +10,9 @@ use integration_tests::eth;
 use k256::elliptic_curve::sec1::ToEncodedPoint as _;
 use k256::{AffinePoint, Scalar};
 use mpc_chain_ethereum::abi::ChainSignatures::{self, SignRequest};
-use mpc_chain_ethereum::{EthConfig, EthereumStream};
+use mpc_chain_ethereum::{
+    EthConfig, EthereumStream, GasConfig, IndexerConfig, PublisherConfig, RpcConfig,
+};
 use mpc_chain_integration_core::{ChainStream, ChainTelemetry, NoopChainTelemetry, StateManager};
 use mpc_crypto::kdf::generate_signature;
 use mpc_node::backlog::Backlog;
@@ -162,6 +164,10 @@ impl EthereumTestEnvironment {
             refresh_finalized_interval: 500,
             optimistic_requests,
             light_client: false,
+            gas: GasConfig::default(),
+            indexer: IndexerConfig::default(),
+            publisher: PublisherConfig::default(),
+            rpc: RpcConfig::default(),
         }
     }
 


### PR DESCRIPTION
- Remove 25 constants across various modules in `mpc-chain-ethereum`
- Introduce 4 new config structs: `RpcConfig`, `GasConfig`, `PublisherConfig`, `IndexerConfig`. All use original constant values as defaults
- Update constructors and wiring to use values from config structs