### PR TITLE
refactor: enhance `EthConfig`

### DIFF
--- a/chain-signatures/chain-ethereum/examples/bench_catchup.rs
+++ b/chain-signatures/chain-ethereum/examples/bench_catchup.rs
@@ -63,12 +63,17 @@ fn env_bool(name: &str, default: bool) -> anyhow::Result<bool> {
 
 fn make_config() -> anyhow::Result<EthConfig> {
     Ok(EthConfig {
-        account_sk: String::new(),
+        // The bench only indexes; the signer is never used.
+        account_sk: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            .parse()
+            .unwrap(),
         consensus_rpc_http_url: String::new(),
-        execution_rpc_http_url: opt_env("RPC_URL")?,
+        execution_rpc_http_url: opt_env("RPC_URL")?
+            .parse()
+            .map_err(|e| anyhow!("invalid RPC_URL: {e}"))?,
         contract_address: opt_env("CONTRACT_ADDRESS")?
-            .trim_start_matches("0x")
-            .to_string(),
+            .parse()
+            .map_err(|e| anyhow!("invalid CONTRACT_ADDRESS: {e}"))?,
         network: std::env::var("NETWORK").unwrap_or_else(|_| "sepolia".to_string()),
         helios_data_path: "/tmp/helios-bench".to_string(),
         refresh_finalized_interval: 1,

--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -209,7 +209,7 @@ impl EthereumClient {
             }
         } else {
             EthereumClientInner::DirectRpc(indexer_eth_direct_rpc::RpcEthereumClient::new(
-                &eth.execution_rpc_http_url,
+                eth.execution_rpc_http_url,
             ))
         };
 

--- a/chain-signatures/chain-ethereum/src/config.rs
+++ b/chain-signatures/chain-ethereum/src/config.rs
@@ -1,4 +1,7 @@
+use alloy::primitives::Address;
+use alloy_signer_local::PrivateKeySigner;
 use mpc_chain_integration_core::utils::retry::RetryConfig;
+use reqwest::Url;
 use std::fmt;
 use std::time::Duration;
 
@@ -149,13 +152,13 @@ impl Default for IndexerConfig {
 #[derive(Clone)]
 pub struct EthConfig {
     /// The ethereum account secret key used to sign eth respond txn.
-    pub account_sk: String,
+    pub account_sk: PrivateKeySigner,
     /// Ethereum consensus HTTP RPC URL
     pub consensus_rpc_http_url: String,
     /// Ethereum execution HTTP RPC URL
-    pub execution_rpc_http_url: String,
-    /// The contract address to watch without the `0x` prefix
-    pub contract_address: String,
+    pub execution_rpc_http_url: Url,
+    /// The contract address to watch
+    pub contract_address: Address,
     /// must be one of sepolia, mainnet
     pub network: String,
     /// path to store helios data
@@ -176,11 +179,7 @@ pub struct EthConfig {
 impl EthConfig {
     /// Ethereum address derived from the configured account secret key.
     pub fn signer_address(&self) -> String {
-        let signer: alloy_signer_local::PrivateKeySigner = self
-            .account_sk
-            .parse()
-            .expect("cannot parse Eth account sk");
-        signer.address().to_string()
+        self.account_sk.address().to_string()
     }
 }
 

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -19,7 +19,6 @@ use mpc_primitives::{
     SignId,
 };
 use std::collections::HashSet;
-use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Notify};
@@ -88,10 +87,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         events_tx: mpsc::Sender<ChainEvent>,
     ) -> anyhow::Result<Self> {
         let client = Arc::new(EthereumClient::new(eth.clone()).await?);
-        let contract_address = format!("0x{}", eth.contract_address);
-        let contract_address = Address::from_str(&contract_address).with_context(|| {
-            format!("failed to parse ethereum contract address: {contract_address}")
-        })?;
+        let contract_address = eth.contract_address;
 
         Ok(Self {
             eth,
@@ -1241,7 +1237,7 @@ mod tests {
         let (mut indexer, mut events_rx) =
             test_utils::TestIndexerBuilder::new("http://127.0.0.1:1")
                 .client_url("http://127.0.0.1:1")
-                .rpc_urls("", "")
+                .rpc_urls("", "http://127.0.0.1:1")
                 .build_with_rx()
                 .await;
 

--- a/chain-signatures/chain-ethereum/src/indexer_eth_direct_rpc.rs
+++ b/chain-signatures/chain-ethereum/src/indexer_eth_direct_rpc.rs
@@ -21,15 +21,15 @@ pub const MAX_CATCHUP_BLOCKS: u64 = u64::MAX;
 #[derive(Clone)]
 pub struct RpcEthereumClient {
     http: reqwest::Client,
-    url: String,
+    url: reqwest::Url,
     id: Arc<AtomicU64>,
 }
 
 impl RpcEthereumClient {
-    pub fn new(endpoint: &str) -> Self {
+    pub fn new(url: reqwest::Url) -> Self {
         Self {
             http: reqwest::Client::new(),
-            url: endpoint.to_owned(),
+            url,
             id: Arc::new(AtomicU64::new(1)),
         }
     }
@@ -242,7 +242,12 @@ impl RpcEthereumClient {
             "params": params,
         });
 
-        let response = self.http.post(&self.url).json(&request).send().await?;
+        let response = self
+            .http
+            .post(self.url.clone())
+            .json(&request)
+            .send()
+            .await?;
         let response = ensure_http_success(response, &format!("rpc {method}")).await?;
         let value: serde_json::Value = response.json().await?;
 
@@ -279,7 +284,12 @@ impl RpcEthereumClient {
         let payload: Vec<serde_json::Value> = requests.into_iter().map(|(_, body)| body).collect();
 
         // Send the batch request and parse the response. The response is expected to be an array of JSON-RPC response objects.
-        let response = self.http.post(&self.url).json(&payload).send().await?;
+        let response = self
+            .http
+            .post(self.url.clone())
+            .json(&payload)
+            .send()
+            .await?;
         let response = ensure_http_success(response, "batch rpc").await?;
         let value: serde_json::Value = response.json().await?;
         let items = if let serde_json::Value::Array(items) = value {
@@ -533,7 +543,7 @@ mod tests {
     #[tokio::test]
     async fn get_blocks_keeps_request_order_when_rpc_responses_are_reordered() {
         let mut server = Server::new_async().await;
-        let client = RpcEthereumClient::new(&server.url());
+        let client = RpcEthereumClient::new(server.url().parse().unwrap());
         let block_ids = vec![
             BlockId::Number(BlockNumberOrTag::Number(7)),
             BlockId::Number(BlockNumberOrTag::Number(8)),
@@ -619,7 +629,7 @@ mod tests {
     #[tokio::test]
     async fn get_logs_issues_address_filtered_eth_getlogs_for_number() {
         let mut server = Server::new_async().await;
-        let client = RpcEthereumClient::new(&server.url());
+        let client = RpcEthereumClient::new(server.url().parse().unwrap());
         let addr = Address::with_last_byte(0x42);
 
         server
@@ -647,7 +657,7 @@ mod tests {
     #[tokio::test]
     async fn get_logs_empty_array_maps_to_empty_vec() {
         let mut server = Server::new_async().await;
-        let client = RpcEthereumClient::new(&server.url());
+        let client = RpcEthereumClient::new(server.url().parse().unwrap());
         let addr = Address::with_last_byte(0x07);
 
         server
@@ -670,7 +680,7 @@ mod tests {
     #[tokio::test]
     async fn get_logs_uses_block_hash_filter_for_hash_block_id() {
         let mut server = Server::new_async().await;
-        let client = RpcEthereumClient::new(&server.url());
+        let client = RpcEthereumClient::new(server.url().parse().unwrap());
         let addr = Address::with_last_byte(0x99);
         let block_hash = B256::with_last_byte(0xab);
 
@@ -697,7 +707,7 @@ mod tests {
     #[tokio::test]
     async fn get_logs_batch_preserves_request_order_when_responses_reordered() {
         let mut server = Server::new_async().await;
-        let client = RpcEthereumClient::new(&server.url());
+        let client = RpcEthereumClient::new(server.url().parse().unwrap());
         let addr = Address::with_last_byte(0x42);
         let block_ids = vec![
             BlockId::Number(BlockNumberOrTag::Number(10)),
@@ -741,7 +751,7 @@ mod tests {
     #[tokio::test]
     async fn get_transaction_receipt_returns_receipt_for_mined_tx() {
         let mut server = Server::new_async().await;
-        let client = RpcEthereumClient::new(&server.url());
+        let client = RpcEthereumClient::new(server.url().parse().unwrap());
         let tx_hash = B256::with_last_byte(0x42);
 
         server
@@ -775,7 +785,7 @@ mod tests {
     #[tokio::test]
     async fn get_transaction_receipt_returns_none_on_null_result() {
         let mut server = Server::new_async().await;
-        let client = RpcEthereumClient::new(&server.url());
+        let client = RpcEthereumClient::new(server.url().parse().unwrap());
         let tx_hash = B256::with_last_byte(0x07);
 
         server

--- a/chain-signatures/chain-ethereum/src/indexer_eth_helios.rs
+++ b/chain-signatures/chain-ethereum/src/indexer_eth_helios.rs
@@ -254,7 +254,7 @@ pub async fn build_client(eth: EthConfig) -> anyhow::Result<HeliosEthereumClient
         .network(network)
         .consensus_rpc(&eth.consensus_rpc_http_url)
         .map_err(|err| anyhow::anyhow!("failed to build consensus rpc: {err:?}"))?
-        .execution_rpc(&eth.execution_rpc_http_url)
+        .execution_rpc(eth.execution_rpc_http_url.as_str())
         .map_err(|err| anyhow::anyhow!("failed to build execution rpc: {err:?}"))?
         .data_dir(PathBuf::from(&eth.helios_data_path))
         .with_file_db()

--- a/chain-signatures/chain-ethereum/src/publisher.rs
+++ b/chain-signatures/chain-ethereum/src/publisher.rs
@@ -2,7 +2,7 @@ use crate::abi::ChainSignatures;
 use crate::config::{GasConfig, PublisherConfig};
 use crate::EthConfig;
 use alloy::network::EthereumWallet;
-use alloy::primitives::{Address, B256, U256};
+use alloy::primitives::{B256, U256};
 use alloy::providers::{
     fillers::{
         BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller, WalletFiller,
@@ -10,14 +10,12 @@ use alloy::providers::{
     Provider, ProviderBuilder, RootProvider, WalletProvider,
 };
 use alloy::rpc::types::TransactionReceipt;
-use alloy_signer_local::PrivateKeySigner;
 use k256::elliptic_curve::{point::AffineCoordinates, sec1::ToEncodedPoint};
 use mpc_chain_integration_core::{
     utils::retry::retry_rpc, ChainPublisher, PublishAction, PublisherTelemetry,
 };
 use mpc_primitives::{SignId, Signature};
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
@@ -65,18 +63,12 @@ pub struct EthClient {
 
 impl EthClient {
     pub fn new(eth: &EthConfig, telemetry: Arc<dyn PublisherTelemetry>) -> Self {
-        let signer: PrivateKeySigner = eth
-            .account_sk
-            .parse()
-            .expect("cannot parse Eth account sk into PrivateKeySigner");
-        let wallet = EthereumWallet::from(signer.clone());
+        let wallet = EthereumWallet::from(eth.account_sk.clone());
         let provider = ProviderBuilder::new()
             .wallet(wallet)
-            .connect_http(eth.execution_rpc_http_url.parse().unwrap());
+            .connect_http(eth.execution_rpc_http_url.clone());
 
-        // Build the contract instance
-        let address = Address::from_str(&format!("0x{}", eth.contract_address)).unwrap();
-        let contract = ChainSignatures::new(address, provider);
+        let contract = ChainSignatures::new(eth.contract_address, provider);
 
         let (batch_tx, batch_rx) = mpsc::channel(eth.publisher.channel_capacity);
 
@@ -328,7 +320,7 @@ impl ChainPublisher for EthClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::primitives::{B256, U256};
+    use alloy::primitives::{Address, B256, U256};
     use k256::{AffinePoint, Scalar};
     use mockito::{Matcher, Server};
     use mpc_chain_integration_core::NoopPublisherTelemetry;
@@ -341,9 +333,10 @@ mod tests {
     fn mock_config(url: &str) -> EthConfig {
         EthConfig {
             account_sk: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-                .to_string(),
-            execution_rpc_http_url: url.to_string(),
-            contract_address: "1234567890123456789012345678901234567890".to_string(),
+                .parse()
+                .unwrap(),
+            execution_rpc_http_url: url.parse().unwrap(),
+            contract_address: "1234567890123456789012345678901234567890".parse().unwrap(),
             consensus_rpc_http_url: "".to_string(),
             network: "sepolia".to_string(),
             helios_data_path: "".to_string(),

--- a/chain-signatures/chain-ethereum/src/test_utils.rs
+++ b/chain-signatures/chain-ethereum/src/test_utils.rs
@@ -8,6 +8,13 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
 
+/// Dummy signer for tests; the read-side client never signs.
+fn test_signer() -> alloy_signer_local::PrivateKeySigner {
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        .parse()
+        .unwrap()
+}
+
 /// Default refresh interval (ms) used by `IndexerBuilder` unless overridden.
 const DEFAULT_REFRESH_FINALIZED_INTERVAL: u64 = 100;
 
@@ -22,11 +29,11 @@ pub async fn create_test_ethereum_client(url: &str) -> EthereumClient {
     };
 
     let eth = EthConfig {
-        execution_rpc_http_url: url.to_string(),
+        execution_rpc_http_url: url.parse().unwrap(),
         light_client: false,
-        account_sk: "".to_string(),
+        account_sk: test_signer(),
         consensus_rpc_http_url: "".to_string(),
-        contract_address: "".to_string(),
+        contract_address: Address::ZERO,
         network: "".to_string(),
         helios_data_path: "".to_string(),
         refresh_finalized_interval: 0,
@@ -61,10 +68,10 @@ impl TestIndexerBuilder {
         Self {
             server_url: server_url.clone(),
             eth: EthConfig {
-                account_sk: String::new(),
+                account_sk: test_signer(),
                 consensus_rpc_http_url: server_url.clone(),
-                execution_rpc_http_url: server_url.clone(),
-                contract_address: format!("{:x}", Address::ZERO),
+                execution_rpc_http_url: server_url.parse().unwrap(),
+                contract_address: Address::ZERO,
                 network: "sepolia".to_string(),
                 helios_data_path: "/tmp/helios-test".to_string(),
                 refresh_finalized_interval: DEFAULT_REFRESH_FINALIZED_INTERVAL,
@@ -84,16 +91,16 @@ impl TestIndexerBuilder {
     /// `EthereumClient`)
     pub fn client_url(mut self, url: impl Into<String>) -> Self {
         let url = url.into();
-        self.eth.execution_rpc_http_url = url.clone();
+        self.eth.execution_rpc_http_url = url.parse().unwrap();
         self.server_url = url;
         self
     }
 
-    /// Override both RPC URLs (e.g. empty strings) — only changes config, not
-    /// the client build URL.
+    /// Override both RPC URLs (e.g. empty consensus URL) — only changes
+    /// config, not the client build URL.
     pub fn rpc_urls(mut self, consensus: impl Into<String>, execution: impl Into<String>) -> Self {
         self.eth.consensus_rpc_http_url = consensus.into();
-        self.eth.execution_rpc_http_url = execution.into();
+        self.eth.execution_rpc_http_url = execution.into().parse().unwrap();
         self
     }
 

--- a/chain-signatures/node/src/cli/args/ethereum.rs
+++ b/chain-signatures/node/src/cli/args/ethereum.rs
@@ -1,3 +1,4 @@
+use anyhow::Context as _;
 use mpc_chain_ethereum::EthConfig;
 use secrecy::{ExposeSecret, SecretString};
 
@@ -119,7 +120,7 @@ impl EthArgs {
         args
     }
 
-    pub fn into_config(self) -> Option<EthConfig> {
+    pub fn into_config(self) -> anyhow::Result<Option<EthConfig>> {
         #[cfg(not(feature = "helios"))]
         if self.eth_light_client {
             tracing::warn!(
@@ -134,11 +135,30 @@ impl EthArgs {
                  reorg-safe; this flag is intended for dev/demo use only"
             );
         }
-        Some(EthConfig {
-            account_sk: self.eth_account_sk?.expose_secret().to_string(), // this is safe because  EthConfig has custom Debug implementation that redacts the account_sk field
+
+        let Some(account_sk) = self.eth_account_sk else {
+            return Ok(None);
+        };
+        let account_sk = account_sk
+            .expose_secret()
+            .parse()
+            .context("invalid eth account sk")?;
+        let execution_rpc_http_url = self
+            .eth_execution_rpc_http_url
+            .context("eth execution rpc http url is required")?
+            .parse()
+            .context("invalid eth execution rpc http url")?;
+        let contract_address = self
+            .eth_contract_address
+            .context("eth contract address is required")?
+            .parse()
+            .context("invalid eth contract address")?;
+
+        Ok(Some(EthConfig {
+            account_sk, // this is safe because EthConfig has custom Debug implementation that redacts the account_sk field
             consensus_rpc_http_url: self.eth_consensus_rpc_http_url.unwrap_or_default(),
-            execution_rpc_http_url: self.eth_execution_rpc_http_url?,
-            contract_address: self.eth_contract_address?,
+            execution_rpc_http_url,
+            contract_address,
             optimistic_requests: self.eth_optimistic_requests || network == "anvil", // anvil never reports finalized blocks, so requests are emitted without waiting for finality
             network,
             helios_data_path: self.eth_helios_data_path.unwrap_or_default(),
@@ -153,16 +173,18 @@ impl EthArgs {
             gas: Default::default(),
             publisher: Default::default(),
             indexer: Default::default(),
-        })
+        }))
     }
 
     pub fn from_config(config: Option<EthConfig>) -> Self {
         match config {
-            Some(config) if !config.account_sk.is_empty() => Self {
-                eth_account_sk: Some(config.account_sk.into()),
+            Some(config) => Self {
+                eth_account_sk: Some(
+                    format!("{:x}", config.account_sk.credential().to_bytes()).into(),
+                ),
                 eth_consensus_rpc_http_url: Some(config.consensus_rpc_http_url),
-                eth_execution_rpc_http_url: Some(config.execution_rpc_http_url),
-                eth_contract_address: Some(config.contract_address),
+                eth_execution_rpc_http_url: Some(config.execution_rpc_http_url.to_string()),
+                eth_contract_address: Some(format!("{:x}", config.contract_address)),
                 eth_network: Some(config.network),
                 eth_helios_data_path: Some(config.helios_data_path),
                 eth_refresh_finalized_interval: config.refresh_finalized_interval,

--- a/chain-signatures/node/src/cli/args/ethereum.rs
+++ b/chain-signatures/node/src/cli/args/ethereum.rs
@@ -14,7 +14,7 @@ pub struct EthArgs {
         requires_all = ["eth_execution_rpc_http_url", "eth_contract_address"]
     )]
     pub eth_account_sk: Option<SecretString>,
-    /// The contract address to watch without the `0x` prefix
+    /// The contract address to watch, with or without the `0x` prefix
     #[clap(long, env("MPC_ETH_CONTRACT_ADDRESS"), requires = "eth_account_sk")]
     pub eth_contract_address: Option<String>,
 
@@ -179,12 +179,10 @@ impl EthArgs {
     pub fn from_config(config: Option<EthConfig>) -> Self {
         match config {
             Some(config) => Self {
-                eth_account_sk: Some(
-                    format!("{:x}", config.account_sk.credential().to_bytes()).into(),
-                ),
+                eth_account_sk: Some(hex::encode(config.account_sk.credential().to_bytes()).into()),
                 eth_consensus_rpc_http_url: Some(config.consensus_rpc_http_url),
                 eth_execution_rpc_http_url: Some(config.execution_rpc_http_url.to_string()),
-                eth_contract_address: Some(format!("{:x}", config.contract_address)),
+                eth_contract_address: Some(config.contract_address.to_string()),
                 eth_network: Some(config.network),
                 eth_helios_data_path: Some(config.helios_data_path),
                 eth_refresh_finalized_interval: config.refresh_finalized_interval,

--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -282,7 +282,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 synced_peer_tx,
             } = MeshHandles::new(message_options, mesh_options, &account_id);
 
-            let chains = ChainConfigs::from_args(eth, sol, hydration, canton);
+            let chains = ChainConfigs::from_args(eth, sol, hydration, canton)?;
             let network = NetworkConfig { cipher_sk, sign_sk };
             let signer = InMemorySigner::from_secret_key(account_id.clone(), account_sk);
 
@@ -469,13 +469,18 @@ struct ChainConfigs {
 }
 
 impl ChainConfigs {
-    fn from_args(eth: EthArgs, sol: SolArgs, hydration: HydrationArgs, canton: CantonArgs) -> Self {
-        Self {
-            eth: eth.into_config(),
+    fn from_args(
+        eth: EthArgs,
+        sol: SolArgs,
+        hydration: HydrationArgs,
+        canton: CantonArgs,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            eth: eth.into_config()?,
             sol: sol.into_config(),
             hydration: hydration.into_config(),
             canton: canton.into_config(),
-        }
+        })
     }
 
     /// Build the registry of chain publishers, keyed by chain. NEAR is always present;
@@ -545,7 +550,7 @@ fn log_startup(
         git_commit_hash = %crate::metrics::git_commit_hash(),
         sign_pk = %network.sign_sk.public_key(),
         near_rpc_url = %near_client.rpc_addr(),
-        eth_contract_address = %chains.eth.as_ref().map(|c| c.contract_address.as_str()).unwrap_or("None"),
+        eth_contract_address = %chains.eth.as_ref().map(|c| c.contract_address.to_string()).unwrap_or_else(|| "None".to_string()),
         eth_signer_address = %eth_signer_address.as_deref().unwrap_or("None"),
         sol_program_address = %chains.sol.as_ref().map(|c| c.program_address.as_str()).unwrap_or("None"),
         sol_rpc_url = %chains.sol.as_ref().map(|c| c.rpc_http_url.as_str()).unwrap_or("None"),

--- a/integration-tests/src/actions/sign.rs
+++ b/integration-tests/src/actions/sign.rs
@@ -12,7 +12,6 @@ use alloy::signers::local::PrivateKeySigner;
 use alloy::sol_types::SolEvent;
 use anchor_client::anchor_lang::{AnchorDeserialize, Discriminator};
 use anchor_client::{Client, Cluster as AnchorCluster};
-use anyhow::Context as _;
 use cait_sith::FullSignature;
 use elliptic_curve::sec1::FromEncodedPoint;
 use futures::StreamExt;
@@ -908,7 +907,7 @@ fn parse_sol_signature(
 /// Ethereum contract signature request outcome
 pub struct EthSignOutcome {
     pub signer_address: Address,
-    pub contract_address: String,
+    pub contract_address: Address,
     pub eth_tx_hash: Option<String>,
     pub deposit_amount: u64,
     pub signature: FullSignature<Secp256k1>,
@@ -939,7 +938,7 @@ impl fmt::Debug for EthSignOutcome {
 /// ETH contract signature request builder
 pub struct EthSignAction<'a> {
     sign_action: SignAction<'a>,
-    contract_addr: String,
+    contract_addr: Address,
     signer: PrivateKeySigner,
     deposit_amount: U256,
     algo: String,
@@ -952,7 +951,7 @@ impl<'a> EthSignAction<'a> {
         let eth = sign_action.nodes.cfg.eth.as_ref().unwrap().clone();
         Self {
             sign_action,
-            contract_addr: format!("{:x}", eth.contract_address),
+            contract_addr: eth.contract_address,
             signer: eth.account_sk,
             deposit_amount: U256::from(1), // 1 wei
             algo: "ECDSA".to_string(),
@@ -963,7 +962,7 @@ impl<'a> EthSignAction<'a> {
 
     /// Set the ETH contract address to interact with
     pub fn contract_address(mut self, address: &str) -> Self {
-        self.contract_addr = address.to_string();
+        self.contract_addr = address.parse().expect("invalid contract address");
         self
     }
 
@@ -1036,13 +1035,9 @@ impl EthSignAction<'_> {
             .unwrap_or_else(|| rand::thread_rng().gen());
         let payload_hash = *alloy::primitives::keccak256(payload);
         let rpc_url = "https://ethereum-sepolia-rpc.publicnode.com";
-        let contract_addr: Address = self
-            .contract_addr
-            .parse()
-            .with_context(|| format!("invalid contract address {}", self.contract_addr))?;
 
         tracing::info!(
-            "calling ETH ChainSignatures contract: contract=0x{}, payload={:?}, path={}, algo={}, dest={}, params={}, deposit={}",
+            "calling ETH ChainSignatures contract: contract={}, payload={:?}, path={}, algo={}, dest={}, params={}, deposit={}",
             self.contract_addr,
             payload,
             path,
@@ -1057,7 +1052,7 @@ impl EthSignAction<'_> {
         let provider = ProviderBuilder::new()
             .wallet(self.signer)
             .connect_http(rpc_url.parse()?);
-        let contract = ChainSignatures::new(contract_addr, provider.clone());
+        let contract = ChainSignatures::new(self.contract_addr, provider.clone());
 
         // Prepare the sign request
         let sign_request = ChainSignatures::SignRequest {
@@ -1070,7 +1065,7 @@ impl EthSignAction<'_> {
         };
 
         tracing::info!(
-            contract = format!("0x{}", self.contract_addr),
+            contract = %self.contract_addr,
             from = format!("0x{:x}", signer_address),
             payload = format!("0x{}", hex::encode(payload_hash)),
             path,
@@ -1146,7 +1141,7 @@ impl EthSignAction<'_> {
 
             // filter for SignatureResponded events
             let filter = alloy::rpc::types::Filter::new()
-                .address(contract_addr)
+                .address(self.contract_addr)
                 .from_block(current_block.saturating_sub(10)) // Look back 10 blocks
                 .to_block(current_block)
                 .event_signature(alloy::primitives::keccak256(

--- a/integration-tests/src/actions/sign.rs
+++ b/integration-tests/src/actions/sign.rs
@@ -950,13 +950,10 @@ pub struct EthSignAction<'a> {
 impl<'a> EthSignAction<'a> {
     pub fn new(sign_action: SignAction<'a>) -> Self {
         let eth = sign_action.nodes.cfg.eth.as_ref().unwrap().clone();
-        let signer = PrivateKeySigner::from_str(eth.account_sk.as_ref())
-            .with_context(|| "invalid private key")
-            .unwrap();
         Self {
             sign_action,
-            contract_addr: eth.contract_address.clone(),
-            signer,
+            contract_addr: format!("{:x}", eth.contract_address),
+            signer: eth.account_sk,
             deposit_amount: U256::from(1), // 1 wei
             algo: "ECDSA".to_string(),
             dest: "ethereum".to_string(),

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -385,12 +385,19 @@ pub async fn setup(spawner: &mut ClusterSpawner) -> anyhow::Result<Context> {
 
         let contract_address_hex = hex::encode(contract_address);
         spawner.cfg.eth = Some(EthConfig {
-            account_sk: sandbox.secret_key.clone(),
+            account_sk: sandbox
+                .secret_key
+                .parse()
+                .context("invalid ethereum sandbox secret key")?,
             consensus_rpc_http_url: rpc_endpoint.clone(),
-            execution_rpc_http_url: rpc_endpoint,
-            contract_address: contract_address_hex.clone(),
+            execution_rpc_http_url: rpc_endpoint
+                .parse()
+                .context("invalid ethereum sandbox rpc endpoint")?,
+            contract_address: contract_address_hex
+                .parse()
+                .context("invalid deployed contract address")?,
             network: "anvil".to_string(),
-            helios_data_path: format!("/tmp/helios-{}", contract_address_hex),
+            helios_data_path: format!("/tmp/helios-{contract_address_hex}"),
             refresh_finalized_interval: 1_000,
             optimistic_requests: true,
             light_client: false,

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -67,10 +67,16 @@ async fn main() -> anyhow::Result<()> {
                 nodes,
                 threshold,
                 eth: Some(EthConfig {
-                    account_sk: eth_account_sk,
+                    account_sk: eth_account_sk
+                        .parse()
+                        .map_err(|e| anyhow::anyhow!("invalid eth account sk: {e}"))?,
                     consensus_rpc_http_url: eth_consensus_rpc_http_url,
-                    execution_rpc_http_url: eth_execution_rpc_http_url,
-                    contract_address: eth_contract_address,
+                    execution_rpc_http_url: eth_execution_rpc_http_url
+                        .parse()
+                        .map_err(|e| anyhow::anyhow!("invalid eth execution rpc url: {e}"))?,
+                    contract_address: eth_contract_address
+                        .parse()
+                        .map_err(|e| anyhow::anyhow!("invalid eth contract address: {e}"))?,
                     optimistic_requests: eth_network == "anvil",
                     network: eth_network,
                     helios_data_path: eth_helios_data_path,

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -153,10 +153,10 @@ impl EthereumTestEnvironment {
 
     fn config(&self, optimistic_requests: bool) -> EthConfig {
         EthConfig {
-            account_sk: self.sandbox.secret_key.clone(),
+            account_sk: self.sandbox.secret_key.parse().unwrap(),
             consensus_rpc_http_url: self.sandbox.external_http_endpoint.clone(),
-            execution_rpc_http_url: self.sandbox.external_http_endpoint.clone(),
-            contract_address: format!("{:x}", self.contract_address),
+            execution_rpc_http_url: self.sandbox.external_http_endpoint.parse().unwrap(),
+            contract_address: self.contract_address,
             network: "sepolia".to_string(),
             helios_data_path: "/tmp/helios".to_string(),
             refresh_finalized_interval: 500,


### PR DESCRIPTION
- Stricter types: `EthConfig` now holds `PrivateKeySigner`, `reqwest::Url`, `Address` instead of `String`
- Drop all `.expect()`, `.unwrap()`, `format!("0x{}")` in `indexer.rs` and `publisher.rs`
- Validate config once at startup