### PR TITLE
test(integration): demonstrate the divergent-active-views liveness stall

### DIFF
--- a/integration-tests/src/mpc_fixture/fixture_tasks.rs
+++ b/integration-tests/src/mpc_fixture/fixture_tasks.rs
@@ -36,6 +36,10 @@ pub(super) fn test_mock_network(
 ) -> JoinHandle<()> {
     let msg_log = Arc::clone(&shared_output.msg_log);
     let rpc_actions = Arc::clone(&shared_output.rpc_actions);
+    // Participant info as of network start, consulted only for the recipient's
+    // encryption key. A node's active set may shrink during a test; delivery in
+    // the mock network must not depend on the sender's view of liveness.
+    let initial_participants = mesh.borrow().active().clone();
 
     tokio::spawn(async move {
         tracing::debug!(target: "mock_network", "Test message executor started");
@@ -53,7 +57,10 @@ pub(super) fn test_mock_network(
                     let config = config.borrow().clone();
                     let participants = mesh.borrow().active().clone();
                     let SendMessage { message: msg, from, to, .. } = &send_message;
-                    let receiver_info = participants.get(to).expect("TODO: support sending to non-active participants in tests");
+                    let receiver_info = participants
+                        .get(to)
+                        .or_else(|| initial_participants.get(to))
+                        .unwrap_or_else(|| panic!("no participant info for recipient {to:?}"));
                     match SignedMessage::encrypt(
                         &[msg],
                         *from,

--- a/integration-tests/src/mpc_fixture/fixture_tasks.rs
+++ b/integration-tests/src/mpc_fixture/fixture_tasks.rs
@@ -36,9 +36,7 @@ pub(super) fn test_mock_network(
 ) -> JoinHandle<()> {
     let msg_log = Arc::clone(&shared_output.msg_log);
     let rpc_actions = Arc::clone(&shared_output.rpc_actions);
-    // Participant info as of network start, consulted only for the recipient's
-    // encryption key. A node's active set may shrink during a test; delivery in
-    // the mock network must not depend on the sender's view of liveness.
+    // Participant info as of network start, consulted for recipient's encryption key
     let initial_participants = mesh.borrow().active().clone();
 
     tokio::spawn(async move {

--- a/integration-tests/tests/cases/mpc_with_stream.rs
+++ b/integration-tests/tests/cases/mpc_with_stream.rs
@@ -161,9 +161,74 @@ async fn test_channel_contention_multiple_blocks_at_once() {
 
 #[test(tokio::test(flavor = "multi_thread"))]
 async fn test_channel_contention_multiple_blocks_at_once_delayed() {
-    // TODO: delay should be > ORGANIZE_POSIT_TIMEOUT but right now the system can't handle it
+    // Half the organize/posit timeout, so no node reaches its round deadline
+    // before the last one has observed the block.
     let delay = mpc_node::protocol::request::organize_posit_timeout() / 2;
     check_channel_contention(5, 10, 50, Some(delay)).await;
+}
+
+/// A request must settle even when nodes permanently disagree about who is
+/// active.
+///
+/// Every node hides one peer — its successor in participant order — for the
+/// whole run. Each node's active set therefore still holds `threshold`
+/// participants (itself plus three peers), so `wait_for_active_participants`
+/// never blocks and any stall here is attributable to proposer election alone.
+///
+/// The invariant under test: nodes must agree on the proposer, and on the round
+/// they are in, regardless of their local active sets. An election that derives
+/// either from the local active set breaks this — disagreeing views put nodes on
+/// different rounds, proposals then arrive as future-round messages and are
+/// buffered instead of accepted, accepts never reach `threshold`, and the
+/// request never settles.
+#[ignore = "fails until proposer election stops reading the local active set; un-ignore together with that change"]
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_divergent_active_views_still_converge() {
+    let num_nodes = 5;
+    let threshold = 4;
+    let network = MpcFixtureBuilder::new(num_nodes, threshold)
+        .only_generate_signatures()
+        .with_mock_stream(Chain::Solana, MockStream::default())
+        .await
+        .build()
+        .await;
+
+    let participants = network.sorted_participants();
+    for node in network.nodes.iter() {
+        let index = participants
+            .iter()
+            .position(|p| *p == node.me)
+            .expect("node is a participant");
+        let hidden = participants[(index + 1) % participants.len()];
+        let mut view = node.mesh.borrow().clone();
+        view.remove(hidden);
+        // Must not be silently dropped: without the divergent views installed
+        // the request settles trivially and the test proves nothing.
+        node.mesh.send(view).expect("mesh receivers are alive");
+    }
+
+    network
+        .process_sign_requests(Chain::Solana, &[sign_request(0)])
+        .await;
+
+    let deadline = Duration::from_secs(90);
+    let start = std::time::Instant::now();
+    loop {
+        let settled = {
+            let actions = network.output.rpc_actions.lock().await;
+            actions.iter().any(|action| {
+                !action.contains("kind: Checkpoint") && action.contains("RpcAction::Publish")
+            })
+        };
+        if settled {
+            break;
+        }
+        if start.elapsed() >= deadline {
+            network.print_actions().await;
+            panic!("request never settled under divergent active views within {deadline:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
 }
 
 #[test(tokio::test(flavor = "multi_thread"))]


### PR DESCRIPTION
## What

A component test that demonstrates a liveness failure of the current proposer election, plus the fixture change needed to express it.

The test belongs to the class of stall logged in #690 ("replicate with a test"). Related: #182 (closed predecessor), #228, #907.

Also drops a stale claim on the sibling staggered-observation test that the system cannot handle an observation delay above the organize/posit timeout — measurement shows it can, on this branch and with the follow-up change.

### Scenario

* 5 nodes, threshold 4. 
* Every node permanently hides one peer (its successor) from its `MeshState`. 
* Each node's active set still holds `threshold` participants (itself plus three peers), so `wait_for_active_participants` never blocks and any stall is attributable to proposer election alone.

### Failure

Election scans the node's own active set for a proposer and moves `state.round` to whichever round that scan lands on. With views disagreeing, nodes land on different rounds and never co-locate: a proposer that jumped ahead broadcasts at its round, deliberators on a lower round buffer that Propose as a future-round message instead of accepting, then time out waiting for a proposal at their own round.

On this branch: no signature within 90s, nothing reaches Start, and zero rejects — the stall is round divergence, not rejection.

The test is `#[ignore]`d so CI stays green. Reproduce with:

```
cargo test -p integration-tests -- --ignored test_divergent_active_views_still_converge
```

It is un-ignored by the election change in the follow-up PR, where it settles.

## Fixture change

The mock network resolved a recipient's encryption key from *the sender's* active set, so shrinking a node's view made it unable to send at all (it panicked on `participants.get(to).expect(...)`). This implements that method's existing `// TODO: support sending to non-active participants` by falling back to the participant set the network started with. The live active set stays the primary lookup, so existing tests are unaffected; the fallback only fires where the old code panicked. Message delivery must not depend on the sender's view of liveness, or a divergent failure detector cannot be modelled at all.

