### PR TITLE
refactor: migrate Solana indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7435,6 +7435,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber 0.3.20",
 ]

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -12,6 +12,7 @@ use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use async_trait::async_trait;
 use futures_util::{stream, Stream, StreamExt};
+use mpc_chain_integration_core::utils::task::AbortOnDrop;
 use mpc_chain_integration_core::{ChainIndexer, ChainTelemetry, StateManager};
 use mpc_primitives::{
     BidirectionalTx, BidirectionalTxId, Chain, ChainEvent, ExecutionOutcome, IndexedSignRequest,
@@ -24,17 +25,6 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration, Instant};
 use tokio_util::sync::CancellationToken;
-
-// TODO: Move this to some common crate so it can be shared across workspace
-/// Aborts the wrapped task on drop, prevents leaking a background task
-/// if the indexer is dropped while the live block fetcher is still running.
-struct AbortOnDrop(tokio::task::JoinHandle<()>);
-
-impl Drop for AbortOnDrop {
-    fn drop(&mut self) {
-        self.0.abort();
-    }
-}
 
 pub struct BlockAndRequests {
     block_number: u64,

--- a/chain-signatures/chain-integration-core/src/utils/mod.rs
+++ b/chain-signatures/chain-integration-core/src/utils/mod.rs
@@ -4,4 +4,5 @@
 pub mod hashing;
 pub mod retry;
 pub mod stream;
+pub mod task;
 pub mod test;

--- a/chain-signatures/chain-integration-core/src/utils/task.rs
+++ b/chain-signatures/chain-integration-core/src/utils/task.rs
@@ -1,0 +1,9 @@
+/// Aborts the wrapped task on drop, preventing a leaked background task when
+/// the owner (e.g. an indexer `run()` loop) is dropped or cancelled.
+pub struct AbortOnDrop(pub tokio::task::JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}

--- a/chain-signatures/chain-solana/Cargo.toml
+++ b/chain-signatures/chain-solana/Cargo.toml
@@ -26,6 +26,7 @@ solana-sdk.workspace = true
 solana-transaction-status.workspace = true
 solana-client.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/chain-signatures/chain-solana/src/client.rs
+++ b/chain-signatures/chain-solana/src/client.rs
@@ -231,6 +231,7 @@ impl SolanaClient {
         )
     }
 
+    // TODO: Do not retry indefinitely on deterministic block errors like SlotWasSkipped or BlockNotAvailable
     pub async fn get_block(&self, slot: u64) -> anyhow::Result<UiConfirmedBlock> {
         let max_attempts = self.catchup_retry.max_times;
         retry_rpc!(

--- a/chain-signatures/chain-solana/src/client.rs
+++ b/chain-signatures/chain-solana/src/client.rs
@@ -39,9 +39,6 @@ const MAX_CONCURRENT_FETCH: usize = 5;
 /// The max chunk size for fetching slots and blocks per batch.
 const MAX_CHUNK_SIZE: usize = 50;
 
-/// The max chunk size allowed for fetching concurrently.
-pub const MAX_CONCURRENT_CHUNK_SIZE: usize = MAX_CONCURRENT_FETCH * MAX_CHUNK_SIZE;
-
 const SOL_RPC_TIMEOUT: Duration = Duration::from_secs(2);
 const SOL_BATCH_TIMEOUT: Duration = Duration::from_secs(30);
 const SOL_RPC_MIN_DELAY: Duration = Duration::from_millis(500);

--- a/chain-signatures/chain-solana/src/indexer.rs
+++ b/chain-signatures/chain-solana/src/indexer.rs
@@ -1287,7 +1287,6 @@ mod tests {
         }
     }
 
-    // TODO: do we need live event channel?
     #[tokio::test]
     async fn forward_live_events_forwards_until_cancel() {
         let indexer = test_indexer("http://localhost:1", MockStateManager::new());

--- a/chain-signatures/chain-solana/src/indexer.rs
+++ b/chain-signatures/chain-solana/src/indexer.rs
@@ -1167,22 +1167,19 @@ mod tests {
             Arc::new(NoopPublisherTelemetry),
         );
 
-        let mut indexer = SolanaIndexer {
+        let indexer = SolanaIndexer {
             program_id: Pubkey::from_str(&sol_addr).unwrap(),
             client,
-            events_tx,
             state_manager,
             telemetry: NoopChainTelemetry,
-            live_rx: None,
-            live_task: None,
         };
 
-        // Initialize livestream (resolves anchor slot via get_slot and starts WS)
+        // Resolve anchor slot 
         let anchor_height = indexer
-            .livestream()
+            .client
+            .get_slot()
             .await
-            .expect("Failed to initialize livestream")
-            .expect("Anchor height missing");
+            .expect("Failed to fetch current slot");
 
         tracing::debug!("Resolved anchor slot: {anchor_height}");
 
@@ -1195,23 +1192,26 @@ mod tests {
             .set_processed_block(Chain::Solana, start_slot.saturating_sub(1))
             .await;
 
-        // Run catchup range
-        let catchup_stream = indexer.catchup_range(anchor_height).await;
-        tokio::pin!(catchup_stream);
-        let mut processed_any = false;
-        while let Some(item) = catchup_stream.next().await {
-            indexer
-                .process_catchup(&item)
-                .await
-                .expect("Failed to process catchup block");
-            processed_any = true;
+        // Start the indexer in a separate task
+        let cancel = CancellationToken::new();
+        let run_handle = tokio::spawn({
+            let cancel = cancel.clone();
+            async move { indexer.run(events_tx, cancel).await }
+        });
+
+        // Drain events until catchup completes
+        loop {
+            match events_rx.recv().await {
+                Some(ChainEvent::CatchupCompleted) => {
+                    tracing::debug!("Solana catchup complete");
+                    break;
+                }
+                Some(event) => tracing::debug!("Received event: {:?}", event),
+                None => break,
+        }
         }
 
-        tracing::debug!("Solana catchup complete. Processed blocks: {processed_any}");
-
-        // Check if any events were received in the channel
-        while let Ok(event) = events_rx.try_recv() {
-            tracing::debug!("Received event: {:?}", event);
-        }
+        cancel.cancel();
+        run_handle.abort();
     }
 }

--- a/chain-signatures/chain-solana/src/indexer.rs
+++ b/chain-signatures/chain-solana/src/indexer.rs
@@ -85,10 +85,10 @@ impl<S: StateManager, T: ChainTelemetry> SolanaIndexer<S, T> {
         );
 
         Ok(Self {
-                program_id,
+            program_id,
             client,
-                state_manager,
-                telemetry,
+            state_manager,
+            telemetry,
         })
     }
 
@@ -259,8 +259,8 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for SolanaIndexer<S, T> {
         // runs, and resolves the anchor slot once the WS is live so catchup
         // covers `[persisted_block, anchor)` with no gaps. The abort-on-drop
         // guard ties the task's lifetime to this `run()`.
-        
-        // TODO: live channel is bounded, if catchup takes too long live 
+
+        // TODO: live channel is bounded, if catchup takes too long live
         // channel will fill up and block subscription task, websocket connection will be closed.
         // Consider better solution.
         let (live_tx, mut live_rx) = chain_event_channel();
@@ -1009,6 +1009,65 @@ mod tests {
         TransactionDetails, UiTransactionEncoding, UiTransactionStatusMeta,
     };
 
+    /// Create a test indexer with a mock state manager and a given RPC URL.
+    fn test_indexer(
+        url: &str,
+        state_manager: MockStateManager,
+    ) -> SolanaIndexer<MockStateManager, NoopChainTelemetry> {
+        let program_id = Pubkey::new_unique();
+        let client = SolanaClient::for_indexer(
+            url.to_string(),
+            url.replace("http", "ws"),
+            program_id,
+            Arc::new(NoopPublisherTelemetry),
+        )
+        .with_fast_retry();
+        SolanaIndexer {
+            program_id,
+            client,
+            state_manager,
+            telemetry: NoopChainTelemetry,
+        }
+    }
+
+    /// Create a mock signature entry for testing, with a given slot.
+    fn signature_entry(slot: u64) -> serde_json::Value {
+        serde_json::json!({
+            "signature": Signature::new_unique().to_string(),
+            "slot": slot,
+            "err": null,
+            "memo": null,
+            "blockTime": null,
+            "confirmationStatus": "confirmed"
+        })
+    }
+
+    /// Create a mock JSON-RPC response for a list of signature entries.
+    fn signatures_response(entries: &[serde_json::Value]) -> String {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": entries
+        })
+        .to_string()
+    }
+
+    /// Create a mock JSON-RPC response for a block at a given slot.
+    fn block_response(id: usize, slot: u64) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "result": {
+                "blockHeight": slot,
+                "blockTime": null,
+                "blockhash": "11111111111111111111111111111111",
+                "parentSlot": slot.saturating_sub(1),
+                "previousBlockhash": "11111111111111111111111111111111",
+                "transactions": [],
+                "rewards": []
+            }
+        })
+    }
+
     #[test]
     fn request_id_matches_ethabi() {
         let event = SignatureRequestedEvent {
@@ -1141,6 +1200,148 @@ mod tests {
         assert!(meta.err.is_some(), "expected err to be set");
     }
 
+    #[tokio::test]
+    async fn catchup_blocks_empty_when_up_to_date() {
+        let server = mockito::Server::new_async().await;
+        let indexer = test_indexer(&server.url(), MockStateManager::new());
+        const ANCHOR_SLOT: u64 = 10;
+
+        // No processed block persisted: start == anchor, so no catchup and no RPC calls.
+        let mut stream = indexer.catchup_blocks(ANCHOR_SLOT).await.unwrap();
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn catchup_blocks_propagates_fetch_slots_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(500)
+            .expect(3) // 1 attempt + 2 retries (fast retry config)
+            .create_async()
+            .await;
+
+        let state_manager = MockStateManager::new();
+        state_manager.set_processed_block(Chain::Solana, 5).await;
+        let indexer = test_indexer(&server.url(), state_manager);
+
+        let result = indexer.catchup_blocks(10).await;
+        assert!(result.is_err(), "fetch_slots error should propagate");
+    }
+
+    #[tokio::test]
+    async fn catchup_processes_slots_in_order() {
+        let mut server = mockito::Server::new_async().await;
+
+        // Signatures walk back from the anchor: slots 9..=6 are in range,
+        // slot 5 (< start_slot 6) terminates the walk.
+        let entries: Vec<_> = [9, 8, 7, 6, 5].into_iter().map(signature_entry).collect();
+        let _signatures = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                "getSignaturesForAddress".to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(signatures_response(&entries))
+            .create_async()
+            .await;
+
+        let blocks = serde_json::json!([
+            block_response(0, 6),
+            block_response(1, 7),
+            block_response(2, 8),
+            block_response(3, 9),
+        ])
+        .to_string();
+        let _blocks = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex("getBlock".to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(blocks)
+            .create_async()
+            .await;
+
+        let state_manager = MockStateManager::new();
+        state_manager.set_processed_block(Chain::Solana, 5).await;
+        let indexer = test_indexer(&server.url(), state_manager);
+
+        let (events_tx, mut events_rx) = mpsc::channel(16);
+        let cancel = CancellationToken::new();
+
+        let mut stream = indexer.catchup_blocks(10).await.unwrap();
+        while let Some((slot, block)) = stream.next().await {
+            indexer
+                .process_catchup_retrying(&events_tx, slot, &block, &cancel)
+                .await;
+        }
+
+        // Verify that the events were emitted in order
+        for expected in 6..=9 {
+            let event = events_rx.recv().await.unwrap();
+            assert!(
+                matches!(event, ChainEvent::Block(slot) if slot == expected),
+                "expected Block({expected}), got {event:?}"
+            );
+        }
+    }
+
+    // TODO: do we need live event channel?
+    #[tokio::test]
+    async fn forward_live_events_forwards_until_cancel() {
+        let indexer = test_indexer("http://localhost:1", MockStateManager::new());
+        let (events_tx, mut events_rx) = mpsc::channel(16);
+        let (live_tx, mut live_rx) = mpsc::channel(16);
+        let cancel = CancellationToken::new();
+
+        live_tx.send(ChainEvent::Block(42)).await.unwrap();
+
+        let mut forward = Box::pin(indexer.forward_live_events(&events_tx, &mut live_rx, &cancel));
+        tokio::select! {
+            result = &mut forward => panic!("forwarding ended early: {result:?}"),
+            event = events_rx.recv() => {
+                assert!(matches!(event, Some(ChainEvent::Block(42))));
+            }
+        }
+
+        cancel.cancel();
+        tokio::time::timeout(Duration::from_secs(5), &mut forward)
+            .await
+            .expect("forwarding should stop promptly on cancel")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn forward_live_events_bails_when_producer_drops() {
+        let indexer = test_indexer("http://localhost:1", MockStateManager::new());
+        let (events_tx, _events_rx) = mpsc::channel(16);
+        let (live_tx, mut live_rx) = mpsc::channel::<ChainEvent>(16);
+        drop(live_tx);
+
+        let result = indexer
+            .forward_live_events(&events_tx, &mut live_rx, &CancellationToken::new())
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn process_catchup_retrying_stops_on_cancel() {
+        // No mock: any RPC attempt fails after fast retries; cancel must
+        // interrupt the retry loop without waiting for it.
+        let indexer = test_indexer("http://localhost:1", MockStateManager::new());
+        let (events_tx, _events_rx) = mpsc::channel(16);
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            indexer.process_catchup_retrying(&events_tx, 7, &SolanaCatchupBlock::Missing, &cancel),
+        )
+        .await
+        .expect("process_catchup_retrying should stop promptly on cancel");
+    }
+
     // Very expensive test in terms of RPC usage.
     #[tokio::test]
     #[ignore]
@@ -1178,7 +1379,7 @@ mod tests {
             telemetry: NoopChainTelemetry,
         };
 
-        // Resolve anchor slot 
+        // Resolve anchor slot
         let anchor_height = indexer
             .client
             .get_slot()
@@ -1212,7 +1413,7 @@ mod tests {
                 }
                 Some(event) => tracing::debug!("Received event: {:?}", event),
                 None => break,
-        }
+            }
         }
 
         cancel.cancel();

--- a/chain-signatures/chain-solana/src/indexer.rs
+++ b/chain-signatures/chain-solana/src/indexer.rs
@@ -112,7 +112,9 @@ impl<S: StateManager, T: ChainTelemetry> SolanaIndexer<S, T> {
             return Ok(Box::pin(futures_util::stream::empty()));
         }
 
-        // TODO: double-check if we should propagate or keep as is
+        // TODO: The error should be propagated, otherwise an empty stream is returned,
+        // catchup finishes without processing missing blocks and ChainEvent::CatchupCompleted is emitted.
+        // Let supervisor restart on error.
         let slots = match self.client.fetch_slots(start_slot, end_slot).await {
             Ok(slots) => slots,
             Err(err) => {
@@ -267,6 +269,10 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for SolanaIndexer<S, T> {
         // runs, and resolves the anchor slot once the WS is live so catchup
         // covers `[persisted_block, anchor)` with no gaps. The abort-on-drop
         // guard ties the task's lifetime to this `run()`.
+        
+        // TODO: live channel is bounded, if catchup takes too long live 
+        // channel will fill up and block subscription task, websocket connection will be closed.
+        // Consider better solution.
         let (live_tx, mut live_rx) = chain_event_channel();
         let (anchor_tx, anchor_rx) = oneshot::channel::<u64>();
         let _live_task = AbortOnDrop(tokio::spawn(subscribe_and_buffer_live_events(
@@ -480,6 +486,8 @@ async fn subscribe_and_buffer_live_events<T: ChainTelemetry>(
     }
 }
 
+// TODO: move this to an events.rs file
+// TODO: enhance to handle malformed events and prevent panic
 fn parse_cpi_events(
     tx: &EncodedTransactionWithStatusMeta,
     target_program_id: &Pubkey,
@@ -593,6 +601,8 @@ async fn subscribe_to_program_events<T: ChainTelemetry>(
     // with no gaps. We do not wait for the first WS event because that could deadlock if
     // no program-mentioning transactions arrive (e.g. in tests after a single sign call).
     if let Some(anchor_tx) = anchor_tx.take() {
+        // TODO: this should probably use client.get_slot with retry strategy,
+        // otherwise if RPC fails the anchor will not be sent and catchup will not run
         match client
             .rpc_client
             .get_slot_with_commitment(CommitmentConfig::confirmed())
@@ -629,6 +639,7 @@ async fn subscribe_to_program_events<T: ChainTelemetry>(
     let program_invoke_log = format!("Program {program_id} invoke [");
 
     loop {
+        // TODO: this might introduce CPU overhead if the WS is busy, consider a more efficient alternative
         cleanup_seen_cache(&mut seen, ttl);
         tokio::select! {
             // Receive WS logs
@@ -746,6 +757,8 @@ fn has_log_starts_with(logs: &[String], start_with: &str) -> bool {
     logs.iter().any(|l| l.starts_with(start_with))
 }
 
+// TODO: move this to an events.rs file
+// TODO: enhance to handle malformed events and prevent panic
 fn parse_cpi_respond_events(
     tx: &EncodedTransactionWithStatusMeta,
     target_program_id: &Pubkey,
@@ -850,6 +863,7 @@ fn parse_cpi_respond_events(
     Ok((respond_bidirectional_events, signature_responded_events))
 }
 
+// TODO: move this to an events.rs file
 enum SolanaEvents {
     Sign(Vec<SolanaSignEvent>),
     Respond {

--- a/chain-signatures/chain-solana/src/indexer.rs
+++ b/chain-signatures/chain-solana/src/indexer.rs
@@ -1,7 +1,7 @@
 use mpc_chain_integration_core::utils::stream::chain_event_channel;
 use mpc_chain_integration_core::NoopPublisherTelemetry;
 
-use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeSet, HashMap};
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -13,7 +13,7 @@ use anchor_lang::solana_program::keccak;
 use anchor_lang::Discriminator;
 use anyhow::Context;
 use async_trait::async_trait;
-use futures_util::stream::StreamExt;
+use futures_util::stream::{self, StreamExt};
 use futures_util::Stream;
 use k256::elliptic_curve::sec1::FromEncodedPoint;
 use k256::{AffinePoint, Scalar};
@@ -47,7 +47,7 @@ use solana_transaction_status::{
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
-use crate::client::{SolanaCatchupBlock, MAX_CONCURRENT_CHUNK_SIZE};
+use crate::client::SolanaCatchupBlock;
 use crate::utils::current_unix_timestamp;
 use crate::{SolConfig, SolanaClient};
 
@@ -97,50 +97,139 @@ impl<S: StateManager, T: ChainTelemetry> SolanaIndexer<S, T> {
     async fn catchup_blocks(
         &self,
         anchor_height: u64,
-    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = (u64, SolanaCatchupBlock)> + Send + 'static>>>
-    {
-        // Get the last persisted processed block height from backlog
-        // TODO: https://github.com/sig-net/mpc/issues/777
+    ) -> anyhow::Result<
+        Pin<Box<dyn Stream<Item = anyhow::Result<(u64, SolanaCatchupBlock)>> + Send + 'static>>,
+    > {
+        let Some((start_slot, end_slot)) = self.catchup_range(anchor_height).await else {
+            return Ok(Box::pin(stream::empty()));
+        };
+
+        let pages =
+            Self::paginate_slots(self.client.clone(), self.program_id, start_slot, end_slot);
+        Ok(Self::fetch_blocks_for_pages(self.client.clone(), pages))
+    }
+
+    /// Range of slots that still need to be caught up, inclusive on both ends.
+    /// `None` means we're already caught up.
+    // TODO: https://github.com/sig-net/mpc/issues/777
+    async fn catchup_range(&self, anchor_height: u64) -> Option<(u64, u64)> {
         let start_slot = self
             .state_manager
             .get_processed_block(Chain::Solana)
             .await
             .map(|n| n.saturating_add(1))
             .unwrap_or(anchor_height);
-        let end_slot = anchor_height.saturating_sub(1); // We want to catch up to just before the anchor
-        if start_slot > end_slot {
-            return Ok(Box::pin(futures_util::stream::empty()));
+
+        let end_slot = anchor_height.saturating_sub(1);
+        (start_slot <= end_slot).then_some((start_slot, end_slot))
+    }
+
+    /// Paginate `getSignaturesForAddress` backwards from the anchor, yielding
+    /// pages of slots within `[start_slot, end_slot]`. Stops once the cursor
+    /// walks past `start_slot` or the RPC runs dry.
+    fn paginate_slots(
+        client: SolanaClient,
+        program_id: Pubkey,
+        start_slot: u64,
+        end_slot: u64,
+    ) -> impl Stream<Item = anyhow::Result<BTreeSet<u64>>> {
+        struct PageState {
+            client: SolanaClient,
+            program_id: Pubkey,
+            start_slot: u64,
+            end_slot: u64,
+            cursor: Option<Signature>,
+            finished: bool,
         }
 
-        // The error should be propagated, to let supervisor restart on error, otherwise
-        // an empty stream is returned and catchup finishes without processing missing blocks.
-        let slots = self.client.fetch_slots(start_slot, end_slot).await?;
-        let remaining_slots: VecDeque<u64> = slots.into_iter().collect();
-
-        let client = self.client.clone();
-        let stream = futures_util::stream::unfold(
-            (remaining_slots, client, VecDeque::new()),
-            |state| async move {
-                let (mut remaining_slots, client, mut current_chunk) = state;
-                loop {
-                    if let Some(block) = current_chunk.pop_front() {
-                        return Some((block, (remaining_slots, client, current_chunk)));
-                    }
-                    if remaining_slots.is_empty() {
-                        return None;
-                    }
-
-                    let chunk_slots: BTreeSet<u64> = remaining_slots
-                        .drain(..std::cmp::min(MAX_CONCURRENT_CHUNK_SIZE, remaining_slots.len()))
-                        .collect();
-
-                    let blocks = client.fetch_blocks_for_slots(chunk_slots).await;
-                    current_chunk = blocks.into_iter().collect();
-                }
+        stream::unfold(
+            PageState {
+                client,
+                program_id,
+                start_slot,
+                end_slot,
+                cursor: None,
+                finished: false,
             },
-        );
+            |mut state| async move {
+                if state.finished {
+                    return None;
+                }
 
-        Ok(Box::pin(stream))
+                let batch = match state
+                    .client
+                    .fetch_signatures_from_latest(&state.program_id, state.cursor)
+                    .await
+                {
+                    Ok(b) if b.is_empty() => return None,
+                    Ok(b) => b,
+                    Err(e) => {
+                        state.finished = true;
+                        return Some((Err(e), state));
+                    }
+                };
+
+                state.cursor = batch
+                    .last()
+                    .and_then(|s| Signature::from_str(&s.signature).ok());
+                if state.cursor.is_none() {
+                    state.finished = true;
+                }
+
+                let mut slots = BTreeSet::new();
+                for sig in batch {
+                    if sig.slot < state.start_slot {
+                        state.finished = true;
+                    } else if sig.slot <= state.end_slot {
+                        slots.insert(sig.slot);
+                    }
+                }
+
+                Some((Ok(slots), state))
+            },
+        )
+    }
+
+    /// Fetch blocks for each page of slots and flatten into a stream of `(slot, block)` items.
+    fn fetch_blocks_for_pages(
+        client: SolanaClient,
+        pages: impl Stream<Item = anyhow::Result<BTreeSet<u64>>> + Send + 'static,
+    ) -> Pin<Box<dyn Stream<Item = anyhow::Result<(u64, SolanaCatchupBlock)>> + Send + 'static>>
+    {
+        let stream = pages
+            .filter_map(|res| async move {
+                match res {
+                    Ok(slots) if slots.is_empty() => None,
+                    Ok(slots) => Some(Ok(slots)),
+                    Err(e) => Some(Err(e)),
+                }
+            })
+            .then(move |res| {
+                let client = client.clone();
+                async move {
+                    let slots = res?;
+                    let mut blocks = client.fetch_blocks_for_slots(slots.clone()).await;
+                    let items: Vec<(u64, SolanaCatchupBlock)> = slots
+                        .into_iter()
+                        .map(|s| {
+                            let block = blocks.remove(&s).unwrap_or(SolanaCatchupBlock::Missing);
+                            (s, block)
+                        })
+                        .collect();
+                    Ok(items)
+                }
+            })
+            .map(|res| match res {
+                Ok(items) => {
+                    let stream_items: Vec<anyhow::Result<(u64, SolanaCatchupBlock)>> =
+                        items.into_iter().map(Ok).collect();
+                    stream::iter(stream_items)
+                }
+                Err(e) => stream::iter(vec![Err(e)]),
+            })
+            .flatten();
+
+        Box::pin(stream)
     }
 
     async fn process_catchup_item(
@@ -284,7 +373,9 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for SolanaIndexer<S, T> {
                 _ = cancel.cancelled() => return Ok(()),
                 item = catchup_iter.next() => item,
             };
-            let Some((slot, block)) = item else { break };
+            let Some(res) = item else { break };
+            // Propagate RPC page errors so supervisor restarts cleanly
+            let (slot, block) = res?;
             self.process_catchup_retrying(&events_tx, slot, &block, &cancel)
                 .await;
         }
@@ -1224,9 +1315,11 @@ mod tests {
         let state_manager = MockStateManager::new();
         state_manager.set_processed_block(Chain::Solana, 5).await;
         let indexer = test_indexer(&server.url(), state_manager);
+        const ANCHOR_SLOT: u64 = 10;
 
-        let result = indexer.catchup_blocks(10).await;
-        assert!(result.is_err(), "fetch_slots error should propagate");
+        let mut stream = indexer.catchup_blocks(ANCHOR_SLOT).await.unwrap();
+        let first = stream.next().await;
+        assert!(first.is_some() && first.unwrap().is_err());
     }
 
     #[tokio::test]
@@ -1269,9 +1362,12 @@ mod tests {
 
         let (events_tx, mut events_rx) = mpsc::channel(16);
         let cancel = CancellationToken::new();
+        const ANCHOR_SLOT: u64 = 10;
 
-        let mut stream = indexer.catchup_blocks(10).await.unwrap();
-        while let Some((slot, block)) = stream.next().await {
+        let mut stream = indexer.catchup_blocks(ANCHOR_SLOT).await.unwrap();
+
+        while let Some(res) = stream.next().await {
+            let (slot, block) = res.unwrap();
             indexer
                 .process_catchup_retrying(&events_tx, slot, &block, &cancel)
                 .await;

--- a/chain-signatures/chain-solana/src/indexer.rs
+++ b/chain-signatures/chain-solana/src/indexer.rs
@@ -18,8 +18,11 @@ use futures_util::Stream;
 use k256::elliptic_curve::sec1::FromEncodedPoint;
 use k256::{AffinePoint, Scalar};
 use mpc_chain_integration_core::{
-    utils::hashing::{compute_request_id, hash_payload},
-    ChainIndexer, ChainStream, ChainTelemetry, StateManager,
+    utils::{
+        hashing::{compute_request_id, hash_payload},
+        task::AbortOnDrop,
+    },
+    ChainIndexer, ChainTelemetry, StateManager,
 };
 use mpc_crypto::kdf::derive_epsilon_sol;
 use mpc_crypto::ScalarExt as _;
@@ -42,6 +45,7 @@ use solana_transaction_status::{
     UiParsedInstruction,
 };
 use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
 
 use crate::client::{SolanaCatchupBlock, MAX_CONCURRENT_CHUNK_SIZE};
 use crate::utils::current_unix_timestamp;
@@ -57,41 +61,14 @@ const CPI_RESPOND_EVENT_HINTS: &[&str] = &[
     "Program log: Instruction: RespondBidirectional",
 ];
 
-/// Solana stream that implements the new ChainStream abstraction
-pub struct SolanaStream<S: StateManager, T: ChainTelemetry> {
-    rx: Option<mpsc::Receiver<ChainEvent>>,
-    start_state: Option<SolanaStreamStartState<S, T>>,
-    tasks: Vec<tokio::task::JoinHandle<()>>,
-}
-
 pub struct SolanaIndexer<S: StateManager, T: ChainTelemetry> {
-    pub program_id: Pubkey,
-    pub client: SolanaClient,
-    pub events_tx: mpsc::Sender<ChainEvent>,
-    pub state_manager: S,
-    pub telemetry: T,
-    pub live_rx: Option<mpsc::Receiver<ChainEvent>>,
-    live_task: Option<tokio::task::JoinHandle<()>>,
-}
-
-struct SolanaStreamStartState<S: StateManager, T: ChainTelemetry> {
     program_id: Pubkey,
-    rpc_http_url: String,
-    rpc_ws_url: String,
+    client: SolanaClient,
     state_manager: S,
     telemetry: T,
-    tx: mpsc::Sender<ChainEvent>,
 }
 
-impl<S: StateManager, T: ChainTelemetry> Drop for SolanaStream<S, T> {
-    fn drop(&mut self) {
-        for task in &self.tasks {
-            task.abort();
-        }
-    }
-}
-
-impl<S: StateManager, T: ChainTelemetry> SolanaStream<S, T> {
+impl<S: StateManager, T: ChainTelemetry> SolanaIndexer<S, T> {
     pub fn new(sol: SolConfig, state_manager: S, telemetry: T) -> anyhow::Result<Self> {
         let program_id = Pubkey::from_str(&sol.program_address).with_context(|| {
             format!(
@@ -100,93 +77,28 @@ impl<S: StateManager, T: ChainTelemetry> SolanaStream<S, T> {
             )
         })?;
 
-        let (tx, rx) = chain_event_channel();
-
-        Ok(SolanaStream {
-            rx: Some(rx),
-            start_state: Some(SolanaStreamStartState {
-                program_id,
-                rpc_http_url: sol.rpc_http_url.clone(),
-                rpc_ws_url: sol.rpc_ws_url.clone(),
-                state_manager,
-                telemetry,
-                tx,
-            }),
-            tasks: Vec::new(),
-        })
-    }
-}
-
-#[async_trait]
-impl<S: StateManager, T: ChainTelemetry> ChainStream for SolanaStream<S, T> {
-    type Indexer = SolanaIndexer<S, T>;
-
-    async fn start(&mut self) -> anyhow::Result<Self::Indexer> {
-        let Some(start_state) = self.start_state.take() else {
-            anyhow::bail!("solana stream already started");
-        };
-
         let client = SolanaClient::for_indexer(
-            start_state.rpc_http_url.clone(),
-            start_state.rpc_ws_url.clone(),
-            start_state.program_id,
+            sol.rpc_http_url.clone(),
+            sol.rpc_ws_url.clone(),
+            program_id,
             Arc::new(NoopPublisherTelemetry), // Indexer does not publish
         );
 
-        let indexer = SolanaIndexer {
-            program_id: start_state.program_id,
+        Ok(Self {
+                program_id,
             client,
-            events_tx: start_state.tx.clone(),
-            state_manager: start_state.state_manager,
-            telemetry: start_state.telemetry,
-            live_rx: None,
-            live_task: None,
-        };
-
-        Ok(indexer)
+                state_manager,
+                telemetry,
+        })
     }
 
-    async fn next_event(&mut self) -> Option<ChainEvent> {
-        match self.rx.as_mut() {
-            Some(rx) => rx.recv().await,
-            None => None,
-        }
-    }
-}
-
-#[async_trait]
-impl<S: StateManager, T: ChainTelemetry> ChainIndexer for SolanaIndexer<S, T> {
-    const CHAIN: Chain = Chain::Solana;
-    type Block = (u64, SolanaCatchupBlock);
-    type Iter = Pin<Box<dyn Stream<Item = Self::Block> + Send + 'static>>;
-
-    async fn livestream(&mut self) -> anyhow::Result<Option<u64>> {
-        if let Some(prev) = self.live_task.take() {
-            tracing::info!("aborting previous solana live subscription task");
-            prev.abort();
-        }
-
-        let (live_tx, live_rx) = chain_event_channel();
-        self.live_rx = Some(live_rx);
-
-        let program_id = self.program_id;
-
-        // Oneshot to receive the first observed slot from the live subscription.
-        let (anchor_tx, anchor_rx) = oneshot::channel::<u64>();
-
-        self.live_task = Some(tokio::spawn(subscribe_and_buffer_live_events(
-            program_id,
-            self.client.clone(),
-            live_tx,
-            anchor_tx,
-            self.telemetry.clone(),
-        )));
-
-        // Wait for the first slot observed on the live feed to use as anchor.
-        Ok(Some(anchor_rx.await?))
-    }
-
-    async fn catchup_range(&self, anchor_height: u64) -> Self::Iter {
+    /// Catchup items in `[processed + 1, anchor)` fetched in chunks.
+    /// `fetch_slots` failures are propagated so the supervisor can restart.
+    async fn catchup_blocks(
+        &self,
+        anchor_height: u64,
+    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = (u64, SolanaCatchupBlock)> + Send + 'static>>>
+    {
         // Get the last persisted processed block height from backlog
         // TODO: https://github.com/sig-net/mpc/issues/777
         let start_slot = self
@@ -197,20 +109,10 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for SolanaIndexer<S, T> {
             .unwrap_or(anchor_height);
         let end_slot = anchor_height.saturating_sub(1); // We want to catch up to just before the anchor
         if start_slot > end_slot {
-            return Box::pin(futures_util::stream::empty());
+            return Ok(Box::pin(futures_util::stream::empty()));
         }
 
-        // TODO: should probably propagate the error, but it would require updating the ChainIndexer trait
-        let slots = match self.client.fetch_slots(start_slot, end_slot).await {
-            Ok(slots) => slots,
-            Err(err) => {
-                tracing::warn!(
-                    ?err,
-                    "failed to fetch slots for catchup, returning empty stream"
-                );
-                return Box::pin(futures_util::stream::empty());
-            }
-        };
+        let slots = self.client.fetch_slots(start_slot, end_slot).await?;
         let remaining_slots: VecDeque<u64> = slots.into_iter().collect();
 
         let client = self.client.clone();
@@ -236,54 +138,86 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for SolanaIndexer<S, T> {
             },
         );
 
-        Box::pin(stream)
+        Ok(Box::pin(stream))
     }
 
-    async fn process_catchup(&mut self, (slot, block): &Self::Block) -> anyhow::Result<()> {
+    async fn process_catchup_item(
+        &self,
+        events_tx: &mpsc::Sender<ChainEvent>,
+        slot: u64,
+        block: &SolanaCatchupBlock,
+    ) -> anyhow::Result<()> {
         match block {
-            SolanaCatchupBlock::Block(block) => self.process_block(*slot, block).await,
+            SolanaCatchupBlock::Block(block) => self.process_block(events_tx, slot, block).await,
             SolanaCatchupBlock::Missing => {
-                let block = self.client.get_block(*slot).await?;
-                self.process_block(*slot, &block).await
+                let block = self.client.get_block(slot).await?;
+                self.process_block(events_tx, slot, &block).await
             }
         }
     }
 
-    async fn process_next_block(&mut self) -> bool {
-        let Some(rx) = self.live_rx.as_mut() else {
-            return false;
-        };
-        let Some(event) = rx.recv().await else {
-            return false;
-        };
-        if let Err(err) = self.events_tx.send(event).await {
-            tracing::warn!(?err, "failed to forward live solana event");
-            return false;
+    /// Retries `process_catchup_item` with `RETRY_DELAY` backoff until it
+    /// succeeds or `cancel` fires.
+    async fn process_catchup_retrying(
+        &self,
+        events_tx: &mpsc::Sender<ChainEvent>,
+        slot: u64,
+        block: &SolanaCatchupBlock,
+        cancel: &CancellationToken,
+    ) {
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => return,
+                result = self.process_catchup_item(events_tx, slot, block) => {
+                    match result {
+                        Ok(()) => return,
+                        Err(err) => {
+                            tracing::warn!(?err, slot, "solana catchup block processing failed; retrying");
+                        }
+                    }
+                }
+            }
+            tokio::select! {
+                _ = cancel.cancelled() => return,
+                _ = tokio::time::sleep(Self::RETRY_DELAY) => {}
+            }
         }
-        true
     }
 
-    async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {
-        self.events_tx.send(ChainEvent::CatchupCompleted).await?;
-        Ok(())
-    }
-}
-
-impl<S: StateManager, T: ChainTelemetry> Drop for SolanaIndexer<S, T> {
-    fn drop(&mut self) {
-        if let Some(task) = self.live_task.take() {
-            task.abort();
+    /// Live phase: forward events produced by the live subscription until
+    /// `cancel` fires or the producer terminates.
+    async fn forward_live_events(
+        &self,
+        events_tx: &mpsc::Sender<ChainEvent>,
+        live_rx: &mut mpsc::Receiver<ChainEvent>,
+        cancel: &CancellationToken,
+    ) -> anyhow::Result<()> {
+        loop {
+            let event = tokio::select! {
+                _ = cancel.cancelled() => return Ok(()),
+                event = live_rx.recv() => event,
+            };
+            let Some(event) = event else {
+                anyhow::bail!("solana live event producer terminated");
+            };
+            events_tx
+                .send(event)
+                .await
+                .context("failed to forward live solana event")?;
         }
     }
-}
 
-impl<S: StateManager, T: ChainTelemetry> SolanaIndexer<S, T> {
-    async fn process_block(&mut self, height: u64, block: &UiConfirmedBlock) -> anyhow::Result<()> {
+    async fn process_block(
+        &self,
+        events_tx: &mpsc::Sender<ChainEvent>,
+        height: u64,
+        block: &UiConfirmedBlock,
+    ) -> anyhow::Result<()> {
         // Update indexed block metrics
         self.telemetry.block_indexed(height);
 
         let Some(transactions) = &block.transactions else {
-            self.events_tx.send(ChainEvent::Block(height)).await?;
+            events_tx.send(ChainEvent::Block(height)).await?;
             return Ok(());
         };
 
@@ -300,11 +234,62 @@ impl<S: StateManager, T: ChainTelemetry> SolanaIndexer<S, T> {
             };
 
             let signature = extract_tx_signature(&tx.transaction)?;
-            emit_events(&self.events_tx, &self.program_id, signature, tx, logs).await?;
+            emit_events(events_tx, &self.program_id, signature, tx, logs).await?;
         }
 
-        self.events_tx.send(ChainEvent::Block(height)).await?;
+        events_tx.send(ChainEvent::Block(height)).await?;
         Ok(())
+    }
+}
+
+#[async_trait]
+impl<S: StateManager, T: ChainTelemetry> ChainIndexer for SolanaIndexer<S, T> {
+    const CHAIN: Chain = Chain::Solana;
+    type Block = (u64, SolanaCatchupBlock);
+    type Iter = Pin<Box<dyn Stream<Item = Self::Block> + Send + 'static>>;
+
+    async fn run(
+        &self,
+        events_tx: mpsc::Sender<ChainEvent>,
+        cancel: CancellationToken,
+    ) -> anyhow::Result<()> {
+        // Start the live subscription first: it buffers events while catchup
+        // runs, and resolves the anchor slot once the WS is live so catchup
+        // covers `[persisted_block, anchor)` with no gaps. The abort-on-drop
+        // guard ties the task's lifetime to this `run()`.
+        let (live_tx, mut live_rx) = chain_event_channel();
+        let (anchor_tx, anchor_rx) = oneshot::channel::<u64>();
+        let _live_task = AbortOnDrop(tokio::spawn(subscribe_and_buffer_live_events(
+            self.program_id,
+            self.client.clone(),
+            live_tx,
+            anchor_tx,
+            self.telemetry.clone(),
+        )));
+
+        let anchor = tokio::select! {
+            _ = cancel.cancelled() => return Ok(()),
+            anchor = anchor_rx => anchor.context("solana live subscription ended before resolving anchor slot")?,
+        };
+
+        let mut catchup_iter = self.catchup_blocks(anchor).await?;
+        loop {
+            let item = tokio::select! {
+                _ = cancel.cancelled() => return Ok(()),
+                item = catchup_iter.next() => item,
+            };
+            let Some((slot, block)) = item else { break };
+            self.process_catchup_retrying(&events_tx, slot, &block, &cancel)
+                .await;
+        }
+
+        events_tx
+            .send(ChainEvent::CatchupCompleted)
+            .await
+            .context("failed to send catchup completed event")?;
+
+        self.forward_live_events(&events_tx, &mut live_rx, &cancel)
+            .await
     }
 }
 
@@ -451,7 +436,7 @@ impl SolanaSignEvent {
 
 /// Subscribe to the live WS feed, preprocess events into `ChainEvent`s, and buffer them
 /// in `live_tx`. The anchor slot (current confirmed slot at subscription time) is sent
-/// via `anchor_tx` so that `livestream()` can return it to the catchup logic.
+/// via `anchor_tx` so that `run()` can bound catchup with it.
 ///
 /// The anchor is resolved inside `subscribe_to_program_events` immediately after the WS
 /// subscription is established — ensuring the subscription is live before we anchor, so

--- a/chain-signatures/chain-solana/src/indexer.rs
+++ b/chain-signatures/chain-solana/src/indexer.rs
@@ -68,6 +68,8 @@ pub struct SolanaIndexer<S: StateManager, T: ChainTelemetry> {
     telemetry: T,
 }
 
+type CatchupBlockItem = (u64, SolanaCatchupBlock);
+
 impl<S: StateManager, T: ChainTelemetry> SolanaIndexer<S, T> {
     pub fn new(sol: SolConfig, state_manager: S, telemetry: T) -> anyhow::Result<Self> {
         let program_id = Pubkey::from_str(&sol.program_address).with_context(|| {
@@ -98,7 +100,7 @@ impl<S: StateManager, T: ChainTelemetry> SolanaIndexer<S, T> {
         &self,
         anchor_height: u64,
     ) -> anyhow::Result<
-        Pin<Box<dyn Stream<Item = anyhow::Result<(u64, SolanaCatchupBlock)>> + Send + 'static>>,
+        Pin<Box<dyn Stream<Item = anyhow::Result<CatchupBlockItem>> + Send + 'static>>,
     > {
         let Some((start_slot, end_slot)) = self.catchup_range(anchor_height).await else {
             return Ok(Box::pin(stream::empty()));
@@ -194,8 +196,7 @@ impl<S: StateManager, T: ChainTelemetry> SolanaIndexer<S, T> {
     fn fetch_blocks_for_pages(
         client: SolanaClient,
         pages: impl Stream<Item = anyhow::Result<BTreeSet<u64>>> + Send + 'static,
-    ) -> Pin<Box<dyn Stream<Item = anyhow::Result<(u64, SolanaCatchupBlock)>> + Send + 'static>>
-    {
+    ) -> Pin<Box<dyn Stream<Item = anyhow::Result<CatchupBlockItem>> + Send + 'static>> {
         let stream = pages
             .filter_map(|res| async move {
                 match res {
@@ -209,7 +210,7 @@ impl<S: StateManager, T: ChainTelemetry> SolanaIndexer<S, T> {
                 async move {
                     let slots = res?;
                     let mut blocks = client.fetch_blocks_for_slots(slots.clone()).await;
-                    let items: Vec<(u64, SolanaCatchupBlock)> = slots
+                    let items: Vec<CatchupBlockItem> = slots
                         .into_iter()
                         .map(|s| {
                             let block = blocks.remove(&s).unwrap_or(SolanaCatchupBlock::Missing);
@@ -221,7 +222,7 @@ impl<S: StateManager, T: ChainTelemetry> SolanaIndexer<S, T> {
             })
             .map(|res| match res {
                 Ok(items) => {
-                    let stream_items: Vec<anyhow::Result<(u64, SolanaCatchupBlock)>> =
+                    let stream_items: Vec<anyhow::Result<CatchupBlockItem>> =
                         items.into_iter().map(Ok).collect();
                     stream::iter(stream_items)
                 }

--- a/chain-signatures/chain-solana/src/indexer.rs
+++ b/chain-signatures/chain-solana/src/indexer.rs
@@ -112,7 +112,17 @@ impl<S: StateManager, T: ChainTelemetry> SolanaIndexer<S, T> {
             return Ok(Box::pin(futures_util::stream::empty()));
         }
 
-        let slots = self.client.fetch_slots(start_slot, end_slot).await?;
+        // TODO: double-check if we should propagate or keep as is
+        let slots = match self.client.fetch_slots(start_slot, end_slot).await {
+            Ok(slots) => slots,
+            Err(err) => {
+                tracing::warn!(
+                    ?err,
+                    "failed to fetch slots for catchup, returning empty stream"
+                );
+                return Ok(Box::pin(futures_util::stream::empty()));
+            }
+        };
         let remaining_slots: VecDeque<u64> = slots.into_iter().collect();
 
         let client = self.client.clone();

--- a/chain-signatures/chain-solana/src/indexer.rs
+++ b/chain-signatures/chain-solana/src/indexer.rs
@@ -112,19 +112,9 @@ impl<S: StateManager, T: ChainTelemetry> SolanaIndexer<S, T> {
             return Ok(Box::pin(futures_util::stream::empty()));
         }
 
-        // TODO: The error should be propagated, otherwise an empty stream is returned,
-        // catchup finishes without processing missing blocks and ChainEvent::CatchupCompleted is emitted.
-        // Let supervisor restart on error.
-        let slots = match self.client.fetch_slots(start_slot, end_slot).await {
-            Ok(slots) => slots,
-            Err(err) => {
-                tracing::warn!(
-                    ?err,
-                    "failed to fetch slots for catchup, returning empty stream"
-                );
-                return Ok(Box::pin(futures_util::stream::empty()));
-            }
-        };
+        // The error should be propagated, to let supervisor restart on error, otherwise
+        // an empty stream is returned and catchup finishes without processing missing blocks.
+        let slots = self.client.fetch_slots(start_slot, end_slot).await?;
         let remaining_slots: VecDeque<u64> = slots.into_iter().collect();
 
         let client = self.client.clone();

--- a/chain-signatures/chain-solana/src/lib.rs
+++ b/chain-signatures/chain-solana/src/lib.rs
@@ -6,4 +6,4 @@ mod utils;
 pub use anchor_lang::prelude::Pubkey;
 pub use client::SolanaClient;
 pub use config::SolConfig;
-pub use indexer::{SolanaIndexer, SolanaStream};
+pub use indexer::SolanaIndexer;

--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -35,7 +35,7 @@ use mpc_chain_canton::{CantonClient, CantonConfig, CantonStream};
 use mpc_chain_ethereum::{publisher, EthConfig, EthereumIndexer};
 use mpc_chain_integration_core::ChainPublisher;
 use mpc_chain_near::NearClient;
-use mpc_chain_solana::{SolConfig, SolanaClient, SolanaStream};
+use mpc_chain_solana::{SolConfig, SolanaClient, SolanaIndexer};
 use mpc_keys::hpke;
 use mpc_primitives::{Chain, CheckpointDigest, SignCommand};
 use near_account_id::AccountId;
@@ -813,11 +813,11 @@ async fn spawn_indexers(
 
     if let Some(sol_config) = sol {
         let sol_telemetry = NodeTelemetry::new(Chain::Solana);
-        match SolanaStream::new(sol_config, backlog.clone(), sol_telemetry.clone()) {
-            Ok(sol_stream) => {
-                tracing::info!("solana indexer stream created successfully");
-                tokio::spawn(run_stream(
-                    sol_stream,
+        match SolanaIndexer::new(sol_config, backlog.clone(), sol_telemetry.clone()) {
+            Ok(sol_indexer) => {
+                tracing::info!("solana indexer created successfully");
+                tokio::spawn(run_supervised(
+                    sol_indexer,
                     StreamContext::new(
                         backlog.clone(),
                         sign_tx.clone(),
@@ -831,7 +831,7 @@ async fn spawn_indexers(
                 ));
             }
             Err(err) => {
-                tracing::error!(?err, "failed to create solana indexer stream");
+                tracing::error!(?err, "failed to create solana indexer");
             }
         }
     }

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -2,8 +2,10 @@ use anyhow::{Context, Result};
 use cait_sith::protocol::Participant;
 use integration_tests::containers::Solana;
 use k256::{AffinePoint, Scalar};
-use mpc_chain_integration_core::{ChainStream, ChainTelemetry, NoopChainTelemetry, StateManager};
-use mpc_chain_solana::{SolConfig, SolanaStream};
+use mpc_chain_integration_core::{
+    utils::stream::chain_event_channel, ChainIndexer, NoopChainTelemetry, StateManager,
+};
+use mpc_chain_solana::{SolConfig, SolanaIndexer};
 use mpc_crypto::ScalarExt;
 use mpc_node::backlog::Backlog;
 use mpc_node::mesh::connection::NodeStatus;
@@ -13,10 +15,10 @@ use mpc_node::protocol::contract::primitives::{ParticipantInfo, Participants};
 use mpc_node::rpc::{ContractStateWatcher, RpcAction, RpcChannel};
 use mpc_node::sign_bidirectional::{PublishState, SignStatus};
 use mpc_node::storage::checkpoint_storage::CheckpointStorage;
-use mpc_node::stream::{run_stream, ChainPipeline, ChainStreaming, StreamContext};
+use mpc_node::stream::{supervisor::run_supervised, StreamContext};
 use mpc_primitives::{
-    Chain, ChainEvent, CheckpointDigest, IndexedSignRequest, SignArgs, SignCommand, SignId,
-    Signature, LATEST_MPC_KEY_VERSION,
+    Chain, ChainEvent, IndexedSignRequest, SignArgs, SignCommand, SignId, Signature,
+    LATEST_MPC_KEY_VERSION,
 };
 use near_primitives::types::AccountId;
 use solana_sdk::signer::Signer;
@@ -24,6 +26,7 @@ use tokio::sync::mpsc;
 use tokio::sync::watch;
 use tokio::time::timeout;
 use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
 
 use std::time::Duration;
 
@@ -40,69 +43,68 @@ fn test_dependencies() -> (Backlog, watch::Receiver<MeshState>, NodeClient) {
     (backlog, mesh_rx, node_client)
 }
 
-async fn stream_solana(
-    config: SolConfig,
-) -> Result<(
-    SolanaStream<impl StateManager, impl ChainTelemetry>,
-    watch::Sender<Option<CheckpointDigest>>,
-)> {
-    let (backlog, _, _) = test_dependencies();
-    stream_solana_with_backlog(config, backlog).await
+struct RunningSolanaIndexer {
+    events_rx: mpsc::Receiver<ChainEvent>,
+    cancel: CancellationToken,
+    run_handle: tokio::task::JoinHandle<anyhow::Result<()>>,
 }
 
-async fn stream_solana_with_backlog(
+impl RunningSolanaIndexer {
+    async fn next_event(&mut self) -> Option<ChainEvent> {
+        self.events_rx.recv().await
+    }
+}
+
+impl Drop for RunningSolanaIndexer {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        self.run_handle.abort();
+    }
+}
+
+async fn run_solana_indexer(config: SolConfig) -> Result<RunningSolanaIndexer> {
+    let (backlog, _, _) = test_dependencies();
+    run_solana_indexer_with_backlog(config, backlog).await
+}
+
+async fn run_solana_indexer_with_backlog(
     config: SolConfig,
     backlog: Backlog,
-) -> Result<(
-    SolanaStream<impl StateManager, impl ChainTelemetry>,
-    watch::Sender<Option<CheckpointDigest>>,
-)> {
-    let mut stream = SolanaStream::new(config, backlog.clone(), NoopChainTelemetry)
-        .context("failed to create SolanaStream")?;
-    let indexer = ChainStream::start(&mut stream).await?;
-    let (cp_tx, cp_rx) = watch::channel(None);
-    let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
-    let node_client = NodeClient::new(&Default::default());
-    // Start from Recovery so that handle_recovery() calls livestream(), which
-    // spawns the live event subscription and initializes the live_rx channel.
-    // Starting in Live would skip this initialization and produce no events.
-    let (sign_tx, _sign_rx) = mpsc::channel(1);
-    let (pipeline, mut state_rx) = ChainPipeline::new(
-        indexer,
-        cp_rx,
-        backlog,
-        sign_tx,
-        mesh_rx,
-        node_client,
-        0,
-        "test.near".parse().unwrap(),
-    );
-    tokio::spawn(pipeline.run());
+) -> Result<RunningSolanaIndexer> {
+    let indexer = SolanaIndexer::new(config, backlog, NoopChainTelemetry)
+        .context("failed to create SolanaIndexer")?;
+    let (events_tx, mut events_rx) = chain_event_channel();
+    let cancel = CancellationToken::new();
+    let run_handle = tokio::spawn({
+        let cancel = cancel.clone();
+        async move { indexer.run(events_tx, cancel).await }
+    });
 
-    // Wait until the pipeline is live so the WS subscription and anchor are established
+    // Wait until catchup completes so the WS subscription and anchor are established
     // before callers begin submitting transactions.
     timeout(Duration::from_secs(30), async {
         loop {
-            if *state_rx.borrow() == ChainStreaming::Live {
-                return Ok(());
-            }
-            if state_rx.changed().await.is_err() {
-                anyhow::bail!("pipeline shut down before reaching Live state");
+            match events_rx.recv().await {
+                Some(ChainEvent::CatchupCompleted) => return Ok(()),
+                Some(_) => continue,
+                None => anyhow::bail!("indexer stopped before completing catchup"),
             }
         }
     })
     .await
-    .context("timed out waiting for pipeline to reach Live state")??;
+    .context("timed out waiting for catchup to complete")??;
 
-    Ok((stream, cp_tx))
+    Ok(RunningSolanaIndexer {
+        events_rx,
+        cancel,
+        run_handle,
+    })
 }
 
 /// Helper to wait for a specific event type, skipping block events
-async fn wait_for_sign_request<S: StateManager, T: ChainTelemetry>(
-    stream: &mut SolanaStream<S, T>,
-) -> Result<IndexedSignRequest> {
+async fn wait_for_sign_request(indexer: &mut RunningSolanaIndexer) -> Result<IndexedSignRequest> {
     loop {
-        match timeout(Duration::from_secs(6), stream.next_event()).await {
+        match timeout(Duration::from_secs(6), indexer.next_event()).await {
             Ok(Some(ChainEvent::SignRequest { request, .. })) => return Ok(request),
             Ok(Some(ChainEvent::Block(_))) => continue,
             Ok(Some(ChainEvent::CatchupCompleted)) => {
@@ -110,25 +112,25 @@ async fn wait_for_sign_request<S: StateManager, T: ChainTelemetry>(
                 continue;
             }
             Ok(Some(other)) => anyhow::bail!("Expected SignRequest, got {:?}", other),
-            Ok(None) => anyhow::bail!("stream returned None"),
+            Ok(None) => anyhow::bail!("indexer returned None"),
             Err(_) => anyhow::bail!("timeout waiting for SignRequest event"),
         }
     }
 }
 
-/// Test that SolanaStream can parse basic Sign events
+/// Test that the Solana indexer can parse basic Sign events
 ///
 /// This test:
 /// 1. Spins up Solana sandbox and deploys contract
-/// 2. Creates a SolanaStream with test configuration
+/// 2. Creates a SolanaIndexer with test configuration
 /// 3. Submits a Sign request directly to the contract
-/// 4. Verifies stream.next_event() returns ChainEvent::SignRequest with correct data
+/// 4. Verifies the indexer emits ChainEvent::SignRequest with correct data
 #[test_log::test(tokio::test)]
 async fn test_solana_stream_parse_sign_event() -> Result<()> {
     let solana = solana_sandbox().await?;
     let program_address = solana.program_keypair.pubkey().to_string();
     let config = solana.get_config(program_address);
-    let (mut stream, _cp_tx) = stream_solana(config).await?;
+    let mut indexer = run_solana_indexer(config).await?;
 
     // Submit sign request
     let payload = [1u8; 32];
@@ -139,7 +141,7 @@ async fn test_solana_stream_parse_sign_event() -> Result<()> {
         .await?;
 
     // Wait for SignRequest event
-    let req = wait_for_sign_request(&mut stream).await?;
+    let req = wait_for_sign_request(&mut indexer).await?;
 
     // Verify the request
     assert_eq!(req.chain, Chain::Solana);
@@ -150,14 +152,14 @@ async fn test_solana_stream_parse_sign_event() -> Result<()> {
     Ok(())
 }
 
-/// Test that SolanaStream emits block events regularly
+/// Test that the Solana indexer emits block events regularly
 #[test_log::test(tokio::test)]
 async fn test_solana_stream_emits_blocks() -> Result<()> {
     let solana = solana_sandbox().await?;
     let program_address = solana.program_keypair.pubkey().to_string();
 
     let config = solana.get_config(program_address);
-    let (mut stream, _cp_tx) = stream_solana(config).await?;
+    let mut indexer = run_solana_indexer(config).await?;
 
     // Submit a transaction to generate activity
     let payload = [2u8; 32];
@@ -168,7 +170,7 @@ async fn test_solana_stream_emits_blocks() -> Result<()> {
     // Collect events and verify we get block markers
     let mut found_block = false;
     for _ in 0..5 {
-        if let Ok(Some(event)) = timeout(Duration::from_secs(3), stream.next_event()).await {
+        if let Ok(Some(event)) = timeout(Duration::from_secs(3), indexer.next_event()).await {
             if matches!(event, ChainEvent::Block(_)) {
                 found_block = true;
                 break;
@@ -180,7 +182,7 @@ async fn test_solana_stream_emits_blocks() -> Result<()> {
     Ok(())
 }
 
-/// Test that SolanaStream can linearly catch up when starting behind
+/// Test that the Solana indexer can linearly catch up when starting behind
 #[test_log::test(tokio::test)]
 async fn test_solana_stream_catchup_linear() -> Result<()> {
     let solana = solana_sandbox().await?;
@@ -188,7 +190,7 @@ async fn test_solana_stream_catchup_linear() -> Result<()> {
 
     // Create first client and process some events
     let config = solana.get_config(program_address.clone());
-    let (mut stream1, _cp_tx) = stream_solana(config.clone()).await?;
+    let mut indexer1 = run_solana_indexer(config.clone()).await?;
 
     // Submit requests while client is running
     for i in 0..3 {
@@ -202,7 +204,7 @@ async fn test_solana_stream_catchup_linear() -> Result<()> {
     let mut seen_by_client1 = 0;
     let mut last_block_client1 = 0;
     for _ in 0..10 {
-        if let Ok(Some(event)) = timeout(Duration::from_millis(500), stream1.next_event()).await {
+        if let Ok(Some(event)) = timeout(Duration::from_millis(500), indexer1.next_event()).await {
             match event {
                 ChainEvent::SignRequest { .. } => seen_by_client1 += 1,
                 ChainEvent::Block(block) => last_block_client1 = last_block_client1.max(block),
@@ -214,10 +216,10 @@ async fn test_solana_stream_catchup_linear() -> Result<()> {
     assert!(last_block_client1 > 0, "first client saw no block events");
 
     // Drop first client
-    drop(stream1);
+    drop(indexer1);
 
     // Create new client immediately (before more events) - should start processing from now
-    let (mut stream2, _cp_tx2) = stream_solana(config).await?;
+    let mut indexer2 = run_solana_indexer(config).await?;
 
     // Submit new requests while second client is running
     for i in 3..6 {
@@ -231,7 +233,7 @@ async fn test_solana_stream_catchup_linear() -> Result<()> {
     let mut sign_events = Vec::new();
     let mut caught_up = false;
     for _ in 0..20 {
-        if let Ok(Some(event)) = timeout(Duration::from_secs(1), stream2.next_event()).await {
+        if let Ok(Some(event)) = timeout(Duration::from_secs(1), indexer2.next_event()).await {
             match event {
                 ChainEvent::SignRequest { request, .. } => {
                     sign_events.push(request);
@@ -259,13 +261,13 @@ async fn test_solana_stream_catchup_linear() -> Result<()> {
     Ok(())
 }
 
-/// Test that SolanaStream can parse SignBidirectional events
+/// Test that the Solana indexer can parse SignBidirectional events
 #[test_log::test(tokio::test)]
 async fn test_solana_stream_parse_sign_bidirectional() -> Result<()> {
     let solana = solana_sandbox().await?;
     let program_address = solana.program_keypair.pubkey().to_string();
     let config = solana.get_config(program_address);
-    let (mut stream, _cp_tx) = stream_solana(config).await?;
+    let mut indexer = run_solana_indexer(config).await?;
 
     // Submit bidirectional sign request
     let serialized_tx = vec![1, 2, 3, 4];
@@ -287,7 +289,7 @@ async fn test_solana_stream_parse_sign_bidirectional() -> Result<()> {
         .await?;
 
     // Wait for SignRequest event
-    let req = wait_for_sign_request(&mut stream).await?;
+    let req = wait_for_sign_request(&mut indexer).await?;
 
     // Verify it's a bidirectional sign request
     assert_eq!(req.chain, Chain::Solana);
@@ -299,13 +301,13 @@ async fn test_solana_stream_parse_sign_bidirectional() -> Result<()> {
     Ok(())
 }
 
-/// Test that SolanaStream handles multiple concurrent submissions
+/// Test that the Solana indexer handles multiple concurrent submissions
 #[test_log::test(tokio::test)]
 async fn test_solana_stream_concurrent_events() -> Result<()> {
     let solana = solana_sandbox().await?;
     let program_address = solana.program_keypair.pubkey().to_string();
     let config = solana.get_config(program_address);
-    let (mut stream, _cp_tx) = stream_solana(config).await?;
+    let mut indexer = run_solana_indexer(config).await?;
 
     // Submit multiple concurrent sign requests
     let num_requests = 5;
@@ -327,7 +329,7 @@ async fn test_solana_stream_concurrent_events() -> Result<()> {
         }
 
         if let Ok(Some(ChainEvent::SignRequest { request, .. })) =
-            timeout(remaining, stream.next_event()).await
+            timeout(remaining, indexer.next_event()).await
         {
             sign_events.push(request);
         }
@@ -359,7 +361,7 @@ async fn test_solana_stream_checkpoint_persistence() -> Result<()> {
     let program_address = solana.program_keypair.pubkey().to_string();
     let (backlog, _, _) = test_dependencies();
     let config = solana.get_config(program_address.clone());
-    let (mut stream1, _cp_tx) = stream_solana_with_backlog(config.clone(), backlog.clone()).await?;
+    let mut indexer1 = run_solana_indexer_with_backlog(config.clone(), backlog.clone()).await?;
     // Submit request and wait for a block marker
     solana
         .sign(
@@ -375,7 +377,7 @@ async fn test_solana_stream_checkpoint_persistence() -> Result<()> {
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut checkpoint_block = None;
     while Instant::now() < deadline {
-        match timeout(Duration::from_secs(1), stream1.next_event()).await {
+        match timeout(Duration::from_secs(1), indexer1.next_event()).await {
             Ok(Some(ChainEvent::Block(block))) => {
                 tracing::info!(block, "received block event");
                 checkpoint_block = Some(block);
@@ -395,10 +397,10 @@ async fn test_solana_stream_checkpoint_persistence() -> Result<()> {
         checkpoint_block.is_some(),
         "did not receive block event within time"
     );
-    drop(stream1);
+    drop(indexer1);
 
     // Create new client with same backlog - should resume from checkpoint
-    let (mut stream2, _cp_tx2) = stream_solana_with_backlog(config, backlog.clone()).await?;
+    let mut indexer2 = run_solana_indexer_with_backlog(config, backlog.clone()).await?;
 
     // Verify the backlog was persisted
     let persisted_block = backlog.get_processed_block(Chain::Solana).await;
@@ -422,7 +424,7 @@ async fn test_solana_stream_checkpoint_persistence() -> Result<()> {
     // New client should pick up new events
     timeout(Duration::from_secs(5), async {
         loop {
-            match stream2.next_event().await {
+            match indexer2.next_event().await {
                 Some(ChainEvent::SignRequest { request, .. }) => break Ok(request),
                 Some(other) => {
                     tracing::info!(?other, "received non-sign/block event");
@@ -490,8 +492,8 @@ async fn test_solana_stream_republishes_pending_publish_after_checkpoint_recover
         .await;
 
     let recovered_backlog = Backlog::persisted(storage);
-    let stream = SolanaStream::new(config, recovered_backlog.clone(), NoopChainTelemetry)
-        .context("failed to create SolanaStream")?;
+    let indexer = SolanaIndexer::new(config, recovered_backlog.clone(), NoopChainTelemetry)
+        .context("failed to create SolanaIndexer")?;
 
     let (sign_tx, mut sign_rx) = mpsc::channel::<SignCommand>(4);
     let (rpc_tx, mut rpc_rx) = mpsc::channel::<RpcAction>(4);
@@ -516,8 +518,8 @@ async fn test_solana_stream_republishes_pending_publish_after_checkpoint_recover
 
     let (_cp_tx, checkpoints_rx) = watch::channel(None);
     let run_handle = tokio::spawn(async move {
-        run_stream(
-            stream,
+        run_supervised(
+            indexer,
             StreamContext::new(
                 recovered_backlog.clone(),
                 sign_tx.clone(),


### PR DESCRIPTION
- Move `AbortOnDrop` to `mpc_chain_integration_core::utils::task`, re-use for both Ethereum and Solana
- Drop `SolanaStream` and implement `run` method for `ChainIndexer`
- Update `SolanaIndexer` wiring to use `supervisor::run_supervised` (same as Ethereum)
- Fix potential false positive watchdog timeout for long catchups in `catchup_blocks` by using streams, break it down into smaller methods: 
  - `catchup_range` - to get range of slots 
  - `paginate_slots` - returns stream of pages of slots
  - `fetch_blocks_for_pages` - returns stream of `(slot, block)`
- Add 6 unit tests for `SolanaIndexer`