### PR TITLE
refactor: migrate Canton to supervised actor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7339,6 +7339,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.29.0",
+ "tokio-util",
  "tracing",
 ]
 

--- a/chain-signatures/chain-canton/Cargo.toml
+++ b/chain-signatures/chain-canton/Cargo.toml
@@ -24,6 +24,7 @@ serde_json.workspace = true
 serde-aux = { version = "4", default-features = false }
 tokio.workspace = true
 tokio-tungstenite = { version = "0.29", features = ["native-tls"] }
+tokio-util.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/chain-signatures/chain-canton/src/indexer.rs
+++ b/chain-signatures/chain-canton/src/indexer.rs
@@ -1,19 +1,18 @@
-//! Canton stream and indexer implementation.
+//! Canton indexer implementation.
 
 use crate::client::CantonClient;
 use crate::config::CantonConfig;
-use crate::events::{catchup_offset_range, process_canton_event};
+use crate::events::process_canton_event;
 use crate::ledger_api;
 
+use anyhow::Context as _;
 use async_trait::async_trait;
-use futures_util::stream::{self, SplitSink, SplitStream};
+use futures_util::stream::{Empty, SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
-use mpc_chain_integration_core::utils::stream::chain_event_channel;
 use mpc_chain_integration_core::{
-    ChainIndexer, ChainStream, ChainTelemetry, NoopPublisherTelemetry, StateManager,
+    ChainIndexer, ChainTelemetry, NoopPublisherTelemetry, StateManager,
 };
 use mpc_primitives::{Chain, ChainEvent};
-use std::ops::Range;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -22,54 +21,11 @@ use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::http::header;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+use tokio_util::sync::CancellationToken;
 
 type CantonWs = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
 type CantonWsRead = SplitStream<CantonWs>;
 type CantonWsWrite = SplitSink<CantonWs, Message>;
-
-pub struct CantonStream<S: StateManager, T: ChainTelemetry> {
-    client: Option<CantonClient>,
-    state_manager: S,
-    telemetry: T,
-    events_rx: mpsc::Receiver<ChainEvent>,
-    events_tx: Option<mpsc::Sender<ChainEvent>>,
-}
-
-impl<S: StateManager, T: ChainTelemetry> CantonStream<S, T> {
-    pub async fn new(config: CantonConfig, state_manager: S, telemetry: T) -> anyhow::Result<Self> {
-        let client = CantonClient::new(&config, Arc::new(NoopPublisherTelemetry)).await?; // Indexer does not publish
-        let (events_tx, events_rx) = chain_event_channel();
-        Ok(CantonStream {
-            client: Some(client),
-            state_manager,
-            telemetry,
-            events_rx,
-            events_tx: Some(events_tx),
-        })
-    }
-}
-
-#[async_trait]
-impl<S: StateManager, T: ChainTelemetry> ChainStream for CantonStream<S, T> {
-    type Indexer = CantonIndexer<S, T>;
-
-    async fn start(&mut self) -> anyhow::Result<Self::Indexer> {
-        let (Some(events_tx), Some(client)) = (self.events_tx.take(), self.client.take()) else {
-            anyhow::bail!("canton stream already started");
-        };
-
-        Ok(Self::Indexer::new(
-            client,
-            self.state_manager.clone(),
-            self.telemetry.clone(),
-            events_tx,
-        ))
-    }
-
-    async fn next_event(&mut self) -> Option<ChainEvent> {
-        self.events_rx.recv().await
-    }
-}
 
 enum CantonConnection {
     Connected(CantonWsRead, CantonWsWrite),
@@ -131,7 +87,8 @@ impl CantonConnection {
         Ok(Self::Connected(ws_read, ws_write))
     }
 
-    /// Read the next message from the WebSocket. Closes the connection if the WebSocket is closed.
+    /// Read the next message from the WebSocket. Returns `None` (transitioning to
+    /// `Disconnected`) on close, error, or a 60s message stall.
     async fn next(&mut self) -> Option<Message> {
         let Self::Connected(ws_read, _) = self else {
             tracing::warn!("canton WebSocket not initialized");
@@ -184,33 +141,32 @@ pub struct CantonIndexer<S: StateManager, T: ChainTelemetry> {
     client: CantonClient,
     state_manager: S,
     telemetry: T,
-    events_tx: mpsc::Sender<ChainEvent>,
-    ws_conn: CantonConnection,
-    last_seen_offset: u64,
 }
 
 impl<S: StateManager, T: ChainTelemetry> CantonIndexer<S, T> {
-    pub fn new(
-        client: CantonClient,
-        state_manager: S,
-        telemetry: T,
-        events_tx: mpsc::Sender<ChainEvent>,
-    ) -> Self {
-        Self {
+    pub async fn new(config: CantonConfig, state_manager: S, telemetry: T) -> anyhow::Result<Self> {
+        let client = CantonClient::new(&config, Arc::new(NoopPublisherTelemetry)).await?; // Indexer does not publish
+        Ok(Self {
             client,
             state_manager,
             telemetry,
-            events_tx,
-            ws_conn: CantonConnection::Disconnected,
-            last_seen_offset: 0,
-        }
+        })
     }
 
-    async fn connect_and_subscribe(&mut self, begin_exclusive: u64) -> anyhow::Result<()> {
+    // TODO: ws_conn + last_seen_offset are threaded as explicit params because
+    // `run(&self)` is immutable. A cleaner shape (matching Solana/Ethereum) would
+    // spawn a WS-driver task owning the connection and emitting Updates on a
+    // channel, leaving `run()` to drain it; CantonClient is Clone so this is
+    // feasible. Revisit post-migration.
+    async fn connect_and_subscribe(
+        &self,
+        ws_conn: &mut CantonConnection,
+        begin_exclusive: u64,
+    ) -> anyhow::Result<()> {
         let jwt_token = self.client.bearer_token().await?;
         let ws_url = format!("{}/v2/updates", self.client.config.json_api_ws_url);
         let party_id = &self.client.config.party_id;
-        self.ws_conn = CantonConnection::connect(
+        *ws_conn = CantonConnection::connect(
             &ws_url,
             &jwt_token,
             party_id,
@@ -221,22 +177,18 @@ impl<S: StateManager, T: ChainTelemetry> CantonIndexer<S, T> {
         Ok(())
     }
 
-    async fn reconnect(&mut self, begin_exclusive: u64) {
+    async fn reconnect(&self, ws_conn: &mut CantonConnection, resume_offset: u64) {
         let mut backoff = Duration::from_secs(1);
-
         loop {
-            match self.connect_and_subscribe(begin_exclusive).await {
+            match self.connect_and_subscribe(ws_conn, resume_offset).await {
                 Ok(()) => {
-                    tracing::info!(
-                        resume_offset = self.last_seen_offset,
-                        "canton WebSocket reconnected"
-                    );
+                    tracing::info!(resume_offset, "canton WebSocket reconnected");
                     return;
                 }
                 Err(err) => {
                     tracing::warn!(
                         ?err,
-                        resume_offset = self.last_seen_offset,
+                        resume_offset,
                         backoff_secs = backoff.as_secs(),
                         "canton WebSocket reconnect failed; retrying"
                     );
@@ -247,10 +199,14 @@ impl<S: StateManager, T: ChainTelemetry> CantonIndexer<S, T> {
         }
     }
 
-    async fn next_update(&mut self) -> Option<ledger_api::Update> {
+    async fn next_update(
+        &self,
+        ws_conn: &mut CantonConnection,
+        last_seen_offset: u64,
+    ) -> Option<ledger_api::Update> {
         loop {
-            let Some(msg) = self.ws_conn.next().await else {
-                self.reconnect(self.last_seen_offset).await;
+            let Some(msg) = ws_conn.next().await else {
+                self.reconnect(ws_conn, last_seen_offset).await;
                 continue;
             };
             let Message::Text(text) = msg else {
@@ -277,14 +233,21 @@ impl<S: StateManager, T: ChainTelemetry> CantonIndexer<S, T> {
         }
     }
 
-    async fn process_update(&mut self, update: &ledger_api::Update) -> anyhow::Result<u64> {
+    /// Decode a ledger update, emit its events + a `Block(offset)`, and report the
+    /// offset so the caller can advance its cursor. Errors only when `events_tx` is
+    /// closed (supervisor shutdown) — there is no transient failure worth retrying.
+    async fn process_update(
+        &self,
+        events_tx: &mpsc::Sender<ChainEvent>,
+        update: &ledger_api::Update,
+    ) -> anyhow::Result<u64> {
         let offset = match update {
             ledger_api::Update::Transaction { value } => {
                 for event in &value.events {
                     process_canton_event(
                         event,
                         &value.events,
-                        &self.events_tx,
+                        events_tx,
                         &self.client.config.signer_contract_id,
                     )
                     .await;
@@ -294,26 +257,40 @@ impl<S: StateManager, T: ChainTelemetry> CantonIndexer<S, T> {
             ledger_api::Update::OffsetCheckpoint { value } => value.offset,
         };
 
-        // Update the telemetry with the latest block number seen by the indexer
         self.telemetry.block_indexed(offset);
-
-        self.events_tx.send(ChainEvent::Block(offset)).await?;
-        self.last_seen_offset = offset;
+        events_tx.send(ChainEvent::Block(offset)).await?;
         Ok(offset)
     }
 
-    async fn process_catchup_offset(&mut self, target_offset: u64) -> anyhow::Result<()> {
-        // If we're already at or past the target offset, we're done
-        if self.last_seen_offset >= target_offset {
+    /// Drive the WebSocket until `last_seen_offset >= target_offset`. A 2s per-pull
+    /// timeout falls back to checking the ledger end: if the global ledger has passed
+    /// the target with no events for our party, catchup completes without emitting.
+    async fn process_catchup_offset(
+        &self,
+        ws_conn: &mut CantonConnection,
+        events_tx: &mpsc::Sender<ChainEvent>,
+        last_seen_offset: &mut u64,
+        target_offset: u64,
+        cancel: &CancellationToken,
+    ) -> anyhow::Result<()> {
+        if *last_seen_offset >= target_offset {
             return Ok(());
         }
 
         loop {
             // Try to get the next update with a conservative timeout during catchup.
             // If the WebSocket is silent for a short period, we check the current ledger end.
-            match tokio::time::timeout(Duration::from_secs(2), self.next_update()).await {
+            let outcome = tokio::select! {
+                _ = cancel.cancelled() => return Ok(()),
+                r = tokio::time::timeout(
+                    Duration::from_secs(2),
+                    self.next_update(ws_conn, *last_seen_offset),
+                ) => r,
+            };
+            match outcome {
                 Ok(Some(update)) => {
-                    let offset = self.process_update(&update).await?;
+                    let offset = self.process_update(events_tx, &update).await?;
+                    *last_seen_offset = offset;
                     if offset >= target_offset {
                         return Ok(());
                     }
@@ -333,7 +310,7 @@ impl<S: StateManager, T: ChainTelemetry> CantonIndexer<S, T> {
                             target_offset,
                             "catchup timeout: ledger has passed target offset with no new updates for our party"
                         );
-                        self.last_seen_offset = target_offset;
+                        *last_seen_offset = target_offset;
                         return Ok(());
                     }
                 }
@@ -345,45 +322,50 @@ impl<S: StateManager, T: ChainTelemetry> CantonIndexer<S, T> {
 #[async_trait]
 impl<S: StateManager, T: ChainTelemetry> ChainIndexer for CantonIndexer<S, T> {
     const CHAIN: Chain = Chain::Canton;
-    type Block = u64;
-    type Iter = stream::Iter<Range<u64>>;
 
-    async fn livestream(&mut self) -> anyhow::Result<Option<u64>> {
+    // TODO: not used, required by trait, remove later
+    type Block = ();
+    type Iter = Empty<()>;
+
+    async fn run(
+        &self,
+        events_tx: mpsc::Sender<ChainEvent>,
+        cancel: CancellationToken,
+    ) -> anyhow::Result<()> {
         let checkpoint = self
             .state_manager
             .get_processed_block(Chain::Canton)
             .await
             .unwrap_or(0);
-        self.last_seen_offset = checkpoint;
-        let anchor_height = self.client.fetch_ledger_end().await?;
-        self.reconnect(self.last_seen_offset).await;
-        Ok(Some(anchor_height))
-    }
+        let mut last_seen_offset = checkpoint;
 
-    async fn catchup_range(&self, anchor_height: u64) -> Self::Iter {
-        // After a reconnect, we resume from last_seen_offset, so catchup should start there.
-        stream::iter(catchup_offset_range(self.last_seen_offset, anchor_height))
-    }
+        let anchor = self.client.fetch_ledger_end().await?;
+        let mut ws_conn = CantonConnection::Disconnected;
+        self.reconnect(&mut ws_conn, last_seen_offset).await;
 
-    async fn process_catchup(&mut self, &item: &Self::Block) -> anyhow::Result<()> {
-        self.process_catchup_offset(item).await
-    }
+        self.process_catchup_offset(
+            &mut ws_conn,
+            &events_tx,
+            &mut last_seen_offset,
+            anchor,
+            &cancel,
+        )
+        .await?;
 
-    async fn notify_catchup_completed(&mut self) -> anyhow::Result<()> {
-        self.events_tx.send(ChainEvent::CatchupCompleted).await?;
-        Ok(())
-    }
+        events_tx
+            .send(ChainEvent::CatchupCompleted)
+            .await
+            .context("failed to send canton catchup completed event")?;
 
-    async fn process_next_block(&mut self) -> bool {
-        let Some(update) = self.next_update().await else {
-            return false;
-        };
-
-        while let Err(err) = self.process_update(&update).await {
-            tracing::warn!(?err, "live block processing failed; retrying");
-            tokio::time::sleep(Self::RETRY_DELAY).await;
+        loop {
+            let update = tokio::select! {
+                _ = cancel.cancelled() => return Ok(()),
+                u = self.next_update(&mut ws_conn, last_seen_offset) => match u {
+                    Some(u) => u,
+                    None => anyhow::bail!("canton WebSocket producer terminated"),
+                },
+            };
+            last_seen_offset = self.process_update(&events_tx, &update).await?;
         }
-
-        true
     }
 }

--- a/chain-signatures/chain-canton/src/indexer.rs
+++ b/chain-signatures/chain-canton/src/indexer.rs
@@ -156,10 +156,7 @@ impl<S: StateManager, T: ChainTelemetry> CantonIndexer<S, T> {
     }
 
     // TODO: ws_conn + last_seen_offset are threaded as explicit params because
-    // `run(&self)` is immutable. A cleaner shape (matching Solana/Ethereum) would
-    // spawn a WS-driver task owning the connection and emitting Updates on a
-    // channel, leaving `run()` to drain it; CantonClient is Clone so this is
-    // feasible. Revisit post-migration.
+    // `run(&self)` is immutable. Consider better approache post migration
     async fn connect_and_subscribe(
         &self,
         ws_conn: &mut CantonConnection,
@@ -235,9 +232,9 @@ impl<S: StateManager, T: ChainTelemetry> CantonIndexer<S, T> {
         }
     }
 
-    /// Decode a ledger update, emit its events + a `Block(offset)`, and report the
-    /// offset so the caller can advance its cursor. Errors only when `events_tx` is
-    /// closed (supervisor shutdown) — there is no transient failure worth retrying.
+    /// Process a single `Update` (transaction or offset checkpoint) and emit the
+    /// corresponding `ChainEvent::Block(offset)` event. Returns the offset of the
+    /// processed update.
     async fn process_update(
         &self,
         events_tx: &mpsc::Sender<ChainEvent>,
@@ -264,9 +261,8 @@ impl<S: StateManager, T: ChainTelemetry> CantonIndexer<S, T> {
         Ok(offset)
     }
 
-    /// Drive the WebSocket until `last_seen_offset >= target_offset`. A 2s per-pull
-    /// timeout falls back to checking the ledger end: if the global ledger has passed
-    /// the target with no events for our party, catchup completes without emitting.
+    /// Process catchup from `last_seen_offset` (exclusive) to `target_offset` (inclusive),
+    /// emitting `ChainEvent::Block(offset)` events for each processed update.
     async fn process_catchup_offset(
         &self,
         ws_conn: &mut CantonConnection,

--- a/chain-signatures/chain-canton/src/indexer.rs
+++ b/chain-signatures/chain-canton/src/indexer.rs
@@ -34,6 +34,8 @@ enum CantonConnection {
 
 impl CantonConnection {
     const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+    // TODO: this 60s message stall overlaps with the supervisor's per-chain
+    // `live_block_timeout` watchdog. Consolidate into one stall authority
     const MESSAGE_TIMEOUT: Duration = Duration::from_secs(60);
     const DISCONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -327,6 +329,8 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for CantonIndexer<S, T> {
     type Block = ();
     type Iter = Empty<()>;
 
+    // TODO: add unit tests for `run()` mirroring Ethereum's `RunFixture`
+    // (catchup ordering, live-after-catchup, cancel-during-catchup, cancel-while-live).
     async fn run(
         &self,
         events_tx: mpsc::Sender<ChainEvent>,

--- a/chain-signatures/chain-canton/src/lib.rs
+++ b/chain-signatures/chain-canton/src/lib.rs
@@ -9,7 +9,7 @@ pub mod signing;
 
 pub use client::CantonClient;
 pub use config::{CantonAuthConfig, CantonConfig};
-pub use indexer::CantonStream;
+pub use indexer::CantonIndexer;
 pub use signing::{
     compute_request_id, der_encode_signature, parse_canton_signature, CantonChainCtx,
 };

--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -21,7 +21,7 @@ use crate::storage::checkpoint_storage::CheckpointStorage;
 use crate::storage::presignature_storage::PresignatureStorage;
 use crate::storage::secret_storage::SecretNodeStorageVariant;
 use crate::storage::triple_storage::{TriplePair, TripleStorage};
-use crate::stream::{run_stream, supervisor::run_supervised, StreamContext};
+use crate::stream::{supervisor::run_supervised, StreamContext};
 use crate::{logs, storage, web};
 pub use args::{canton::CantonArgs, ethereum::EthArgs, hydration::HydrationArgs, solana::SolArgs};
 
@@ -31,7 +31,7 @@ use deadpool_redis::Runtime;
 use enum_map::EnumMap;
 use k256::sha2::Sha256;
 use local_ip_address::local_ip;
-use mpc_chain_canton::{CantonClient, CantonConfig, CantonStream};
+use mpc_chain_canton::{CantonClient, CantonConfig, CantonIndexer};
 use mpc_chain_ethereum::{publisher, EthConfig, EthereumIndexer};
 use mpc_chain_integration_core::ChainPublisher;
 use mpc_chain_near::NearClient;
@@ -857,11 +857,11 @@ async fn spawn_indexers(
 
     if let Some(canton_config) = canton {
         let canton_telemetry = NodeTelemetry::new(Chain::Canton);
-        match CantonStream::new(canton_config, backlog.clone(), canton_telemetry.clone()).await {
-            Ok(canton_stream) => {
-                tracing::info!("canton indexer stream created successfully");
-                tokio::spawn(run_stream(
-                    canton_stream,
+        match CantonIndexer::new(canton_config, backlog.clone(), canton_telemetry.clone()).await {
+            Ok(canton_indexer) => {
+                tracing::info!("canton indexer created successfully");
+                tokio::spawn(run_supervised(
+                    canton_indexer,
                     StreamContext::new(
                         backlog,
                         sign_tx,
@@ -875,7 +875,7 @@ async fn spawn_indexers(
                 ));
             }
             Err(err) => {
-                tracing::error!(?err, "failed to create canton indexer stream");
+                tracing::error!(?err, "failed to create canton indexer");
             }
         }
     }

--- a/integration-tests/tests/cases/canton_stream.rs
+++ b/integration-tests/tests/cases/canton_stream.rs
@@ -43,8 +43,7 @@ impl Drop for RunningCantonIndexer {
 }
 
 /// Spawn `CantonIndexer::run()` against the sandbox, waiting for catchup to
-/// complete before returning. Accepts Backlog as parameter (needed for
-/// checkpoint tests).
+/// complete before returning.
 async fn run_canton_indexer(
     sandbox: &CantonSandbox,
     backlog: Backlog,

--- a/integration-tests/tests/cases/canton_stream.rs
+++ b/integration-tests/tests/cases/canton_stream.rs
@@ -4,83 +4,91 @@ use integration_tests::canton::{
 };
 use mpc_chain_canton::{
     daml::{CantonSignature, EcdsaSigData},
-    der_encode_signature, CantonChainCtx, CantonStream,
+    der_encode_signature, CantonChainCtx, CantonIndexer,
 };
 use mpc_chain_integration_core::{
-    utils::hashing::hash_payload, ChainStream, ChainTelemetry, NoopChainTelemetry, StateManager,
+    utils::hashing::hash_payload, utils::stream::chain_event_channel, ChainIndexer,
+    NoopChainTelemetry, StateManager,
 };
 use mpc_node::backlog::Backlog;
-use mpc_node::mesh::MeshState;
-use mpc_node::node_client::NodeClient;
 use mpc_node::protocol::{Chain, IndexedSignRequest};
 use mpc_node::sign_bidirectional::SignBidirectionalEventExt;
-use mpc_node::stream::{ChainPipeline, ChainStreaming};
-use mpc_primitives::{
-    ChainEvent, CheckpointDigest, ScalarExt, SignKind, Signature, LATEST_MPC_KEY_VERSION,
-};
+use mpc_primitives::{ChainEvent, ScalarExt, SignKind, Signature, LATEST_MPC_KEY_VERSION};
 use serde_json::json;
 use serial_test::serial;
 use std::collections::HashSet;
 use std::time::Duration;
 use test_log::test;
-use tokio::sync::watch;
+use tokio::sync::mpsc;
 use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
 
-/// Create a CantonStream from the sandbox config with an externally-provided Backlog.
-/// Accepts Backlog as parameter (needed for checkpoint tests).
-async fn stream_canton(
+struct RunningCantonIndexer {
+    events_rx: mpsc::Receiver<ChainEvent>,
+    cancel: CancellationToken,
+    run_handle: tokio::task::JoinHandle<anyhow::Result<()>>,
+}
+
+impl RunningCantonIndexer {
+    async fn next_event(&mut self) -> Option<ChainEvent> {
+        self.events_rx.recv().await
+    }
+}
+
+impl Drop for RunningCantonIndexer {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        self.run_handle.abort();
+    }
+}
+
+/// Spawn `CantonIndexer::run()` against the sandbox, waiting for catchup to
+/// complete before returning. Accepts Backlog as parameter (needed for
+/// checkpoint tests).
+async fn run_canton_indexer(
     sandbox: &CantonSandbox,
     backlog: Backlog,
-) -> Result<(
-    CantonStream<impl StateManager, impl ChainTelemetry>,
-    watch::Sender<Option<CheckpointDigest>>,
-)> {
+) -> Result<RunningCantonIndexer> {
     let config = sandbox.get_config();
-    let mut stream = CantonStream::new(config, backlog.clone(), NoopChainTelemetry)
+    let indexer = CantonIndexer::new(config, backlog, NoopChainTelemetry)
         .await
-        .context("failed to create CantonStream")?;
-    let indexer = ChainStream::start(&mut stream).await?;
-    let (cp_tx, cp_rx) = tokio::sync::watch::channel(None);
-    let (_mesh_tx, mesh_rx) = tokio::sync::watch::channel(MeshState::default());
-    let node_client = NodeClient::new(&Default::default());
-    let (sign_tx, _sign_rx) = tokio::sync::mpsc::channel(1);
-    let (pipeline, mut state_rx) = ChainPipeline::new(
-        indexer,
-        cp_rx,
-        backlog,
-        sign_tx,
-        mesh_rx,
-        node_client,
-        0,
-        "test.near".parse().unwrap(),
-    );
-    tokio::spawn(pipeline.run());
+        .context("failed to create CantonIndexer")?;
+    let (events_tx, mut events_rx) = chain_event_channel();
+    let cancel = CancellationToken::new();
+    let run_handle = tokio::spawn({
+        let cancel = cancel.clone();
+        async move { indexer.run(events_tx, cancel).await }
+    });
 
-    // Wait until the pipeline is live so the subscription and anchor are established
+    // Wait until catchup completes so the subscription and anchor are established
     // before callers begin submitting transactions.
     timeout(Duration::from_secs(30), async {
         loop {
-            if *state_rx.borrow() == ChainStreaming::Live {
-                return Ok(());
-            }
-            if state_rx.changed().await.is_err() {
-                anyhow::bail!("pipeline shut down before reaching Live state");
+            match events_rx.recv().await {
+                Some(ChainEvent::CatchupCompleted) => return Ok(()),
+                Some(_) => continue,
+                None => anyhow::bail!("indexer stopped before completing catchup"),
             }
         }
     })
     .await
-    .context("timed out waiting for pipeline to reach Live state")??;
-    Ok((stream, cp_tx))
+    .context("timed out waiting for catchup to complete")??;
+
+    Ok(RunningCantonIndexer {
+        events_rx,
+        cancel,
+        run_handle,
+    })
 }
 
-/// Poll stream for a SignRequest event with timeout.
+/// Poll indexer for a SignRequest event with timeout.
 async fn wait_for_sign_request(
-    stream: &mut CantonStream<impl StateManager, impl ChainTelemetry>,
+    indexer: &mut RunningCantonIndexer,
     timeout_secs: u64,
 ) -> Result<IndexedSignRequest> {
     timeout(Duration::from_secs(timeout_secs), async {
         loop {
-            match stream.next_event().await {
+            match indexer.next_event().await {
                 Some(ChainEvent::SignRequest { request, .. }) => return Ok(request),
                 Some(ChainEvent::Block(_)) => continue,
                 Some(_) => continue,
@@ -98,13 +106,13 @@ async fn wait_for_sign_request(
 async fn test_canton_stream_parse_sign_event() -> Result<()> {
     let sandbox = CantonSandbox::run().await?;
     let backlog = Backlog::new();
-    let (mut stream, _cp_tx) = stream_canton(&sandbox, backlog).await?;
+    let mut indexer = run_canton_indexer(&sandbox, backlog).await?;
 
     let expected_case = test_evm_type2_anvil_cases()[0].clone();
     let expected_event = test_sign_request_event(&sandbox, &expected_case);
     sandbox.submit_sign_request(None).await?;
 
-    let event = wait_for_sign_request(&mut stream, 30).await?;
+    let event = wait_for_sign_request(&mut indexer, 30).await?;
 
     assert_eq!(event.chain, Chain::Canton);
     assert_eq!(event.args.key_version, LATEST_MPC_KEY_VERSION);
@@ -147,13 +155,13 @@ async fn test_canton_stream_parse_sign_event() -> Result<()> {
 async fn test_canton_stream_emits_blocks() -> Result<()> {
     let sandbox = CantonSandbox::run().await?;
     let backlog = Backlog::new();
-    let (mut stream, _cp_tx) = stream_canton(&sandbox, backlog).await?;
+    let mut indexer = run_canton_indexer(&sandbox, backlog).await?;
 
     sandbox.submit_sign_request(None).await?;
 
     let mut saw_block = false;
     for _ in 0..10 {
-        match timeout(Duration::from_secs(5), stream.next_event()).await {
+        match timeout(Duration::from_secs(5), indexer.next_event()).await {
             Ok(Some(ChainEvent::Block(_))) => {
                 saw_block = true;
                 break;
@@ -178,7 +186,7 @@ async fn test_canton_stream_emits_blocks() -> Result<()> {
 async fn test_canton_stream_concurrent_events() -> Result<()> {
     let sandbox = CantonSandbox::run().await?;
     let backlog = Backlog::new();
-    let (mut stream, _cp_tx) = stream_canton(&sandbox, backlog).await?;
+    let mut indexer = run_canton_indexer(&sandbox, backlog).await?;
 
     // Distinct EVM nonces produce distinct request_ids, which is what this
     // test exercises — the Canton stream must deliver each as a separate event.
@@ -189,7 +197,7 @@ async fn test_canton_stream_concurrent_events() -> Result<()> {
     // Collect SignRequest events until we have all 3, verifying content on each
     let mut received_ids = HashSet::new();
     for _ in 0..20 {
-        match timeout(Duration::from_secs(5), stream.next_event()).await {
+        match timeout(Duration::from_secs(5), indexer.next_event()).await {
             Ok(Some(ChainEvent::SignRequest { request, .. })) => {
                 assert_eq!(request.chain, Chain::Canton);
                 assert_eq!(request.args.path, sandbox.requester_party);
@@ -214,43 +222,43 @@ async fn test_canton_stream_concurrent_events() -> Result<()> {
 async fn test_canton_stream_catchup_linear() -> Result<()> {
     let sandbox = CantonSandbox::run().await?;
 
-    // Phase 1: stream1 sees events
+    // Phase 1: indexer1 sees events
     let backlog1 = Backlog::new();
-    let (mut stream1, _cp_tx1) = stream_canton(&sandbox, backlog1).await?;
+    let mut indexer1 = run_canton_indexer(&sandbox, backlog1).await?;
 
     sandbox.submit_sign_request(None).await?;
 
-    let mut seen_by_stream1 = 0;
-    let mut last_block_stream1: u64 = 0;
+    let mut seen_by_indexer1 = 0;
+    let mut last_block_indexer1: u64 = 0;
     for _ in 0..10 {
-        match timeout(Duration::from_millis(500), stream1.next_event()).await {
-            Ok(Some(ChainEvent::SignRequest { .. })) => seen_by_stream1 += 1,
+        match timeout(Duration::from_millis(500), indexer1.next_event()).await {
+            Ok(Some(ChainEvent::SignRequest { .. })) => seen_by_indexer1 += 1,
             Ok(Some(ChainEvent::Block(b))) => {
-                if b > last_block_stream1 {
-                    last_block_stream1 = b;
+                if b > last_block_indexer1 {
+                    last_block_indexer1 = b;
                 }
             }
             Ok(Some(_)) => {}
             _ => break,
         }
     }
-    assert!(seen_by_stream1 > 0, "stream1 saw no events");
-    assert!(last_block_stream1 > 0, "stream1 saw no blocks");
+    assert!(seen_by_indexer1 > 0, "indexer1 saw no events");
+    assert!(last_block_indexer1 > 0, "indexer1 saw no blocks");
 
-    // Drop stream1
-    drop(stream1);
+    // Drop indexer1
+    drop(indexer1);
 
-    // Phase 2: stream2 should catch up and see new events
+    // Phase 2: indexer2 should catch up and see new events
     let backlog2 = Backlog::new();
-    let (mut stream2, _cp_tx2) = stream_canton(&sandbox, backlog2).await?;
+    let mut indexer2 = run_canton_indexer(&sandbox, backlog2).await?;
 
     sandbox.submit_sign_request(None).await?;
 
     let mut caught_up = false;
     let mut seen_sign_events = false;
     for _ in 0..20 {
-        match timeout(Duration::from_secs(1), stream2.next_event()).await {
-            Ok(Some(ChainEvent::Block(b))) if b >= last_block_stream1 => caught_up = true,
+        match timeout(Duration::from_secs(1), indexer2.next_event()).await {
+            Ok(Some(ChainEvent::Block(b))) if b >= last_block_indexer1 => caught_up = true,
             Ok(Some(ChainEvent::SignRequest { .. })) => seen_sign_events = true,
             Ok(Some(_)) => {}
             _ => break,
@@ -261,9 +269,9 @@ async fn test_canton_stream_catchup_linear() -> Result<()> {
     }
     assert!(
         caught_up,
-        "stream2 did not catch up to stream1's block height"
+        "indexer2 did not catch up to indexer1's block height"
     );
-    assert!(seen_sign_events, "stream2 saw no SignRequest events");
+    assert!(seen_sign_events, "indexer2 saw no SignRequest events");
     Ok(())
 }
 
@@ -277,7 +285,7 @@ async fn test_canton_stream_checkpoint_persistence() -> Result<()> {
 
     let sandbox = CantonSandbox::run().await?;
     let backlog = Backlog::new();
-    let (mut stream, _cp_tx) = stream_canton(&sandbox, backlog.clone()).await?;
+    let mut indexer = run_canton_indexer(&sandbox, backlog.clone()).await?;
 
     sandbox.submit_sign_request(None).await?;
 
@@ -286,7 +294,7 @@ async fn test_canton_stream_checkpoint_persistence() -> Result<()> {
     let checkpoint = tokio::time::timeout(Duration::from_secs(30), async {
         let mut saw_sign_request = false;
         loop {
-            let Some(event) = stream.next_event().await else {
+            let Some(event) = indexer.next_event().await else {
                 break None;
             };
             match event {
@@ -319,22 +327,22 @@ async fn test_canton_stream_checkpoint_persistence() -> Result<()> {
     );
     let checkpoint_height = checkpoint.block_height;
     let phase1_request_id = checkpoint.pending_requests[0].sign_id.request_id;
-    drop(stream);
+    drop(indexer);
 
     // Verify the backlog actually persisted the block height
     assert_eq!(
         backlog.get_processed_block(Chain::Canton).await,
         Some(checkpoint_height),
-        "backlog should retain checkpoint height after stream1 is dropped"
+        "backlog should retain checkpoint height after indexer is dropped"
     );
 
-    // Phase 2: new stream with same backlog should resume from checkpoint.
-    // Key invariant: stream2 must start from the checkpointed offset, not
+    // Phase 2: new indexer with same backlog should resume from checkpoint.
+    // Key invariant: indexer2 must start from the checkpointed offset, not
     // replay from 0. Phase 2 uses a distinct EVM nonce so its request_id
     // differs from phase 1, letting us prove no replay occurred. We verify:
     // (a) the first Block event is >= checkpoint_height
     // (b) exactly 1 SignRequest arrives (the new one, not a replay of phase 1)
-    let (mut stream2, _cp_tx2) = stream_canton(&sandbox, backlog.clone()).await?;
+    let mut indexer2 = run_canton_indexer(&sandbox, backlog.clone()).await?;
 
     sandbox.submit_sign_request(Some(1)).await?;
 
@@ -342,7 +350,7 @@ async fn test_canton_stream_checkpoint_persistence() -> Result<()> {
     let mut first_block: Option<u64> = None;
     let mut saw_new_checkpoint = false;
     for _ in 0..20 {
-        match timeout(Duration::from_secs(5), stream2.next_event()).await {
+        match timeout(Duration::from_secs(5), indexer2.next_event()).await {
             Ok(Some(ChainEvent::SignRequest { request, .. })) => {
                 sign_request_ids.push(request.id.request_id);
                 backlog.insert(request).await;
@@ -370,11 +378,11 @@ async fn test_canton_stream_checkpoint_persistence() -> Result<()> {
         }
     }
 
-    // stream2 must have started at or past the checkpoint, not from 0
-    let first_block = first_block.expect("stream2 did not emit any Block events");
+    // indexer2 must have started at or past the checkpoint, not from 0
+    let first_block = first_block.expect("indexer2 did not emit any Block events");
     assert!(
         first_block >= checkpoint_height,
-        "stream2 started at offset {first_block}, expected >= {checkpoint_height} (checkpoint was not used)"
+        "indexer2 started at offset {first_block}, expected >= {checkpoint_height} (checkpoint was not used)"
     );
 
     // Exactly one sign request: the Phase 2 submission, not a replay of Phase 1
@@ -386,12 +394,12 @@ async fn test_canton_stream_checkpoint_persistence() -> Result<()> {
     );
     assert_ne!(
         sign_request_ids[0], phase1_request_id,
-        "stream2 replayed the phase 1 request instead of skipping it"
+        "indexer2 replayed the phase 1 request instead of skipping it"
     );
 
     assert!(
         saw_new_checkpoint,
-        "stream2 did not produce a new checkpoint"
+        "indexer2 did not produce a new checkpoint"
     );
     Ok(())
 }
@@ -402,10 +410,10 @@ async fn test_canton_stream_checkpoint_persistence() -> Result<()> {
 async fn test_canton_stream_sign_and_respond_flow() -> Result<()> {
     let sandbox = CantonSandbox::run().await?;
     let backlog = Backlog::new();
-    let (mut stream, _cp_tx) = stream_canton(&sandbox, backlog).await?;
+    let mut indexer = run_canton_indexer(&sandbox, backlog).await?;
 
     sandbox.submit_sign_request(None).await?;
-    let sign_event = wait_for_sign_request(&mut stream, 30).await?;
+    let sign_event = wait_for_sign_request(&mut indexer, 30).await?;
     assert_eq!(sign_event.chain, Chain::Canton);
     let request_id = hex::encode(sign_event.id.request_id);
     let sign_event_cid = match &sign_event.kind {
@@ -453,7 +461,7 @@ async fn test_canton_stream_sign_and_respond_flow() -> Result<()> {
 
     let mut saw_respond = false;
     for _ in 0..10 {
-        match timeout(Duration::from_secs(5), stream.next_event()).await {
+        match timeout(Duration::from_secs(5), indexer.next_event()).await {
             Ok(Some(ChainEvent::Respond(ev))) => {
                 assert_eq!(ev.chain, mpc_primitives::Chain::Canton);
                 assert_eq!(hex::encode(ev.request_id), request_id);
@@ -481,13 +489,13 @@ async fn test_canton_stream_sign_and_respond_flow() -> Result<()> {
 async fn test_canton_stream_parse_sign_bidirectional_fields() -> Result<()> {
     let sandbox = CantonSandbox::run().await?;
     let backlog = Backlog::new();
-    let (mut stream, _cp_tx) = stream_canton(&sandbox, backlog).await?;
+    let mut indexer = run_canton_indexer(&sandbox, backlog).await?;
 
     let expected_case = test_evm_type2_anvil_cases()[0].clone();
     let expected_event = test_sign_request_event(&sandbox, &expected_case);
     sandbox.submit_sign_request(None).await?;
 
-    let req = wait_for_sign_request(&mut stream, 30).await?;
+    let req = wait_for_sign_request(&mut indexer, 30).await?;
     assert_eq!(req.chain, Chain::Canton);
 
     let SignKind::SignBidirectional(ref bidir) = req.kind else {


### PR DESCRIPTION
Migrate Canton to a single-method `ChainIndexer::run()` and supervisor pattern (similar to Ethereum and Solana).

- Delete `CantonStream`
- Update `CantonIndexer` constructor
- Implement `run()` method responsible for the whole cycle from checkpoint loading to live loop. Cancel-aware.
- Update wiring in `cli` module, now identical in shape to Ethereum and Solana
- Update integration tests setup: replace `ChainPipeline` and `ChainStreaming` with a single `RunningCantonIndexer`. All test preserved.

Final cleanup will be done in a separate PR (`ChainStream` trait, `ChainIndexer` legacy methods and assoc types, etc.)