### PR TITLE
feat(request): deterministic proposer rotation with scheduled round timeout

### DIFF
--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -64,25 +64,22 @@ const ROUND_TIMEOUT_FLOOR: Duration = ACCEPT_POSIT_TIMEOUT
     .saturating_mul(2)
     .saturating_add(Duration::from_secs(1));
 
-/// Per-round growth factor, as a 23/20 ratio.
+/// Per-round growth factor of 1.15 (=23/20).
 ///
-/// Multiplicative rather than additive. Nodes that index a request at different
-/// times enter the same round at different moments, and can only transact while
-/// both are inside it — so a round has to grow past that skew before the request
-/// can settle. An additive step overshoots the skew by one step however long it
-/// has been growing, leaving a window too short to complete a round; a ratio
-/// overshoots by a fraction of the skew, so the window scales with the problem.
-///
-/// Any ratio above 1 eventually crosses the skew, so the value is chosen for
-/// what it costs the other case: rotating past dead proposers wants rounds to
-/// stay short. At 23/20 a round only doubles after five rotations, so rotating
-/// past a run of dead proposers stays cheap for as long as it plausibly needs to.
+/// Nodes that index a request at different times enter the same round at
+/// different moments, and can only transact while both are inside it.
+/// Thus, a round length has to exceed that skew before the request
+/// can be processed.
+/// Any factor above 1 eventually crosses the skew, so the value is chosen
+/// for what it costs the other case: rotating past inactive proposers
+/// benefits from short rounds. At 1.15 the round length doubles after five rounds.
 const ROUND_TIMEOUT_GROWTH_NUM: u32 = 23;
 const ROUND_TIMEOUT_GROWTH_DEN: u32 = 20;
 
 /// Longest a round may be. High enough that any plausible indexing skew is
 /// crossed, low enough that a wedged request keeps rotating visibly instead of
 /// disappearing into a multi-hour round.
+/// tolerable skew < ROUND_TIMEOUT_CEILING - ROUND_TIMEOUT_FLOOR
 const ROUND_TIMEOUT_CEILING: Duration = Duration::from_secs(if cfg!(feature = "test-feature") {
     30
 } else {
@@ -677,22 +674,17 @@ mod tests {
 
     #[test]
     fn round_timeout_schedule() {
-        // Every round must outlast a deliberator's post-Accept wait, or the
-        // round is too short for any proposer to gather accepts and rotating
-        // through it accomplishes nothing.
-        let min_viable = 2 * ACCEPT_POSIT_TIMEOUT;
+        // Every round must outlast a propose broadcast (<1s) plus accept
+        // gathering inside.  For r >= 1 this holds by construction today;
+        // the test serves as a guard so the code can't silently drift.
         for r in 0..64usize {
             assert!(
-                round_timeout(r) > min_viable,
+                round_timeout(r) >= ROUND_TIMEOUT_FLOOR,
                 "round {r} is too short to complete"
             );
         }
 
-        // Rotating past a dead proposer must be cheaper than the round-0 wait,
-        // otherwise the schedule buys nothing.
-        assert!(round_timeout(1) < round_timeout(0));
-
-        // Growth is monotonic, so a request that keeps failing keeps getting
+        // Growth is monotonic from round 1, so a request that keeps failing gets
         // more time rather than retrying forever on equally short rounds.
         for r in 1..64usize {
             assert!(
@@ -704,15 +696,32 @@ mod tests {
 
         // Rounds must grow past a late node's indexing skew, or the two never
         // overlap: both advance at the same rate, so a fixed ceiling below the
-        // skew leaves them permanently offset. Growth must also clear the skew
-        // by enough to complete a round, not merely exceed it.
-        let skew = 4 * ORGANIZE_POSIT_TIMEOUT;
-        let crossing = (1..1024usize)
-            .find(|&r| round_timeout(r) > skew)
-            .expect("schedule must grow past the skew");
+        // skew leaves them permanently offset.
+        // In addition, the overlap of the two nodes in the same round must fit a
+        // Propose broadcast plus accept gathering inside (`ROUND_TIMEOUT_FLOOR`).
+        let settling_overlap = |skew: Duration| {
+            (1..1024usize)
+                .map(round_timeout)
+                .find(|&t| t.saturating_sub(skew) > ROUND_TIMEOUT_FLOOR)
+                .map(|t| t - skew)
+                .expect("schedule must clear the skew by a full round")
+        };
+
+        let skew = ORGANIZE_POSIT_TIMEOUT;
+        let wider = 4 * skew;
+
+        // The shared window has to scale with the skew
+        // (up to some ceiling to avoid rounds that last hours).
+        // `settling_overlap` needs a round that clears the skew by more than
+        // ROUND_TIMEOUT_FLOOR. No round exceeds the ceiling, so that's only
+        // reachable while the skew leaves enough room under it.
         assert!(
-            round_timeout(crossing) - skew > min_viable,
-            "round {crossing} clears the skew by too little to settle in"
+            wider < ROUND_TIMEOUT_CEILING - ROUND_TIMEOUT_FLOOR,
+            "the skews compared here must leave a full round of room under the ceiling"
+        );
+        assert!(
+            settling_overlap(wider) > settling_overlap(skew),
+            "a 4x larger skew must leave a wider window, not the same floor-sized one"
         );
 
         // A wedged request keeps rotating rather than vanishing into an

--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -20,9 +20,6 @@ use cait_sith::protocol::Participant;
 use lru::LruCache;
 use mpc_contract::config::ProtocolConfig;
 use mpc_primitives::{ChainConfig as _, IndexedSignRequest, SignCommand, SignId};
-use rand::rngs::StdRng;
-use rand::seq::IteratorRandom;
-use rand::SeedableRng;
 use std::collections::{BTreeSet, HashMap};
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -44,13 +41,10 @@ use task::SignTask;
 
 pub(crate) use work_queue::{SignPositWorkQueue, SignTaskMessage};
 
-/// How many rounds ahead the organizing phase searches for an active proposer.
-const PROPOSER_SEARCH_WINDOW: usize = 512;
-
 /// Max number of concurrent proposers, with unlimited deliberators.
 const MAX_CONCURRENT_PROPOSERS: usize = 4;
 
-/// Timeout budget for organizing and posit phases (shorter under test for speed).
+/// Maximum timeout budget for organizing and posit phases (shorter under test for speed).
 const ORGANIZE_POSIT_TIMEOUT: Duration = Duration::from_secs(if cfg!(feature = "test-feature") {
     5
 } else {
@@ -60,6 +54,28 @@ const ORGANIZE_POSIT_TIMEOUT: Duration = Duration::from_secs(if cfg!(feature = "
 /// A proposer tries to include all eligible deliberators but will go ahead with
 /// a subset after this timeout, if above the minimum threshold.
 const ACCEPT_POSIT_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Shortest a round may be. A round has to fit a Propose broadcast plus accept
+/// gathering, and an accepted deliberator keeps waiting twice
+/// [`ACCEPT_POSIT_TIMEOUT`] no matter what the budget says. Below that, a round
+/// cannot complete and rotating through it is pure churn.
+const ROUND_TIMEOUT_FLOOR: Duration = ACCEPT_POSIT_TIMEOUT
+    .saturating_mul(2)
+    .saturating_add(Duration::from_secs(1));
+
+/// Added to floor per round, so a request that keeps failing gets more time
+const ROUND_TIMEOUT_STEP: Duration = Duration::from_secs(1);
+
+/// Timeout for round `r`: round 0 gets [`ORGANIZE_POSIT_TIMEOUT`], later rounds
+/// start at [`ROUND_TIMEOUT_FLOOR`] and grow linearly back up to it. Depends
+/// only on `r`, so peers that agree on the round agree on the deadline.
+fn round_timeout(round: usize) -> Duration {
+    if round == 0 {
+        return ORGANIZE_POSIT_TIMEOUT;
+    }
+    let steps = u32::try_from(round - 1).unwrap_or(u32::MAX);
+    (ROUND_TIMEOUT_FLOOR + ROUND_TIMEOUT_STEP * steps).min(ORGANIZE_POSIT_TIMEOUT)
+}
 
 /// Upper bound on the number of recently-completed/aborted sign IDs we remember
 /// so that late-arriving peer posit messages do not re-create orphan queues.
@@ -625,5 +641,30 @@ mod tests {
         assert!(spawner.test_requests_contains(&sign_id));
         assert!(spawner.test_posit_queues_contains(&sign_id));
         assert!(!spawner.test_dead_ids_contains(&sign_id));
+    }
+
+    #[test]
+    fn round_timeout_schedule() {
+        // Every round must outlast a deliberator's post-Accept wait, or the
+        // round is too short for any proposer to gather accepts and rotating
+        // through it accomplishes nothing.
+        let min_viable = 2 * ACCEPT_POSIT_TIMEOUT;
+        for r in 0..64usize {
+            assert!(
+                round_timeout(r) > min_viable,
+                "round {r} is too short to complete"
+            );
+        }
+
+        // Rotating past a dead proposer must be cheaper than the round-0 wait,
+        // otherwise the schedule buys nothing.
+        assert!(round_timeout(1) < round_timeout(0));
+
+        // A request that keeps failing gets back to the full round-0 budget
+        // rather than retrying forever on short rounds.
+        assert_eq!(round_timeout(64), ORGANIZE_POSIT_TIMEOUT);
+
+        // `round` derives from a peer-supplied value, so it may be arbitrary.
+        assert_eq!(round_timeout(usize::MAX), ORGANIZE_POSIT_TIMEOUT);
     }
 }

--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -44,7 +44,8 @@ pub(crate) use work_queue::{SignPositWorkQueue, SignTaskMessage};
 /// Max number of concurrent proposers, with unlimited deliberators.
 const MAX_CONCURRENT_PROPOSERS: usize = 4;
 
-/// Maximum timeout budget for organizing and posit phases (shorter under test for speed).
+/// Timeout budget for the organizing and posit phases of round 0 (shorter under
+/// test for speed). Later rounds follow [`round_timeout`], which may exceed this.
 const ORGANIZE_POSIT_TIMEOUT: Duration = Duration::from_secs(if cfg!(feature = "test-feature") {
     5
 } else {
@@ -63,18 +64,49 @@ const ROUND_TIMEOUT_FLOOR: Duration = ACCEPT_POSIT_TIMEOUT
     .saturating_mul(2)
     .saturating_add(Duration::from_secs(1));
 
-/// Added to floor per round, so a request that keeps failing gets more time
-const ROUND_TIMEOUT_STEP: Duration = Duration::from_secs(1);
+/// Per-round growth factor, as a 23/20 ratio.
+///
+/// Multiplicative rather than additive. Nodes that index a request at different
+/// times enter the same round at different moments, and can only transact while
+/// both are inside it — so a round has to grow past that skew before the request
+/// can settle. An additive step overshoots the skew by one step however long it
+/// has been growing, leaving a window too short to complete a round; a ratio
+/// overshoots by a fraction of the skew, so the window scales with the problem.
+///
+/// Any ratio above 1 eventually crosses the skew, so the value is chosen for
+/// what it costs the other case: rotating past dead proposers wants rounds to
+/// stay short. At 23/20 a round only doubles after five rotations, so rotating
+/// past a run of dead proposers stays cheap for as long as it plausibly needs to.
+const ROUND_TIMEOUT_GROWTH_NUM: u32 = 23;
+const ROUND_TIMEOUT_GROWTH_DEN: u32 = 20;
+
+/// Longest a round may be. High enough that any plausible indexing skew is
+/// crossed, low enough that a wedged request keeps rotating visibly instead of
+/// disappearing into a multi-hour round.
+const ROUND_TIMEOUT_CEILING: Duration = Duration::from_secs(if cfg!(feature = "test-feature") {
+    30
+} else {
+    600
+});
 
 /// Timeout for round `r`: round 0 gets [`ORGANIZE_POSIT_TIMEOUT`], later rounds
-/// start at [`ROUND_TIMEOUT_FLOOR`] and grow linearly back up to it. Depends
-/// only on `r`, so peers that agree on the round agree on the deadline.
+/// start at [`ROUND_TIMEOUT_FLOOR`] and grow geometrically to
+/// [`ROUND_TIMEOUT_CEILING`]. Depends only on `r`, so peers that agree on the
+/// round agree on the deadline.
 fn round_timeout(round: usize) -> Duration {
     if round == 0 {
         return ORGANIZE_POSIT_TIMEOUT;
     }
-    let steps = u32::try_from(round - 1).unwrap_or(u32::MAX);
-    (ROUND_TIMEOUT_FLOOR + ROUND_TIMEOUT_STEP * steps).min(ORGANIZE_POSIT_TIMEOUT)
+    // Saturates at the ceiling within ~16 iterations, which bounds the loop:
+    // `round` derives from `highest_seen_round`, so a peer can make it huge.
+    let mut timeout = ROUND_TIMEOUT_FLOOR;
+    for _ in 1..round {
+        if timeout >= ROUND_TIMEOUT_CEILING {
+            return ROUND_TIMEOUT_CEILING;
+        }
+        timeout = timeout * ROUND_TIMEOUT_GROWTH_NUM / ROUND_TIMEOUT_GROWTH_DEN;
+    }
+    timeout.min(ROUND_TIMEOUT_CEILING)
 }
 
 /// Upper bound on the number of recently-completed/aborted sign IDs we remember
@@ -660,11 +692,33 @@ mod tests {
         // otherwise the schedule buys nothing.
         assert!(round_timeout(1) < round_timeout(0));
 
-        // A request that keeps failing gets back to the full round-0 budget
-        // rather than retrying forever on short rounds.
-        assert_eq!(round_timeout(64), ORGANIZE_POSIT_TIMEOUT);
+        // Growth is monotonic, so a request that keeps failing keeps getting
+        // more time rather than retrying forever on equally short rounds.
+        for r in 1..64usize {
+            assert!(
+                round_timeout(r + 1) >= round_timeout(r),
+                "round {r} is longer than round {}",
+                r + 1
+            );
+        }
 
-        // `round` derives from a peer-supplied value, so it may be arbitrary.
-        assert_eq!(round_timeout(usize::MAX), ORGANIZE_POSIT_TIMEOUT);
+        // Rounds must grow past a late node's indexing skew, or the two never
+        // overlap: both advance at the same rate, so a fixed ceiling below the
+        // skew leaves them permanently offset. Growth must also clear the skew
+        // by enough to complete a round, not merely exceed it.
+        let skew = 4 * ORGANIZE_POSIT_TIMEOUT;
+        let crossing = (1..1024usize)
+            .find(|&r| round_timeout(r) > skew)
+            .expect("schedule must grow past the skew");
+        assert!(
+            round_timeout(crossing) - skew > min_viable,
+            "round {crossing} clears the skew by too little to settle in"
+        );
+
+        // A wedged request keeps rotating rather than vanishing into an
+        // unbounded round. `round` derives from a peer-supplied value, so it
+        // may be arbitrary.
+        assert_eq!(round_timeout(1024), ROUND_TIMEOUT_CEILING);
+        assert_eq!(round_timeout(usize::MAX), ROUND_TIMEOUT_CEILING);
     }
 }

--- a/chain-signatures/node/src/protocol/request/organize.rs
+++ b/chain-signatures/node/src/protocol/request/organize.rs
@@ -9,13 +9,17 @@ pub struct OrganizingPhase;
 
 impl OrganizingPhase {
     /// Seeded by request entropy so all nodes pick the same proposer.
+    ///
+    /// Both operands are reduced before adding: `round` comes from
+    /// `highest_seen_round`, which a peer sets, so it can be arbitrarily large.
     fn proposer_per_round(
         round: usize,
         participants: &[Participant],
         entropy: &[u8; 32],
     ) -> Participant {
-        let index = entropy[0] as usize + round;
-        participants[index % participants.len()]
+        let n = participants.len();
+        let index = (entropy[0] as usize % n + round % n) % n;
+        participants[index]
     }
 
     /// Waits for threshold active participants to be present.
@@ -79,21 +83,10 @@ impl OrganizingPhase {
                 return state.reorganize("no active participants");
             };
 
-            let max_rounds = state.round + PROPOSER_SEARCH_WINDOW;
-            let (selected_round, proposer) = (state.round..max_rounds)
-                .map(|r| (r, Self::proposer_per_round(r, &participants, &entropy)))
-                .find(|(_, potential_proposer)| active.contains(potential_proposer))
-                .unwrap_or_else(|| {
-                    (
-                        max_rounds,
-                        *active
-                            .iter()
-                            .choose(&mut StdRng::from_seed(entropy))
-                            .unwrap(),
-                    )
-                });
-
-            state.round = selected_round;
+            // Elect from inputs every node shares (round, membership, entropy), no
+            // local-only information: filtering by the local active set makes nodes
+            // elect different proposers and diverge permanently (#907).
+            let proposer = Self::proposer_per_round(state.round, &participants, &entropy);
 
             // If proposing is paused (generating already ongoing), we act as if we weren't a proposer.
             let skip_proposing = state
@@ -104,7 +97,7 @@ impl OrganizingPhase {
 
             tracing::info!(
                 ?sign_id,
-                round = selected_round,
+                round = ?state.round,
                 ?proposer,
                 ?me,
                 is_proposer,
@@ -247,5 +240,38 @@ mod tests {
             OrganizingPhase::proposer_per_round(2, &participants, &entropy),
             Participant::from(0)
         );
+    }
+
+    /// From any starting round, with any `f < n` participants down, rotation must
+    /// reach a live proposer within `f + 1` rounds — the bound that lets a request
+    /// make progress past dead proposers. A rotation that revisited a participant
+    /// before covering the rest (say a hash of the round, or a stride sharing a
+    /// factor with `n`) would silently lose it.
+    #[test]
+    fn rotation_reaches_live_proposer_within_f_plus_1_rounds() {
+        // Only `entropy[0]` selects the offset, so varying the seed is the same
+        // as varying the starting round, which the loop below already sweeps.
+        let entropy = [0u8; 32];
+        for n in [4usize, 5] {
+            let participants: Vec<Participant> = (0..n as u32).map(Participant::from).collect();
+            // Every down-set except "all down", which has no live proposer.
+            for down_mask in 0..((1u32 << n) - 1) {
+                let down: BTreeSet<Participant> = (0..n)
+                    .filter(|&i| down_mask & (1 << i) != 0)
+                    .map(|i| participants[i])
+                    .collect();
+                let budget = down.len() + 1;
+                for start in 0..n {
+                    let reached_live = (start..start + budget).any(|r| {
+                        let p = OrganizingPhase::proposer_per_round(r, &participants, &entropy);
+                        !down.contains(&p)
+                    });
+                    assert!(
+                        reached_live,
+                        "n {n}, down {down:?}, start {start}: no live proposer within {budget} rounds"
+                    );
+                }
+            }
+        }
     }
 }

--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -230,7 +230,7 @@ impl PositPhase {
             // to gather more accepts before sending Start.
             // We must wait at least that long so we don't abandon the round after promising to participate,
             // which would cause the proposer's generation phase to hang.
-            let min_wait = ACCEPT_POSIT_TIMEOUT + Duration::from_millis(500);
+            let min_wait = 2 * ACCEPT_POSIT_TIMEOUT;
             if remaining < min_wait {
                 remaining = min_wait;
             }

--- a/chain-signatures/node/src/protocol/request/state.rs
+++ b/chain-signatures/node/src/protocol/request/state.rs
@@ -32,7 +32,7 @@ impl SignState {
             round: 0,
             request,
             mesh_state,
-            budget: TimeoutBudget::new(ORGANIZE_POSIT_TIMEOUT),
+            budget: TimeoutBudget::new(round_timeout(0)),
             permit: None,
             highest_seen_round: 0,
             buffered_messages: HashMap::new(),
@@ -62,7 +62,7 @@ impl SignState {
     fn bump_round(&mut self) {
         let prev_round = self.round;
         self.round = std::cmp::max(self.round + 1, self.highest_seen_round);
-        self.budget.reset(ORGANIZE_POSIT_TIMEOUT);
+        self.budget.reset(round_timeout(self.round));
         self.permit = None;
         tracing::debug!(prev_round, new_round = self.round, "bumped round");
     }

--- a/chain-signatures/node/src/protocol/request/state.rs
+++ b/chain-signatures/node/src/protocol/request/state.rs
@@ -61,7 +61,7 @@ impl SignState {
 
     fn bump_round(&mut self) {
         let prev_round = self.round;
-        self.round = std::cmp::max(self.round + 1, self.highest_seen_round);
+        self.round = std::cmp::max(self.round.saturating_add(1), self.highest_seen_round);
         self.budget.reset(round_timeout(self.round));
         self.permit = None;
         tracing::debug!(prev_round, new_round = self.round, "bumped round");

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -1232,9 +1232,11 @@ async fn test_non_participants_pause_posits() {
         "expected AlreadyGenerating to be sent to node 2, but count was {count}"
     );
 
-    // Node 2 still hasn't seen the signature. Wait until it proposes again.
-    // After the pause, node 2 may need up to (num_nodes+1) more rounds to get
-    // its turn as proposer. Each round lasts ORGANIZE_POSIT_TIMEOUT.
+    // Node 2 still hasn't seen the signature. Wait until it proposes again:
+    // one generation timeout for the pause to lapse, plus a few rounds for
+    // node 2's turn in the rotation. Generous rather than exact — a round can
+    // outlast ORGANIZE_POSIT_TIMEOUT if it blocks on the mesh gate or reaches
+    // Generating.
     let organize_timeout = mpc_node::protocol::request::organize_posit_timeout();
     let second_wait = Duration::from_millis(signature_timeout_ms) + 4 * organize_timeout;
     tokio::time::timeout(second_wait, async {

--- a/integration-tests/tests/cases/mpc_with_stream.rs
+++ b/integration-tests/tests/cases/mpc_with_stream.rs
@@ -181,7 +181,6 @@ async fn test_channel_contention_multiple_blocks_at_once_delayed() {
 /// different rounds, proposals then arrive as future-round messages and are
 /// buffered instead of accepted, accepts never reach `threshold`, and the
 /// request never settles.
-#[ignore = "fails until proposer election stops reading the local active set; un-ignore together with that change"]
 #[test(tokio::test(flavor = "multi_thread"))]
 async fn test_divergent_active_views_still_converge() {
     let num_nodes = 5;


### PR DESCRIPTION
Closes #907. Realizes the design in #228; original intent of #182. 


## What

- **Election** (`organize.rs`): drop the forward scan for a locally-active proposer, the entropy-seeded fallback, and the `state.round = selected_round` jump. `proposer(r)` is now a pure function of `(round, participants, entropy)`; `state.round` advances only through `bump_round`.
- **Schedule** (`mod.rs`, `state.rs`): `T(0)` keeps the generous inherited budget; `T(r ≥ 1)` starts at a short floor and grows by `23/20` up to a separate ceiling, so rotating past a dead proposer no longer costs a full round-0 wait.
- `wait_for_active_participants` is untouched — it gates supply, not election.
- `proposer_per_round` reduces both operands before adding: `round` derives from `highest_seen_round`, which a peer sets unbounded, so the bare sum overflows.
- The deliberator's post-Accept wait carried an unexplained `500ms` literal (`ACCEPT_POSIT_TIMEOUT + 500ms`); it is now `2 * ACCEPT_POSIT_TIMEOUT`, and the schedule's floor is asserted to exceed it.

## Why

- Nodes with differing liveness views elected different proposers *and advanced to different rounds*, so they never co-located and the request could not settle.
- This PR un-ignores the test from the stacked PR below: it stalls indefinitely without this change, settles with it.

## Cost, deliberately paid

- A dead proposer now burns `T(r)` before rotating, where the local filter used to skip it free. That is the price of peer-identical election; skipping needs the local knowledge being removed.
- `T(r ≥ 1)` being short is what buys the cost down. Rounds 1..18 are shorter than the old uniform 20s, so an alive-but-contended proposer (permit or presignature wait) has less time than before.
- `23/20` over doubling: most failed rounds are dead-or-unable proposers, where the cheapest early rounds waste least, and rotation changes proposer every round so doubling would penalise a healthy node for its predecessors. A round only doubles after five rotations. Multiplicative over additive, though: a fixed step clears a late node's indexing skew by one step however long it has been growing, leaving a window too short to complete a round in, and a ceiling below that skew leaves the two permanently offset since both advance at the same rate.

## Open question: per-chain `T(0)`?

- `T(0)` decides whether this change is free or a latency regression, and one global value serves budgets differing by three orders of magnitude.
- `Chain::expected_response_time_secs`: NEAR/Solana **11s**, Hydration 29, Canton 35, Ethereum 3605, Bitcoin ~4805. At `T(0) = 20s` a single dead round-0 proposer is over budget on NEAR and Solana; the regression fires with probability ≈ (nodes down)/`n`.
- `chain` is on-chain request data, so a per-chain `T(0)` stays peer-identical 
- Options: one global `T(0)` sized for the tightest chain / derive from `expected_response_time_secs` / a per-chain constant beside `expected_finality_time_secs`. Flagging, not choosing.

## Known exposure, not introduced here

`entropy` is requester-supplied, and `entropy[0]` alone fixes the rotation offset, so a requester can grind for a cycle that front-loads nodes it believes are down. Bounded (one round each) but repeatable per request. The local filter used to mask it.

Using an input fixed after submission works (block hash), which `IndexedSignRequest` does not carry. This is a separate issue, not addressed in this PR.

## Tests

- `round_timeout_schedule` — every round outlasts the post-Accept wait, rotation is cheaper than round 0, the cap is reached.
- `rotation_reaches_live_proposer_within_f_plus_1_rounds` — exhaustive over down-sets and start rounds for `n = 4, 5`. `n = 4` is load-bearing: a stride sharing a factor with `n` covers only half the participants, which an odd `n` masks.
- The now-active integration test from the stacked PR.




