### PR TITLE
refactor(request): retire the pause_proposing fail-over

### DIFF
--- a/chain-signatures/node/src/protocol/request/organize.rs
+++ b/chain-signatures/node/src/protocol/request/organize.rs
@@ -84,11 +84,7 @@ impl OrganizingPhase {
             // and a dead proposer costs one silent round bounded by `T(r)`.
             let proposer = Self::proposer_per_round(state.round, &participants, &entropy);
 
-            // If proposing is paused (generating already ongoing), we act as if we weren't a proposer.
-            let skip_proposing = state
-                .pause_proposing_until
-                .is_some_and(|until| until > std::time::Instant::now());
-            let is_proposer = proposer == me && !skip_proposing;
+            let is_proposer = proposer == me;
             ctx.is_proposer.store(is_proposer, Ordering::Relaxed);
 
             tracing::info!(
@@ -97,7 +93,6 @@ impl OrganizingPhase {
                 ?proposer,
                 ?me,
                 is_proposer,
-                skip_proposing,
                 active_count = active.len(),
                 "organized: selected proposer"
             );

--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -298,23 +298,16 @@ impl PositPhase {
                         }
 
                         if counter.enough_rejects(ctx.governance.threshold) {
+                            // No pause under single-leader rotation; just reorganize.
+                            // `num_ongoing` (peers already generating) is diagnostic only.
                             let num_ongoing = counter.num_peers_with_ongoing_generation();
-                            if ctx.governance.participants.len().saturating_sub(num_ongoing) < ctx.governance.threshold {
-                                state.pause_proposing_until = Some(Instant::now() + Duration::from_millis(ctx.cfg.signature.generation_timeout));
-                                tracing::info!(
-                                    ?sign_id,
-                                    ?round,
-                                    resume=?state.pause_proposing_until,
-                                    "pausing proposer: peers already generating this signature"
-                                );
-                            } else {
-                                tracing::warn!(
-                                    ?sign_id,
-                                    ?round,
-                                    ?from,
-                                    "received enough REJECTs, reorganizing"
-                                );
-                            }
+                            tracing::warn!(
+                                ?sign_id,
+                                ?round,
+                                ?from,
+                                num_ongoing,
+                                "received enough REJECTs, reorganizing"
+                            );
                             if let Some(_reservation) = presignature {
                                 tracing::warn!(?sign_id, "returning presignature to pool due to REJECTs");
                             }

--- a/chain-signatures/node/src/protocol/request/state.rs
+++ b/chain-signatures/node/src/protocol/request/state.rs
@@ -21,9 +21,6 @@ pub struct SignState {
     /// INVARIANT: All messages stored here are for `highest_seen_round`. Must
     /// be cleared when `highest_seen_round` changes. One slot per sender.
     pub buffered_messages: HashMap<Participant, SignTaskMessage>,
-    /// When Some, another group is already generating this signature.
-    /// The timestamp is when proposing can be resumed.
-    pub pause_proposing_until: Option<std::time::Instant>,
 }
 
 impl SignState {
@@ -36,7 +33,6 @@ impl SignState {
             permit: None,
             highest_seen_round: 0,
             buffered_messages: HashMap::new(),
-            pause_proposing_until: None,
         }
     }
 

--- a/chain-signatures/node/src/protocol/request/task.rs
+++ b/chain-signatures/node/src/protocol/request/task.rs
@@ -53,9 +53,6 @@ impl GeneratingPhase {
         state: &mut SignState,
         posit_queue: &SignPositWorkQueue,
     ) -> SignPhase {
-        // We successfully committed to generating; future rounds should be unrestricted.
-        state.pause_proposing_until = None;
-
         let sign_id = ctx.sign_id;
         let round = state.round;
 


### PR DESCRIPTION
## What

Remove `pause_proposing_until` (its field, the `skip_proposing` read, the `enough_rejects -> pause` set, and the reset on entering generation). Keep the `AlreadyGenerating` reject reply and the `SignLimiter` permit.

## Why

`pause_proposing` only ever fired when free peers < threshold — i.e. when a *competing* generation was impossible anyway; it just stopped a re-elected proposer from spinning futilely. With one deterministic leader per round (the rotation PR this stacks on) and the `T(r)` schedule bounding re-election cost, that spin is already cheap, and the fast `AlreadyGenerating` reject still prevents duplicate generation. `num_peers_with_ongoing_generation` is retained (unit-tested; logged on reorganize) as diagnostic input.
