### PR TITLE
Remove contract-state handling from SignTask

### DIFF
--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -11,7 +11,7 @@ use crate::protocol::contract::primitives::intersect_vec;
 use crate::protocol::message::{MessageChannel, PositMessage, PositProtocolId, Subscriber};
 use crate::protocol::posit::{PositAction, PositRejectReason, SinglePositCounter};
 use crate::protocol::presignature::PresignatureId;
-use crate::protocol::{Chain, ProtocolState};
+use crate::protocol::Chain;
 use crate::rpc::{ContractStateWatcher, GovernanceInfo, RpcChannel};
 use crate::storage::presignature_storage::PresignatureReservation;
 use crate::storage::PresignatureStorage;
@@ -69,6 +69,13 @@ const SIGN_POSIT_INBOX_LABEL: &str = "sign_posit_inbox";
 /// so that late-arriving peer posit messages do not re-create orphan inboxes.
 const MAX_DEAD_IDS: usize = 4096;
 
+/// A retained in-flight request. `is_proposer` is shared with the current
+/// task incarnation and read by the deadline watcher.
+struct SignEntry {
+    request: IndexedSignRequest,
+    is_proposer: Arc<AtomicBool>,
+}
+
 /// Router and lifecycle owner for all in-flight sign tasks: one task per
 /// `sign_id`, plus the posit inboxes, delayed-response watchers, and dedup state
 /// that outlive individual tasks. (TODO: needs refactoring)
@@ -82,9 +89,8 @@ pub struct SignatureSpawner {
     posit_inboxes: HashMap<SignId, Subscriber<SignTaskMessage>>,
     /// Watchers that increment the delayed metric when response time exceeds expected.
     delayed_watchers: HashMap<SignId, JoinHandle<()>>,
-    /// In-flight requests by id: enables chain-scoped bulk abort and respawning
-    /// tasks on governance changes.
-    requests: HashMap<SignId, IndexedSignRequest>,
+    /// In-flight requests: enables chain-scoped abort and respawning.
+    requests: HashMap<SignId, SignEntry>,
     /// Recently completed/aborted sign IDs; prevents late peer posit messages from recreating orphan inboxes.
     dead_ids: LruCache<SignId, ()>,
     mesh_state: watch::Receiver<MeshState>,
@@ -102,8 +108,9 @@ impl SignatureSpawner {
         crate::metrics::requests::SIGN_QUEUE_SIZE.set(self.tasks.len() as i64);
     }
 
-    /// Spawn a signature task that internally handles the organize, posit, and generation phases.
-    fn spawn_task(
+    /// Admit a request: retain it, start its deadline watcher, and spawn its
+    /// task (held until `spawn_tasks` when governance is not running).
+    fn add_request(
         &mut self,
         governance: &GovernanceInfo,
         request: IndexedSignRequest,
@@ -113,8 +120,14 @@ impl SignatureSpawner {
         // Ensure we don't retain the dead tag from a prior incarnation of this
         // sign ID (e.g. after regression recovery re-queues a completed request).
         self.dead_ids.pop(&sign_id);
-        self.requests.insert(sign_id, request.clone());
-        tracing::info!(?sign_id, "spawning signature task");
+        let is_proposer = Arc::new(AtomicBool::new(false));
+        self.requests.insert(
+            sign_id,
+            SignEntry {
+                request: request.clone(),
+                is_proposer: Arc::clone(&is_proposer),
+            },
+        );
 
         // Watcher that increments the delayed metric if not completed within the expected response time.
         let chain = request.chain;
@@ -123,7 +136,6 @@ impl SignatureSpawner {
         let already_elapsed = crate::util::unix_elapsed(unix_timestamp_indexed);
         let remaining_time =
             Duration::from_secs(expected_response_time_secs).saturating_sub(already_elapsed);
-        let is_proposer = Arc::new(AtomicBool::new(false));
         // prevent incrementing delayed metric for already delayed requests
         if remaining_time > Duration::from_secs(0)
             && !matches!(request.kind, SignKind::Checkpoint(_))
@@ -148,6 +160,29 @@ impl SignatureSpawner {
             });
             self.delayed_watchers.insert(sign_id, watcher);
         }
+
+        if !governance.is_running {
+            tracing::info!(?sign_id, "holding sign request until governance is running");
+            return;
+        }
+        self.spawn_task(governance, request, cfg);
+    }
+
+    /// Spawn a task incarnation for an already-admitted request.
+    fn spawn_task(
+        &mut self,
+        governance: &GovernanceInfo,
+        request: IndexedSignRequest,
+        cfg: ProtocolConfig,
+    ) {
+        let sign_id = request.id;
+        tracing::info!(?sign_id, "spawning signature task");
+
+        let is_proposer = self
+            .requests
+            .get(&sign_id)
+            .map(|entry| Arc::clone(&entry.is_proposer))
+            .unwrap_or_default();
 
         // Subscribe to (or create) the posit inbox for this sign request
         let inbox = self
@@ -179,7 +214,6 @@ impl SignatureSpawner {
             rpc: self.rpc.clone(),
             backlog: self.backlog.clone(),
             cfg,
-            contract: self.contract.clone(),
             is_proposer,
             limiter: self.limiter.clone(),
             node_account_id: self.node_account_id.clone(),
@@ -190,6 +224,24 @@ impl SignatureSpawner {
             sign_id,
             task.run(request, self.mesh_state.clone(), posit_queue),
         );
+    }
+
+    /// Spawn a fresh incarnation for every retained request; the caller must
+    /// have aborted previous incarnations. Not a retirement: inboxes,
+    /// watchers, and dedup state survive.
+    fn spawn_tasks(&mut self, governance: &GovernanceInfo, cfg: &ProtocolConfig) {
+        let requests: Vec<IndexedSignRequest> = self
+            .requests
+            .values()
+            .map(|entry| entry.request.clone())
+            .collect();
+        tracing::info!(
+            count = requests.len(),
+            "respawning sign tasks under new governance"
+        );
+        for request in requests {
+            self.spawn_task(governance, request, cfg.clone());
+        }
     }
 
     /// Handle a posit message - routes to existing task or buffers if task not yet created
@@ -302,11 +354,8 @@ impl SignatureSpawner {
             SignCommand::Request(request) | SignCommand::Checkpoint(request) => {
                 let sign_id = request.id;
 
-                // Skip if we already have a task handling this request.
-                // Use tasks instead of inbox map since it may already contain buffered messages
-                // (e.g. a Propose arriving before the indexer notifies us), so we must only look
-                // at the task map to decide whether the request is truly a duplicate.
-                if self.tasks.contains_key(&sign_id) {
+                // Skip requests we already track
+                if self.requests.contains_key(&sign_id) {
                     tracing::info!(?sign_id, "skipping duplicate sign request");
                     return;
                 }
@@ -318,7 +367,7 @@ impl SignatureSpawner {
                     request.unix_timestamp_indexed,
                 );
 
-                self.spawn_task(governance, request, cfg.clone());
+                self.add_request(governance, request, cfg.clone());
             }
             SignCommand::AbortChain(chain) => {
                 tracing::warn!(
@@ -328,7 +377,7 @@ impl SignatureSpawner {
                 let to_abort: Vec<SignId> = self
                     .requests
                     .iter()
-                    .filter(|(_, request)| request.chain == chain)
+                    .filter(|(_, entry)| entry.request.chain == chain)
                     .map(|(id, _)| *id)
                     .collect();
                 for sign_id in to_abort {
@@ -377,6 +426,18 @@ impl SignatureSpawner {
                 }
                 Some(new_governance) = contract_watcher.next_governance(governance.clone()) => {
                     governance = new_governance;
+                    // A governance change invalidates every incarnation — even
+                    // running -> running: the watch coalesces fast transitions.
+                    self.tasks.abort_all();
+                    if governance.is_running {
+                        self.spawn_tasks(&governance, &protocol);
+                    } else {
+                        // Entries stay in `requests` and respawn once running again.
+                        tracing::info!(
+                            count = self.requests.len(),
+                            "governance not running; holding sign requests"
+                        );
+                    }
                 }
             }
         }
@@ -532,7 +593,7 @@ mod tests {
         let request = IndexedSignRequest::sign(sign_id, args, Chain::Solana, 0);
 
         // Step 1: Spawn → inbox created, request retained, not dead
-        spawner.spawn_task(&governance, request.clone(), cfg.clone());
+        spawner.add_request(&governance, request.clone(), cfg.clone());
         assert!(spawner.test_tasks_contains(sign_id));
         assert!(spawner.test_posit_inboxes_contains(&sign_id));
         assert!(spawner.test_requests_contains(&sign_id));
@@ -557,7 +618,7 @@ mod tests {
         assert!(!spawner.test_posit_inboxes_contains(&sign_id));
 
         // Step 4: Re-spawn → dead cleared, request retained again
-        spawner.spawn_task(&governance, request, cfg.clone());
+        spawner.add_request(&governance, request, cfg.clone());
         assert!(spawner.test_tasks_contains(sign_id));
         assert!(!spawner.test_dead_ids_contains(&sign_id));
 
@@ -571,5 +632,13 @@ mod tests {
             PositAction::Propose,
         );
         assert!(spawner.test_posit_inboxes_contains(&sign_id));
+
+        // Step 6: Governance respawn → task swapped in place, nothing retired.
+        spawner.tasks.abort_all();
+        spawner.spawn_tasks(&governance, &cfg);
+        assert!(spawner.test_tasks_contains(sign_id));
+        assert!(spawner.test_requests_contains(&sign_id));
+        assert!(spawner.test_posit_inboxes_contains(&sign_id));
+        assert!(!spawner.test_dead_ids_contains(&sign_id));
     }
 }

--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -182,7 +182,7 @@ impl SignatureSpawner {
             .requests
             .get(&sign_id)
             .map(|entry| Arc::clone(&entry.is_proposer))
-            .unwrap_or_default();
+            .expect("sign request entry must exist when spawning its task");
 
         // Subscribe to (or create) the posit inbox for this sign request
         let inbox = self

--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -374,10 +374,8 @@ impl SignatureSpawner {
                 Ok(()) = cfg.changed() => {
                     protocol = cfg.borrow().protocol.clone();
                 }
-                Some(state) = contract_watcher.next_state() => {
-                    if let Some(new_governance) = state.governance(&self.node_account_id) {
-                        governance = new_governance;
-                    }
+                Some(new_governance) = contract_watcher.next_governance(governance.clone()) => {
+                    governance = new_governance;
                 }
             }
         }

--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -82,8 +82,9 @@ pub struct SignatureSpawner {
     posit_inboxes: HashMap<SignId, Subscriber<SignTaskMessage>>,
     /// Watchers that increment the delayed metric when response time exceeds expected.
     delayed_watchers: HashMap<SignId, JoinHandle<()>>,
-    /// Maps in-flight tasks to their chain, enabling bulk abort on checkpoint regression.
-    task_chains: HashMap<SignId, Chain>,
+    /// In-flight requests by id: enables chain-scoped bulk abort and respawning
+    /// tasks on governance changes.
+    requests: HashMap<SignId, IndexedSignRequest>,
     /// Recently completed/aborted sign IDs; prevents late peer posit messages from recreating orphan inboxes.
     dead_ids: LruCache<SignId, ()>,
     mesh_state: watch::Receiver<MeshState>,
@@ -112,7 +113,7 @@ impl SignatureSpawner {
         // Ensure we don't retain the dead tag from a prior incarnation of this
         // sign ID (e.g. after regression recovery re-queues a completed request).
         self.dead_ids.pop(&sign_id);
-        self.task_chains.insert(sign_id, request.chain);
+        self.requests.insert(sign_id, request.clone());
         tracing::info!(?sign_id, "spawning signature task");
 
         // Watcher that increments the delayed metric if not completed within the expected response time.
@@ -280,7 +281,7 @@ impl SignatureSpawner {
     /// its delayed watcher. Does not touch `tasks` (aborting varies per caller).
     fn retire_task(&mut self, sign_id: SignId, reason: &str) {
         self.mark_dead(sign_id);
-        self.task_chains.remove(&sign_id);
+        self.requests.remove(&sign_id);
         if let Some(inbox) = self.posit_inboxes.remove(&sign_id) {
             inbox.clear_capacity_global();
         }
@@ -325,9 +326,9 @@ impl SignatureSpawner {
                     "aborting all in-flight signature tasks on chain regression"
                 );
                 let to_abort: Vec<SignId> = self
-                    .task_chains
+                    .requests
                     .iter()
-                    .filter(|(_, c)| **c == chain)
+                    .filter(|(_, request)| request.chain == chain)
                     .map(|(id, _)| *id)
                     .collect();
                 for sign_id in to_abort {
@@ -396,8 +397,8 @@ impl SignatureSpawner {
         self.tasks.contains_key(&sign_id)
     }
 
-    fn test_task_chains_contains(&self, sign_id: &SignId) -> bool {
-        self.task_chains.contains_key(sign_id)
+    fn test_requests_contains(&self, sign_id: &SignId) -> bool {
+        self.requests.contains_key(sign_id)
     }
 }
 
@@ -430,7 +431,7 @@ impl SignatureSpawnerTask {
             tasks: JoinMap::new(),
             posit_inboxes: HashMap::new(),
             delayed_watchers: HashMap::new(),
-            task_chains: HashMap::new(),
+            requests: HashMap::new(),
             dead_ids: LruCache::new(NonZeroUsize::new(MAX_DEAD_IDS).unwrap()),
             presignatures: presignature_storage,
             mesh_state,
@@ -509,7 +510,7 @@ mod tests {
             tasks: JoinMap::new(),
             posit_inboxes: HashMap::new(),
             delayed_watchers: HashMap::new(),
-            task_chains: HashMap::new(),
+            requests: HashMap::new(),
             dead_ids: LruCache::new(NonZeroUsize::new(MAX_DEAD_IDS).unwrap()),
             mesh_state: mesh_rx,
             limiter: SignLimiter::new(MAX_CONCURRENT_PROPOSERS),
@@ -530,18 +531,18 @@ mod tests {
         };
         let request = IndexedSignRequest::sign(sign_id, args, Chain::Solana, 0);
 
-        // Step 1: Spawn → inbox created, task_chains populated, not dead
+        // Step 1: Spawn → inbox created, request retained, not dead
         spawner.spawn_task(&governance, request.clone(), cfg.clone());
         assert!(spawner.test_tasks_contains(sign_id));
         assert!(spawner.test_posit_inboxes_contains(&sign_id));
-        assert!(spawner.test_task_chains_contains(&sign_id));
+        assert!(spawner.test_requests_contains(&sign_id));
         assert!(!spawner.test_dead_ids_contains(&sign_id));
 
-        // Step 2: Abort chain → inbox removed, task_chains cleared, marked dead
+        // Step 2: Abort chain → inbox removed, request dropped, marked dead
         spawner.handle_sign(&governance, SignCommand::AbortChain(Chain::Solana), &cfg);
         assert!(!spawner.test_tasks_contains(sign_id));
         assert!(!spawner.test_posit_inboxes_contains(&sign_id));
-        assert!(!spawner.test_task_chains_contains(&sign_id));
+        assert!(!spawner.test_requests_contains(&sign_id));
         assert!(spawner.test_dead_ids_contains(&sign_id));
 
         // Step 3: Late posit → dropped (dead_id check), inbox NOT recreated
@@ -555,7 +556,7 @@ mod tests {
         );
         assert!(!spawner.test_posit_inboxes_contains(&sign_id));
 
-        // Step 4: Re-spawn → dead cleared, task_chains repopulated
+        // Step 4: Re-spawn → dead cleared, request retained again
         spawner.spawn_task(&governance, request, cfg.clone());
         assert!(spawner.test_tasks_contains(sign_id));
         assert!(!spawner.test_dead_ids_contains(&sign_id));

--- a/chain-signatures/node/src/protocol/request/task.rs
+++ b/chain-signatures/node/src/protocol/request/task.rs
@@ -183,7 +183,6 @@ pub struct SignTask {
     pub rpc: RpcChannel,
     pub backlog: Backlog,
     pub cfg: ProtocolConfig,
-    pub contract: ContractStateWatcher,
     pub is_proposer: Arc<AtomicBool>,
     pub limiter: SignLimiter,
     pub node_account_id: near_account_id::AccountId,
@@ -202,10 +201,6 @@ impl SignTask {
 
         let mut state = SignState::new(request, mesh_state);
         let mut phase = SignPhase::Organizing(OrganizingPhase);
-        let mut contract_watcher = self.contract.clone();
-
-        // If started during resharing, we won't advance until back in running state.
-        let mut is_running = self.governance.is_running;
 
         // Sum per-phase time across loop attempts; emit on Complete(Ok) only.
         let mut durations = PhaseDurations::default();
@@ -219,68 +214,26 @@ impl SignTask {
                 SignPhase::Complete(_) => None,
             };
 
-            tokio::select! {
-                Some(contract_state) = contract_watcher.next_state() => {
-                    // `phase.advance` was cancelled. Attribute its partial
-                    // elapsed time only if `is_running` was true; otherwise
-                    // the branch was gated off and the iteration was idle.
-                    if is_running {
-                        if let Some(step) = current_phase_step {
-                            durations.add(step, phase_start.elapsed());
-                        }
-                    }
-                    is_running = self.refresh_governance(&contract_state);
-                    if is_running {
-                        // Back in running; the interrupted attempt is abandoned and we
-                        // retry with a fresh round, like any other failed attempt.
-                        phase = state.reorganize();
-                    } else {
-                        tracing::info!(
-                            ?sign_id,
-                            gov = ?self.governance,
-                            "signature task paused waiting for running governance"
-                        );
-                    }
+            let new_phase = phase.advance(&mut self, &mut state, &posit_queue).await;
+            if let Some(step) = current_phase_step {
+                durations.add(step, phase_start.elapsed());
+                if matches!(&new_phase, SignPhase::Organizing(_)) {
+                    SIGN_REQUEST_LOOPS
+                        .with_label_values(&[state.request().chain.as_str(), step.as_str()])
+                        .inc();
                 }
-                // This branch in tokio::select will get cancelled since the future for next contract
-                // state is reached first. This effectively pauses this branch from executing and
-                // further advancing the signature organization/positing/generation flow.
-                new_phase = phase.advance(&mut self, &mut state, &posit_queue), if is_running => {
-                    if let Some(step) = current_phase_step {
-                        durations.add(step, phase_start.elapsed());
-                        if matches!(&new_phase, SignPhase::Organizing(_)) {
-                            SIGN_REQUEST_LOOPS
-                                .with_label_values(&[
-                                    state.request().chain.as_str(),
-                                    step.as_str(),
-                                ])
-                                .inc();
-                        }
-                    }
+            }
 
-                    match new_phase {
-                        SignPhase::Complete(result) => {
-                            if result.is_ok() {
-                                durations.emit(state.request().chain);
-                            }
-                            return result;
-                        }
-                        new_phase => phase = new_phase,
+            match new_phase {
+                SignPhase::Complete(result) => {
+                    if result.is_ok() {
+                        durations.emit(state.request().chain);
                     }
+                    return result;
                 }
-            };
+                new_phase => phase = new_phase,
+            }
         }
-    }
-
-    /// Refresh the governance info from the contract state, returning whether we are
-    /// in a running state with valid governance info after the refresh.
-    fn refresh_governance(&mut self, contract_state: &ProtocolState) -> bool {
-        if let Some(governance) = contract_state.governance(&self.node_account_id) {
-            self.governance = governance;
-        } else {
-            self.governance.is_running = false;
-        }
-        self.governance.is_running
     }
 
     /// Snapshot the fields the generation protocol needs.
@@ -293,101 +246,5 @@ impl SignTask {
             cfg: self.cfg.clone(),
             node_account_id: self.node_account_id.clone(),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::protocol::contract::primitives::{ParticipantInfo, Participants};
-    use crate::protocol::contract::{ResharingContractState, RunningContractState};
-    use crate::protocol::presignature::Presignature;
-    use crate::protocol::ProtocolState;
-    use deadpool_redis::Runtime;
-
-    #[test]
-    fn sign_task_refreshes_and_pauses_on_resharing() {
-        let account_id: near_account_id::AccountId = "p-0".parse().unwrap();
-        let mut participants = Participants::default();
-        participants.insert(&Participant::from(0), ParticipantInfo::new(0));
-
-        let governance = GovernanceInfo {
-            me: Participant::from(0),
-            threshold: 1,
-            epoch: 0,
-            public_key: k256::AffinePoint::default(),
-            participants: [Participant::from(0)].into_iter().collect(),
-            is_running: true,
-        };
-
-        let redis_cfg = deadpool_redis::Config::from_url("redis://127.0.0.1/");
-        let pool = redis_cfg.create_pool(Some(Runtime::Tokio1)).unwrap();
-        let presignatures = Presignature::storage(&pool, &account_id);
-        let (_inbox, _outbox, msg_channel) = MessageChannel::new();
-        let (rpc_tx, _rpc_rx) = mpsc::channel(1);
-        let rpc_channel = RpcChannel { tx: rpc_tx };
-        let (contract, _tx) = ContractStateWatcher::with_running(
-            &account_id,
-            k256::AffinePoint::default(),
-            1,
-            participants.clone(),
-        );
-
-        let mut sign_task = SignTask {
-            governance: governance.clone(),
-            sign_id: SignId::new([0u8; 32]),
-            presignatures,
-            msg: msg_channel,
-            rpc: rpc_channel,
-            backlog: Backlog::new(),
-            cfg: ProtocolConfig::default(),
-            contract,
-            is_proposer: Arc::new(AtomicBool::new(false)),
-            limiter: SignLimiter::new(1),
-            node_account_id: account_id.clone(),
-        };
-
-        let initial = RunningContractState {
-            epoch: 0,
-            public_key: k256::AffinePoint::default(),
-            participants: participants.clone(),
-            candidates: Default::default(),
-            join_votes: Default::default(),
-            leave_votes: Default::default(),
-            threshold: 1,
-        };
-        assert!(sign_task.refresh_governance(&ProtocolState::Running(initial)));
-        assert_eq!(sign_task.governance.epoch, 0);
-        assert_eq!(sign_task.governance.threshold, 1);
-        assert_eq!(sign_task.governance.me, Participant::from(0));
-
-        let resharing = ResharingContractState {
-            old_epoch: 0,
-            old_participants: participants.clone(),
-            new_participants: participants.clone(),
-            threshold: 1,
-            new_threshold: 1,
-            public_key: k256::AffinePoint::default(),
-            finished_votes: Default::default(),
-            cancel_votes: Default::default(),
-        };
-
-        // refreshing here should yield false where we are no longer in running.
-        assert!(!sign_task.refresh_governance(&ProtocolState::Resharing(resharing)));
-
-        let running = RunningContractState {
-            epoch: 1,
-            public_key: k256::AffinePoint::default(),
-            participants,
-            candidates: Default::default(),
-            join_votes: Default::default(),
-            leave_votes: Default::default(),
-            threshold: 1,
-        };
-
-        assert!(sign_task.refresh_governance(&ProtocolState::Running(running)));
-        assert_eq!(sign_task.governance.epoch, 1);
-        assert_eq!(sign_task.governance.threshold, 1);
-        assert_eq!(sign_task.governance.me, Participant::from(0));
     }
 }

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -190,6 +190,26 @@ impl ContractStateWatcher {
         self.contract_state.borrow_and_update().clone()
     }
 
+    pub async fn next_governance(&mut self, current: GovernanceInfo) -> Option<GovernanceInfo> {
+        loop {
+            if self.contract_state.changed().await.is_err() {
+                return None;
+            }
+            let Some(state) = self.contract_state.borrow_and_update().clone() else {
+                continue;
+            };
+            let next = state.governance(&self.account_id).unwrap_or_else(|| {
+                let mut stale = current.clone();
+                stale.is_running = false;
+                stale
+            });
+            if next != current {
+                tracing::info!(old = ?current, new = ?next, "signing governance changed");
+                return Some(next);
+            }
+        }
+    }
+
     pub fn mark_changed(&mut self) {
         self.contract_state.mark_changed();
     }
@@ -523,6 +543,70 @@ mod tests {
     use cait_sith::protocol::Participant;
     use mpc_chain_integration_core::utils::test::make_publish_action;
     use mpc_primitives::SignKind;
+
+    /// Vote churn must be absorbed without completing; real governance changes
+    /// and leaving the running state must be delivered.
+    #[tokio::test]
+    async fn next_governance_filters_non_governance_changes() {
+        let account_id: AccountId = "p-0".parse().unwrap();
+        let mut participants = Participants::default();
+        participants.insert(&Participant::from(0), ParticipantInfo::new(0));
+        let (mut watcher, tx) = ContractStateWatcher::with_running(
+            &account_id,
+            k256::AffinePoint::default(),
+            1,
+            participants.clone(),
+        );
+        let governance = watcher.governance().unwrap();
+
+        let running = |epoch, join_votes| RunningContractState {
+            epoch,
+            public_key: k256::AffinePoint::default(),
+            participants: participants.clone(),
+            candidates: Default::default(),
+            join_votes,
+            leave_votes: Default::default(),
+            threshold: 1,
+        };
+
+        // Vote churn: state changed, governance content did not.
+        let churn = crate::protocol::contract::primitives::Votes {
+            votes: [("p-1".parse().unwrap(), Default::default())].into(),
+        };
+        tx.send(Some(ProtocolState::Running(running(0, churn))))
+            .unwrap();
+        let pending = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            watcher.next_governance(governance.clone()),
+        )
+        .await;
+        assert!(pending.is_err(), "vote churn must not wake next_governance");
+
+        // Epoch bump: a real governance change is delivered.
+        tx.send(Some(ProtocolState::Running(running(1, Default::default()))))
+            .unwrap();
+        let next = watcher.next_governance(governance.clone()).await.unwrap();
+        assert_eq!(next.epoch, 1);
+
+        // Leaving the running state is reported as is_running = false.
+        let resharing = ResharingContractState {
+            old_epoch: 1,
+            old_participants: participants.clone(),
+            new_participants: participants.clone(),
+            threshold: 1,
+            new_threshold: 1,
+            public_key: k256::AffinePoint::default(),
+            finished_votes: Default::default(),
+            cancel_votes: Default::default(),
+        };
+        tx.send(Some(ProtocolState::Resharing(resharing))).unwrap();
+        let next = watcher.next_governance(next).await.unwrap();
+        assert!(!next.is_running);
+
+        // Channel closed.
+        drop(tx);
+        assert!(watcher.next_governance(next).await.is_none());
+    }
 
     /// A publisher that counts the number of times it has been called.
     struct CountingPublisher {

--- a/chain-signatures/node/src/util/mod.rs
+++ b/chain-signatures/node/src/util/mod.rs
@@ -129,6 +129,14 @@ impl<T, U> JoinMap<T, U> {
     pub fn is_empty(&self) -> bool {
         self.tasks.is_empty()
     }
+
+    pub fn abort_all(&mut self) {
+        for handle in self.mapping.values() {
+            handle.abort();
+        }
+        self.mapping.clear();
+        self.mapping_id.clear();
+    }
 }
 
 impl<T, U> JoinMap<T, U>


### PR DESCRIPTION
- Removed contract-state handling from SignTask. Such lightweight, short-lived tasks should not be aware of it. I'm also thinking about recreating the whole SignatureSpawner, not to track contract state there as well; happy to get your opinion.
- SignTasks are recreated on `not_running => running` and killed on `running => not_running`
- Added `next_governance()` to avoid triggering Spawner without a good reason