### PR TITLE
fix(request): bound peer-supplied round lookahead

### DIFF
--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -47,6 +47,16 @@ pub(crate) use work_queue::{SignPositWorkQueue, SignTaskMessage};
 /// How many rounds ahead the organizing phase searches for an active proposer.
 const PROPOSER_SEARCH_WINDOW: usize = 512;
 
+/// How far ahead of us a peer's round may be before we stop believing it.
+///
+/// Rounds only advance on `ORGANIZE_POSIT_TIMEOUT` expiry, so even a peer that
+/// has been unreachable for hours cannot legitimately be this far ahead. The
+/// bound matters because `round` is peer-supplied and feeds unchecked
+/// arithmetic (`round + 1`, `round + PROPOSER_SEARCH_WINDOW`, `entropy[0] +
+/// round`): an unbounded value overflows there, and once `round` saturates,
+/// bumping it is a no-op and proposer rotation stops for good.
+const MAX_ROUND_LOOKAHEAD: usize = 1024;
+
 /// Max number of concurrent proposers, with unlimited deliberators.
 const MAX_CONCURRENT_PROPOSERS: usize = 4;
 

--- a/chain-signatures/node/src/protocol/request/state.rs
+++ b/chain-signatures/node/src/protocol/request/state.rs
@@ -69,7 +69,9 @@ impl SignState {
             ..
         } = msg;
 
-        if peer_round < self.highest_seen_round {
+        if peer_round < self.highest_seen_round
+            || peer_round > self.round.saturating_add(MAX_ROUND_LOOKAHEAD)
+        {
             return;
         }
         if peer_round > self.highest_seen_round {
@@ -87,6 +89,73 @@ impl SignState {
             self.buffered_messages.remove(&key)
         } else {
             None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mpc_primitives::{Chain, SignArgs, SignId, SignKind};
+
+    fn state() -> SignState {
+        let request = IndexedSignRequest::new(
+            SignId {
+                request_id: [0u8; 32],
+            },
+            SignArgs {
+                entropy: [0u8; 32],
+                epsilon: Default::default(),
+                payload: Default::default(),
+                path: String::new(),
+                key_version: 0,
+            },
+            Chain::Ethereum,
+            0,
+            SignKind::Sign,
+        );
+        let (_tx, rx) = watch::channel(MeshState::default());
+        SignState::new(request, rx)
+    }
+
+    fn posit(round: usize) -> SignTaskMessage {
+        SignTaskMessage::PositMessage {
+            presignature_id: 0,
+            round,
+            from: Participant::from(0),
+            action: PositAction::Propose,
+        }
+    }
+
+    #[test]
+    fn peer_round_within_lookahead_is_adopted() {
+        let mut state = state();
+        state.buffer_future_posit_message(posit(MAX_ROUND_LOOKAHEAD));
+
+        assert_eq!(state.highest_seen_round, MAX_ROUND_LOOKAHEAD);
+        assert_eq!(state.buffered_messages.len(), 1);
+    }
+
+    #[test]
+    fn peer_round_beyond_lookahead_is_ignored() {
+        let mut state = state();
+        state.buffer_future_posit_message(posit(usize::MAX));
+
+        assert_eq!(state.highest_seen_round, 0);
+        assert!(state.buffered_messages.is_empty());
+    }
+
+    #[test]
+    fn peer_cannot_stall_rotation_with_an_implausible_round() {
+        let mut state = state();
+        for _ in 0..8 {
+            state.buffer_future_posit_message(posit(usize::MAX));
+            let prev = state.round;
+            state.reorganize();
+            assert!(
+                state.round > prev,
+                "round must keep advancing so the proposer keeps rotating"
+            );
         }
     }
 }


### PR DESCRIPTION
## What

Reject posit messages whose `round` is further ahead of ours than any node could legitimately have reached.

## Why

`highest_seen_round` is adopted straight off the wire in `buffer_future_posit_message` with no bound, and it feeds three unguarded additions:

- `self.round + 1` — `bump_round`
- `state.round + PROPOSER_SEARCH_WINDOW` — `OrganizingPhase::advance`
- `entropy[0] as usize + round` — `proposer_per_round`

A participant that sends one message with `round: usize::MAX` for a request sets `highest_seen_round = usize::MAX`. The next `bump_round` moves us there without overflowing (`max(small + 1, MAX)`); the one after that computes `usize::MAX + 1`.

- **Debug builds:** overflow panic, the sign task dies.
- **Release builds:** wraps to `0`, `max(0, usize::MAX)` is `usize::MAX` again, so the round is pinned. Since the round drives proposer selection, **rotation stops** — the same node stays proposer for that request forever. One message, repeatable per request.

## The fix

Bound the round at the point it enters from an untrusted source, rather than patching the three arithmetic sites. Rounds only advance on `ORGANIZE_POSIT_TIMEOUT` expiry (20s), so `MAX_ROUND_LOOKAHEAD = 1024` is ~5.7 hours of continuous rotation — far beyond what a genuinely lagging node needs to catch up, while keeping `round` bounded well away from overflow.

The bound is relative to our own round, so it still permits normal catch-up: a peer can pull us forward repeatedly, just at most 1024 rounds per bump.

## Scope

This is a **hardening fix against a misbehaving participant**, present on `develop` today. It is independent of the proposer-election work in #1050/#1051 — that is a separate liveness question and this does not address it. Worth landing on its own either way; #1051 would make the consequence worse, since pure rotation has no forward scan to stumble past a frozen round.

## Tests

`state::tests` — a round within the lookahead is adopted, one beyond it is ignored, and repeated `usize::MAX` rounds do not stop the round from advancing. The last one panics on `develop`.
