### PR TITLE
fix(rpc): deduplicate SignIds in publish batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7509,6 +7509,7 @@ dependencies = [
  "chrono",
  "ciborium",
  "clap",
+ "dashmap 6.1.0",
  "deadpool-redis",
  "ed25519-zebra",
  "enum-map",

--- a/chain-signatures/chain-canton/src/client.rs
+++ b/chain-signatures/chain-canton/src/client.rs
@@ -366,7 +366,7 @@ mod tests {
     use crate::config::{CantonAuthConfig, CantonConfig};
     use mockito::{Matcher, Server, ServerGuard};
     use mpc_chain_integration_core::{utils::test::make_publish_action, NoopPublisherTelemetry};
-    use mpc_primitives::{Chain, RespondBidirectionalTx, SignBidirectionalEvent, SignKind};
+    use mpc_primitives::{Chain, RespondBidirectionalTx, SignBidirectionalEvent, SignId, SignKind};
     use serde_json::json;
 
     /// Fast retry strategy for testing
@@ -453,7 +453,11 @@ mod tests {
             chain_ctx: Some(chain_ctx),
         };
 
-        let action = make_publish_action(Chain::Canton, SignKind::SignBidirectional(event));
+        let action = make_publish_action(
+            Chain::Canton,
+            SignKind::SignBidirectional(event),
+            SignId::new([0u8; 32]),
+        );
         assert!(client.publish_signature(&action).await.is_ok());
         submit_mock.assert_async().await;
     }
@@ -488,7 +492,11 @@ mod tests {
             chain_ctx: Some(chain_ctx),
         };
 
-        let action = make_publish_action(Chain::Canton, SignKind::RespondBidirectional(tx));
+        let action = make_publish_action(
+            Chain::Canton,
+            SignKind::RespondBidirectional(tx),
+            SignId::new([0u8; 32]),
+        );
         assert!(client.publish_signature(&action).await.is_ok());
         submit_mock.assert_async().await;
     }
@@ -510,7 +518,11 @@ mod tests {
             chain_ctx: None, // Missing
         };
 
-        let action = make_publish_action(Chain::Canton, SignKind::RespondBidirectional(tx));
+        let action = make_publish_action(
+            Chain::Canton,
+            SignKind::RespondBidirectional(tx),
+            SignId::new([0u8; 32]),
+        );
         let err = client.publish_signature(&action).await.unwrap_err();
         assert!(err.to_string().contains("missing chain_ctx"));
     }
@@ -543,7 +555,11 @@ mod tests {
             output: vec![],
             chain_ctx: Some(chain_ctx),
         };
-        let action = make_publish_action(Chain::Canton, SignKind::RespondBidirectional(tx));
+        let action = make_publish_action(
+            Chain::Canton,
+            SignKind::RespondBidirectional(tx),
+            SignId::new([0u8; 32]),
+        );
 
         let err = client.publish_signature(&action).await.unwrap_err();
         assert!(err.to_string().contains("500"));
@@ -587,7 +603,11 @@ mod tests {
             output: vec![],
             chain_ctx: Some(chain_ctx),
         };
-        let action = make_publish_action(Chain::Canton, SignKind::RespondBidirectional(tx));
+        let action = make_publish_action(
+            Chain::Canton,
+            SignKind::RespondBidirectional(tx),
+            SignId::new([0u8; 32]),
+        );
 
         assert!(client.publish_signature(&action).await.is_ok());
         ok.assert_async().await;
@@ -621,7 +641,11 @@ mod tests {
             output: vec![],
             chain_ctx: Some(chain_ctx),
         };
-        let action = make_publish_action(Chain::Canton, SignKind::RespondBidirectional(tx));
+        let action = make_publish_action(
+            Chain::Canton,
+            SignKind::RespondBidirectional(tx),
+            SignId::new([0u8; 32]),
+        );
 
         let err = client.publish_signature(&action).await.unwrap_err();
         assert!(err.to_string().contains("400"));

--- a/chain-signatures/chain-integration-core/src/publish.rs
+++ b/chain-signatures/chain-integration-core/src/publish.rs
@@ -59,7 +59,7 @@ mod tests {
     use super::*;
     use crate::utils::test::{make_indexed, make_signature, scalar};
     use k256::AffinePoint;
-    use mpc_primitives::{Chain, SignKind};
+    use mpc_primitives::{Chain, SignId, SignKind};
 
     #[test]
     fn publish_action_accepts_valid_signature() {
@@ -69,7 +69,13 @@ mod tests {
         let payload = scalar(&[42u8; 32]);
 
         let output = make_signature(&sk, epsilon, payload);
-        let request = make_indexed(Chain::NEAR, epsilon, payload, SignKind::Sign);
+        let request = make_indexed(
+            Chain::NEAR,
+            epsilon,
+            payload,
+            SignKind::Sign,
+            SignId::new([0u8; 32]),
+        );
 
         assert!(PublishAction::new(pk, request, output, vec![]).is_some());
     }
@@ -83,7 +89,13 @@ mod tests {
 
         let mut output = make_signature(&sk, epsilon, payload);
         output.s += k256::Scalar::ONE;
-        let request = make_indexed(Chain::NEAR, epsilon, payload, SignKind::Sign);
+        let request = make_indexed(
+            Chain::NEAR,
+            epsilon,
+            payload,
+            SignKind::Sign,
+            SignId::new([0u8; 32]),
+        );
 
         assert!(PublishAction::new(pk, request, output, vec![]).is_none());
     }

--- a/chain-signatures/chain-integration-core/src/utils/test.rs
+++ b/chain-signatures/chain-integration-core/src/utils/test.rs
@@ -39,9 +39,10 @@ pub fn make_indexed(
     epsilon: k256::Scalar,
     payload: k256::Scalar,
     kind: SignKind,
+    sign_id: SignId,
 ) -> IndexedSignRequest {
     IndexedSignRequest {
-        id: SignId::new([0u8; 32]),
+        id: sign_id,
         args: SignArgs {
             entropy: [0u8; 32],
             epsilon,
@@ -55,13 +56,13 @@ pub fn make_indexed(
     }
 }
 
-pub fn make_publish_action(chain: Chain, kind: SignKind) -> PublishAction {
+pub fn make_publish_action(chain: Chain, kind: SignKind, sign_id: SignId) -> PublishAction {
     let sk = k256::SecretKey::random(&mut rand::thread_rng());
     let pk: AffinePoint = sk.public_key().into();
     let epsilon = scalar(&[1u8; 32]);
     let payload = scalar(&[42u8; 32]);
     let output = make_signature(&sk, epsilon, payload);
-    let request = make_indexed(chain, epsilon, payload, kind);
+    let request = make_indexed(chain, epsilon, payload, kind, sign_id);
     PublishAction::new(pk, request, output, vec![])
         .expect("valid signature should produce a publish action")
 }

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -12,6 +12,7 @@ async-trait.workspace = true
 axum = "0.7.9"
 axum-extra = "0.9.6"
 chrono = "0.4.24"
+dashmap = "6.1"
 google-datastore1 = "=5.0.4"
 google-secretmanager1 = "5"
 highway = "1.1.0"

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -15,13 +15,14 @@ pub use near_governance::NearGovernanceClient;
 
 use cait_sith::protocol::Participant;
 use cait_sith::FullSignature;
+use dashmap::DashSet;
 use k256::{AffinePoint, Secp256k1};
 use mpc_chain_integration_core::{
     utils::retry::{retry_rpc, RetryConfig},
     ChainPublisher, PublishAction,
 };
 pub use mpc_contract::primitives::{Read, View};
-use mpc_primitives::{CheckpointDigest, Signature};
+use mpc_primitives::{CheckpointDigest, SignId, Signature};
 
 use near_account_id::AccountId;
 use std::collections::HashMap;
@@ -394,6 +395,8 @@ impl RpcExecutor {
         publishers: &HashMap<Chain, Arc<dyn ChainPublisher>>,
         action_rx: &mut mpsc::Receiver<RpcAction>,
     ) {
+        // Keep track of in-flight publish requests to avoid duplicate publishes for the same sign_id.
+        let in_flight: Arc<DashSet<SignId>> = Arc::new(DashSet::new());
         loop {
             let Some(RpcAction::Publish(action)) = action_rx.recv().await else {
                 tracing::error!("rpc channel closed unexpectedly");
@@ -401,17 +404,25 @@ impl RpcExecutor {
             };
 
             let chain = action.request.chain;
+            let sign_id = action.request.id;
+
+            if !in_flight.insert(sign_id) {
+                tracing::info!(?sign_id, ?chain, "publish already in flight; skipping duplicate");
+                continue;
+            }
 
             // Check if a publisher is configured for the chain. If not, log a warning and continue to the next action.
             let Some(publisher) = publishers.get(&chain) else {
+                in_flight.remove(&sign_id);
                 tracing::warn!(?chain, "no publisher configured for chain");
                 continue;
             };
 
-            // Spawn a task to execute the publish action.
             let publisher = publisher.clone();
+            let in_flight = in_flight.clone();
             tokio::spawn(async move {
                 execute_publish(publisher, action).await;
+                in_flight.remove(&sign_id);
             });
         }
     }

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -407,7 +407,11 @@ impl RpcExecutor {
             let sign_id = action.request.id;
 
             if !in_flight.insert(sign_id) {
-                tracing::info!(?sign_id, ?chain, "publish already in flight; skipping duplicate");
+                tracing::info!(
+                    ?sign_id,
+                    ?chain,
+                    "publish already in flight; skipping duplicate"
+                );
                 continue;
             }
 
@@ -553,7 +557,7 @@ mod tests {
     use crate::protocol::ProtocolState;
     use cait_sith::protocol::Participant;
     use mpc_chain_integration_core::utils::test::make_publish_action;
-    use mpc_primitives::SignKind;
+    use mpc_primitives::{SignId, SignKind};
 
     /// Vote churn must be absorbed without completing; real governance changes
     /// and leaving the running state must be delivered.
@@ -724,6 +728,7 @@ mod tests {
         tx.send(RpcAction::Publish(make_publish_action(
             Chain::Ethereum,
             SignKind::Sign,
+            SignId::new([0u8; 32]),
         )))
         .await
         .unwrap();
@@ -758,6 +763,7 @@ mod tests {
         tx.send(RpcAction::Publish(make_publish_action(
             Chain::Ethereum,
             SignKind::Sign,
+            SignId::new([0u8; 32]),
         )))
         .await
         .unwrap();
@@ -790,12 +796,14 @@ mod tests {
         tx.send(RpcAction::Publish(make_publish_action(
             Chain::NEAR,
             SignKind::Sign,
+            SignId::new([0u8; 32]),
         )))
         .await
         .unwrap();
         tx.send(RpcAction::Publish(make_publish_action(
             Chain::Solana,
             SignKind::Sign,
+            SignId::new([1u8; 32]),
         )))
         .await
         .unwrap();
@@ -840,19 +848,21 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(16);
 
         // Send multiple publish actions for NEAR and Solana
-        for _ in 0..NEAR_ACTION_COUNT {
+        for i in 0..NEAR_ACTION_COUNT {
             tx.send(RpcAction::Publish(make_publish_action(
                 Chain::NEAR,
                 SignKind::Sign,
+                SignId::new([i as u8; 32]),
             )))
             .await
             .unwrap();
         }
 
-        for _ in 0..SOL_ACTION_COUNT {
+        for i in 0..SOL_ACTION_COUNT {
             tx.send(RpcAction::Publish(make_publish_action(
                 Chain::Solana,
                 SignKind::Sign,
+                SignId::new([(NEAR_ACTION_COUNT + i) as u8; 32]),
             )))
             .await
             .unwrap();

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -876,4 +876,40 @@ mod tests {
         assert_eq!(near_count.load(Ordering::SeqCst), NEAR_ACTION_COUNT);
         assert_eq!(sol_count.load(Ordering::SeqCst), SOL_ACTION_COUNT);
     }
+
+    #[tokio::test]
+    async fn executor_dedupes_concurrent_publishes_with_the_same_sign_id() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+
+        let mut publishers: HashMap<Chain, Arc<dyn ChainPublisher>> = HashMap::new();
+        publishers.insert(
+            Chain::Ethereum,
+            Arc::new(CountingPublisher {
+                call_count: call_count.clone(),
+            }),
+        );
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let sign_id = SignId::new([7u8; 32]);
+
+        // Multiple publishes for the SAME SignId
+        for _ in 0..5 {
+            tx.send(RpcAction::Publish(make_publish_action(
+                Chain::Ethereum,
+                SignKind::Sign,
+                sign_id,
+            )))
+            .await
+            .unwrap();
+        }
+
+        drop(tx);
+
+        RpcExecutor::dispatch_loop(&publishers, &mut rx).await;
+
+        // Let the single in-flight publish finish.
+        tokio::task::yield_now().await;
+
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
 }

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -425,8 +425,11 @@ impl RpcExecutor {
             let publisher = publisher.clone();
             let in_flight = in_flight.clone();
             tokio::spawn(async move {
+                let _guard = InFlightGuard {
+                    in_flight,
+                    id: sign_id,
+                };
                 execute_publish(publisher, action).await;
-                in_flight.remove(&sign_id);
             });
         }
     }
@@ -497,6 +500,19 @@ async fn update_contract_data(
                 true
             });
         }
+    }
+}
+
+/// Releases a `SignId` from the dispatch loop's in-flight set when dropped,
+/// including during a panic unwind, so the slot is always freed for re-publish.
+struct InFlightGuard {
+    in_flight: Arc<DashSet<SignId>>,
+    id: SignId,
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        self.in_flight.remove(&self.id);
     }
 }
 


### PR DESCRIPTION
Currently nothing prevents publishing batches with the same `SignId` (can happen if node restarts), which may result in wasted gas and extra log noise. This PR implements a deduplication mechanism in `RpcExecutor` 

Changes:

- Add `dashmap` crate (already was a transitive dependency)
- Use `Arc<DashSet<SignId>>` to track in-flight publish requests in `RpcExecutor`
- Add `InFlightGuard` struct to release `SignId` from in-flight set on drop (so the slot is freed for re-publish)
- Add `executor_dedupes_concurrent_publishes_with_the_same_sign_id` test
- Update `make_indexed` and `make_publish_action` test utils to accept `SignId` param. Update tests to provide `SignId` explicitly