### PR TITLE
feat(chain-midnight): drive respond from Rust over a stdio child

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -425,7 +425,7 @@ dependencies = [
  "derive_more 2.0.1",
  "foldhash 0.2.0",
  "getrandom 0.3.2",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "indexmap 2.9.0",
  "itoa",
  "k256",
@@ -616,7 +616,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -723,7 +723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "954d1b2533b9b2c7959652df3076954ecb1122a28cc740aa84e7b0a49f6ac0a9"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1092,6 +1092,15 @@ name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "archery"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cd774058b1b415c4855d8b86436c04bf050c003156fe24bc326fb3fe75c343"
+dependencies = [
+ "static_assertions",
+]
 
 [[package]]
 name = "archery"
@@ -1611,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -1755,7 +1764,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-io 2.4.0",
  "async-lock 3.4.0",
  "async-signal",
@@ -1816,13 +1825,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.101",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2060,6 +2069,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
+
+[[package]]
 name = "base58"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,6 +2109,12 @@ name = "base64ct"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+
+[[package]]
+name = "bech32"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "beef"
@@ -2183,11 +2204,11 @@ dependencies = [
 
 [[package]]
 name = "bip39"
-version = "2.2.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d193de1f7487df1914d3a568b772458861d33f9c54249612cc2893d6915054"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes 0.14.0",
  "serde",
  "unicode-normalization",
 ]
@@ -2377,7 +2398,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-task",
  "futures-io",
  "futures-lite 2.6.0",
@@ -2922,7 +2943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3303,6 +3324,21 @@ checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "crypto_secretbox"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+dependencies = [
+ "aead",
+ "cipher",
+ "generic-array",
+ "poly1305",
+ "salsa20",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4419,6 +4455,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher 1.0.1",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4643,6 +4691,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-decode"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88cda60c640572c970c544ba5879375a18ecfb2c47c617be8265830b63df193d"
+dependencies = [
+ "frame-metadata",
+ "parity-scale-codec",
+ "scale-decode",
+ "scale-encode",
+ "scale-info",
+ "scale-info-legacy",
+ "scale-type-resolver",
+ "serde_yaml",
+ "sp-crypto-hashing",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "frame-metadata"
 version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4697,9 +4763,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4712,9 +4778,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -4722,27 +4788,26 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -4774,9 +4839,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -4796,15 +4861,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
@@ -4818,9 +4883,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4830,7 +4895,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -5236,14 +5300,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5801,7 +5866,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6938,14 +7003,41 @@ dependencies = [
 
 [[package]]
 name = "konst"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97feab15b395d1860944abe6a8dd8ed9f8eadfae01750fada8427abda531d887"
+dependencies = [
+ "const_panic",
+ "konst_kernel",
+ "konst_proc_macros 0.3.10",
+ "typewit",
+]
+
+[[package]]
+name = "konst"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f660d5f887e3562f9ab6f4a14988795b694099d66b4f5dedc02d197ba9becb1d"
 dependencies = [
  "const_panic",
- "konst_proc_macros",
+ "konst_proc_macros 0.4.1",
  "typewit",
 ]
+
+[[package]]
+name = "konst_kernel"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4b1eb7788f3824c629b1116a7a9060d6e898c358ebff59070093d51103dcc3c"
+dependencies = [
+ "typewit",
+]
+
+[[package]]
+name = "konst_proc_macros"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00af7901ba50898c9e545c24d5c580c96a982298134e8037d8978b6594782c07"
 
 [[package]]
 name = "konst_proc_macros"
@@ -7463,9 +7555,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -7491,7 +7583,7 @@ version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -7517,6 +7609,25 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "lzma-rs"
@@ -7614,6 +7725,15 @@ name = "memmap2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -7748,6 +7868,23 @@ dependencies = [
 
 [[package]]
 name = "midnight-coin-structure"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "295ff7814b0288a9f0cbfea0cf13e5bfaa9a631f0525fd43175d572ca9af03ce"
+dependencies = [
+ "fake",
+ "lazy_static",
+ "midnight-base-crypto",
+ "midnight-serialize",
+ "midnight-storage-core",
+ "midnight-transient-crypto 2.2.0",
+ "rand 0.8.5",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "midnight-coin-structure"
 version = "3.0.0"
 source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=coin-structure-3.0.0-rc.1#8c27955d6d986223ad5fed796a2b3f12522aba54"
 dependencies = [
@@ -7820,6 +7957,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "midnight-ledger"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc8b6b6c9d55af6c8852092eb76e72a52d227be435bfa1bd0be158bc2ac7b28"
+dependencies = [
+ "anyhow",
+ "derive-where",
+ "fake",
+ "futures",
+ "introspection",
+ "introspection-derive",
+ "is_sorted",
+ "itertools 0.14.0",
+ "lazy_static",
+ "midnight-base-crypto",
+ "midnight-coin-structure 2.0.1",
+ "midnight-ledger-static",
+ "midnight-onchain-runtime 2.0.1",
+ "midnight-serialize",
+ "midnight-storage 1.1.1",
+ "midnight-transient-crypto 2.2.0",
+ "midnight-zswap 7.0.3",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "sha2 0.10.9",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.20",
+ "zeroize",
+]
+
+[[package]]
+name = "midnight-ledger"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2182054f3a43ccabac514448fff2487437be293f517a01afc23905df701e8548"
+dependencies = [
+ "anyhow",
+ "derive-where",
+ "fake",
+ "futures",
+ "introspection",
+ "introspection-derive",
+ "is_sorted",
+ "itertools 0.14.0",
+ "lazy_static",
+ "midnight-base-crypto",
+ "midnight-coin-structure 2.0.1",
+ "midnight-ledger-static",
+ "midnight-onchain-runtime 3.1.0",
+ "midnight-serialize",
+ "midnight-storage 2.0.1",
+ "midnight-transient-crypto 2.2.0",
+ "midnight-zswap 8.1.0",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "sha2 0.10.9",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.20",
+ "zeroize",
+]
+
+[[package]]
 name = "midnight-ledger-static"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7845,22 +8048,124 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "midnight-base-crypto",
- "midnight-coin-structure",
+ "midnight-coin-structure 3.0.0",
  "midnight-ledger-static",
- "midnight-onchain-runtime",
+ "midnight-onchain-runtime 4.0.0",
  "midnight-serialize",
- "midnight-storage",
+ "midnight-storage 2.0.1",
  "midnight-transient-crypto 2.2.0",
  "midnight-transient-crypto 3.0.0",
- "midnight-zswap",
+ "midnight-zkir",
+ "midnight-zswap 9.0.0",
  "rand 0.8.5",
  "rayon",
+ "reqwest 0.13.4",
  "serde",
  "sha2 0.11.0",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.20",
  "zeroize",
+]
+
+[[package]]
+name = "midnight-node-ledger-helpers"
+version = "0.1.0"
+source = "git+https://github.com/midnightntwrk/midnight-node?tag=node-2.0.0-rc.4#651e043b61ed445bf7a5066c60c87ea7bd606073"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bech32",
+ "bip32",
+ "bip39",
+ "derive-where",
+ "futures",
+ "hex",
+ "itertools 0.14.0",
+ "lazy_static",
+ "log",
+ "midnight-base-crypto",
+ "midnight-coin-structure 2.0.1",
+ "midnight-coin-structure 3.0.0",
+ "midnight-ledger 7.0.3",
+ "midnight-ledger 8.1.0",
+ "midnight-ledger-v9",
+ "midnight-onchain-runtime 2.0.1",
+ "midnight-onchain-runtime 3.1.0",
+ "midnight-onchain-runtime 4.0.0",
+ "midnight-serialize",
+ "midnight-storage 1.1.1",
+ "midnight-storage 2.0.1",
+ "midnight-transient-crypto 2.2.0",
+ "midnight-transient-crypto 3.0.0",
+ "midnight-zkir",
+ "midnight-zswap 7.0.3",
+ "midnight-zswap 8.1.0",
+ "midnight-zswap 9.0.0",
+ "rand 0.8.5",
+ "rayon",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "subxt 0.50.2",
+ "subxt-signer",
+ "thiserror 2.0.12",
+ "tokio",
+ "toml 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "midnight-onchain-runtime"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "251e828965432c89a3d13fec3c82fda23649eda3f8f76fa1326d97e00f195334"
+dependencies = [
+ "derive-where",
+ "enum_index",
+ "enum_index_derive",
+ "fake",
+ "hex",
+ "konst 0.3.17",
+ "lazy_static",
+ "midnight-base-crypto",
+ "midnight-coin-structure 2.0.1",
+ "midnight-onchain-state 2.0.1",
+ "midnight-onchain-vm 1.0.2",
+ "midnight-serialize",
+ "midnight-storage 1.1.1",
+ "midnight-transient-crypto 2.2.0",
+ "rand 0.8.5",
+ "serde",
+ "serde_bytes",
+ "tracing",
+]
+
+[[package]]
+name = "midnight-onchain-runtime"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cbc5ffd4440bcadc02ad13d7e608c48de5facdc860f949eef4a22be50cb29b7"
+dependencies = [
+ "derive-where",
+ "enum_index",
+ "enum_index_derive",
+ "fake",
+ "hex",
+ "konst 0.4.3",
+ "lazy_static",
+ "midnight-base-crypto",
+ "midnight-coin-structure 2.0.1",
+ "midnight-onchain-state 3.0.0",
+ "midnight-onchain-vm 3.1.0",
+ "midnight-serialize",
+ "midnight-storage 2.0.1",
+ "midnight-transient-crypto 2.2.0",
+ "rand 0.8.5",
+ "serde",
+ "serde_bytes",
+ "tracing",
 ]
 
 [[package]]
@@ -7873,19 +8178,57 @@ dependencies = [
  "enum_index_derive",
  "fake",
  "hex",
- "konst",
+ "konst 0.4.3",
  "lazy_static",
  "midnight-base-crypto",
- "midnight-coin-structure",
- "midnight-onchain-state",
- "midnight-onchain-vm",
+ "midnight-coin-structure 3.0.0",
+ "midnight-onchain-state 4.0.0",
+ "midnight-onchain-vm 4.0.0",
  "midnight-serialize",
- "midnight-storage",
+ "midnight-storage 2.0.1",
  "midnight-transient-crypto 3.0.0",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
  "tracing",
+]
+
+[[package]]
+name = "midnight-onchain-state"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e153e26062e19ad07a065f8b4466243a6964e5fce5820d371fc9f4b036666ee7"
+dependencies = [
+ "derive-where",
+ "fake",
+ "hex",
+ "midnight-base-crypto",
+ "midnight-coin-structure 2.0.1",
+ "midnight-serialize",
+ "midnight-storage 1.1.1",
+ "midnight-transient-crypto 2.2.0",
+ "rand 0.8.5",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "midnight-onchain-state"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf32b5175d303251d7051fb30532d4fdef3c19c7e36c5831c002a27e8440163"
+dependencies = [
+ "derive-where",
+ "fake",
+ "hex",
+ "midnight-base-crypto",
+ "midnight-coin-structure 2.0.1",
+ "midnight-serialize",
+ "midnight-storage 2.0.1",
+ "midnight-transient-crypto 2.2.0",
+ "rand 0.8.5",
+ "serde",
+ "serde_bytes",
 ]
 
 [[package]]
@@ -7897,12 +8240,56 @@ dependencies = [
  "fake",
  "hex",
  "midnight-base-crypto",
- "midnight-coin-structure",
+ "midnight-coin-structure 3.0.0",
  "midnight-serialize",
- "midnight-storage",
+ "midnight-storage 2.0.1",
  "midnight-transient-crypto 2.2.0",
  "midnight-transient-crypto 3.0.0",
  "rand 0.8.5",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "midnight-onchain-vm"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f737f8a5d227d07683d0c5829e1de02bdf297e39ab8ef954a3d4f49072f973f"
+dependencies = [
+ "derive-where",
+ "fake",
+ "hex",
+ "konst 0.3.17",
+ "midnight-base-crypto",
+ "midnight-coin-structure 2.0.1",
+ "midnight-onchain-state 2.0.1",
+ "midnight-serialize",
+ "midnight-storage 1.1.1",
+ "midnight-transient-crypto 2.2.0",
+ "rand 0.8.5",
+ "rpds 0.13.0",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "midnight-onchain-vm"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950c687ea706f5dd92270e06474829c732b0d7e8119430a14ea60e635050071a"
+dependencies = [
+ "derive-where",
+ "fake",
+ "hex",
+ "konst 0.4.3",
+ "midnight-base-crypto",
+ "midnight-coin-structure 2.0.1",
+ "midnight-onchain-state 3.0.0",
+ "midnight-serialize",
+ "midnight-storage 2.0.1",
+ "midnight-transient-crypto 2.2.0",
+ "rand 0.8.5",
+ "rpds 1.2.1",
  "serde",
  "serde_bytes",
 ]
@@ -7915,15 +8302,15 @@ dependencies = [
  "derive-where",
  "fake",
  "hex",
- "konst",
+ "konst 0.4.3",
  "midnight-base-crypto",
- "midnight-coin-structure",
- "midnight-onchain-state",
+ "midnight-coin-structure 3.0.0",
+ "midnight-onchain-state 4.0.0",
  "midnight-serialize",
- "midnight-storage",
+ "midnight-storage 2.0.1",
  "midnight-transient-crypto 3.0.0",
  "rand 0.8.5",
- "rpds",
+ "rpds 1.2.1",
  "serde",
  "serde_bytes",
 ]
@@ -7975,7 +8362,7 @@ version = "1.2.0"
 source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=serialize-1.2.0-rc.1#7267bca4478c4512e48db3def9d6894e0b5b7c7f"
 dependencies = [
  "crypto",
- "konst",
+ "konst 0.4.3",
  "lazy_static",
  "midnight-serialize-macros",
  "serde",
@@ -7991,6 +8378,24 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.40",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "midnight-storage"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df40bcb4aa0a709f5c4441f6d05aa15e853f434d777c6ef8a4692c00f24d3f6e"
+dependencies = [
+ "crypto",
+ "derive-where",
+ "midnight-base-crypto",
+ "midnight-serialize",
+ "midnight-storage-core",
+ "parking_lot 0.12.5",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.10.9",
+ "tempfile",
 ]
 
 [[package]]
@@ -8018,17 +8423,18 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "191bb2abbf18ca8d151c201e1c2dc0b4cf96ee4ced17a08951cb4c4fd5550031"
 dependencies = [
- "archery",
+ "archery 1.2.2",
  "crypto",
  "derive-where",
  "fake",
  "hex",
  "itertools 0.14.0",
- "konst",
+ "konst 0.4.3",
  "lru 0.16.4",
  "midnight-base-crypto",
  "midnight-serialize",
  "midnight-storage-macros",
+ "parity-db",
  "parking_lot 0.12.5",
  "rand 0.8.5",
  "serde",
@@ -8199,6 +8605,56 @@ dependencies = [
 
 [[package]]
 name = "midnight-zswap"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56bc2635ed2de0cb18c8ca3aafcbb4910d42cd50cc7c73b5ae7dd31a6f5b5b1f"
+dependencies = [
+ "derive-where",
+ "fake",
+ "futures",
+ "is_sorted",
+ "itertools 0.14.0",
+ "lazy_static",
+ "midnight-base-crypto",
+ "midnight-coin-structure 2.0.1",
+ "midnight-ledger-static",
+ "midnight-onchain-runtime 2.0.1",
+ "midnight-serialize",
+ "midnight-storage 1.1.1",
+ "midnight-transient-crypto 2.2.0",
+ "rand 0.8.5",
+ "serde",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "midnight-zswap"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c83f946d8ac03abea38ca470599801fa08e91e2ddf3cb0963027a7701180c7c"
+dependencies = [
+ "derive-where",
+ "fake",
+ "futures",
+ "is_sorted",
+ "itertools 0.14.0",
+ "lazy_static",
+ "midnight-base-crypto",
+ "midnight-coin-structure 2.0.1",
+ "midnight-ledger-static",
+ "midnight-onchain-runtime 3.1.0",
+ "midnight-serialize",
+ "midnight-storage 2.0.1",
+ "midnight-transient-crypto 2.2.0",
+ "rand 0.8.5",
+ "serde",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "midnight-zswap"
 version = "9.0.0"
 source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=zswap-9.0.0-rc.3#d495446e618ea92577d920bfdf01f3eb1118a322"
 dependencies = [
@@ -8210,11 +8666,11 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "midnight-base-crypto",
- "midnight-coin-structure",
+ "midnight-coin-structure 3.0.0",
  "midnight-ledger-static",
- "midnight-onchain-runtime",
+ "midnight-onchain-runtime 4.0.0",
  "midnight-serialize",
- "midnight-storage",
+ "midnight-storage 2.0.1",
  "midnight-transient-crypto 2.2.0",
  "midnight-transient-crypto 3.0.0",
  "midnight-zkir",
@@ -8392,16 +8848,17 @@ dependencies = [
  "k256",
  "midnight-base-crypto",
  "midnight-ledger-v9",
- "midnight-onchain-state",
+ "midnight-node-ledger-helpers",
+ "midnight-onchain-state 4.0.0",
  "midnight-serialize",
- "midnight-storage",
+ "midnight-storage 2.0.1",
  "midnight-transient-crypto 3.0.0",
  "mpc-chain-integration-core",
  "mpc-crypto",
  "mpc-primitives",
  "serde",
  "serde_json",
- "subxt",
+ "subxt 0.44.0",
  "tokio",
  "tokio-util",
  "tracing",
@@ -8581,7 +9038,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-trie",
- "subxt",
+ "subxt 0.44.0",
  "sysinfo 0.32.1",
  "tempfile",
  "test-log",
@@ -10172,10 +10629,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes 0.13.0",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
+]
+
+[[package]]
+name = "parity-db"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd67682e0852e7b476b8502a4abe27890f82d3c482a65e4acf985d17f6048f9d"
+dependencies = [
+ "ahash",
+ "blake2",
+ "crc32fast",
+ "fs2",
+ "hex",
+ "libc",
+ "log",
+ "lz4",
+ "memmap2 0.9.11",
+ "parking_lot 0.12.5",
+ "rand 0.9.5",
+ "siphasher 1.0.1",
+ "snap",
+ "winapi",
 ]
 
 [[package]]
@@ -10893,7 +11372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote 1.0.40",
  "syn 2.0.101",
@@ -11017,7 +11496,7 @@ checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "fastbloom",
+ "fastbloom 0.14.1",
  "getrandom 0.3.2",
  "lru-slab",
  "rand 0.9.5",
@@ -11198,9 +11677,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -11208,9 +11687,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -11810,11 +12289,20 @@ dependencies = [
 
 [[package]]
 name = "rpds"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd6ce569b15c331b1e5fd8cf6adb0bf240678b5f0cdc4d0f41e11683f6feba9"
+dependencies = [
+ "archery 0.5.0",
+]
+
+[[package]]
+name = "rpds"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e025feb26210bc196b908e72deb063b1b4000754304341cbc168a1e72c857ebc"
 dependencies = [
- "archery",
+ "archery 1.2.2",
  "smallvec",
 ]
 
@@ -12218,6 +12706,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12267,9 +12764,9 @@ dependencies = [
 
 [[package]]
 name = "scale-encode"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64901733157f9d25ef86843bd783eda439fac7efb0ad5a615d12d2cf3a29464b"
+checksum = "f2a976d73564a59e482b74fd5d95f7518b79ca8c8ca5865398a4d629dd15ee50"
 dependencies = [
  "parity-scale-codec",
  "primitive-types 0.13.1",
@@ -12320,6 +12817,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "scale-info-legacy"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d972ce93a4f81efc40fce251e992faf99ecb090c02bcbd3614e213991038c181"
+dependencies = [
+ "hashbrown 0.16.1",
+ "scale-type-resolver",
+ "serde",
+ "smallstr",
+ "smallvec",
+ "thiserror 2.0.12",
+ "yap",
+]
+
+[[package]]
 name = "scale-type-resolver"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12334,6 +12846,19 @@ name = "scale-typegen"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c61b6b706a3eaad63b506ab50a1d2319f817ae01cf753adcc3f055f9f0fcd6"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "scale-info",
+ "syn 2.0.101",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "scale-typegen"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "642d2f13f3fc9a34ea2c1e36142984eba78cd2405a61632492f8b52993e98879"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -12438,6 +12963,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "password-hash",
+ "pbkdf2 0.12.2",
+ "salsa20",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "sct"
@@ -12768,6 +13305,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -13118,6 +13664,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallstr"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862077b1e764f04c251fe82a2ef562fd78d7cadaeb072ca7c2bcaf7217b1ff3b"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13154,7 +13709,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-executor",
  "async-fs",
  "async-io 2.4.0",
@@ -13220,12 +13775,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "smoldot"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9879c3b19576797ad597164a07898aab5c6a99d9aed38a7d17120cace4c0f187"
+dependencies = [
+ "arrayvec 0.7.6",
+ "async-lock 3.4.0",
+ "atomic-take",
+ "base32",
+ "base64 0.22.1",
+ "bip39",
+ "blake2-rfc",
+ "bs58 0.5.1",
+ "chacha20",
+ "crossbeam-queue",
+ "derive_more 2.0.1",
+ "ed25519-zebra",
+ "either",
+ "event-listener 5.4.0",
+ "fastbloom 0.17.0",
+ "fnv",
+ "futures-lite 2.6.0",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "hex",
+ "hmac 0.12.1",
+ "itertools 0.14.0",
+ "libm",
+ "libsecp256k1 0.7.2",
+ "merlin",
+ "nom 8.0.0",
+ "num-bigint 0.4.6",
+ "num-rational 0.4.2",
+ "num-traits",
+ "pbkdf2 0.12.2",
+ "pin-project",
+ "poly1305",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "ruzstd",
+ "schnorrkel",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sha3",
+ "siphasher 1.0.1",
+ "slab",
+ "smallvec",
+ "soketto 0.8.1",
+ "twox-hash 2.1.2",
+ "wasmi",
+ "x25519-dalek 2.0.1",
+ "zeroize",
+]
+
+[[package]]
 name = "smoldot-light"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bba9e591716567d704a8252feeb2f1261a286e1e2cbdd4e49e9197c34a14e2"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-lock 3.4.0",
  "base64 0.22.1",
  "blake2-rfc",
@@ -13251,7 +13862,43 @@ dependencies = [
  "siphasher 1.0.1",
  "slab",
  "smol",
- "smoldot",
+ "smoldot 0.19.4",
+ "zeroize",
+]
+
+[[package]]
+name = "smoldot-light"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e376a31b252053309ef1668c750ef54b2ed82d408beb40d88a018ecd2c0079ae"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-lock 3.4.0",
+ "base64 0.22.1",
+ "blake2-rfc",
+ "bs58 0.5.1",
+ "derive_more 2.0.1",
+ "either",
+ "event-listener 5.4.0",
+ "fnv",
+ "futures-channel",
+ "futures-lite 2.6.0",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "hex",
+ "itertools 0.14.0",
+ "log",
+ "lru 0.16.4",
+ "parking_lot 0.12.5",
+ "pin-project",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "serde_json",
+ "siphasher 1.0.1",
+ "slab",
+ "smol",
+ "smoldot 1.1.0",
  "zeroize",
 ]
 
@@ -13866,7 +14513,7 @@ checksum = "968dabd2b92d57131473eddbd475339da530e14f54397386abf303de3a2595a2"
 dependencies = [
  "bincode 1.3.3",
  "chrono",
- "memmap2",
+ "memmap2 0.5.10",
  "serde",
  "serde_derive",
  "solana-account",
@@ -16397,15 +17044,56 @@ dependencies = [
  "serde_json",
  "sp-crypto-hashing",
  "subxt-core",
- "subxt-lightclient",
- "subxt-macro",
- "subxt-metadata",
- "subxt-rpcs",
+ "subxt-lightclient 0.44.0",
+ "subxt-macro 0.44.0",
+ "subxt-metadata 0.44.0",
+ "subxt-rpcs 0.44.0",
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tracing",
  "url 2.5.4",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "subxt"
+version = "0.50.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440b28070d3bba98d637791bc7ebbe362f5beb9e749204c16caaf344fef260ba"
+dependencies = [
+ "async-trait",
+ "derive-where",
+ "either",
+ "frame-decode 0.17.2",
+ "frame-metadata",
+ "futures",
+ "hex",
+ "impl-serde",
+ "jsonrpsee 0.24.10",
+ "keccak-hash",
+ "parity-scale-codec",
+ "primitive-types 0.13.1",
+ "scale-bits",
+ "scale-decode",
+ "scale-encode",
+ "scale-info",
+ "scale-info-legacy",
+ "scale-type-resolver",
+ "scale-value",
+ "serde",
+ "serde_json",
+ "sp-crypto-hashing",
+ "subxt-lightclient 0.50.2",
+ "subxt-macro 0.50.2",
+ "subxt-metadata 0.50.2",
+ "subxt-rpcs 0.50.2",
+ "subxt-utils-accountid32",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util",
+ "tracing",
  "wasm-bindgen-futures",
  "web-time",
 ]
@@ -16421,8 +17109,25 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.40",
  "scale-info",
- "scale-typegen",
- "subxt-metadata",
+ "scale-typegen 0.11.1",
+ "subxt-metadata 0.44.0",
+ "syn 2.0.101",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "subxt-codegen"
+version = "0.50.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc8a165f929034fd00e9bfa86b63e5d7c26b635e526fa9cadb01389eab92029"
+dependencies = [
+ "heck 0.5.0",
+ "parity-scale-codec",
+ "proc-macro2",
+ "quote 1.0.40",
+ "scale-info",
+ "scale-typegen 0.12.0",
+ "subxt-metadata 0.50.2",
  "syn 2.0.101",
  "thiserror 2.0.12",
 ]
@@ -16436,7 +17141,7 @@ dependencies = [
  "base58",
  "blake2",
  "derive-where",
- "frame-decode",
+ "frame-decode 0.9.0",
  "frame-metadata",
  "hashbrown 0.14.5",
  "hex",
@@ -16452,7 +17157,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-crypto-hashing",
- "subxt-metadata",
+ "subxt-metadata 0.44.0",
  "thiserror 2.0.12",
  "tracing",
 ]
@@ -16467,7 +17172,24 @@ dependencies = [
  "futures-util",
  "serde",
  "serde_json",
- "smoldot-light",
+ "smoldot-light 0.17.2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "subxt-lightclient"
+version = "0.50.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4556eeef22af52ed4a77e4b665003f2e63264336d351376ef44bcab2a3bc1e"
+dependencies = [
+ "futures",
+ "futures-util",
+ "serde",
+ "serde_json",
+ "smoldot-light 1.1.1",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
@@ -16484,10 +17206,27 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro-error2",
  "quote 1.0.40",
- "scale-typegen",
- "subxt-codegen",
- "subxt-metadata",
- "subxt-utils-fetchmetadata",
+ "scale-typegen 0.11.1",
+ "subxt-codegen 0.44.0",
+ "subxt-metadata 0.44.0",
+ "subxt-utils-fetchmetadata 0.44.0",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "subxt-macro"
+version = "0.50.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5132bb78596d4957bf3039b9c54f5f88cefefd64ab61f0e71592526e14ef7f13"
+dependencies = [
+ "darling 0.20.11",
+ "parity-scale-codec",
+ "proc-macro-error2",
+ "quote 1.0.40",
+ "scale-typegen 0.12.0",
+ "subxt-codegen 0.50.2",
+ "subxt-metadata 0.50.2",
+ "subxt-utils-fetchmetadata 0.50.2",
  "syn 2.0.101",
 ]
 
@@ -16497,11 +17236,28 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01fb7c0bfafad78dda7084c6a2444444744af3bbf7b2502399198b9b4c20eddf"
 dependencies = [
- "frame-decode",
+ "frame-decode 0.9.0",
  "frame-metadata",
  "hashbrown 0.14.5",
  "parity-scale-codec",
  "scale-info",
+ "sp-crypto-hashing",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "subxt-metadata"
+version = "0.50.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e48c34696956f995df947adeb77061cb413377fb412487c41e7c2089112d5b"
+dependencies = [
+ "frame-decode 0.17.2",
+ "frame-metadata",
+ "hashbrown 0.14.5",
+ "parity-scale-codec",
+ "scale-info",
+ "scale-info-legacy",
+ "scale-type-resolver",
  "sp-crypto-hashing",
  "thiserror 2.0.12",
 ]
@@ -16523,7 +17279,7 @@ dependencies = [
  "serde",
  "serde_json",
  "subxt-core",
- "subxt-lightclient",
+ "subxt-lightclient 0.44.0",
  "thiserror 2.0.12",
  "tokio-util",
  "tracing",
@@ -16531,10 +17287,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "subxt-rpcs"
+version = "0.50.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c239a933407ae77306be8b6db72db1594c3295ba39781a0668c340e3d909160f"
+dependencies = [
+ "derive-where",
+ "frame-metadata",
+ "futures",
+ "hex",
+ "impl-serde",
+ "jsonrpsee 0.24.10",
+ "parity-scale-codec",
+ "primitive-types 0.13.1",
+ "serde",
+ "serde_json",
+ "subxt-lightclient 0.50.2",
+ "thiserror 2.0.12",
+ "tokio-util",
+ "tracing",
+ "url 2.5.4",
+]
+
+[[package]]
+name = "subxt-signer"
+version = "0.50.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7774081bbbbbcb998428a3c52d44aa3e98d8b1f4eab6230612984ca33316344a"
+dependencies = [
+ "base64 0.22.1",
+ "bip39",
+ "cfg-if 1.0.0",
+ "crypto_secretbox",
+ "hex",
+ "hmac 0.12.1",
+ "parity-scale-codec",
+ "pbkdf2 0.12.2",
+ "regex",
+ "schnorrkel",
+ "scrypt",
+ "secp256k1 0.30.0",
+ "secrecy 0.10.3",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sp-crypto-hashing",
+ "subxt 0.50.2",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
+name = "subxt-utils-accountid32"
+version = "0.50.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d43f74707b4c7b7e1e40bf362aebaf42630211a8bcac46a94318284f305debd"
+dependencies = [
+ "base58",
+ "blake2",
+ "parity-scale-codec",
+ "scale-decode",
+ "scale-encode",
+ "scale-info",
+ "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "subxt-utils-fetchmetadata"
 version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e450f6812a653c5a3e63a079aa3b60a3f4c362722753c3222286eaa1800f9002"
+dependencies = [
+ "hex",
+ "parity-scale-codec",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "subxt-utils-fetchmetadata"
+version = "0.50.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d58c4d891f3f8bd56acae29706b8bcde969ebb7421c447a8dff0117128416cb"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -16582,6 +17416,17 @@ name = "syn"
 version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -17126,9 +17971,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.8",
+ "toml_datetime 0.6.9",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
+dependencies = [
+ "indexmap 2.9.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -17141,6 +18001,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17148,10 +18017,19 @@ checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.8",
+ "toml_datetime 0.6.9",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -17159,6 +18037,12 @@ name = "toml_write"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
@@ -17519,9 +18403,9 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.7",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -17542,6 +18426,15 @@ name = "typewit"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
+dependencies = [
+ "typewit_proc_macros",
+]
+
+[[package]]
+name = "typewit_proc_macros"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36a83ea2b3c704935a01b4642946aadd445cea40b10935e3f8bd8052b8193d6"
 
 [[package]]
 name = "ucd-trie"
@@ -18202,7 +19095,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -18614,12 +19507,18 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.7"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "winreg"

--- a/chain-signatures/chain-midnight/Cargo.toml
+++ b/chain-signatures/chain-midnight/Cargo.toml
@@ -19,6 +19,7 @@ midnight-serialize.workspace = true
 midnight-storage.workspace = true
 midnight-transient-crypto.workspace = true
 midnight-ledger-v9.workspace = true
+midnight-node-ledger-helpers.workspace = true
 mpc-chain-integration-core.workspace = true
 mpc-crypto.workspace = true
 mpc-primitives.workspace = true

--- a/chain-signatures/chain-midnight/src/config.rs
+++ b/chain-signatures/chain-midnight/src/config.rs
@@ -1,6 +1,7 @@
 //! Midnight node configuration.
 
 use mpc_chain_integration_core::utils::retry::RetryConfig;
+use std::fmt;
 use std::time::Duration;
 
 /// Timeouts and retry budget for the subxt node RPC client.
@@ -53,6 +54,104 @@ impl Default for IndexerConfig {
     }
 }
 
+/// How the node runs the out-of-process intent builder, the only piece of the respond
+/// path that stays in TypeScript because the proving stack lives there.
+#[derive(Clone, PartialEq)]
+pub struct PublisherConfig {
+    /// argv of the builder, program first. A list rather than one shell string so no
+    /// operator-supplied path is word-split behind their back, and so a test can point
+    /// this at a stub.
+    pub intent_gen_command: Vec<String>,
+    /// Root of the compiled-contract assets (`contract/`, `keys/`, `zkir/`) the builder
+    /// proves against. Reaches the child as `MIDNIGHT_PUB_MANAGED_DIR`.
+    pub managed_dir: String,
+    /// Hex seed of the wallet that funds respond transactions. Empty is the indexer-only
+    /// deployment, which never spends and so is never asked for a credential.
+    pub funding_seed: String,
+    /// Where the funding wallet reaches the chain: the node, the prover and the indexer,
+    /// all four of them plus the seed above present or absent as one set. The child
+    /// validates that half all-or-none and refuses to boot on any subset, so a
+    /// deployment holding three of them has no builder at all, and `validate` naming the
+    /// missing one is what keeps that from being read off a dead child's stderr.
+    ///
+    /// The four sitting together mirrors the `Endpoints` interface they feed on the
+    /// TypeScript side, and that grouping is load-bearing for the validation rather than
+    /// cosmetic: it is what lets the all-or-none rule be stated in one place instead of
+    /// scattered across whatever holds each value.
+    ///
+    /// Which is why `MidnightConfig::node_ws_url` is duplicated here rather than
+    /// `IntentGen::spawn` being widened to carry it alongside `network_id`: widening it
+    /// changes a public signature and four call sites across three files to move one
+    /// value, and splits the set. `into_config` fills this off the same flag, so the two
+    /// cannot disagree.
+    pub node_ws_url: String,
+    /// Mandatory wherever the wallet is: these contracts are zkir-v3, which cannot be
+    /// proven in process, so a proof server is the only configuration that exists and no
+    /// second one is offered.
+    pub proof_server_url: String,
+    /// Spendable DUST is derived by replaying every block's ledger events from genesis,
+    /// and the indexer is the only surface that serves them. No node RPC carries it,
+    /// which is why an absent indexer is a publisher that cannot spend at all rather
+    /// than one that is merely slower.
+    pub indexer_url: String,
+    pub indexer_ws_url: String,
+    /// Ceiling on one build. Generous because a proving run is seconds, and because
+    /// exceeding it costs a child restart.
+    pub request_timeout: Duration,
+    /// Ceiling on getting a built intent accepted by the node, which waits on block
+    /// production rather than on local work, so it is the looser of the two.
+    pub submit_timeout: Duration,
+    /// Budget for bringing the builder back up after it dies.
+    pub restart_backoff: RetryConfig,
+}
+
+impl Default for PublisherConfig {
+    fn default() -> Self {
+        Self {
+            // The `bin` name the TypeScript package installs, resolved on PATH.
+            intent_gen_command: vec!["midnight-publisher".to_string()],
+            managed_dir: String::new(),
+            // Empty across the whole submit half, which is the deployment that only
+            // builds intents: the child reads all five blank as "no funding wallet" and
+            // boots, and any other combination is what it refuses.
+            funding_seed: String::new(),
+            node_ws_url: String::new(),
+            proof_server_url: String::new(),
+            indexer_url: String::new(),
+            indexer_ws_url: String::new(),
+            request_timeout: Duration::from_secs(120),
+            submit_timeout: Duration::from_secs(300),
+            restart_backoff: RetryConfig {
+                min_delay: Duration::from_millis(500),
+                max_delay: Duration::from_secs(10),
+                max_times: 5,
+                jitter: true,
+            },
+        }
+    }
+}
+
+/// Hand-written so `funding_seed` cannot be printed: `cli::log_startup` renders the
+/// chain configs with `Debug`, so a derived one puts the operator's spending key in the
+/// node's log. Redacted rather than skipped, because a vanished field reads as a struct
+/// that never had one and a later `derive(Debug)` would restore the leak unnoticed.
+impl fmt::Debug for PublisherConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PublisherConfig")
+            .field("intent_gen_command", &self.intent_gen_command)
+            .field("managed_dir", &self.managed_dir)
+            .field("funding_seed", &"<redacted>")
+            .field("node_ws_url", &self.node_ws_url)
+            .field("proof_server_url", &self.proof_server_url)
+            .field("indexer_url", &self.indexer_url)
+            .field("indexer_ws_url", &self.indexer_ws_url)
+            .field("request_timeout", &self.request_timeout)
+            .field("submit_timeout", &self.submit_timeout)
+            .field("restart_backoff", &self.restart_backoff)
+            .finish()
+    }
+}
+
 /// Midnight chain integration configuration.
 #[derive(Clone, Debug, PartialEq)]
 pub struct MidnightConfig {
@@ -61,6 +160,7 @@ pub struct MidnightConfig {
     pub central_address: String,
     /// Ledger network id.
     pub network_id: String,
+    pub publisher: PublisherConfig,
     pub rpc: RpcConfig,
     pub indexer: IndexerConfig,
 }
@@ -89,6 +189,62 @@ impl MidnightConfig {
             "midnight config: central_address must be lowercase hex, the canonical form \
              every comparison site assumes"
         );
+        // Checked only when set. Midnight deploys indexer-only today, so every existing
+        // deployment carries the three endpoint flags and no seed; demanding one from a
+        // node that never spends would only put an invented secret in its deployment.
+        // A publisher without a seed is left unregistered instead.
+        //
+        // Either case, where central_address above is lowercase-only: that address is
+        // compared against decoder output, so its case decides whether attribution
+        // matches. This seed is only ever decoded, never compared, so a case rule here
+        // would reject a working credential to buy nothing.
+        if !self.publisher.funding_seed.is_empty() {
+            let seed = &self.publisher.funding_seed;
+            anyhow::ensure!(
+                seed.len().is_multiple_of(2)
+                    && (32..=128).contains(&seed.len())
+                    && seed.bytes().all(|b| b.is_ascii_hexdigit()),
+                "midnight config: publisher.funding_seed must be 16 to 64 bytes of hex with \
+                 no 0x prefix, got {} characters",
+                seed.len()
+            );
+        }
+        self.validate_submit_half()
+    }
+
+    /// The five values a respond needs, checked as the one set the child treats them as.
+    ///
+    /// The child validates its submit half all-or-none and refuses to boot on any
+    /// subset, and what it says about which value was missing goes to its stderr, which
+    /// is a place nobody reads before the first signature goes unanswered. Named here
+    /// instead, at startup, off the flags an operator actually sets.
+    ///
+    /// Only the names are rendered. One of the five is a spending key.
+    fn validate_submit_half(&self) -> anyhow::Result<()> {
+        let publisher = &self.publisher;
+        let submit_half = [
+            ("publisher.funding_seed", &publisher.funding_seed),
+            ("publisher.node_ws_url", &publisher.node_ws_url),
+            ("publisher.proof_server_url", &publisher.proof_server_url),
+            ("publisher.indexer_url", &publisher.indexer_url),
+            ("publisher.indexer_ws_url", &publisher.indexer_ws_url),
+        ];
+        let missing: Vec<&str> = submit_half
+            .iter()
+            .filter(|(_, value)| value.is_empty())
+            .map(|(name, _)| *name)
+            .collect();
+        anyhow::ensure!(
+            missing.is_empty() || missing.len() == submit_half.len(),
+            "midnight config: responding needs all of {}, or none of them for a node that \
+             only indexes; missing {}",
+            submit_half
+                .iter()
+                .map(|(name, _)| *name)
+                .collect::<Vec<_>>()
+                .join(", "),
+            missing.join(", ")
+        );
         Ok(())
     }
 }
@@ -102,9 +258,22 @@ mod tests {
             node_ws_url: "ws://127.0.0.1:9944".to_string(),
             central_address: "ab".repeat(32),
             network_id: "undeployed".to_string(),
+            publisher: Default::default(),
             rpc: Default::default(),
             indexer: Default::default(),
         }
+    }
+
+    /// A node that answers as well as indexes: the whole submit half filled, which is
+    /// the only shape in which any one of those five values validates.
+    fn responding_config() -> MidnightConfig {
+        let mut config = valid_config();
+        config.publisher.funding_seed = "0f".repeat(32);
+        config.publisher.node_ws_url = config.node_ws_url.clone();
+        config.publisher.proof_server_url = "http://127.0.0.1:6300".to_string();
+        config.publisher.indexer_url = "http://127.0.0.1:8088/api/v3/graphql".to_string();
+        config.publisher.indexer_ws_url = "ws://127.0.0.1:8088/api/v3/graphql/ws".to_string();
+        config
     }
 
     #[test]
@@ -112,6 +281,150 @@ mod tests {
         // Probe-and-degrade is the default policy: a pruned node logs loudly and falls
         // back to watermark catchup.
         assert!(!IndexerConfig::default().require_archive_state);
+    }
+
+    #[test]
+    fn publisher_defaults_are_pinned() {
+        // The timeouts have no flags, so nothing else observes them: retune
+        // `submit_timeout` or `request_timeout` by accident and this assert is the only
+        // thing that goes red.
+        let publisher = PublisherConfig::default();
+        assert_eq!(publisher.request_timeout, Duration::from_secs(120));
+        assert_eq!(publisher.submit_timeout, Duration::from_secs(300));
+        // The submit half defaults blank as a set, which is the deployment that only
+        // builds intents. A default endpoint would be worse than none: it would name a
+        // host nobody chose, and the child would boot believing it can spend.
+        assert!(publisher.funding_seed.is_empty());
+        assert!(publisher.node_ws_url.is_empty());
+        assert!(publisher.proof_server_url.is_empty());
+        assert!(publisher.indexer_url.is_empty());
+        assert!(publisher.indexer_ws_url.is_empty());
+    }
+
+    #[test]
+    fn debug_redacts_the_funding_seed() {
+        // `cli::log_startup` renders the chain configs with `Debug`, so whatever `Debug`
+        // prints is in the node's startup line and in every `?config` after it.
+        let seed = "0123456789abcdef0123456789abcdef";
+        let mut config = responding_config();
+        config.publisher.funding_seed = seed.to_string();
+
+        let rendered = format!("{config:?}");
+        assert!(
+            !rendered.contains(seed),
+            "the funding seed reached Debug: {rendered}"
+        );
+        assert!(
+            rendered.contains("<redacted>"),
+            "the field must render redacted rather than vanish, or a later \
+             derive(Debug) reinstates the leak unnoticed: {rendered}"
+        );
+    }
+
+    #[test]
+    fn an_empty_funding_seed_validates() {
+        // The indexer-only deployment, which is every deployment today: a node that
+        // never responds has nothing to fund, and rejecting it here would force an
+        // invented secret into its config.
+        let mut seedless = valid_config();
+        seedless.publisher.funding_seed = String::new();
+        seedless
+            .validate()
+            .expect("a node that only indexes needs no funding seed");
+
+        responding_config()
+            .validate()
+            .expect("64 hex characters is 32 bytes");
+    }
+
+    #[test]
+    fn a_funding_seed_may_be_uppercase_hex() {
+        // Pins the asymmetry with central_address, which is lowercase-only, so it reads
+        // as a decision rather than an oversight: this seed is decoded and never
+        // compared, so tightening it to lowercase would reject a working credential.
+        // Nothing else would go red if someone did.
+        let mut config = responding_config();
+        config.publisher.funding_seed = "0F".repeat(32);
+        config
+            .validate()
+            .expect("the seed is decoded, never compared against anything");
+    }
+
+    #[test]
+    fn the_submit_half_validates_as_one_set_or_not_at_all() {
+        // The defect this exists for: the child validates these five all-or-none and
+        // dies at boot on any subset, so a node holding four of them has no builder and
+        // learns why only from a stderr line nobody is reading. Every one of the five
+        // has to be the one that is missing, because a check written against a list can
+        // leave a value off it and stay green for the other four.
+        for blank in [
+            "funding_seed",
+            "node_ws_url",
+            "proof_server_url",
+            "indexer_url",
+            "indexer_ws_url",
+        ] {
+            let mut config = responding_config();
+            let publisher = &mut config.publisher;
+            match blank {
+                "funding_seed" => publisher.funding_seed = String::new(),
+                "node_ws_url" => publisher.node_ws_url = String::new(),
+                "proof_server_url" => publisher.proof_server_url = String::new(),
+                "indexer_url" => publisher.indexer_url = String::new(),
+                _ => publisher.indexer_ws_url = String::new(),
+            }
+            let err = config.validate().unwrap_err().to_string();
+            assert!(
+                err.contains(&format!("missing publisher.{blank}")),
+                "a config missing only {blank} must say so: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_half_configured_publisher_never_renders_the_seed_it_does_have() {
+        // The refusal above lists the five names, and one of them holds a spending key.
+        // Rendering the values would put it in the startup error of exactly the
+        // deployment most likely to be misconfigured.
+        let seed = "0123456789abcdef0123456789abcdef";
+        let mut config = responding_config();
+        config.publisher.funding_seed = seed.to_string();
+        config.publisher.indexer_url = String::new();
+
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("missing publisher.indexer_url"), "got: {err}");
+        assert!(
+            !err.contains(seed),
+            "the funding seed reached an error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_a_malformed_funding_seed() {
+        // Caught here or not at all: the seed is opaque to the node, which forwards it
+        // to the builder, so a typo would otherwise surface as a child that fails to
+        // derive a wallet long after startup.
+        for seed in [
+            // Odd length, so the last byte has one nibble.
+            "0f".repeat(16) + "a",
+            // Hex-shaped but not hex.
+            "zz".repeat(16),
+            // Under 16 bytes.
+            "0f".repeat(15),
+            // Over 64 bytes.
+            "0f".repeat(65),
+        ] {
+            // Endpoint-complete, so the shape check is unambiguously what refuses:
+            // against a blank submit half the all-or-none refusal names this field too,
+            // and the assertion could not tell the two apart.
+            let mut config = responding_config();
+            config.publisher.funding_seed = seed.clone();
+            let err = config.validate().unwrap_err().to_string();
+            assert!(
+                err.contains("16 to 64 bytes of hex"),
+                "unexpected error for {seed:?}: {err}"
+            );
+        }
     }
 
     #[test]

--- a/chain-signatures/chain-midnight/src/indexer.rs
+++ b/chain-signatures/chain-midnight/src/indexer.rs
@@ -1302,6 +1302,7 @@ mod tests {
                     node_ws_url: "ws://127.0.0.1:1".to_string(),
                     central_address: central_address(),
                     network_id: "undeployed".to_string(),
+                    publisher: Default::default(),
                     rpc: Default::default(),
                     indexer: Default::default(),
                 },
@@ -1751,6 +1752,7 @@ mod tests {
                 node_ws_url: "ws://127.0.0.1:1".to_string(),
                 central_address: central,
                 network_id: "undeployed".to_string(),
+                publisher: Default::default(),
                 rpc: Default::default(),
                 indexer: Default::default(),
             },
@@ -2268,6 +2270,7 @@ mod tests {
             node_ws_url: String::new(),
             central_address: "ab".repeat(32),
             network_id: "undeployed".to_string(),
+            publisher: Default::default(),
             rpc: Default::default(),
             indexer: Default::default(),
         };

--- a/chain-signatures/chain-midnight/src/intent_gen.rs
+++ b/chain-signatures/chain-midnight/src/intent_gen.rs
@@ -1,0 +1,1793 @@
+//! Client for the out-of-process intent builder.
+//!
+//! The respond circuit, its proving stack and the wallet that pays for a post only exist
+//! in TypeScript, so both halves of a post run in a child process and this is the only
+//! thing that talks to it: one JSON object per line down its stdin, one back up its
+//! stdout, mirroring `protocol.ts` field for field. Building an intent is a pure
+//! function of what the caller pinned and put on the wire; submitting one spends, which
+//! is the whole reason [`Operation`] exists.
+//!
+//! A reply landing on the wrong request is what this guards hardest against, because it
+//! would put one post's signature into another post's intent. The pipe has no framing
+//! beyond the newline, so once the stream is in any doubt the child is replaced rather
+//! than resynchronized.
+
+use std::collections::VecDeque;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use mpc_chain_integration_core::utils::retry::retry_rpc;
+use mpc_chain_integration_core::utils::task::AbortOnDrop;
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use crate::config::PublisherConfig;
+
+/// One respond call, in the shape the child validates. Every byte field is bare
+/// lowercase hex with no `0x`; the child converts nothing and rejects anything else.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IntentRequest {
+    /// `respond` or `respondBidirectional`. The child discriminates its request union
+    /// on this before anything else, so a wrong value costs the whole request.
+    pub circuit: &'static str,
+    pub contract_address: String,
+    pub request_id: String,
+    pub signature: WireSignature,
+    /// The whole zero-padded ABI return data, not a digest of it. `respondBidirectional`
+    /// only, and the child rejects the request outright if the other circuit carries it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub serialized_output: Option<String>,
+    /// How much of `serialized_output` is meaningful, 0..=128.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_len: Option<u8>,
+    /// The contract state and ledger parameters this caller read, pinned here so the
+    /// child stays a pure function of what it is handed.
+    pub contract_state: String,
+    pub ledger_parameters: String,
+    /// The funding wallet's Zswap public key, public and the only thing about that
+    /// wallet the child is ever told.
+    pub coin_public_key: String,
+    /// Absolute unix seconds, not a duration from now.
+    pub ttl_seconds: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WireSignature {
+    pub big_r: WirePoint,
+    pub s: String,
+    /// 0 or 1.
+    pub recovery_id: u8,
+}
+
+/// SEC1 big-endian affine coordinates, reaching the ledger untouched.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct WirePoint {
+    pub x: String,
+    pub y: String,
+}
+
+/// One submit call: the intent a previous build answered with, in the same bare
+/// lowercase hex every byte field on this wire takes.
+///
+/// Nothing else travels, and none of the reads that built the intent do. The child
+/// balances against a wallet it syncs itself, and the call inside the intent is already
+/// partitioned and priced, so there is nothing left over there for a pinned read to be
+/// weighed against.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct SubmitRequest {
+    intent: String,
+}
+
+/// A hex seed is at least 16 bytes. Kept in step with the child's own floor.
+const SHORTEST_SEED_HEX: usize = 32;
+
+/// Scrubs the funding seed out of anything the child says before this node repeats it.
+///
+/// The child is handed a spending key, and two of its outputs come back through here on
+/// their way to the log: its stderr, which `drain_stderr` forwards verbatim, and the
+/// `message` of a refusal, which the child builds by rendering a dependency's cause
+/// chain and which reaches `tracing` through the retry warning. A wallet library that
+/// quotes its own configuration in an error would put the key in this node's log by
+/// either route. `PublisherConfig`'s `Debug` redacts the seed for exactly this reason;
+/// these are the other two paths to the same place.
+#[derive(Clone)]
+struct SeedRedactor(Vec<String>);
+
+impl SeedRedactor {
+    fn new(seed: &str) -> Self {
+        let seed = seed.trim();
+        // A hex seed is at least 16 bytes, so anything shorter is not one and must not be
+        // blanked out of a message: the empty string sits between every pair of
+        // characters, and a two-character "secret" would redact half the text it appears
+        // in, destroying the diagnostic this exists to preserve. A node that only indexes
+        // legitimately has no seed at all. The child applies the same floor to its own
+        // redaction, and the two have to agree or a line scrubbed on one side arrives
+        // intact on the other.
+        if seed.len() < SHORTEST_SEED_HEX {
+            return Self(Vec::new());
+        }
+        // Every spelling the seed parser accepts, because substring matching is the whole
+        // technique: it catches the seed rendered literally, which is what a config echo
+        // or a "bad key" error does, and only in the spelling it was rendered in.
+        let bare = seed.strip_prefix("0x").unwrap_or(seed);
+        Self(vec![
+            seed.to_string(),
+            bare.to_lowercase(),
+            bare.to_uppercase(),
+        ])
+    }
+
+    fn scrub(&self, text: &str) -> String {
+        let mut out = text.to_string();
+        for form in &self.0 {
+            if out.contains(form.as_str()) {
+                out = out.replace(form.as_str(), "<redacted>");
+            }
+        }
+        out
+    }
+}
+
+/// What the child is being asked to do.
+///
+/// The two differ in more than their budget. Building an intent is a pure function of
+/// what it is handed, so an answer lost to a dead pipe can simply be asked for again.
+/// Submitting spends the funding wallet's single dust UTXO, so a lost answer means the
+/// transaction may already be on chain, and asking again is precisely how a second post
+/// races the first onto that one coin.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Operation {
+    BuildIntent,
+    Submit,
+}
+
+impl Operation {
+    /// How long the child gets.
+    ///
+    /// Per-operation because one budget cannot serve both: a build is milliseconds and a
+    /// submit is minutes. Bounding a submit by the build's budget kills the child
+    /// mid-prove every time, throws the proof away, strands the balanced coin, and hands
+    /// the operator a transport timeout that names none of that.
+    ///
+    /// These are NOT independent knobs. The submit budget has to stay LONGER than the
+    /// dust recipe's TTL, because a deadline blown before the TTL expires means the coin
+    /// may be stranded with the recipe still live, which is why a blown submit deadline
+    /// is fatal here rather than retryable. The service this replaces paired a 360s
+    /// deadline with a 300s recipe TTL for that reason; anyone retuning one must move
+    /// the other.
+    fn deadline(self, config: &PublisherConfig) -> Duration {
+        match self {
+            Self::BuildIntent => config.request_timeout,
+            Self::Submit => config.submit_timeout,
+        }
+    }
+
+    /// Whether an answer lost in transit may simply be asked for again.
+    fn is_repeatable(self) -> bool {
+        matches!(self, Self::BuildIntent)
+    }
+
+    /// The `op` the child discriminates on, where absence is itself one of the values.
+    ///
+    /// A build sends none rather than `"build"`: the child reads a missing `op` as a
+    /// build precisely so the second operation could be added to one side at a time, and
+    /// spending that now would buy nothing.
+    fn wire_op(self) -> Option<&'static str> {
+        match self {
+            Self::BuildIntent => None,
+            Self::Submit => Some("submit"),
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::BuildIntent => "intent build",
+            Self::Submit => "submit",
+        }
+    }
+
+    /// What a lost answer leaves behind, for whoever reads the error.
+    fn lost_answer_warning(self) -> &'static str {
+        match self {
+            // Nothing was spent and nothing was posted: there is nothing to go and check.
+            Self::BuildIntent => "",
+            Self::Submit => {
+                "; the transaction may still reach the chain, so check it for this request \
+                 before posting again, and expect the balanced coin to stay stranded until \
+                 its recipe TTL expires"
+            }
+        }
+    }
+}
+
+/// Builds intents and posts them, by driving one persistent child process.
+pub struct IntentGen {
+    config: PublisherConfig,
+    /// Passed to every child rather than left to the environment. See `spawn_child`.
+    network_id: String,
+    redactor: SeedRedactor,
+    /// One request at a time. Two requests interleaved on one pipe have no correct
+    /// reading, so the lock is the whole concurrency story: callers queue.
+    session: Mutex<Option<Session>>,
+}
+
+impl IntentGen {
+    /// Starts the builder eagerly, so a command that cannot run fails here rather than
+    /// on the first signature that needs it.
+    pub async fn spawn(config: &PublisherConfig, network_id: &str) -> anyhow::Result<Self> {
+        Ok(Self {
+            config: config.clone(),
+            network_id: network_id.to_string(),
+            redactor: SeedRedactor::new(&config.funding_seed),
+            session: Mutex::new(Some(spawn_session(config, network_id).await?)),
+        })
+    }
+
+    /// The serialized ledger `Intent` for `request`.
+    pub async fn build(
+        &self,
+        request: &IntentRequest,
+        cancel: &CancellationToken,
+    ) -> anyhow::Result<Vec<u8>> {
+        let reply = self
+            .dispatch(request, cancel, Operation::BuildIntent)
+            .await?;
+        let intent = reply
+            .intent
+            .context("midnight intent builder granted a request without an intent")?;
+        hex::decode(&intent).context("decoding the intent the builder granted")
+    }
+
+    /// Balances, proves and posts `intent`, answering with what names the transaction on
+    /// chain.
+    ///
+    /// Attempted exactly once, and nothing here says so: `Operation::Submit` carries both
+    /// the budget and the answer to a lost reply, so this call site cannot pair a submit
+    /// with a build's deadline, or with a retry, however carelessly it is written.
+    pub async fn submit(
+        &self,
+        intent: &[u8],
+        cancel: &CancellationToken,
+    ) -> anyhow::Result<String> {
+        let request = SubmitRequest {
+            intent: hex::encode(intent),
+        };
+        let reply = self.dispatch(&request, cancel, Operation::Submit).await?;
+        // The reply also names the block it landed in, which stops here: the child
+        // already waited for that block before answering at all, and the identifier is
+        // what a lookup takes.
+        reply
+            .tx_id
+            .context("midnight intent builder posted a transaction without naming it")
+    }
+
+    /// One operation, start to finish, against at most two children.
+    ///
+    /// It decides its budget and whether a lost answer may be reissued from `operation`,
+    /// never from the caller, so the two cannot be set inconsistently at a call site.
+    /// Answers with the reply's framing rather than a payload, because which field
+    /// carries a granted answer is the one thing the two operations do not share.
+    async fn dispatch<T: Serialize>(
+        &self,
+        request: &T,
+        cancel: &CancellationToken,
+        operation: Operation,
+    ) -> anyhow::Result<WireReply> {
+        let mut session = self.session.lock().await;
+        let (error, retry) = match self.attempt(&mut session, request, cancel, operation).await {
+            Exchange::Answered(result) => return result,
+            Exchange::Broken { error, retry } => (error, retry),
+        };
+        if !retry {
+            return Err(self.blame_the_command(error));
+        }
+        // A child that died between requests costs one respawn, never the caller's post.
+        // Exactly one retry: past that the failure is the builder's rather than the
+        // pipe's, and repeating a proving run is expensive enough to be deliberate.
+        tracing::warn!(
+            reason = "respawning",
+            "midnight intent builder failed: {error:#}; retrying once on a fresh child"
+        );
+        match self.attempt(&mut session, request, cancel, operation).await {
+            Exchange::Answered(result) => result,
+            Exchange::Broken { error, .. } => Err(self.blame_the_command(error)),
+        }
+    }
+
+    /// Names the configured command on any failure of the child itself.
+    ///
+    /// Only on those: a request the child considered and refused is answered, and the
+    /// command is not what is wrong with it. But a child that died, went silent or
+    /// answered nonsense is a failure of the process, and the first thing an operator
+    /// needs is which process, since the likeliest cause by far is that
+    /// `intent_gen_command` names something this host cannot run. The default is a bare
+    /// `midnight-publisher` resolved on PATH, so a container missing that binary hits
+    /// this on every publish, and "closed its stdout" alone would not say why.
+    fn blame_the_command(&self, error: anyhow::Error) -> anyhow::Error {
+        error.context(format!(
+            "midnight intent builder command [{}]",
+            self.config.intent_gen_command.join(" ")
+        ))
+    }
+
+    /// One pass: make sure a child is up, then trade one line with it. A pass that
+    /// breaks always empties the slot, and emptying the slot kills the child it broke
+    /// on, so no later pass can read into what that child left in the pipe.
+    async fn attempt<T: Serialize>(
+        &self,
+        session: &mut Option<Session>,
+        request: &T,
+        cancel: &CancellationToken,
+        operation: Operation,
+    ) -> Exchange {
+        if session.is_none() {
+            match spawn_session(&self.config, &self.network_id).await {
+                Ok(fresh) => *session = Some(fresh),
+                // The restart budget was already spent inside the spawn, so a second
+                // pass would only spend it again.
+                Err(error) => return Exchange::give_up(error),
+            }
+        }
+        let live = session
+            .as_mut()
+            .expect("the slot was just filled or was already full");
+        let outcome = exchange(
+            live,
+            request,
+            operation,
+            &self.config,
+            cancel,
+            &self.redactor,
+        )
+        .await;
+        let Exchange::Broken { error, retry } = outcome else {
+            return outcome;
+        };
+        // The child's own account of what went wrong, which otherwise only ever reaches
+        // a `tracing` subscriber. A child that cannot start says why and dies, and the
+        // pass that notices reports a closed pipe: an operator running the node without
+        // a subscriber gets "closed its stdout" for a missing environment variable the
+        // child named out loud. Attached before the session is emptied, because emptying
+        // it kills the child and takes its stderr with it.
+        let error = match live.last_words().await {
+            Some(said) => error.context(format!("the midnight intent builder said: {said}")),
+            None => error,
+        };
+        *session = None;
+        Exchange::Broken { error, retry }
+    }
+}
+
+/// One live child and the partially read line buffer over its stdout. Dropping it kills
+/// the child, which is what lets every failure path recover by simply forgetting it.
+struct Session {
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    /// The id namespace belongs to the child: a fresh pipe cannot deliver a previous
+    /// child's reply, so counting from zero per session stays unambiguous.
+    next_id: u64,
+    /// What the drain below has heard, for the error that reports this child's death.
+    stderr: StderrTail,
+    /// Held only for `kill_on_drop`. Dropped after `stdin`, so a child that exits on
+    /// end-of-input gets to do that before the kill lands.
+    _child: Child,
+    /// Awaited briefly by `last_words` rather than merely aborted on drop: the drain
+    /// ending is how this side learns the child has finished saying why it died.
+    stderr_drain: AbortOnDrop,
+}
+
+impl Session {
+    /// What the child said on its stderr, already scrubbed, or `None` if it said
+    /// nothing.
+    ///
+    /// Waits for the drain first, briefly. Stdout reaching end of input and stderr
+    /// reaching it are two events on two pipes, so a child that died a moment ago may
+    /// still have its explanation in flight when the read that noticed comes back;
+    /// without the wait the tail would be empty exactly when it matters most. A child
+    /// that is merely wedged never closes its stderr at all, which is what the bound is
+    /// for.
+    async fn last_words(&mut self) -> Option<String> {
+        let _ = tokio::time::timeout(STDERR_TAIL_GRACE, &mut self.stderr_drain.0).await;
+        self.stderr.take()
+    }
+}
+
+/// How many of the child's last stderr lines an error carries. Enough for a refusal and
+/// the first frames under it, few enough that a chatty child cannot grow this without
+/// bound.
+const STDERR_TAIL_LINES: usize = 10;
+
+/// How long a broken pass waits for the drain to finish before reporting what it has.
+const STDERR_TAIL_GRACE: Duration = Duration::from_millis(200);
+
+/// The child's last words, scrubbed, on their way into an error rather than a log.
+///
+/// `drain_stderr` forwards every line to `tracing::warn!`, which reaches nobody in a
+/// process running without a subscriber, so a child that refuses to start leaves the
+/// caller holding "closed its stdout" while the one message that names what is
+/// misconfigured goes nowhere. What it holds is already scrubbed, because `ScrubbedLines`
+/// is the only thing that fills it.
+#[derive(Clone, Default)]
+struct StderrTail(Arc<std::sync::Mutex<VecDeque<String>>>);
+
+impl StderrTail {
+    /// Never panics on a poisoned lock: this runs inside a publisher task, and a panic
+    /// there takes a runtime worker with it over a diagnostic. Nothing inside the lock
+    /// can panic, so the recovered value is the same value.
+    fn lines(&self) -> std::sync::MutexGuard<'_, VecDeque<String>> {
+        self.0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn push(&self, line: String) {
+        let mut lines = self.lines();
+        if lines.len() == STDERR_TAIL_LINES {
+            lines.pop_front();
+        }
+        lines.push_back(line);
+    }
+
+    /// Oldest first, on one line: this becomes an `anyhow` context, and those are read
+    /// as a chain of single-line causes.
+    fn take(&self) -> Option<String> {
+        let lines = self.lines();
+        (!lines.is_empty()).then(|| lines.iter().cloned().collect::<Vec<_>>().join("; "))
+    }
+}
+
+/// What a pass at the child produced.
+enum Exchange {
+    /// A reply that answers this request, whether it granted it or refused it.
+    Answered(anyhow::Result<WireReply>),
+    /// The child can no longer be trusted to be in step with us. It is replaced either
+    /// way; only a transport fault is worth trying a second time.
+    Broken { error: anyhow::Error, retry: bool },
+}
+
+impl Exchange {
+    /// The pipe failed under us, so the request never got a definitive answer.
+    ///
+    /// Whether a fresh child is worth one more try is the operation's to say rather than
+    /// the pipe's: the answer was lost either way, but only an operation that left
+    /// nothing behind on chain can simply be asked for again.
+    fn lost(error: anyhow::Error, operation: Operation) -> Self {
+        Self::Broken {
+            error: unanswered(error, operation),
+            retry: operation.is_repeatable(),
+        }
+    }
+
+    /// The child is finished either way, and asking a new one would only reproduce this.
+    fn give_up(error: anyhow::Error) -> Self {
+        Self::Broken {
+            error,
+            retry: false,
+        }
+    }
+}
+
+/// `error`, plus what an operation that cannot be asked again leaves behind.
+///
+/// Applied wherever a pass breaks PAST THE WRITE and nowhere else. From there on a lost
+/// answer and a landed transaction are indistinguishable from this side, whichever way
+/// the pass broke: the deadline blew, the pipe died, the caller walked away, or the
+/// reply came back unpairable. Before the write there is nothing on chain to go and
+/// check, and an alarm raised there would be a false one on the single path where an
+/// alarm has to mean something.
+fn unanswered(error: anyhow::Error, operation: Operation) -> anyhow::Error {
+    match operation.lost_answer_warning() {
+        "" => error,
+        warning => error.context(format!("the answer was lost{warning}")),
+    }
+}
+
+/// The child's configuration namespace. Every name under it is this process's to supply.
+const PUBLISHER_ENV_PREFIX: &str = "MIDNIGHT_PUB_";
+
+/// The names in `names` that fall in that namespace.
+fn publisher_vars<I>(names: I) -> Vec<std::ffi::OsString>
+where
+    I: IntoIterator<Item = std::ffi::OsString>,
+{
+    names
+        .into_iter()
+        .filter(|name| name.to_string_lossy().starts_with(PUBLISHER_ENV_PREFIX))
+        .collect()
+}
+
+/// Starts the builder under the restart budget, so a child lost to a redeploy or an OOM
+/// kill costs a few hundred milliseconds instead of the request.
+async fn spawn_session(config: &PublisherConfig, network_id: &str) -> anyhow::Result<Session> {
+    // The per-attempt deadline never realistically fires: spawning returns as soon as
+    // the fork does. The request budget is simply the largest wait already sanctioned.
+    retry_rpc!(
+        config.request_timeout,
+        config.restart_backoff,
+        "midnight_intent_gen_spawn",
+        { spawn_child(config, network_id) }
+    )
+}
+
+fn spawn_child(config: &PublisherConfig, network_id: &str) -> anyhow::Result<Session> {
+    let inherited = publisher_vars(std::env::vars_os().map(|(name, _)| name));
+    let mut command = intent_gen_command(config, network_id, &inherited)?;
+    let mut child = command.spawn().with_context(|| {
+        format!(
+            "spawning the midnight intent builder ({})",
+            config.intent_gen_command.join(" ")
+        )
+    })?;
+
+    let stdin = child
+        .stdin
+        .take()
+        .context("intent builder stdin was not piped")?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("intent builder stdout was not piped")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("intent builder stderr was not piped")?;
+    let tail = StderrTail::default();
+    Ok(Session {
+        stdin,
+        stdout: BufReader::new(stdout),
+        next_id: 0,
+        stderr: tail.clone(),
+        _child: child,
+        stderr_drain: AbortOnDrop(tokio::spawn(drain_stderr(
+            stderr,
+            SeedRedactor::new(&config.funding_seed),
+            tail,
+        ))),
+    })
+}
+
+/// The child's command, configured but not spawned.
+///
+/// Split from the spawn so a test can read back the environment the child would get:
+/// `inherited` is the set of publisher variables this process holds, and every one of
+/// them has to be taken away rather than passed on.
+fn intent_gen_command(
+    config: &PublisherConfig,
+    network_id: &str,
+    inherited: &[std::ffi::OsString],
+) -> anyhow::Result<Command> {
+    let (program, args) = config
+        .intent_gen_command
+        .split_first()
+        .context("midnight publisher config: intent_gen_command is empty")?;
+    let mut command = Command::new(program);
+    command.args(args);
+
+    // `MIDNIGHT_PUB_*` is the child's configuration namespace, and this process is its
+    // only author: every name in it is either set below or removed here, never inherited.
+    //
+    // Overriding the ones we set would be enough to stop an ambient value winning today.
+    // Removing the rest is about what happens next: the child holds a spending key, and
+    // the set of names it reads will grow on its own side. A name this process does not
+    // yet know about would otherwise be quietly supplied by whatever is in the node's
+    // environment, which for a wallet means spending from a key nobody chose. Removed,
+    // the child's own required-value check rejects it at startup instead, which is the
+    // failure everyone wants.
+    //
+    // This stays narrower than `env_clear`, deliberately: the child is Node, and taking
+    // away PATH or HOME breaks it and everything it shells out to for no gain here.
+    for name in inherited {
+        command.env_remove(name);
+    }
+
+    command
+        // The network id decides address encoding and which artifacts the circuit is
+        // proved against, and the seed decides which wallet pays. Both are validated on
+        // `MidnightConfig`; a second ambient copy of either would be an unvalidated
+        // source of truth for a value whose disagreement only shows up on chain.
+        .env("MIDNIGHT_PUB_FUNDING_SEED", &config.funding_seed)
+        .env("MIDNIGHT_PUB_MANAGED_DIR", &config.managed_dir)
+        .env("MIDNIGHT_PUB_NETWORK_ID", network_id)
+        // The submit half, which the child needs whole or not at all: it refuses to boot
+        // holding a subset, and `MidnightConfig::validate` is what makes sure a subset
+        // never gets this far. Written unconditionally rather than only when they are
+        // set, because a name left unwritten is a name the `env_remove` above already
+        // took away, and blank is how a build-only deployment says it has no wallet.
+        .env("MIDNIGHT_PUB_NODE_URL", &config.node_ws_url)
+        .env("MIDNIGHT_PUB_PROOF_SERVER_URL", &config.proof_server_url)
+        .env("MIDNIGHT_PUB_INDEXER_URL", &config.indexer_url)
+        .env("MIDNIGHT_PUB_INDEXER_WS_URL", &config.indexer_ws_url)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        // Piped rather than inherited: the child's diagnostics belong in this node's
+        // log, and an unread stderr pipe eventually blocks it mid-proof.
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    Ok(command)
+}
+
+/// Forwards the child's stderr to the log and keeps the tail of it for whichever error
+/// reports the child's death. Both, not either: the log is where a healthy child's
+/// diagnostics belong, and the tail is what a caller with no subscriber gets instead.
+async fn drain_stderr(stderr: ChildStderr, redactor: SeedRedactor, tail: StderrTail) {
+    let mut lines = ScrubbedLines::new(stderr, redactor);
+    while let Some(line) = lines.next().await {
+        tracing::warn!(source = "midnight-intent-builder", "{line}");
+        tail.push(line);
+    }
+}
+
+/// A child's stderr, as lines with the seed already taken out.
+///
+/// There is deliberately no way to read an unscrubbed line: the sole consumer logs
+/// whatever it is handed, so the scrubbing belongs to the reader rather than to the
+/// discipline of whoever writes the next consumer.
+struct ScrubbedLines<R> {
+    lines: tokio::io::Lines<BufReader<R>>,
+    redactor: SeedRedactor,
+}
+
+impl<R: tokio::io::AsyncRead + Unpin> ScrubbedLines<R> {
+    fn new(reader: R, redactor: SeedRedactor) -> Self {
+        Self {
+            lines: BufReader::new(reader).lines(),
+            redactor,
+        }
+    }
+
+    /// The next line, or `None` at end of input and equally on a read error: there is no
+    /// second stderr to report a failure to read the first one on.
+    async fn next(&mut self) -> Option<String> {
+        let line = self.lines.next_line().await.ok()??;
+        Some(self.redactor.scrub(&line))
+    }
+}
+
+/// One line out, one line in. Anything that can leave the pipe in an unknown state
+/// reports `Broken`, because a new stream is the only cheap way to resynchronize one.
+async fn exchange<T: Serialize>(
+    session: &mut Session,
+    request: &T,
+    operation: Operation,
+    config: &PublisherConfig,
+    cancel: &CancellationToken,
+    redactor: &SeedRedactor,
+) -> Exchange {
+    let deadline = operation.deadline(config);
+    let id = session.next_id;
+    session.next_id += 1;
+    let line = match encode_request(request, id, operation) {
+        Ok(line) => line,
+        // Nothing reached the pipe, so the child is still in step; the request itself is
+        // beyond repair here.
+        Err(error) => return Exchange::Answered(Err(error)),
+    };
+
+    let reply = tokio::select! {
+        // A cancelled call walks away from a request the child may still be working on,
+        // and that reply would land on the next caller's read. A shutdown that raced the
+        // write is told apart from one that beat it by nothing available here, so a
+        // cancelled submit reports what it may have left behind rather than guessing it
+        // left nothing.
+        _ = cancel.cancelled() => {
+            return Exchange::give_up(unanswered(
+                anyhow::anyhow!("midnight {} cancelled", operation.name()),
+                operation,
+            ))
+        }
+        // A timed-out child is a dead publisher if it is kept. It has no deadline of its
+        // own and reads strictly one line at a time, so a circuit run that wedges wedges
+        // the process: every later request queues behind a reply that never comes, while
+        // the process itself still looks healthy. Reporting `Broken` is what kills it.
+        //
+        // Killed either way, but a submit is not reissued afterwards: past the write, a
+        // lost answer and a landed transaction look identical from here.
+        result = tokio::time::timeout(deadline, round_trip(session, &line)) => match result {
+            Ok(Ok(reply)) => reply,
+            Ok(Err(error)) => return Exchange::lost(error, operation),
+            Err(_) => return Exchange::lost(
+                anyhow::anyhow!("midnight {} timed out after {deadline:?}", operation.name()),
+                operation,
+            ),
+        },
+    };
+    match decode_reply(&reply, id, redactor) {
+        // The child's own verdict speaks for what it did, granted or refused alike, so it
+        // passes through as it is. Anything else is a reply that cannot be paired to this
+        // request, which past the write leaves the same doubt a dead pipe does.
+        answered @ Exchange::Answered(_) => answered,
+        Exchange::Broken { error, retry } => Exchange::Broken {
+            error: unanswered(error, operation),
+            retry,
+        },
+    }
+}
+
+async fn round_trip(session: &mut Session, line: &str) -> anyhow::Result<String> {
+    session
+        .stdin
+        .write_all(format!("{line}\n").as_bytes())
+        .await
+        .context("writing the intent request to the builder")?;
+    session
+        .stdin
+        .flush()
+        .await
+        .context("flushing the intent request to the builder")?;
+    let mut reply = String::new();
+    let read = session
+        .stdout
+        .read_line(&mut reply)
+        .await
+        .context("reading the intent builder's reply")?;
+    anyhow::ensure!(read > 0, "midnight intent builder closed its stdout");
+    Ok(reply)
+}
+
+/// Reads one reply line as the answer to request `id`.
+fn decode_reply(line: &str, id: u64, redactor: &SeedRedactor) -> Exchange {
+    let reply: WireReply = match serde_json::from_str(line.trim()) {
+        Ok(reply) => reply,
+        // Not this wire at all: a diagnostic on the wrong stream, or a line torn in
+        // half. Either way the reader's idea of where a line starts is now wrong.
+        Err(error) => {
+            return Exchange::give_up(
+                anyhow::Error::new(error)
+                    .context("midnight intent builder sent an unreadable reply"),
+            )
+        }
+    };
+    // A rejection carrying no id is this request's own: the child had nothing honest to
+    // echo off a line it could not read. A reply naming a different request means the
+    // stream has slipped, and one post's signature in another post's intent is the one
+    // outcome worth killing a healthy child over.
+    match reply.id {
+        Some(answered) if answered != id => {
+            return Exchange::give_up(anyhow::anyhow!(
+                "midnight intent builder answered id {answered}, not the id {id} it was asked"
+            ))
+        }
+        // The child only omits an id when it could not read one, which it can only fail
+        // to do on a line it is rejecting. A grant with no id is not an answer to
+        // anything nameable.
+        None if reply.ok => {
+            return Exchange::give_up(anyhow::anyhow!(
+                "midnight intent builder granted a request with no id"
+            ))
+        }
+        _ => {}
+    }
+    Exchange::Answered(granted(reply, redactor))
+}
+
+/// The reply as an answer, or the refusal it describes.
+///
+/// Which field carries a granted answer is the operation's business and is read past
+/// here. What both share is that a refusal is an answer too, and that its `message` is
+/// the child rendering a cause chain it does not control, so it is the one field on this
+/// wire that can carry the key back out.
+fn granted(reply: WireReply, redactor: &SeedRedactor) -> anyhow::Result<WireReply> {
+    if !reply.ok {
+        anyhow::bail!(
+            "midnight intent builder refused the request [{}]: {}",
+            reply.code.as_deref().unwrap_or("no code"),
+            redactor.scrub(reply.message.as_deref().unwrap_or("no message"))
+        );
+    }
+    Ok(reply)
+}
+
+fn encode_request<T: Serialize>(
+    request: &T,
+    id: u64,
+    operation: Operation,
+) -> anyhow::Result<String> {
+    serde_json::to_string(&WireRequest {
+        id,
+        op: operation.wire_op(),
+        request,
+    })
+    .context("encoding the request for the builder")
+}
+
+/// The request as it goes on the wire: the caller's fields, the id that pairs the reply
+/// to them, and the operation the child discriminates on.
+#[derive(Serialize)]
+struct WireRequest<'a, T> {
+    id: u64,
+    /// Absent on a build, which is a value rather than an omission. See
+    /// `Operation::wire_op`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    op: Option<&'static str>,
+    #[serde(flatten)]
+    request: &'a T,
+}
+
+/// Both arms of a reply in one shape, since the arms differ only by which fields carry
+/// anything. Unknown fields are ignored on purpose: growing the wire is meant to be
+/// additive on one side at a time, and the block a submit landed in is one this side
+/// deliberately does not read.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WireReply {
+    /// Null when the child could not read an id off the line it was rejecting.
+    id: Option<u64>,
+    ok: bool,
+    intent: Option<String>,
+    /// What names a posted transaction on chain. The submit arm's own payload.
+    tx_id: Option<String>,
+    code: Option<String>,
+    message: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::config::PublisherConfig;
+    use mpc_chain_integration_core::utils::retry::RetryConfig;
+    use std::path::PathBuf;
+    use std::time::{Duration, Instant};
+    use tokio_util::sync::CancellationToken;
+
+    const NETWORK_ID: &str = "undeployed";
+
+    /// A shell stub in place of the real Node child: the wire is the contract under
+    /// test, and a stub keeps every case here deterministic and Node-free.
+    ///
+    /// Only the fields this seam reads are pinned, and the rest are taken from
+    /// `Default` deliberately, because they belong to parts of the publisher this file
+    /// does not touch. That inheritance is a trap for anything added later: a test of a
+    /// path that reads `submit_timeout` or an endpoint would silently be testing the
+    /// default rather than a value it chose, so such a test must pin its own.
+    fn stub_config(script: &str) -> PublisherConfig {
+        PublisherConfig {
+            intent_gen_command: vec!["sh".to_string(), "-c".to_string(), script.to_string()],
+            managed_dir: "/managed".to_string(),
+            request_timeout: Duration::from_secs(5),
+            restart_backoff: RetryConfig {
+                min_delay: Duration::from_millis(1),
+                max_delay: Duration::from_millis(5),
+                max_times: 2,
+                jitter: false,
+            },
+            ..Default::default()
+        }
+    }
+
+    async fn spawn_stub(config: &PublisherConfig) -> IntentGen {
+        IntentGen::spawn(config, NETWORK_ID)
+            .await
+            .expect("the stub spawns")
+    }
+
+    /// A scratch file a stub counts its own spawns in. A stub script is identical on
+    /// every spawn, so state outside it is the only way to write one that behaves
+    /// differently on the second child than on the first, which is exactly what the
+    /// recovery cases have to observe.
+    struct SpawnCounter(PathBuf);
+
+    impl SpawnCounter {
+        /// Removed up front, so a previous run of this test cannot decide this one.
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "mpc-midnight-intent-gen-{name}-{}",
+                std::process::id()
+            ));
+            let _ = std::fs::remove_file(&path);
+            Self(path)
+        }
+
+        /// A stub prologue that leaves the count of this spawn in `$n`.
+        fn prologue(&self) -> String {
+            let path = self.0.display();
+            format!("n=$(cat {path} 2>/dev/null || echo 0); n=$((n+1)); echo $n > {path};")
+        }
+
+        /// How many children have counted themselves so far.
+        fn spawns(&self) -> u32 {
+            std::fs::read_to_string(&self.0)
+                .ok()
+                .and_then(|text| text.trim().parse().ok())
+                .unwrap_or(0)
+        }
+
+        /// Waits until `count` children have counted themselves. `Command::spawn` returns
+        /// as soon as the fork does, so a test that kills the first child promptly can
+        /// kill it before its shell ever ran, and a child killed before it counted leaves
+        /// the next one believing it is the first.
+        async fn wait_for(&self, count: u32) {
+            for _ in 0..1_000 {
+                if self.spawns() >= count {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+            panic!("the stub never reported {count} spawns");
+        }
+    }
+
+    impl Drop for SpawnCounter {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
+    /// The stub's reply to whatever id it was asked, so a stub can serve more than one
+    /// request on one child.
+    const ECHO_ID_REPLY: &str = r#"id=$(printf "%s" "$line" | sed -n "s/.*\"id\":\([0-9]*\).*/\1/p"); printf "{\"id\":%s,\"ok\":true,\"intent\":\"0a\"}\n" "$id";"#;
+
+    fn sample_request() -> IntentRequest {
+        IntentRequest {
+            circuit: "respond",
+            contract_address: "ab".repeat(32),
+            request_id: "cd".repeat(32),
+            signature: WireSignature {
+                big_r: WirePoint {
+                    x: "11".repeat(32),
+                    y: "22".repeat(32),
+                },
+                s: "33".repeat(32),
+                recovery_id: 1,
+            },
+            serialized_output: None,
+            output_len: None,
+            contract_state: "beef".to_string(),
+            ledger_parameters: "f00d".to_string(),
+            coin_public_key: "44".repeat(32),
+            ttl_seconds: 1_800_000_000,
+        }
+    }
+
+    #[tokio::test]
+    async fn build_returns_the_child_s_intent_bytes() {
+        let builder = spawn_stub(&stub_config(
+            r#"read line; printf '{"id":0,"ok":true,"intent":"deadbeef"}\n'"#,
+        ))
+        .await;
+        let bytes = builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .unwrap();
+        assert_eq!(bytes, vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[tokio::test]
+    async fn build_surfaces_the_child_s_error_code_and_message() {
+        let builder = spawn_stub(&stub_config(
+            r#"read line; printf '{"id":0,"ok":false,"code":"contract_mismatch","message":"no operation"}\n'"#,
+        ))
+        .await;
+        let err = builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("contract_mismatch"),
+            "got: {err:#}"
+        );
+        assert!(format!("{err:#}").contains("no operation"), "got: {err:#}");
+        // A refusal is an answer: the child ran, read the request and declined it, so the
+        // command is the one thing that is demonstrably fine. Naming it here would send
+        // an operator to check their argv when what is wrong is the deployment.
+        assert!(
+            !format!("{err:#}").contains("midnight intent builder command"),
+            "a refusal must not be blamed on the command: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_null_id_on_the_failure_arm_is_the_in_flight_request_s_own_rejection() {
+        // A line that failed to parse has no readable id to echo, so the child sends
+        // null rather than inventing one. Treating that as a mismatch would bury the
+        // real complaint under a framing error.
+        let builder = spawn_stub(&stub_config(
+            r#"read line; printf '{"id":null,"ok":false,"code":"bad_request","message":"invalid JSON"}\n'"#,
+        ))
+        .await;
+        let err = builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("bad_request"), "got: {err:#}");
+        assert!(format!("{err:#}").contains("invalid JSON"), "got: {err:#}");
+    }
+
+    #[tokio::test]
+    async fn a_reply_for_another_request_is_refused_rather_than_returned() {
+        // The one guard against a desynchronized stream: without it a late reply from
+        // an abandoned request becomes this request's signature.
+        let builder = spawn_stub(&stub_config(
+            r#"read line; printf '{"id":7,"ok":true,"intent":"deadbeef"}\n'"#,
+        ))
+        .await;
+        let err = builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("id 7"), "got: {err:#}");
+    }
+
+    #[tokio::test]
+    async fn a_dead_child_is_respawned_rather_than_poisoning_every_later_call() {
+        // The stub exits after its first reply. The second build must still succeed.
+        let builder = spawn_stub(&stub_config(
+            r#"read line; printf '{"id":0,"ok":true,"intent":"01"}\n'"#,
+        ))
+        .await;
+        assert!(builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .is_ok());
+        assert!(builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn a_child_that_closes_its_stdout_is_noticed_without_waiting_out_the_timeout() {
+        // The stub takes the request, closes stdout and lingers, so the process is alive
+        // and the pipe is not. Reading end-of-input as a zero-length line would leave
+        // this looking like an unreadable reply minutes later instead of a dead pipe now.
+        let mut config = stub_config(r#"read line; exec 1>&-; sleep 30"#);
+        // Long enough that the timeout cannot be what saves this test, and short enough
+        // that losing the end-of-input check reports as a failure rather than as a CI
+        // hang. Every stub here is capped for the same reason: the assertions need a
+        // child that outlives the deadline, not one that outlives the suite.
+        config.request_timeout = Duration::from_secs(30);
+        let builder = spawn_stub(&config).await;
+        let started = Instant::now();
+        let err = builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("closed its stdout"),
+            "got: {err:#}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "waited on a pipe that was already closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_returns_promptly_on_cancel_and_does_not_leak_the_child() {
+        let cancel = CancellationToken::new();
+        let builder = spawn_stub(&stub_config("sleep 30")).await;
+        cancel.cancel();
+        let started = Instant::now();
+        let err = builder.build(&sample_request(), &cancel).await.unwrap_err();
+        assert!(format!("{err:#}").contains("cancelled"), "got: {err:#}");
+        // The stub outlives the test by minutes: anything but a prompt return means
+        // shutdown waits on a child that will never answer.
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "waited on a child that was never going to answer"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_child_that_never_answers_times_out_instead_of_hanging_forever() {
+        let mut config = stub_config("sleep 30");
+        config.request_timeout = Duration::from_millis(50);
+        let builder = spawn_stub(&config).await;
+        let err = builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("timed out"), "got: {err:#}");
+        // A build leaves nothing behind, so sending its operator to inspect the chain
+        // would be a false alarm on the one path where alarms have to mean something.
+        assert!(
+            !format!("{err:#}").contains("may still reach the chain"),
+            "a build that timed out spent nothing: {err:#}"
+        );
+    }
+
+    #[test]
+    fn each_operation_takes_its_own_budget_and_its_own_answer_to_a_lost_reply() {
+        let config = stub_config("unused");
+        assert_eq!(
+            Operation::BuildIntent.deadline(&config),
+            config.request_timeout
+        );
+        assert_eq!(Operation::Submit.deadline(&config), config.submit_timeout);
+        assert!(Operation::BuildIntent.is_repeatable());
+        // The whole reason the two are not one knob: a build can be asked again, a
+        // submit cannot, because past the write a lost answer and a landed transaction
+        // are indistinguishable from this side.
+        assert!(!Operation::Submit.is_repeatable());
+    }
+
+    /// Whatever a build answered with. Opaque to this side, so any bytes do.
+    const SAMPLE_INTENT: &[u8] = &[0xde, 0xad, 0xbe, 0xef];
+
+    #[tokio::test]
+    async fn a_submit_carries_the_intent_and_answers_with_the_transaction_id() {
+        // The stub answers only a line that names the operation, and names the
+        // transaction after the intent it was handed, so one assertion covers the whole
+        // exchange: the child branched where it branches, the bytes reached it as the hex
+        // the wire takes, and what it called the transaction reached the caller.
+        let builder = spawn_stub(&stub_config(
+            r#"read -r line; case "$line" in *'"op":"submit"'*) intent=$(printf "%s" "$line" | sed -n 's/.*"intent":"\([0-9a-f]*\)".*/\1/p'); printf '{"id":0,"ok":true,"txId":"%s","blockHash":"cd"}\n' "$intent" ;; *) printf '{"id":0,"ok":false,"code":"bad_request","message":"this line carries no submit op"}\n' ;; esac"#,
+        ))
+        .await;
+        let tx_id = builder
+            .submit(SAMPLE_INTENT, &CancellationToken::new())
+            .await
+            .unwrap();
+        assert_eq!(tx_id, hex::encode(SAMPLE_INTENT));
+    }
+
+    #[tokio::test]
+    async fn a_submit_the_child_granted_without_naming_the_transaction_is_not_a_receipt() {
+        // The identifier is the whole answer. Returning an empty receipt would put
+        // "published successfully" in the log for a post nothing can be looked up by,
+        // which is the one failure this path must never render as a success.
+        let builder = spawn_stub(&stub_config(
+            r#"read -r line; printf '{"id":0,"ok":true,"blockHash":"cd"}\n'"#,
+        ))
+        .await;
+        let err = builder
+            .submit(SAMPLE_INTENT, &CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("without naming it"),
+            "got: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_submit_whose_child_dies_before_answering_says_what_may_be_on_chain() {
+        // The other way an answer is lost, and the one a deadline never sees: the child
+        // took the request and its stdout went away. A dead pipe reads like a transport
+        // fault, and reporting it as one would bury the only thing that matters here,
+        // which is that the transaction may have been posted before the pipe closed.
+        let counter = SpawnCounter::new("submit-dead-pipe");
+        let mut config = stub_config(&format!(
+            "{} read -r line; exec 1>&-; sleep 30",
+            counter.prologue()
+        ));
+        // Long enough that the deadline cannot be what ends this: the closed pipe has to
+        // be what does.
+        config.submit_timeout = Duration::from_secs(30);
+        let builder = spawn_stub(&config).await;
+        counter.wait_for(1).await;
+
+        let started = Instant::now();
+        let err = builder
+            .submit(SAMPLE_INTENT, &CancellationToken::new())
+            .await
+            .unwrap_err();
+        let rendered = format!("{err:#}");
+        assert!(rendered.contains("closed its stdout"), "got: {rendered}");
+        assert!(
+            rendered.contains("check it for this request before posting again"),
+            "a lost answer must not be reported as a bare transport fault: {rendered}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "waited on a pipe that was already closed"
+        );
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            counter.spawns(),
+            1,
+            "a submit must not be reissued on a fresh child"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_cancelled_submit_says_what_may_be_on_chain_too() {
+        // Shutdown cannot tell a cancel that beat the write from one that raced it, so
+        // the same doubt applies: the request may have reached a child that is about to
+        // be killed mid-post.
+        let cancel = CancellationToken::new();
+        let builder = spawn_stub(&stub_config("sleep 30")).await;
+        cancel.cancel();
+
+        let err = builder.submit(SAMPLE_INTENT, &cancel).await.unwrap_err();
+        let rendered = format!("{err:#}");
+        assert!(rendered.contains("cancelled"), "got: {rendered}");
+        assert!(
+            rendered.contains("check it for this request before posting again"),
+            "got: {rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_submit_surfaces_the_child_s_error_code_and_message() {
+        // `wallet_unfunded` is the deployment being out of dust and `state_conflict` is
+        // another writer having won the race: both are the operator's to act on, and
+        // both arrive as an answer rather than as a fault of the pipe.
+        let builder = spawn_stub(&stub_config(
+            r#"read -r line; printf '{"id":0,"ok":false,"code":"wallet_unfunded","message":"no spendable dust"}\n'"#,
+        ))
+        .await;
+        let err = builder
+            .submit(SAMPLE_INTENT, &CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("wallet_unfunded"),
+            "got: {err:#}"
+        );
+        assert!(
+            format!("{err:#}").contains("no spendable dust"),
+            "got: {err:#}"
+        );
+        // A refusal is an answer: the child considered the submit and declined it, so it
+        // knows what it did and nothing here should send an operator to the chain.
+        assert!(
+            !format!("{err:#}").contains("may still reach the chain"),
+            "a refusal spent nothing: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_submit_is_bounded_by_the_submit_budget_and_not_the_build_one() {
+        // The budget the deadline comes from is the operation's and not the caller's.
+        // Bounding a submit by the build's would kill the child mid-prove on every real
+        // post, throw the proof away and strand the balanced coin.
+        let mut config = stub_config("sleep 30");
+        config.request_timeout = Duration::from_millis(50);
+        config.submit_timeout = Duration::from_millis(400);
+        let builder = spawn_stub(&config).await;
+
+        let started = Instant::now();
+        let err = builder
+            .submit(SAMPLE_INTENT, &CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("timed out"), "got: {err:#}");
+        assert!(
+            started.elapsed() >= Duration::from_millis(300),
+            "a submit bounded by the build's 50ms budget would have given up at once, \
+             killing the child mid-prove on every real post"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_submit_that_loses_its_answer_is_not_asked_again() {
+        // The dust wallet has one UTXO. Reissuing a submit whose answer was lost is how
+        // a second post races the first onto that coin, and the child may already have
+        // put the transaction on chain.
+        let counter = SpawnCounter::new("submit-not-repeated");
+        let mut config = stub_config(&format!("{} sleep 30", counter.prologue()));
+        config.submit_timeout = Duration::from_millis(50);
+        let builder = spawn_stub(&config).await;
+        counter.wait_for(1).await;
+
+        let err = builder
+            .submit(SAMPLE_INTENT, &CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("check it for this request before posting again"),
+            "the error has to say what an operator must do before retrying by hand: {err:#}"
+        );
+
+        // The wedged child is still killed, it is simply not asked a second time.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            counter.spawns(),
+            1,
+            "a submit must not be reissued on a fresh child"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_timed_out_child_is_killed_so_a_later_request_is_served_by_a_fresh_one() {
+        // The distinguishing case, and the reason a timeout is not merely an error: the
+        // child has no deadline of its own and reads one line at a time, so a wedged
+        // circuit run wedges the process. Failing the request and keeping the child gives
+        // a publisher that is permanently dead while the process still looks healthy,
+        // and every symptom of that is "respond timed out" all over again.
+        //
+        // The stub hangs on its first two spawns, which is exactly the budget one build
+        // spends, and answers on every spawn after that.
+        let counter = SpawnCounter::new("timeout-recovery");
+        let mut config = stub_config(&format!(
+            r#"{} if [ $n -le 2 ]; then sleep 30; else read -r line; {} fi"#,
+            counter.prologue(),
+            ECHO_ID_REPLY
+        ));
+        config.request_timeout = Duration::from_millis(50);
+        let builder = spawn_stub(&config).await;
+        counter.wait_for(1).await;
+
+        let err = builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("timed out"), "got: {err:#}");
+
+        let bytes = builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .expect("the hung child was killed, so this request gets a fresh one");
+        assert_eq!(bytes, vec![0x0a]);
+    }
+
+    #[tokio::test]
+    async fn a_cancelled_child_is_killed_so_a_later_request_does_not_wait_on_it() {
+        // A cancelled build walks away from a request the child is still working on, and
+        // that child owes a reply nobody will read. Killing it is the choice here rather
+        // than trusting the id check, because the id check turns the stale reply into the
+        // NEXT caller's failure, which is a second lost post for one cancellation.
+        //
+        // Elapsed time is the discriminating observation and there is no other: keeping
+        // the cancelled child would still end in success, because the second build would
+        // time out on it and then respawn into the answering stub. Only the wait tells
+        // the two apart, so the assertion is deliberately far from the timeout.
+        let counter = SpawnCounter::new("cancel-recovery");
+        let config = stub_config(&format!(
+            r#"{} if [ $n -eq 1 ]; then sleep 30; else read -r line; {} fi"#,
+            counter.prologue(),
+            ECHO_ID_REPLY
+        ));
+        let builder = spawn_stub(&config).await;
+        counter.wait_for(1).await;
+
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let err = builder.build(&sample_request(), &cancel).await.unwrap_err();
+        assert!(format!("{err:#}").contains("cancelled"), "got: {err:#}");
+
+        let started = Instant::now();
+        let bytes = builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .expect("the cancelled child was killed, so this request gets a fresh one");
+        assert_eq!(bytes, vec![0x0a]);
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "answered only after waiting out the 5s timeout, so it was handed the cancelled child"
+        );
+    }
+
+    #[tokio::test]
+    async fn queued_callers_all_get_their_turn_after_the_child_in_front_of_them_is_replaced() {
+        // The lock is held across the kill and the respawn, which is right (there is only
+        // ever one child) but is the shape a deadlock would hide in. The stub hangs on its
+        // first spawn and serves every request on the spawns after it, so whichever caller
+        // wins the lock pays the timeout, kills that child and is answered by its
+        // replacement, and the ones queued behind it are answered by that same child.
+        // Every caller therefore succeeds whatever order they arrive in, which is what
+        // keeps this deterministic while still exercising a respawn under contention.
+        let counter = SpawnCounter::new("queued-callers");
+        let mut config = stub_config(&format!(
+            r#"{} if [ $n -le 1 ]; then sleep 30; else while read -r line; do {} done fi"#,
+            counter.prologue(),
+            ECHO_ID_REPLY
+        ));
+        config.request_timeout = Duration::from_millis(50);
+        let builder = std::sync::Arc::new(spawn_stub(&config).await);
+        counter.wait_for(1).await;
+
+        let callers: Vec<_> = (0..3)
+            .map(|_| {
+                let builder = builder.clone();
+                tokio::spawn(async move {
+                    builder
+                        .build(&sample_request(), &CancellationToken::new())
+                        .await
+                })
+            })
+            .collect();
+        for caller in callers {
+            let bytes = caller
+                .await
+                .expect("no caller is lost")
+                .expect("every caller is served, in its turn, by a live child");
+            assert_eq!(bytes, vec![0x0a]);
+        }
+    }
+
+    #[tokio::test]
+    async fn a_command_that_exits_at_once_costs_one_respawn_and_then_gives_up() {
+        // The likeliest misconfiguration this design has: `intent_gen_command` names
+        // something that starts and dies, so every child is dead before a line reaches
+        // it. `spawn` cannot catch that, because a process that exits a millisecond
+        // after `fork` returns is indistinguishable at that moment from a healthy one.
+        // What has to hold instead is that the failure is bounded. A respawn path that
+        // keeps trying turns one bad config value into a node that burns a core, never
+        // publishes, and never says why, which is strictly worse than failing the post.
+        let counter = SpawnCounter::new("exits-at-once");
+        let script = format!("{} exit 1", counter.prologue());
+        let builder = spawn_stub(&stub_config(&script)).await;
+
+        let started = Instant::now();
+        let err = builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .unwrap_err();
+        // The failure an operator sees is an end-of-input or a broken pipe, which says
+        // nothing about which command produced it. Naming the configured argv is what
+        // turns this from "the builder broke" into something actionable.
+        assert!(
+            format!("{err:#}").contains(&script),
+            "the error has to name the command that died: {err:#}"
+        );
+        // Returning at all is the first half of the claim: a spin would never get here.
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "a child that dies at once should cost one retry, not a wait"
+        );
+
+        // The second half is the exact count: the child from `spawn`, and one respawn.
+        // The settle is for the count, not the spawning, which `build` already finished:
+        // a child writes its number a moment after it is forked, and a spinning
+        // implementation would have written hundreds more by the time this elapses.
+        counter.wait_for(2).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            counter.spawns(),
+            2,
+            "one child at startup and exactly one respawn, no more"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_command_that_does_not_exist_fails_at_startup_and_names_itself() {
+        // The other half of the same misconfiguration, and the case the eager spawn does
+        // catch: an operator whose container has no `node` on PATH learns at startup
+        // rather than on the first signature. The restart budget bounds it, so a command
+        // that can never run cannot hold startup open indefinitely either.
+        let mut config = stub_config("unreachable");
+        config.intent_gen_command = vec!["mpc-midnight-no-such-binary".to_string()];
+
+        let started = Instant::now();
+        let Err(err) = IntentGen::spawn(&config, NETWORK_ID).await else {
+            panic!("a command that cannot be run must not produce a usable builder")
+        };
+        assert!(
+            format!("{err:#}").contains("mpc-midnight-no-such-binary"),
+            "the error has to name the command, since that is the thing to fix: {err:#}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the restart budget is capped, so this cannot hold startup open"
+        );
+    }
+
+    /// A 32-byte hex seed, the shape `validate()` requires when one is present.
+    const SEED: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    #[test]
+    fn the_publisher_namespace_is_selected_by_prefix_and_nothing_else() {
+        let names = [
+            "PATH",
+            "MIDNIGHT_PUB_FUNDING_SEED",
+            "MIDNIGHT_PUBLIC",
+            "HOME",
+        ]
+        .into_iter()
+        .map(std::ffi::OsString::from);
+        // `MIDNIGHT_PUBLIC` is the boundary case, and it is deliberately NOT in the
+        // namespace: the trailing underscore in the prefix is what keeps the namespace
+        // exact, so a variable that merely shares a stem belongs to whoever set it and
+        // reaches the child untouched. Taking it away would be this process reaching
+        // outside the configuration it owns.
+        assert_eq!(
+            publisher_vars(names),
+            vec![std::ffi::OsString::from("MIDNIGHT_PUB_FUNDING_SEED")]
+        );
+    }
+
+    #[tokio::test]
+    async fn the_child_s_publisher_namespace_is_exactly_what_this_process_put_there() {
+        // Exact, not "contains": an ambient `MIDNIGHT_PUB_*` that survived into the child
+        // would show up as an extra name here, and a name this process forgot to set
+        // would show up as a missing one. Both are the same defect from the child's side,
+        // which is a value it was never given being supplied by the host instead.
+        //
+        // The count is the load-bearing half. The child needs all seven and validates its
+        // submit half all-or-none, so a deployment that reaches it with three of them has
+        // a child that refuses to boot on every publish.
+        let builder = spawn_stub(&stub_config(
+            r#"read -r line; printf '{"id":0,"ok":false,"code":"bad_request","message":"%s"}\n' "$(env | sed -n "s/^\(MIDNIGHT_PUB_[A-Z_]*\)=.*/\1/p" | sort | tr "\n" ",")""#,
+        ))
+        .await;
+        let err = builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert_eq!(
+            format!("{err:#}"),
+            "midnight intent builder refused the request [bad_request]: \
+             MIDNIGHT_PUB_FUNDING_SEED,MIDNIGHT_PUB_INDEXER_URL,MIDNIGHT_PUB_INDEXER_WS_URL,\
+             MIDNIGHT_PUB_MANAGED_DIR,MIDNIGHT_PUB_NETWORK_ID,MIDNIGHT_PUB_NODE_URL,\
+             MIDNIGHT_PUB_PROOF_SERVER_URL,"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_child_is_handed_every_endpoint_the_funding_wallet_dials() {
+        // The names being present is not enough, which is the trap this covers: an
+        // endpoint set to the empty string is a name the child reads as absent, and a
+        // blank in any one of the five makes it refuse to boot rather than submit. So
+        // the VALUES have to arrive, and each has to be its own, which is why the four
+        // here are distinguishable from one another rather than one URL repeated.
+        let mut config = stub_config(
+            r#"read -r line; printf '{"id":0,"ok":false,"code":"bad_request","message":"node=%s prover=%s indexer=%s ws=%s"}\n' "$MIDNIGHT_PUB_NODE_URL" "$MIDNIGHT_PUB_PROOF_SERVER_URL" "$MIDNIGHT_PUB_INDEXER_URL" "$MIDNIGHT_PUB_INDEXER_WS_URL""#,
+        );
+        config.node_ws_url = "ws://127.0.0.1:9944".to_string();
+        config.proof_server_url = "http://127.0.0.1:6300".to_string();
+        config.indexer_url = "http://127.0.0.1:8088/api/v3/graphql".to_string();
+        config.indexer_ws_url = "ws://127.0.0.1:8088/api/v3/graphql/ws".to_string();
+        let builder = spawn_stub(&config).await;
+
+        let err = builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err:#}").contains(
+                "node=ws://127.0.0.1:9944 prover=http://127.0.0.1:6300 \
+                 indexer=http://127.0.0.1:8088/api/v3/graphql \
+                 ws=ws://127.0.0.1:8088/api/v3/graphql/ws"
+            ),
+            "got: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_child_s_stderr_is_scrubbed_before_it_can_reach_a_log() {
+        // The drain forwards these straight to `tracing::warn!`, so whatever survives
+        // this reader is in the node's log. The child gains a wallet, and a dependency
+        // that quotes its own configuration in a startup line or an error is the ordinary
+        // way a key ends up somewhere it was never meant to be.
+        let stderr = format!("midnight-publisher: opened wallet {SEED}\nsecond line\n");
+        let mut lines = ScrubbedLines::new(stderr.as_bytes(), SeedRedactor::new(SEED));
+        assert_eq!(
+            lines.next().await.unwrap(),
+            "midnight-publisher: opened wallet <redacted>"
+        );
+        assert_eq!(lines.next().await.unwrap(), "second line");
+        assert!(lines.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_child_that_dies_at_boot_reports_what_it_said_on_its_way_out() {
+        // The failure this exists for. The child validates its configuration before it
+        // reads anything, so a misconfigured one names the variable it is missing and
+        // exits, and every pass at it after that fails on a pipe that is simply gone.
+        // Reported as a closed pipe alone, that sends an operator to read the wire; the
+        // child already said which value is wrong, and it went to `tracing::warn!`, which
+        // is nowhere at all in a process running without a subscriber.
+        //
+        // The stub quotes the seed it was handed rather than a literal, because a literal
+        // would have to be in `intent_gen_command`, which the error renders verbatim.
+        let mut config = stub_config(
+            r#"printf 'invalid MIDNIGHT_PUB_* configuration: missing MIDNIGHT_PUB_INDEXER_URL (wallet %s)\n' "$MIDNIGHT_PUB_FUNDING_SEED" >&2; exit 1"#,
+        );
+        config.funding_seed = SEED.to_string();
+        let builder = spawn_stub(&config).await;
+
+        let err = builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .unwrap_err();
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("missing MIDNIGHT_PUB_INDEXER_URL"),
+            "the child's own explanation has to reach whoever asked: {rendered}"
+        );
+        // The same scrubbing the drain applies, because this is that text taking a second
+        // route out. A dependency that quotes its own configuration while refusing to
+        // start is the ordinary way a key ends up in a message, and this one is returned
+        // to the caller rather than merely logged.
+        assert!(
+            rendered.contains("wallet <redacted>"),
+            "the child was handed the seed and quoted it back: {rendered}"
+        );
+        assert!(
+            !rendered.contains(SEED),
+            "the seed reached an error this node reports: {rendered}"
+        );
+    }
+
+    #[test]
+    fn every_publisher_variable_this_process_holds_is_taken_off_the_child() {
+        // The set this process supplies is overridden anyway, so removal is about the
+        // names it does not yet know: the child's required-value check should reject a
+        // missing one loudly, rather than the host quietly supplying it. Synthetic rather
+        // than the real environment, because the assertion has to be non-vacuous on a
+        // machine that happens to have none of these set.
+        let stray = std::ffi::OsString::from("MIDNIGHT_PUB_SOMETHING_ADDED_LATER");
+        let seed = std::ffi::OsString::from("MIDNIGHT_PUB_FUNDING_SEED");
+        let command = intent_gen_command(
+            &stub_config("true"),
+            NETWORK_ID,
+            &[stray.clone(), seed.clone()],
+        )
+        .expect("the stub command is well formed");
+
+        let changes: Vec<_> = command.as_std().get_envs().collect();
+        assert!(
+            changes.iter().any(|(name, value)| *name == stray && value.is_none()),
+            "a publisher variable this process does not set must be removed, not inherited: {changes:?}"
+        );
+        // Ordering, not contradiction: the removal is registered first and the set that
+        // follows replaces it, so a name in both ends up supplied by us.
+        assert!(
+            changes
+                .iter()
+                .any(|(name, value)| *name == seed && value.is_some()),
+            "a publisher variable this process does set must survive its own removal: {changes:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_funding_seed_reaches_the_child_but_not_anything_this_node_says() {
+        // Both halves at once. The child can only echo the seed if it was handed one, so
+        // the echo proves delivery; the assertion proves that what comes back out of the
+        // child, on the one wire field that carries its own rendered cause chain, does
+        // not carry the key with it.
+        let mut config = stub_config(
+            r#"read -r line; printf '{"id":0,"ok":false,"code":"internal","message":"wallet rejected %s"}\n' "$MIDNIGHT_PUB_FUNDING_SEED""#,
+        );
+        config.funding_seed = SEED.to_string();
+        let builder = spawn_stub(&config).await;
+
+        let err = builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .unwrap_err();
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("wallet rejected <redacted>"),
+            "the child was handed the seed and quoted it back: {rendered}"
+        );
+        assert!(
+            !rendered.contains(SEED),
+            "the seed reached an error this node reports: {rendered}"
+        );
+    }
+
+    #[test]
+    fn the_seed_is_scrubbed_whichever_case_the_child_quotes_it_in() {
+        let redactor = SeedRedactor::new(SEED);
+        assert_eq!(
+            redactor.scrub(&format!("loaded {SEED} from disk")),
+            "loaded <redacted> from disk"
+        );
+        assert_eq!(redactor.scrub(&SEED.to_uppercase()), "<redacted>");
+        assert_eq!(
+            redactor.scrub("nothing sensitive here"),
+            "nothing sensitive here"
+        );
+    }
+
+    #[test]
+    fn a_seed_written_with_an_0x_prefix_is_scrubbed_in_the_spelling_the_child_uses() {
+        // The operator's spelling and the child's need not match: a library that strips
+        // the prefix before quoting the key back would otherwise slip straight through a
+        // redactor that only knew the configured form.
+        let redactor = SeedRedactor::new(&format!("0x{SEED}"));
+        assert_eq!(redactor.scrub(&format!("key {SEED}")), "key <redacted>");
+        assert_eq!(
+            redactor.scrub(&format!("key 0x{SEED}")),
+            "key <redacted>".to_string()
+        );
+    }
+
+    #[test]
+    fn something_too_short_to_be_a_seed_is_left_alone() {
+        // Redacting a short string would blank out unrelated text wherever it happened to
+        // occur, which costs the diagnostic and protects nothing: it is not a key.
+        assert_eq!(
+            SeedRedactor::new("abcd").scrub("abcdef is not a secret"),
+            "abcdef is not a secret"
+        );
+    }
+
+    #[test]
+    fn an_absent_seed_scrubs_nothing() {
+        // A node that only indexes has no wallet and a legal empty seed. The empty string
+        // occurs between every pair of characters, so a redactor that did not special
+        // case it would replace the whole line with separators and destroy the very
+        // diagnostic the drain exists to carry.
+        assert_eq!(
+            SeedRedactor::new("").scrub("midnight-publisher: started"),
+            "midnight-publisher: started"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_child_is_told_its_network_and_managed_dir_rather_than_left_to_find_them() {
+        // Both values are validated on `MidnightConfig`. An ambient copy would be a
+        // second, unvalidated source for the one setting that decides address encoding
+        // and which artifacts the circuit proves against, and disagreement between them
+        // fails only on chain. The stub reports what it was handed by refusing with it.
+        let builder = spawn_stub(&stub_config(
+            r#"read -r line; printf '{"id":0,"ok":false,"code":"bad_request","message":"net=%s dir=%s"}\n' "$MIDNIGHT_PUB_NETWORK_ID" "$MIDNIGHT_PUB_MANAGED_DIR""#,
+        ))
+        .await;
+        let err = builder
+            .build(&sample_request(), &CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("net=undeployed dir=/managed"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn the_encoded_line_is_the_shape_the_child_validates() {
+        let encoded: serde_json::Value = serde_json::from_str(
+            &encode_request(&sample_request(), 3, Operation::BuildIntent).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "id": 3,
+                "circuit": "respond",
+                "contractAddress": "ab".repeat(32),
+                "requestId": "cd".repeat(32),
+                "signature": {
+                    "bigR": { "x": "11".repeat(32), "y": "22".repeat(32) },
+                    "s": "33".repeat(32),
+                    "recoveryId": 1,
+                },
+                "contractState": "beef",
+                "ledgerParameters": "f00d",
+                "coinPublicKey": "44".repeat(32),
+                "ttlSeconds": 1_800_000_000u64,
+            }),
+            "the unidirectional circuit carries no output fields, and the child's \
+             discriminated union rejects the request outright if it does. No `op` \
+             either: the child reads an absent one as a build, and that is what lets a \
+             third operation be added to one side at a time"
+        );
+    }
+
+    #[test]
+    fn a_submit_line_names_the_operation_and_carries_nothing_but_the_intent() {
+        let encoded: serde_json::Value = serde_json::from_str(
+            &encode_request(
+                &SubmitRequest {
+                    intent: "deadbeef".to_string(),
+                },
+                4,
+                Operation::Submit,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            encoded,
+            serde_json::json!({ "id": 4, "op": "submit", "intent": "deadbeef" }),
+            "the pinned reads that built the intent have no reader on the other side, \
+             and the child balances against a wallet it syncs itself"
+        );
+    }
+
+    #[test]
+    fn the_bidirectional_circuit_carries_its_output_and_length() {
+        let mut request = sample_request();
+        request.circuit = "respondBidirectional";
+        request.serialized_output = Some("00".repeat(128));
+        request.output_len = Some(32);
+        let encoded: serde_json::Value =
+            serde_json::from_str(&encode_request(&request, 0, Operation::BuildIntent).unwrap())
+                .unwrap();
+        assert_eq!(encoded["circuit"], "respondBidirectional");
+        assert_eq!(encoded["serializedOutput"], "00".repeat(128));
+        assert_eq!(encoded["outputLen"], 32);
+    }
+}

--- a/chain-signatures/chain-midnight/src/lib.rs
+++ b/chain-signatures/chain-midnight/src/lib.rs
@@ -3,6 +3,7 @@
 mod config;
 mod convert;
 mod indexer;
+mod intent_gen;
 mod publisher;
 mod reader;
 pub mod records;
@@ -14,9 +15,11 @@ mod test_utils;
 mod tx;
 mod tx_decode;
 
-pub use config::{IndexerConfig, MidnightConfig, RpcConfig};
+pub use config::{IndexerConfig, MidnightConfig, PublisherConfig, RpcConfig};
 pub use convert::{to_sign_request, MidnightChainCtx};
 pub use indexer::MidnightIndexer;
+pub use intent_gen::{IntentGen, IntentRequest, WirePoint, WireSignature};
 pub use publisher::MidnightPublisher;
+pub use rpc::MidnightRpc;
 pub use state::decode_contract_state;
 pub use tx_decode::{ClaimedCall, DecodedCall, DecodedTransaction, DecodedTransactions};

--- a/chain-signatures/chain-midnight/src/publisher.rs
+++ b/chain-signatures/chain-midnight/src/publisher.rs
@@ -1,28 +1,837 @@
-//! Midnight publisher.
+//! Midnight publisher: a finished MPC signature becomes a respond call on the central
+//! singleton.
+//!
+//! The path is fixed: marshal the action into the shape the out-of-process builder
+//! validates, pin one finalized hash, read the chain at it, have the builder run the
+//! circuit, read what comes back as the ledger's own `Intent`, then balance, prove,
+//! sign and submit it. Only the last step spends anything expensive, which is why
+//! everything that can refuse the action refuses it before reaching there.
+//!
+//! Two seams are traits rather than direct calls, and both for the same reason: the
+//! things behind them cannot exist in a unit test. [`PinnedReads`] hides `MidnightRpc`,
+//! whose subxt client fetches metadata at construction and therefore needs a running
+//! node. [`IntentSubmitter`] hides the ledger transaction, which needs a funding wallet
+//! and a proving run; see [`ChildSubmitter`] for what fills it and why it is not Rust.
 
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::Context as _;
 use async_trait::async_trait;
+use k256::elliptic_curve::sec1::ToEncodedPoint as _;
+use midnight_ledger_v9::structure::{Intent, ProofPreimageMarker, Signature as LedgerSignature};
+use midnight_node_ledger_helpers::ledger_9::{ShieldedWallet, WalletSeed};
+use midnight_storage::DefaultDB;
+use midnight_transient_crypto::commitment::PedersenRandomness;
 use mpc_chain_integration_core::{ChainPublisher, PublishAction};
+use mpc_primitives::{Chain, SignKind, Signature};
+use tokio_util::sync::CancellationToken;
+
+use crate::config::PublisherConfig;
+use crate::convert::MidnightChainCtx;
+use crate::intent_gen::{IntentGen, IntentRequest, WirePoint, WireSignature};
+use crate::rpc::MidnightRpc;
+
+/// Ledger 9's own tagged reading of what the builder wrote: `signature`, `pre-proof`
+/// and `pre-binding`, the three markers the TypeScript side names when it serializes.
+pub(crate) type ChainIntent =
+    Intent<LedgerSignature, ProofPreimageMarker, PedersenRandomness, DefaultDB>;
+
+/// The deployed entry point for a phase-1 signature response.
+const RESPOND: &str = "respond";
+/// The deployed entry point for a response carrying the call's return data.
+const RESPOND_BIDIRECTIONAL: &str = "respondBidirectional";
+
+/// The circuit's `Bytes<128>` return-data slot. The whole slot travels, zero padded,
+/// because the contract stores it whole and a consumer reads `output_len` to know how
+/// much of it is real.
+const OUTPUT_SLOT_BYTES: usize = 128;
+
+/// The reads the respond path pins, as one surface.
+///
+/// A trait because `MidnightRpc` cannot be built without a node: its `OnlineClient`
+/// fetches metadata at construction. `rpc.rs` splits its own reads into `*_over`
+/// functions for the same reason, but those are private to it.
+#[async_trait]
+pub(crate) trait PinnedReads: Send + Sync {
+    /// The node's current finalized head, `0x` prefixed.
+    async fn finalized_head(&self) -> anyhow::Result<String>;
+    /// `None` when no contract lives at `address_64hex` at that block.
+    async fn contract_state(
+        &self,
+        address_64hex: &str,
+        at_hash_0x: &str,
+    ) -> anyhow::Result<Option<Vec<u8>>>;
+    async fn ledger_parameters(&self, at_hash_0x: &str) -> anyhow::Result<Vec<u8>>;
+    async fn zswap_chain_state(
+        &self,
+        address_64hex: &str,
+        at_hash_0x: &str,
+    ) -> anyhow::Result<Vec<u8>>;
+}
+
+#[async_trait]
+impl PinnedReads for MidnightRpc {
+    async fn finalized_head(&self) -> anyhow::Result<String> {
+        Ok(format!("0x{}", hex::encode(self.finalized_head().await?)))
+    }
+
+    async fn contract_state(
+        &self,
+        address_64hex: &str,
+        at_hash_0x: &str,
+    ) -> anyhow::Result<Option<Vec<u8>>> {
+        // The two surfaces disagree about `0x`: `midnight_contractState` answers with
+        // bare hex and `state_call` with a prefix. Both are decoded to bytes inside
+        // `rpc.rs`, so nothing above it may reintroduce the distinction.
+        MidnightRpc::contract_state(self, address_64hex, at_hash_0x).await
+    }
+
+    async fn ledger_parameters(&self, at_hash_0x: &str) -> anyhow::Result<Vec<u8>> {
+        MidnightRpc::ledger_parameters(self, at_hash_0x).await
+    }
+
+    async fn zswap_chain_state(
+        &self,
+        address_64hex: &str,
+        at_hash_0x: &str,
+    ) -> anyhow::Result<Vec<u8>> {
+        MidnightRpc::zswap_chain_state(self, address_64hex, at_hash_0x).await
+    }
+}
+
+/// What one finalized hash yielded, carried together with the hash itself.
+///
+/// One hash for every read is the whole point: fees drift per block, so parameters
+/// priced at one block against a state read at another produce an intent the node
+/// answers `OutOfGas`. Keeping `at_hash` beside the bytes is what makes that
+/// checkable rather than merely intended.
+///
+/// The zswap chain state is read at that hash and is not here, because nothing in this
+/// process balances: see [`ChildSubmitter`] and [`MidnightPublisher::pin`].
+pub(crate) struct PinnedState {
+    pub at_hash: String,
+    pub contract_state: Vec<u8>,
+    pub ledger_parameters: Vec<u8>,
+}
+
+/// What turns the builder's intent into a transaction the node has accepted: balance
+/// it against the funding wallet, prove it, sign it, submit it.
+///
+/// Takes the intent as the bytes the builder wrote rather than as the decoded value.
+/// The decode above this is a gate, not a conversion: whoever submits forwards what
+/// the builder produced, and re-serializing a decoded intent to recover those bytes
+/// would stake the transaction on a round trip nothing checks.
+///
+/// `chain` is carried because the intent means nothing apart from the reads it was built
+/// over: an implementation that balances in this process prices against them, and one
+/// that hands the intent to a wallet elsewhere still needs the hash, because losing a
+/// race to another writer is the one failure a submit has that nothing before it could
+/// have seen. `cancel` because the step outlives a node shutdown otherwise: it is a
+/// proving run, and it belongs to whoever owns the token rather than to whoever
+/// implements this.
+///
+/// The returned string is whatever names the transaction on chain, for the log and for
+/// an end-to-end test that wants to read it back. Opaque here on purpose: this side
+/// neither parses it nor decides its shape.
+#[async_trait]
+pub(crate) trait IntentSubmitter: Send + Sync {
+    async fn submit(
+        &self,
+        intent: &[u8],
+        chain: &PinnedState,
+        cancel: &CancellationToken,
+    ) -> anyhow::Result<String>;
+}
+
+/// The submitter: the same child that built the intent, asked to spend for it.
+///
+/// **Why it is not Rust.** Balancing a ledger-9 transaction spends DUST, and the funding
+/// wallet's `DustLocalState` cannot be built from chain state. `DustWallet` starts it
+/// empty and `DustLocalState::replay_events` is the only thing that fills it, in strict
+/// merkle index order from genesis, out of plaintext that the global commitment and
+/// nullifier state does not carry. None of the three pinned reads supplies it and no
+/// constructor derives it, so a Rust submitter would need a chain-replay subsystem this
+/// node does not have. The child already has a wallet that syncs from the indexer, which
+/// is why the wallet stays on that side, and why the reads pinned here do not travel with
+/// the intent: what balances it is that wallet's own synced state.
+///
+/// **Why the same child rather than a second one.** That wallet holds a single dust UTXO,
+/// so two processes spending it could only race onto the same coin. One child makes
+/// `IntentGen`'s own lock the thing that serializes them, and a build queued behind a
+/// submit is the honest price of that.
+struct ChildSubmitter {
+    intent_gen: Arc<IntentGen>,
+}
+
+#[async_trait]
+impl IntentSubmitter for ChildSubmitter {
+    async fn submit(
+        &self,
+        intent: &[u8],
+        chain: &PinnedState,
+        cancel: &CancellationToken,
+    ) -> anyhow::Result<String> {
+        self.intent_gen
+            .submit(intent, cancel)
+            .await
+            // The hash rather than the bytes: the child refuses a submit whose transcript
+            // no longer replays, and that refusal is only actionable next to the read it
+            // stopped matching.
+            .with_context(|| {
+                format!(
+                    "submitting the midnight respond intent built over the chain at {}",
+                    chain.at_hash
+                )
+            })
+    }
+}
+
+/// One respond call, marshalled off the action before anything is read or spawned.
+struct RespondCall {
+    circuit: &'static str,
+    central_address: String,
+    request_id: String,
+    signature: WireSignature,
+    /// Both `Some` on the bidirectional circuit and both `None` on the other: the
+    /// child discriminates its request union on `circuit` and refuses a request whose
+    /// fields disagree with it.
+    serialized_output: Option<String>,
+    output_len: Option<u8>,
+}
 
 /// Posts MPC responses back to the Midnight central contract.
-#[derive(Clone, Debug, Default)]
-pub struct MidnightPublisher;
+pub struct MidnightPublisher {
+    config: PublisherConfig,
+    reads: Arc<dyn PinnedReads>,
+    intent_gen: Arc<IntentGen>,
+    submitter: Arc<dyn IntentSubmitter>,
+    /// The funding wallet's Zswap public key, derived once at construction. Public,
+    /// and the only thing about that wallet the child is ever told.
+    coin_public_key: String,
+    /// The node's shutdown token, so a build in flight stops with the node rather than
+    /// holding it open for the length of a proving run.
+    cancel: CancellationToken,
+}
+
+impl MidnightPublisher {
+    /// Fallible because the funding seed is decoded here: a seed that cannot produce a
+    /// wallet is a startup fault, not a fault of the first signature that needs one.
+    pub fn new(
+        config: &PublisherConfig,
+        rpc: Arc<MidnightRpc>,
+        intent_gen: Arc<IntentGen>,
+        cancel: CancellationToken,
+    ) -> anyhow::Result<Self> {
+        Self::assemble(
+            config,
+            rpc,
+            intent_gen.clone(),
+            // The one child, twice: see `ChildSubmitter`. A second builder here would be
+            // a second process holding the same funding key.
+            Arc::new(ChildSubmitter { intent_gen }),
+            cancel,
+        )
+    }
+
+    fn assemble(
+        config: &PublisherConfig,
+        reads: Arc<dyn PinnedReads>,
+        intent_gen: Arc<IntentGen>,
+        submitter: Arc<dyn IntentSubmitter>,
+        cancel: CancellationToken,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            coin_public_key: coin_public_key(&config.funding_seed)?,
+            config: config.clone(),
+            reads,
+            intent_gen,
+            submitter,
+            cancel,
+        })
+    }
+
+    /// The three reads, all at `at_hash`.
+    async fn pin(&self, central_address: &str, at_hash: String) -> anyhow::Result<PinnedState> {
+        let contract_state = self
+            .reads
+            .contract_state(central_address, &at_hash)
+            .await?
+            .with_context(|| {
+                format!("midnight central contract {central_address} is not present at {at_hash}")
+            })?;
+        let ledger_parameters = self.reads.ledger_parameters(&at_hash).await?;
+        // Read for whether it answers, not for what it says. The bytes have no consumer:
+        // what balances the transaction is the child's own wallet, which syncs its zswap
+        // and dust state from the indexer and cannot be handed a caller's copy. What the
+        // call still buys is a node that serves zswap state at this exact hash, refused
+        // here rather than after a proving run has been paid for. A balancer moving into
+        // this process is what would make the bytes worth carrying again.
+        self.reads
+            .zswap_chain_state(central_address, &at_hash)
+            .await?;
+        Ok(PinnedState {
+            at_hash,
+            contract_state,
+            ledger_parameters,
+        })
+    }
+}
 
 #[async_trait]
 impl ChainPublisher for MidnightPublisher {
-    async fn publish_signature(&self, _action: &PublishAction) -> anyhow::Result<()> {
-        anyhow::bail!("midnight publisher not implemented")
+    /// Nothing here remembers a request id. A duplicate publish repeats the whole
+    /// path and succeeds, because both circuits are blind appends and the indexer
+    /// skips responds for ids it does not know, so a second response for an answered
+    /// id costs a transaction and changes nothing. A dedupe cache here would be worse
+    /// than useless: a publish that submits and then fails on the way back would be
+    /// remembered as done, and the retry that is supposed to rescue it would be
+    /// dropped instead.
+    async fn publish_signature(&self, action: &PublishAction) -> anyhow::Result<()> {
+        let call = respond_call(action)?;
+        let sign_id = action.request.id;
+        tracing::info!(
+            ?sign_id,
+            circuit = call.circuit,
+            central = %call.central_address,
+            "midnight: publishing signature"
+        );
+
+        // One head for every read below it. Re-reading it per read is the bug this
+        // shape exists to prevent.
+        let at_hash = self.reads.finalized_head().await?;
+        let chain = self.pin(&call.central_address, at_hash).await?;
+
+        let request = IntentRequest {
+            circuit: call.circuit,
+            contract_address: call.central_address,
+            request_id: call.request_id,
+            signature: call.signature,
+            serialized_output: call.serialized_output,
+            output_len: call.output_len,
+            contract_state: hex::encode(&chain.contract_state),
+            ledger_parameters: hex::encode(&chain.ledger_parameters),
+            coin_public_key: self.coin_public_key.clone(),
+            ttl_seconds: ttl_seconds(&self.config, unix_now()?),
+        };
+        let bytes = self.intent_gen.build(&request, &self.cancel).await?;
+        // A gate, not a conversion: what the submitter forwards is `bytes`. Proving
+        // that they are a ledger-9 `Intent` before anything is spent proving and paying
+        // for them is the whole value. Tagged rather than bare, so a ledger line skew
+        // fails by name here instead of as a field-shaped parse error on bytes that
+        // were never ours to read.
+        let intent: ChainIntent = midnight_serialize::tagged_deserialize(&mut &bytes[..])
+            .context("the intent the builder granted did not deserialize as a ledger Intent")?;
+        tracing::debug!(?sign_id, ttl = ?intent.ttl, "midnight: intent decoded");
+
+        let backstop = submit_backstop(&self.config);
+        let receipt = tokio::time::timeout(
+            backstop,
+            self.submitter.submit(&bytes, &chain, &self.cancel),
+        )
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "the midnight submit step ran past its {backstop:?} backstop without returning, \
+                 so it is not enforcing the {:?} submit_timeout it was given",
+                self.config.submit_timeout
+            )
+        })??;
+
+        tracing::info!(
+            ?sign_id,
+            circuit = call.circuit,
+            at_hash = %chain.at_hash,
+            receipt = %receipt,
+            elapsed = ?action.timestamp.elapsed(),
+            "midnight: published respond successfully"
+        );
+        Ok(())
     }
+}
+
+/// The action as one respond call, or a refusal.
+///
+/// Every gate is here, ahead of the first read and the first line to the child, so an
+/// action this node cannot serve costs nothing.
+fn respond_call(action: &PublishAction) -> anyhow::Result<RespondCall> {
+    anyhow::ensure!(
+        action.request.chain == Chain::Midnight,
+        "midnight publisher was handed a {:?} request",
+        action.request.chain
+    );
+    let signature = wire_signature(&action.signature)?;
+    let request_id = hex::encode(action.request.id.request_id);
+
+    match &action.request.kind {
+        SignKind::SignBidirectional(event) => {
+            // The routing chain and the event's own must agree. They are set by
+            // different layers, and a disagreement is a mis-routed request rather
+            // than one this node should answer.
+            anyhow::ensure!(
+                event.chain == Chain::Midnight,
+                "midnight publisher was handed a request routed to it carrying a {:?} event",
+                event.chain
+            );
+            Ok(RespondCall {
+                circuit: RESPOND,
+                central_address: central_address(event.chain_ctx.as_deref())?,
+                request_id,
+                signature,
+                serialized_output: None,
+                output_len: None,
+            })
+        }
+        SignKind::RespondBidirectional(tx) => {
+            let output_len = u8::try_from(tx.output.len())
+                .ok()
+                .filter(|len| usize::from(*len) <= OUTPUT_SLOT_BYTES)
+                .with_context(|| {
+                    format!(
+                        "midnight respondBidirectional carries {} bytes of output, more than the \
+                     circuit's Bytes<{OUTPUT_SLOT_BYTES}> slot holds",
+                        tx.output.len()
+                    )
+                })?;
+            // The whole slot, zero padded: the circuit's argument is fixed width, and
+            // `output_len` is what tells a consumer where the real data stops.
+            let mut slot = tx.output.clone();
+            slot.resize(OUTPUT_SLOT_BYTES, 0);
+            Ok(RespondCall {
+                circuit: RESPOND_BIDIRECTIONAL,
+                central_address: central_address(tx.chain_ctx.as_deref())?,
+                request_id,
+                signature,
+                serialized_output: Some(hex::encode(slot)),
+                output_len: Some(output_len),
+            })
+        }
+        other => anyhow::bail!(
+            "midnight publisher serves SignBidirectional and RespondBidirectional only, not {}",
+            match other {
+                SignKind::Sign => "Sign",
+                SignKind::Checkpoint(_) => "Checkpoint",
+                _ => "an unhandled kind",
+            }
+        ),
+    }
+}
+
+/// The central singleton this response belongs on, off the request's own chain
+/// context rather than off configuration: the indexer recorded which contract minted
+/// the request, and a node whose config has since moved must still answer it where it
+/// was asked.
+fn central_address(chain_ctx: Option<&[u8]>) -> anyhow::Result<String> {
+    let bytes = chain_ctx.context("midnight request carries no chain_ctx")?;
+    let ctx: MidnightChainCtx =
+        borsh::from_slice(bytes).context("midnight chain_ctx did not deserialize")?;
+    // The child validates this as 64 lowercase hex and `MidnightConfig::validate`
+    // produced it in that form, so the check is only for a ctx that reached us some
+    // other way. Refusing here names the field; refusing at the child names the wire.
+    anyhow::ensure!(
+        ctx.central_address.len() == 64
+            && ctx
+                .central_address
+                .bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b)),
+        "midnight chain_ctx central_address is not 64 lowercase hex: {}",
+        ctx.central_address
+    );
+    Ok(ctx.central_address)
+}
+
+/// The signature in the shape the circuit pushes: SEC1 big-endian affine coordinates
+/// and the scalar, each a bare 32-byte hex string. Nothing re-encodes downstream, so a
+/// transposition introduced here would land on chain under the right request id and
+/// recover a different key.
+fn wire_signature(signature: &Signature) -> anyhow::Result<WireSignature> {
+    let encoded = signature.big_r.to_encoded_point(false);
+    let (Some(x), Some(y)) = (encoded.x(), encoded.y()) else {
+        anyhow::bail!("midnight respond: big_r has no affine coordinates (identity point)");
+    };
+    // The circuit's field is one bit wide and the child's union rejects anything else.
+    anyhow::ensure!(
+        signature.recovery_id <= 1,
+        "midnight respond: recovery_id {} is not 0 or 1",
+        signature.recovery_id
+    );
+    Ok(WireSignature {
+        big_r: WirePoint {
+            x: hex::encode(x),
+            y: hex::encode(y),
+        },
+        s: hex::encode(signature.s.to_bytes()),
+        recovery_id: signature.recovery_id,
+    })
+}
+
+/// The funding wallet's Zswap public key.
+///
+/// Contained rather than only pre-validated. `MidnightConfig::validate` bounds the
+/// seed to 16..=64 bytes, which is bip32's own rule, so the panic inside `derive_seed`
+/// is unreachable from a validated config; unreachable is not impossible, this crate
+/// takes the helpers with `can-panic` on, and a panic in a publisher task takes a
+/// runtime worker with it. Doing it once at construction is what keeps the containment
+/// off the per-signature path.
+fn coin_public_key(funding_seed: &str) -> anyhow::Result<String> {
+    let seed = WalletSeed::try_from_hex_str(funding_seed)
+        .map_err(|err| anyhow::anyhow!("midnight publisher funding_seed is unusable: {err}"))?;
+    let key = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        ShieldedWallet::<DefaultDB>::default(seed).coin_public_key
+    }))
+    .map_err(|_| {
+        anyhow::anyhow!("deriving the midnight funding wallet's zswap public key panicked")
+    })?;
+    Ok(hex::encode(key.0 .0))
+}
+
+/// The intent's expiry, as the absolute unix seconds the child wants.
+///
+/// Sized from the two budgets a publish actually spends rather than picked: the child
+/// may take `request_timeout` to answer and the node `submit_timeout` to accept, and
+/// past their sum this publish has already given up, so a longer window would only
+/// leave an intent alive that nobody is still trying to land. Both circuits are blind
+/// appends, so an expired intent costs a repost and nothing else.
+fn ttl_seconds(config: &PublisherConfig, now: u64) -> u64 {
+    now.saturating_add(config.request_timeout.as_secs())
+        .saturating_add(config.submit_timeout.as_secs())
+}
+
+/// The outer bound on the submit step.
+///
+/// `submit_timeout` is the budget the step itself enforces, because only it knows what
+/// it is waiting on and only it can kill what it is waiting on. This is the second
+/// line, and it exists for one failure: a step that forgot its own deadline would hold
+/// a publisher task open for as long as whatever it talks to feels like.
+///
+/// Deliberately looser than the budget it backs. Were the two equal, which one fired
+/// would be a race, and the operator would get a coin flip between "the node did not
+/// accept it in time" and "the step is not enforcing its budget", which are different
+/// faults with different fixes.
+///
+/// The headroom is one build budget, because that is the most the step can spend
+/// before its own deadline starts: a submit is not repeatable, so it is attempted
+/// exactly once, but the attempt may first have to bring a dead child back up, and
+/// that respawn runs under the restart backoff bounded by `request_timeout`.
+fn submit_backstop(config: &PublisherConfig) -> Duration {
+    config.submit_timeout.saturating_add(config.request_timeout)
+}
+
+fn unix_now() -> anyhow::Result<u64> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("the system clock is before the unix epoch")?
+        .as_secs())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mpc_chain_integration_core::utils::test::make_publish_action;
-    use mpc_primitives::{Chain, SignBidirectionalEvent, SignId, SignKind};
 
-    #[tokio::test]
-    async fn publish_signature_reports_failure() {
-        let event = SignBidirectionalEvent {
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    use midnight_base_crypto::time::Timestamp;
+    use midnight_node_ledger_helpers::ledger_9::{SeedableRng as _, StdRng};
+    use mpc_chain_integration_core::utils::retry::RetryConfig;
+    use mpc_chain_integration_core::utils::test::make_publish_action;
+    use mpc_primitives::{
+        BidirectionalTxId, Chain, RespondBidirectionalTx, SignBidirectionalEvent, SignId, SignKind,
+    };
+
+    /// The contract the fixtures were captured from, and the only address these tests
+    /// ever name.
+    const CENTRAL: &str = "d7b3c45da613be25050bbdf3fde4cef8f66154d3a52ca8c1edd878bd6391f169";
+    const REQUEST_ID: [u8; 32] = [0x5c; 32];
+    /// Two different heads, so a publisher that re-reads the head per read cannot pass
+    /// the one-hash assertion by accident.
+    const HEAD_ONE: &str = "0x1111111111111111111111111111111111111111111111111111111111111111";
+    const HEAD_TWO: &str = "0x2222222222222222222222222222222222222222222222222222222222222222";
+
+    fn funding_seed() -> String {
+        "0f".repeat(32)
+    }
+
+    /// Distinct per read, so a test can tell which read produced which bytes.
+    const CONTRACT_STATE: &[u8] = b"contract-state";
+    const LEDGER_PARAMETERS: &[u8] = b"ledger-parameters";
+    const ZSWAP_CHAIN_STATE: &[u8] = b"zswap-chain-state";
+
+    /// One read the publisher made: which surface, and at which hash.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct Read {
+        method: &'static str,
+        at_hash: String,
+    }
+
+    /// An in-process stand-in for the node. Serves a DIFFERENT finalized head on every
+    /// ask, which is the whole discrimination in the one-hash test.
+    #[derive(Default)]
+    struct StubReads {
+        calls: Mutex<Vec<Read>>,
+        heads_served: Mutex<usize>,
+        /// `false` makes `contract_state` answer "no contract here".
+        contract_present: bool,
+    }
+
+    impl StubReads {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                contract_present: true,
+                ..Default::default()
+            })
+        }
+
+        fn absent() -> Arc<Self> {
+            Arc::new(Self::default())
+        }
+
+        fn reads(&self) -> Vec<Read> {
+            self.calls.lock().unwrap().clone()
+        }
+
+        fn record(&self, method: &'static str, at_hash: &str) {
+            self.calls.lock().unwrap().push(Read {
+                method,
+                at_hash: at_hash.to_string(),
+            });
+        }
+    }
+
+    #[async_trait]
+    impl PinnedReads for StubReads {
+        async fn finalized_head(&self) -> anyhow::Result<String> {
+            let mut served = self.heads_served.lock().unwrap();
+            *served += 1;
+            self.record("finalized_head", "");
+            Ok(if *served == 1 { HEAD_ONE } else { HEAD_TWO }.to_string())
+        }
+
+        async fn contract_state(
+            &self,
+            _address: &str,
+            at_hash: &str,
+        ) -> anyhow::Result<Option<Vec<u8>>> {
+            self.record("contract_state", at_hash);
+            Ok(self.contract_present.then(|| CONTRACT_STATE.to_vec()))
+        }
+
+        async fn ledger_parameters(&self, at_hash: &str) -> anyhow::Result<Vec<u8>> {
+            self.record("ledger_parameters", at_hash);
+            Ok(LEDGER_PARAMETERS.to_vec())
+        }
+
+        async fn zswap_chain_state(
+            &self,
+            _address: &str,
+            at_hash: &str,
+        ) -> anyhow::Result<Vec<u8>> {
+            self.record("zswap_chain_state", at_hash);
+            Ok(ZSWAP_CHAIN_STATE.to_vec())
+        }
+    }
+
+    /// Records what it was asked to submit. Counting is the only way to observe that a
+    /// refused intent cost no proving run, because the run itself leaves no other mark.
+    #[derive(Default)]
+    struct StubSubmitter {
+        /// One entry per submission, naming the hash the intent it was handed was built
+        /// over: an intent submitted against a later read is one the node can refuse for
+        /// a state that moved, and nothing above this would see which read it was.
+        submitted: Mutex<Vec<String>>,
+        /// Held before answering, so a test can drive the caller's deadline.
+        delay: Duration,
+        /// What it refuses with, standing in for the child's own verdict on a submit it
+        /// could not make.
+        failure: Option<&'static str>,
+        /// Whether the token this step was handed was ever cancelled. A step given a
+        /// fresh token instead of the node's own would look identical in every other
+        /// observation and would keep proving through a shutdown.
+        saw_cancelled_token: std::sync::atomic::AtomicBool,
+        /// Signalled on entry, so a test can cancel at a point where the step is
+        /// certainly running rather than racing the reads and the build ahead of it.
+        entered: tokio::sync::Notify,
+    }
+
+    impl StubSubmitter {
+        fn new() -> Arc<Self> {
+            Arc::new(Self::default())
+        }
+
+        fn slow() -> Arc<Self> {
+            Arc::new(Self {
+                delay: Duration::from_secs(300),
+                ..Default::default()
+            })
+        }
+
+        fn refusing(failure: &'static str) -> Arc<Self> {
+            Arc::new(Self {
+                failure: Some(failure),
+                ..Default::default()
+            })
+        }
+
+        fn submissions(&self) -> Vec<String> {
+            self.submitted.lock().unwrap().clone()
+        }
+
+        fn saw_cancelled_token(&self) -> bool {
+            self.saw_cancelled_token
+                .load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl IntentSubmitter for StubSubmitter {
+        async fn submit(
+            &self,
+            intent: &[u8],
+            chain: &PinnedState,
+            cancel: &CancellationToken,
+        ) -> anyhow::Result<String> {
+            self.entered.notify_one();
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    self.saw_cancelled_token
+                        .store(true, std::sync::atomic::Ordering::SeqCst);
+                    anyhow::bail!("stub submit cancelled");
+                }
+                _ = tokio::time::sleep(self.delay) => {}
+            }
+            // The bytes have to be the builder's own, not a re-serialization of a
+            // decoded value: whatever is proved and paid for downstream is this.
+            assert_eq!(
+                hex::encode(intent),
+                intent_hex(),
+                "the submitter must be handed the bytes the builder wrote"
+            );
+            if let Some(failure) = self.failure {
+                // Before the record: a submit that failed posted nothing, and a test that
+                // counts submissions has to be able to tell the two apart.
+                anyhow::bail!("{failure}");
+            }
+            self.submitted.lock().unwrap().push(chain.at_hash.clone());
+            Ok("stub-receipt".to_string())
+        }
+    }
+
+    /// A scratch file the stub child writes the request line it was handed into, so a
+    /// test can assert on exactly what this crate marshalled.
+    struct Recorder(PathBuf);
+
+    impl Recorder {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "mpc-midnight-publisher-{name}-{}",
+                std::process::id()
+            ));
+            let _ = std::fs::remove_file(&path);
+            Self(path)
+        }
+
+        fn request(&self) -> serde_json::Value {
+            let line = std::fs::read_to_string(&self.0).expect("the stub recorded its request");
+            serde_json::from_str(&line).expect("the recorded request is JSON")
+        }
+    }
+
+    impl Drop for Recorder {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
+    /// A real serialized ledger `Intent`, so the deserialize step in the publish path
+    /// is exercised rather than stepped over. Empty: nothing above the submitter reads
+    /// the actions, and the seam test drives the real builder for the case that does.
+    fn intent_hex() -> String {
+        let mut rng = StdRng::seed_from_u64(7);
+        let intent: ChainIntent = Intent::empty(&mut rng, Timestamp::from_secs(1_800_000_000));
+        let mut bytes = Vec::new();
+        midnight_serialize::tagged_serialize(&intent, &mut bytes)
+            .expect("an empty intent serializes");
+        hex::encode(bytes)
+    }
+
+    /// A stub child that answers every request with `intent_hex`, echoing the id it was
+    /// asked so more than one request can be served on one child.
+    fn granting_child(recorder: &Recorder) -> Vec<String> {
+        script(&format!(
+            r#"while read -r line; do printf '%s' "$line" > {}; id=$(printf "%s" "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p'); printf '{{"id":%s,"ok":true,"intent":"{}"}}\n' "$id"; done"#,
+            recorder.0.display(),
+            intent_hex(),
+        ))
+    }
+
+    /// A stub child that refuses, the way a managed dir pointed at a different build
+    /// than what is deployed refuses.
+    fn refusing_child() -> Vec<String> {
+        script(
+            r#"read -r line; printf '{"id":0,"ok":false,"code":"contract_mismatch","message":"exposes no operation"}\n'"#,
+        )
+    }
+
+    fn script(body: &str) -> Vec<String> {
+        vec!["sh".to_string(), "-c".to_string(), body.to_string()]
+    }
+
+    /// Every field pinned, none inherited: the defaults are a trap for a test of a path
+    /// that reads one of them, which would then be testing the default rather than a
+    /// value it chose.
+    fn config(intent_gen_command: Vec<String>) -> PublisherConfig {
+        PublisherConfig {
+            intent_gen_command,
+            managed_dir: "/managed".to_string(),
+            funding_seed: funding_seed(),
+            node_ws_url: "ws://127.0.0.1:9944".to_string(),
+            proof_server_url: "http://127.0.0.1:6300".to_string(),
+            indexer_url: "http://127.0.0.1:8088/api/v3/graphql".to_string(),
+            indexer_ws_url: "ws://127.0.0.1:8088/api/v3/graphql/ws".to_string(),
+            request_timeout: Duration::from_secs(5),
+            submit_timeout: Duration::from_secs(30),
+            restart_backoff: RetryConfig {
+                min_delay: Duration::from_millis(1),
+                max_delay: Duration::from_millis(5),
+                max_times: 1,
+                jitter: false,
+            },
+        }
+    }
+
+    async fn publisher(
+        config: &PublisherConfig,
+        reads: Arc<dyn PinnedReads>,
+        submitter: Arc<dyn IntentSubmitter>,
+    ) -> MidnightPublisher {
+        publisher_with_cancel(config, reads, submitter, CancellationToken::new()).await
+    }
+
+    async fn publisher_with_cancel(
+        config: &PublisherConfig,
+        reads: Arc<dyn PinnedReads>,
+        submitter: Arc<dyn IntentSubmitter>,
+        cancel: CancellationToken,
+    ) -> MidnightPublisher {
+        let intent_gen = IntentGen::spawn(config, "undeployed")
+            .await
+            .expect("the stub child spawns");
+        MidnightPublisher::assemble(config, reads, Arc::new(intent_gen), submitter, cancel)
+            .expect("a validated funding seed derives a wallet")
+    }
+
+    fn chain_ctx(central: &str) -> Option<Vec<u8>> {
+        Some(
+            borsh::to_vec(&MidnightChainCtx {
+                central_address: central.to_string(),
+            })
+            .expect("MidnightChainCtx serializes"),
+        )
+    }
+
+    fn sign_event(chain: Chain, central: &str) -> SignBidirectionalEvent {
+        SignBidirectionalEvent {
             sender: [0; 32],
             serialized_transaction: vec![],
             caip2_id: "midnight:testnet".to_string(),
@@ -34,15 +843,540 @@ mod tests {
             params: String::new(),
             output_deserialization_schema: vec![],
             respond_serialization_schema: vec![],
-            chain: Chain::Midnight,
-            chain_ctx: None,
-        };
+            chain,
+            chain_ctx: chain_ctx(central),
+        }
+    }
+
+    fn respond_action() -> PublishAction {
+        make_publish_action(
+            Chain::Midnight,
+            SignKind::SignBidirectional(sign_event(Chain::Midnight, CENTRAL)),
+            SignId::new(REQUEST_ID),
+        )
+    }
+
+    fn bidirectional_action(output: Vec<u8>) -> PublishAction {
+        make_publish_action(
+            Chain::Midnight,
+            SignKind::RespondBidirectional(RespondBidirectionalTx {
+                tx_id: BidirectionalTxId([0x11; 32]),
+                output,
+                chain_ctx: chain_ctx(CENTRAL),
+            }),
+            SignId::new(REQUEST_ID),
+        )
+    }
+
+    #[tokio::test]
+    async fn publish_signature_rejects_a_chain_it_does_not_serve() {
+        // A request routed elsewhere must not reach the intent builder, the node or the
+        // submitter: the refusal is free and everything past it is not.
+        let reads = StubReads::new();
+        let submitter = StubSubmitter::new();
+        let recorder = Recorder::new("wrong-chain");
+        let config = config(granting_child(&recorder));
+        let publisher = publisher(&config, reads.clone(), submitter.clone()).await;
+
+        let action = make_publish_action(
+            Chain::Canton,
+            SignKind::SignBidirectional(sign_event(Chain::Canton, CENTRAL)),
+            SignId::new(REQUEST_ID),
+        );
+        let err = publisher
+            .publish_signature(&action)
+            .await
+            .expect_err("midnight does not serve canton");
+        assert!(format!("{err:#}").contains("Canton"), "got: {err:#}");
+        assert!(reads.reads().is_empty(), "a refused chain read the node");
+        assert!(submitter.submissions().is_empty());
+    }
+
+    #[tokio::test]
+    async fn publish_signature_rejects_a_midnight_request_carrying_another_chain_s_event() {
+        // The routing chain and the event's own are set by different layers. Trusting
+        // the routing field alone would post a Canton response to Midnight's contract.
+        let reads = StubReads::new();
+        let recorder = Recorder::new("mixed-chain");
+        let config = config(granting_child(&recorder));
+        let publisher = publisher(&config, reads.clone(), StubSubmitter::new()).await;
 
         let action = make_publish_action(
             Chain::Midnight,
-            SignKind::SignBidirectional(event),
-            SignId::new([0u8; 32]),
+            SignKind::SignBidirectional(sign_event(Chain::Canton, CENTRAL)),
+            SignId::new(REQUEST_ID),
         );
-        assert!(MidnightPublisher.publish_signature(&action).await.is_err());
+        assert!(publisher.publish_signature(&action).await.is_err());
+        assert!(reads.reads().is_empty());
+    }
+
+    #[tokio::test]
+    async fn publish_signature_rejects_a_kind_neither_circuit_answers() {
+        let reads = StubReads::new();
+        let recorder = Recorder::new("wrong-kind");
+        let config = config(granting_child(&recorder));
+        let publisher = publisher(&config, reads.clone(), StubSubmitter::new()).await;
+
+        let action = make_publish_action(Chain::Midnight, SignKind::Sign, SignId::new(REQUEST_ID));
+        let err = publisher
+            .publish_signature(&action)
+            .await
+            .expect_err("there is no respond circuit for a plain Sign");
+        assert!(format!("{err:#}").contains("Sign"), "got: {err:#}");
+        assert!(reads.reads().is_empty());
+    }
+
+    #[tokio::test]
+    async fn publish_signature_reads_all_three_states_at_one_finalized_hash() {
+        // The stub serves a different head on every ask, so a publisher that took the
+        // head per read would spread the three across two blocks. Fees drift per block,
+        // and that spread is what produces an OutOfGas on a correctly built intent.
+        let reads = StubReads::new();
+        let submitter = StubSubmitter::new();
+        let recorder = Recorder::new("one-hash");
+        let config = config(granting_child(&recorder));
+        let publisher = publisher(&config, reads.clone(), submitter.clone()).await;
+
+        publisher
+            .publish_signature(&respond_action())
+            .await
+            .expect("the stub child grants and the stub submitter accepts");
+
+        let at_hashes: Vec<String> = reads
+            .reads()
+            .into_iter()
+            .filter(|read| read.method != "finalized_head")
+            .map(|read| read.at_hash)
+            .collect();
+        assert_eq!(
+            at_hashes,
+            vec![HEAD_ONE.to_string(); 3],
+            "all three reads must pin the FIRST head, and there must be exactly three"
+        );
+        assert_eq!(
+            reads
+                .reads()
+                .iter()
+                .filter(|read| read.method == "finalized_head")
+                .count(),
+            1,
+            "the head is taken once per publish"
+        );
+        assert_eq!(
+            submitter.submissions(),
+            vec![HEAD_ONE.to_string()],
+            "the submit step is handed the hash its intent was built over, not a later one"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_rejected_intent_fails_the_publish_without_spending_a_proof() {
+        // The child's own verdict has to end the publish. Proving is the one expensive
+        // step, and there is nothing to prove: the refusal means no intent was built.
+        let reads = StubReads::new();
+        let submitter = StubSubmitter::new();
+        let config = config(refusing_child());
+        let publisher = publisher(&config, reads.clone(), submitter.clone()).await;
+
+        let err = publisher
+            .publish_signature(&respond_action())
+            .await
+            .expect_err("a refused request cannot be published");
+        assert!(
+            format!("{err:#}").contains("contract_mismatch"),
+            "the child's code has to survive to the caller: {err:#}"
+        );
+        assert!(
+            submitter.submissions().is_empty(),
+            "a refused intent reached the prover"
+        );
+    }
+
+    #[tokio::test]
+    async fn bytes_that_are_not_a_ledger_intent_never_reach_the_submit_step() {
+        // The decode is the only thing standing between the child's output and a
+        // proving run paid for out of the funding wallet. Well-formed hex that is not
+        // an Intent is exactly what a ledger line skew produces, and it has to fail
+        // here, by name, rather than deeper inside something that assumed it parsed.
+        let submitter = StubSubmitter::new();
+        let config = config(script(
+            r#"read -r line; printf '{"id":0,"ok":true,"intent":"deadbeef"}\n'"#,
+        ));
+        let publisher = publisher(&config, StubReads::new(), submitter.clone()).await;
+
+        let err = publisher
+            .publish_signature(&respond_action())
+            .await
+            .expect_err("four bytes are not a ledger Intent");
+        assert!(
+            format!("{err:#}").contains("did not deserialize"),
+            "got: {err:#}"
+        );
+        assert!(
+            submitter.submissions().is_empty(),
+            "unreadable bytes reached the step that pays for them"
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_signature_is_idempotent_for_a_duplicate_request_id() {
+        // Both circuits are blind appends and the indexer skips responds for unknown
+        // ids, so a second response for an id already answered costs a transaction and
+        // changes nothing. The count is the load-bearing half: a dedupe cache would
+        // also make this Ok twice, while silently dropping the retry that rescues a
+        // publish which submitted and then failed on its way back.
+        let reads = StubReads::new();
+        let submitter = StubSubmitter::new();
+        let recorder = Recorder::new("duplicate");
+        let config = config(granting_child(&recorder));
+        let publisher = publisher(&config, reads.clone(), submitter.clone()).await;
+
+        let action = respond_action();
+        publisher
+            .publish_signature(&action)
+            .await
+            .expect("the first publish lands");
+        publisher
+            .publish_signature(&action)
+            .await
+            .expect("a duplicate publish is an Ok, not an Err");
+        assert_eq!(
+            submitter.submissions().len(),
+            2,
+            "the second publish must be posted, not remembered as already done"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_submit_that_fails_must_not_be_reported_as_a_published_signature() {
+        // An `Ok` here settles the signature as answered and nothing retries it, so a
+        // submit that posted nothing has to end the publish. The count is the other half:
+        // a failure recorded as a submission would mean the publisher believed it had
+        // posted something.
+        let submitter = StubSubmitter::refusing("no spendable dust");
+        let recorder = Recorder::new("failing-submit");
+        let config = config(granting_child(&recorder));
+        let publisher = publisher(&config, StubReads::new(), submitter.clone()).await;
+
+        let err = publisher
+            .publish_signature(&respond_action())
+            .await
+            .expect_err("a post that never landed is not a published signature");
+        assert!(
+            format!("{err:#}").contains("no spendable dust"),
+            "got: {err:#}"
+        );
+        assert!(submitter.submissions().is_empty());
+    }
+
+    /// The reads one publish pinned, as the submit step is handed them.
+    fn pinned_state() -> PinnedState {
+        PinnedState {
+            at_hash: HEAD_ONE.to_string(),
+            contract_state: CONTRACT_STATE.to_vec(),
+            ledger_parameters: LEDGER_PARAMETERS.to_vec(),
+        }
+    }
+
+    /// The real submitter over a stub child, which is as far as this seam can be driven
+    /// without a funding wallet, an indexer and a proof server.
+    async fn child_submitter(config: &PublisherConfig) -> ChildSubmitter {
+        ChildSubmitter {
+            intent_gen: Arc::new(
+                IntentGen::spawn(config, "undeployed")
+                    .await
+                    .expect("the stub child spawns"),
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn the_submit_step_answers_with_the_transaction_id_the_child_reported() {
+        // The identifier is what the success line carries and what an operator reads the
+        // chain back with, so it has to be the child's own rather than anything this side
+        // composed.
+        let tx_id = "ab".repeat(32);
+        let config = config(script(&format!(
+            r#"read -r line; printf '{{"id":0,"ok":true,"txId":"{tx_id}","blockHash":"{}"}}\n'"#,
+            "cd".repeat(32)
+        )));
+        let submitter = child_submitter(&config).await;
+
+        let receipt = submitter
+            .submit(&[0xde, 0xad], &pinned_state(), &CancellationToken::new())
+            .await
+            .expect("the stub child posts");
+        assert_eq!(receipt, tx_id);
+    }
+
+    #[tokio::test]
+    async fn the_child_s_own_verdict_on_a_submit_reaches_the_publisher() {
+        // `wallet_unfunded` is a deployment out of dust and `state_conflict` is another
+        // writer having won the race. Both are the operator's to act on and neither is a
+        // fault of the pipe, so a generic transport error here would send them to read
+        // the wire instead of the deployment.
+        let config = config(script(
+            r#"read -r line; printf '{"id":0,"ok":false,"code":"wallet_unfunded","message":"no spendable dust"}\n'"#,
+        ));
+        let submitter = child_submitter(&config).await;
+
+        let err = submitter
+            .submit(&[0xde, 0xad], &pinned_state(), &CancellationToken::new())
+            .await
+            .expect_err("a child that will not post cannot be answered");
+        let rendered = format!("{err:#}");
+        assert!(rendered.contains("wallet_unfunded"), "got: {rendered}");
+        assert!(rendered.contains("no spendable dust"), "got: {rendered}");
+        assert!(
+            rendered.contains(HEAD_ONE),
+            "a submit refused for a state that moved is only actionable next to the read \
+             it stopped matching: {rendered}"
+        );
+    }
+
+    #[test]
+    fn the_submit_backstop_is_strictly_looser_than_the_budget_it_backs() {
+        // The property, not the arithmetic. A backstop equal to `submit_timeout` turns
+        // an ordinary slow submit into a race between two different error messages, one
+        // saying the node was slow and one saying the step ignored its budget. Both
+        // budgets are read, so retuning either moves this with it.
+        let config = config(vec!["true".to_string()]);
+        let backstop = submit_backstop(&config);
+        assert!(
+            backstop > config.submit_timeout,
+            "the backstop must never fire before the budget it backs: {backstop:?} vs {:?}",
+            config.submit_timeout
+        );
+        assert_eq!(
+            backstop,
+            config.submit_timeout + config.request_timeout,
+            "headroom for the one thing that can run before the step's own deadline \
+             starts: bringing a dead child back up, which the restart backoff bounds by \
+             request_timeout"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_submit_step_is_handed_the_node_s_own_shutdown_token() {
+        // A step handed a fresh token instead of the node's own is indistinguishable in
+        // every other observation and keeps proving straight through a shutdown, holding
+        // the node open for the length of a proving run. The stub signals on entry, so
+        // the cancel lands while the step is certainly running rather than racing the
+        // reads and the build ahead of it.
+        let cancel = CancellationToken::new();
+        let submitter = StubSubmitter::slow();
+        let recorder = Recorder::new("shutdown-token");
+        let config = config(granting_child(&recorder));
+        let publisher = Arc::new(
+            publisher_with_cancel(&config, StubReads::new(), submitter.clone(), cancel.clone())
+                .await,
+        );
+
+        let publishing = tokio::spawn({
+            let publisher = publisher.clone();
+            async move { publisher.publish_signature(&respond_action()).await }
+        });
+        submitter.entered.notified().await;
+        cancel.cancel();
+
+        let err = publishing
+            .await
+            .expect("the publish task is not lost")
+            .expect_err("a cancelled submit cannot report success");
+        assert!(format!("{err:#}").contains("cancelled"), "got: {err:#}");
+        assert!(
+            submitter.saw_cancelled_token(),
+            "the step was handed a token that shutdown never reaches"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_submit_step_that_never_returns_does_not_hold_the_publisher_task() {
+        // The reason `submit_timeout` is read at all. The step is expected to enforce
+        // its own budget, and this is what happens when it does not: the publish ends
+        // and says which fault it is, rather than parking a task on a child that will
+        // never answer.
+        let mut config = config(granting_child(&Recorder::new("submit-backstop")));
+        config.submit_timeout = Duration::from_millis(20);
+        config.request_timeout = Duration::from_millis(30);
+        let publisher = publisher(&config, StubReads::new(), StubSubmitter::slow()).await;
+
+        let started = std::time::Instant::now();
+        let err = publisher
+            .publish_signature(&respond_action())
+            .await
+            .expect_err("a submit that never returns must not hold the task");
+        let rendered = format!("{err:#}");
+        assert!(rendered.contains("backstop"), "got: {rendered}");
+        assert!(
+            rendered.contains("not enforcing"),
+            "the message has to name which of the two faults this is: {rendered}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "waited past the 70ms backstop this config sets"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_central_contract_absent_at_the_pinned_hash_fails_the_publish() {
+        // Not a possible state for a request this node indexed off that contract, so it
+        // is a wrong central address or a node that cannot reach the block. Either way
+        // there is nothing to prove against.
+        let recorder = Recorder::new("absent");
+        let config = config(granting_child(&recorder));
+        let publisher = publisher(&config, StubReads::absent(), StubSubmitter::new()).await;
+
+        let err = publisher
+            .publish_signature(&respond_action())
+            .await
+            .expect_err("an absent contract has no respond operation");
+        assert!(format!("{err:#}").contains("not present"), "got: {err:#}");
+    }
+
+    #[tokio::test]
+    async fn the_request_is_the_shape_the_child_validates() {
+        // The only place the marshalling is observable. The publisher package pins the
+        // same wire from its own TypeScript input, so it cannot see a field this side
+        // transposed, dropped or misnamed.
+        let recorder = Recorder::new("wire-shape");
+        let config = config(granting_child(&recorder));
+        let publisher = publisher(&config, StubReads::new(), StubSubmitter::new()).await;
+
+        let action = respond_action();
+        publisher.publish_signature(&action).await.expect("granted");
+
+        let request = recorder.request();
+        assert_eq!(request["circuit"], RESPOND);
+        assert_eq!(request["contractAddress"], CENTRAL);
+        assert_eq!(request["requestId"], hex::encode(REQUEST_ID));
+        assert_eq!(request["contractState"], hex::encode(CONTRACT_STATE));
+        assert_eq!(request["ledgerParameters"], hex::encode(LEDGER_PARAMETERS));
+        assert!(
+            request.get("serializedOutput").is_none() && request.get("outputLen").is_none(),
+            "the unidirectional circuit carries no output fields: {request}"
+        );
+
+        // Against the action's own signature, so a swapped x and y is caught. Equal
+        // looking components would make that invisible, which is exactly the bug: a
+        // transposed signature still lands under the right id and recovers another key.
+        let encoded = action.signature.big_r.to_encoded_point(false);
+        assert_eq!(
+            request["signature"],
+            serde_json::json!({
+                "bigR": {
+                    "x": hex::encode(encoded.x().unwrap()),
+                    "y": hex::encode(encoded.y().unwrap()),
+                },
+                "s": hex::encode(action.signature.s.to_bytes()),
+                "recoveryId": action.signature.recovery_id,
+            })
+        );
+
+        let ttl = request["ttlSeconds"].as_u64().expect("ttl is an integer");
+        let now = unix_now().unwrap();
+        assert_eq!(
+            ttl.saturating_sub(now),
+            config.request_timeout.as_secs() + config.submit_timeout.as_secs(),
+            "the ttl is the sum of the two budgets a publish spends, from now"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_bidirectional_circuit_carries_its_output_padded_to_the_whole_slot() {
+        // A separate deployed operation with a wider event struct, so the other case
+        // passing says nothing about it. The slot is fixed width and `outputLen` is
+        // what tells a consumer how much of it is real.
+        let recorder = Recorder::new("bidirectional");
+        let config = config(granting_child(&recorder));
+        let publisher = publisher(&config, StubReads::new(), StubSubmitter::new()).await;
+
+        publisher
+            .publish_signature(&bidirectional_action(vec![0xab; 32]))
+            .await
+            .expect("granted");
+
+        let request = recorder.request();
+        assert_eq!(request["circuit"], RESPOND_BIDIRECTIONAL);
+        assert_eq!(request["outputLen"], 32);
+        assert_eq!(
+            request["serializedOutput"],
+            format!("{}{}", "ab".repeat(32), "00".repeat(96)),
+            "the whole Bytes<128> travels, zero padded on the right"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_output_wider_than_the_slot_is_refused_before_anything_is_read() {
+        // Truncating would post a response whose payload is not the one that was
+        // signed, and the child would accept the request because it only sees the
+        // truncated slot.
+        let reads = StubReads::new();
+        let recorder = Recorder::new("overlong-output");
+        let config = config(granting_child(&recorder));
+        let publisher = publisher(&config, reads.clone(), StubSubmitter::new()).await;
+
+        let err = publisher
+            .publish_signature(&bidirectional_action(vec![0xab; 129]))
+            .await
+            .expect_err("129 bytes do not fit a Bytes<128> slot");
+        assert!(format!("{err:#}").contains("129"), "got: {err:#}");
+        assert!(reads.reads().is_empty());
+    }
+
+    #[test]
+    fn a_missing_or_malformed_chain_ctx_is_refused() {
+        // The address is the request's own, not configuration's, so there is no
+        // fallback to a configured value: answering the wrong contract is worse than
+        // not answering.
+        let mut action = respond_action();
+        let SignKind::SignBidirectional(event) = &mut action.request.kind else {
+            panic!("the fixture is a SignBidirectional");
+        };
+        event.chain_ctx = None;
+        assert!(respond_call(&action).is_err());
+
+        let SignKind::SignBidirectional(event) = &mut action.request.kind else {
+            panic!("the fixture is a SignBidirectional");
+        };
+        event.chain_ctx = Some(vec![0xff, 0xff]);
+        assert!(respond_call(&action).is_err());
+
+        let SignKind::SignBidirectional(event) = &mut action.request.kind else {
+            panic!("the fixture is a SignBidirectional");
+        };
+        // Uppercase is a valid Borsh string and an address the child refuses, so it has
+        // to be caught by name here rather than as a wire error there.
+        event.chain_ctx = chain_ctx(&CENTRAL.to_uppercase());
+        assert!(respond_call(&action).is_err());
+    }
+
+    #[test]
+    fn the_coin_public_key_is_derived_from_the_configured_seed() {
+        // Transcribed from the helpers' own derivation for this seed, so a ledger-line
+        // bump that moves the Zswap role's key is caught here rather than by a proof
+        // that verifies against a key the funding wallet does not hold.
+        let key = coin_public_key(&funding_seed()).expect("a 32 byte seed derives");
+        assert_eq!(
+            key,
+            "687a8db8e44bbd007b6baaf9004c742d1d89ee7bd8f367e6ec6b017a2cf98baf"
+        );
+        // The half a transcribed value cannot check on its own: that the seed is read
+        // at all. A key returned from anywhere but this seed passes the line above for
+        // as long as nobody changes the seed.
+        let other = coin_public_key(&"11".repeat(32)).expect("another 32 byte seed derives");
+        assert_ne!(key, other);
+        assert_eq!(other.len(), 64);
+    }
+
+    #[test]
+    fn an_unusable_funding_seed_fails_at_construction_rather_than_at_the_first_signature() {
+        // The seed is decoded once. A publisher that deferred it would look healthy
+        // until the first request it could not answer, which is the worst moment to
+        // discover a deployment typo.
+        assert!(coin_public_key("").is_err());
+        assert!(coin_public_key("zz".repeat(32).as_str()).is_err());
+        // 17 bytes: hex-clean, and neither of the three lengths a wallet seed takes.
+        assert!(coin_public_key(&"0f".repeat(17)).is_err());
     }
 }

--- a/chain-signatures/chain-midnight/src/rpc.rs
+++ b/chain-signatures/chain-midnight/src/rpc.rs
@@ -10,7 +10,7 @@ use subxt::backend::legacy::rpc_methods::NumberOrHex;
 use subxt::backend::legacy::LegacyRpcMethods;
 use subxt::backend::rpc::RpcClient;
 use subxt::client::OnlineClient;
-use subxt::ext::codec::{Compact, Decode};
+use subxt::ext::codec::{Compact, Decode, Encode};
 use subxt::ext::subxt_rpcs::rpc_params;
 use subxt::utils::H256;
 use subxt::SubstrateConfig;
@@ -30,6 +30,24 @@ pub(crate) const STATE_UNSERVABLE_MSG: &str =
 /// can ANSWER a state query at an old block, not about any real contract, so "contract
 /// not present" is as much positive evidence as served state bytes.
 const PROBE_ADDRESS: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+
+/// `MidnightRuntimeApi::get_ledger_parameters`, spelled the way `sp_api` names a
+/// dispatch entry point: `{Trait}_{method}`. Read from node 2.0.0-rc.4's own v15
+/// metadata on 2026-07-28, which lists this entry point under `MidnightRuntimeApi`;
+/// the polkadot.js camelCase spelling is a client-side alias and does not resolve
+/// here, and `state_call` answers an unknown entry point with a bare "function
+/// doesn't exist" that carries no diagnosis.
+const LEDGER_PARAMETERS_ENTRY: &str = "MidnightRuntimeApi_get_ledger_parameters";
+
+/// `MidnightRuntimeApi::get_zswap_chain_state`, from the same metadata read as
+/// [`LEDGER_PARAMETERS_ENTRY`].
+const ZSWAP_CHAIN_STATE_ENTRY: &str = "MidnightRuntimeApi_get_zswap_chain_state";
+
+/// Substrate's own signature for "this node cannot reach state at that hash",
+/// pruned or never known: `sp_blockchain::Error::UnknownBlock` reaches the caller
+/// as `Client error: UnknownBlock: ...`. `state_call` carries no per-pallet
+/// message to match on, unlike `midnight_contractState`.
+const UNKNOWN_BLOCK_MSG: &str = "UnknownBlock";
 
 /// What the startup probe concluded about the node's state retention.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -201,6 +219,43 @@ impl MidnightRpc {
         .await
     }
 
+    /// The ledger parameters at `at_block_hash_0x` (`0x`-prefixed). Fees drift per
+    /// block, so a caller proving against a state must read these at that state's
+    /// own hash.
+    // Only the respond path reads this pair, and it does not call into this crate,
+    // which exports no part of `mod rpc`: unreachable to the dead-code pass, which
+    // CI promotes to an error.
+    #[allow(dead_code)]
+    pub async fn ledger_parameters(&self, at_block_hash_0x: &str) -> anyhow::Result<Vec<u8>> {
+        ledger_parameters_over(
+            &self.legacy,
+            self.request_timeout,
+            self.retry,
+            at_block_hash_0x,
+        )
+        .await
+    }
+
+    /// The zswap ledger state at `at_block_hash_0x`, which is the whole chain's, not
+    /// one contract's. `address_64hex` (64 hex chars, no `0x`) selects nothing: the
+    /// entry point declares an address argument and ignores it, so unlike
+    /// [`Self::contract_state`] there is no absent case for this to report.
+    #[allow(dead_code)]
+    pub async fn zswap_chain_state(
+        &self,
+        address_64hex: &str,
+        at_block_hash_0x: &str,
+    ) -> anyhow::Result<Vec<u8>> {
+        zswap_chain_state_over(
+            &self.legacy,
+            self.request_timeout,
+            self.retry,
+            address_64hex,
+            at_block_hash_0x,
+        )
+        .await
+    }
+
     /// Probes whether the node retains contract state `window` blocks behind the
     /// finalized head, classifying it [`ArchiveState::Archive`] or
     /// [`ArchiveState::Pruned`].
@@ -267,10 +322,7 @@ impl MidnightRpc {
         &self,
         hash_0x: &str,
     ) -> anyhow::Result<Vec<Vec<u8>>> {
-        let bytes: [u8; 32] = hex::decode(hash_0x.trim_start_matches("0x"))
-            .context("block hash is not hex")?
-            .try_into()
-            .map_err(|_| anyhow::anyhow!("block hash is not 32 bytes"))?;
+        let hash = block_hash(hash_0x)?;
         let block = retry_rpc!(
             self.request_timeout,
             self.retry,
@@ -278,7 +330,7 @@ impl MidnightRpc {
             {
                 self.client
                     .blocks()
-                    .at(H256::from(bytes))
+                    .at(hash)
                     .await
                     .context("failed to fetch a finalized block by hash")
             }
@@ -361,6 +413,128 @@ async fn contract_state_over(
             }
         }
     })
+}
+
+fn block_hash(hash_0x: &str) -> anyhow::Result<H256> {
+    let bytes: [u8; 32] = hex::decode(hash_0x.trim_start_matches("0x"))
+        .context("block hash is not hex")?
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("block hash is not 32 bytes"))?;
+    Ok(H256::from(bytes))
+}
+
+/// The bare payload of a `Result<Vec<u8>, _>` runtime-API answer: discriminant byte
+/// and compact length both dropped, leaving the tagged blob the ledger
+/// deserializers take. Both entry points read here answer in that shape at
+/// `MidnightRuntimeApi` version 2, which is what `midnight_apiVersions` reports on
+/// node 2.0.0-rc.4; anything older answers with a bare `Vec<u8>` whose first byte
+/// would be read here as the discriminant.
+///
+/// `None` is the `Err` variant. The error is never decoded, only its discriminant,
+/// so a ledger error this build has never seen still reads as an `Err` rather than
+/// as a decode failure. Neither read here has an absent case, so both callers turn
+/// it into a fault, but they do it outside the retry budget: the runtime has
+/// settled the question and re-asking spends attempts on a fixed answer.
+fn unwrap_runtime_api_result(answer: &[u8]) -> anyhow::Result<Option<Vec<u8>>> {
+    let (variant, mut payload) = answer
+        .split_first()
+        .context("runtime api returned an empty Result envelope")?;
+    match *variant {
+        0 => {
+            let value = Vec::<u8>::decode(&mut payload)
+                .context("runtime api Ok payload is not a SCALE Vec<u8>")?;
+            anyhow::ensure!(
+                payload.is_empty(),
+                "runtime api Ok payload has {} trailing bytes",
+                payload.len()
+            );
+            Ok(Some(value))
+        }
+        1 => Ok(None),
+        other => anyhow::bail!("runtime api returned Result variant {other}"),
+    }
+}
+
+/// One `MidnightRuntimeApi` read: a `state_call` at `at_block_hash_0x`, unwrapped
+/// to the bare payload. Takes the transport explicitly for the same reason
+/// [`contract_state_over`] does, and goes through [`LegacyRpcMethods`] rather than
+/// the crate's `OnlineClient`: `runtime_api().at(hash).call_raw(..)` puts the same
+/// three parameters on the same `state_call` through the legacy backend, but an
+/// `OnlineClient` cannot be built offline, and its backend adds a reconnect loop
+/// outside the retry budget below.
+async fn runtime_api_bytes_over(
+    legacy: &LegacyRpcMethods<SubstrateConfig>,
+    request_timeout: Duration,
+    retry: RetryConfig,
+    entry_point: &str,
+    call_parameters: &[u8],
+    at_block_hash_0x: &str,
+) -> anyhow::Result<Option<Vec<u8>>> {
+    let at = block_hash(at_block_hash_0x)?;
+    // Same split as contract_state_over: whatever the runtime itself answers is
+    // definitive and returns Ok, Err envelope included, while transport faults and a
+    // node that cannot reach the state surface as Err and spend the retry budget.
+    retry_rpc!(request_timeout, retry, "midnight_state_call", {
+        match legacy
+            .state_call(entry_point, Some(call_parameters), Some(at))
+            .await
+        {
+            Ok(answer) => unwrap_runtime_api_result(&answer),
+            Err(err) if err.to_string().contains(UNKNOWN_BLOCK_MSG) => {
+                Err(anyhow::Error::new(err).context(STATE_UNSERVABLE_MSG))
+            }
+            Err(err) => Err(anyhow::Error::new(err).context(format!("{entry_point} failed"))),
+        }
+    })
+}
+
+/// [`MidnightRpc::ledger_parameters`] over an explicit transport.
+async fn ledger_parameters_over(
+    legacy: &LegacyRpcMethods<SubstrateConfig>,
+    request_timeout: Duration,
+    retry: RetryConfig,
+    at_block_hash_0x: &str,
+) -> anyhow::Result<Vec<u8>> {
+    runtime_api_bytes_over(
+        legacy,
+        request_timeout,
+        retry,
+        LEDGER_PARAMETERS_ENTRY,
+        &[],
+        at_block_hash_0x,
+    )
+    .await?
+    // An Err is the node declining to produce the chain's own fee schedule, which
+    // leaves nothing to prove against.
+    .with_context(|| format!("midnight node has no ledger parameters at {at_block_hash_0x}"))
+}
+
+/// [`MidnightRpc::zswap_chain_state`] over an explicit transport.
+async fn zswap_chain_state_over(
+    legacy: &LegacyRpcMethods<SubstrateConfig>,
+    request_timeout: Duration,
+    retry: RetryConfig,
+    address_64hex: &str,
+    at_block_hash_0x: &str,
+) -> anyhow::Result<Vec<u8>> {
+    // The entry point declares a `Vec<u8>`, so the address goes on the wire SCALE
+    // encoded, length prefix and all. The bare 32 bytes do not fail legibly: they
+    // trap the runtime wasm on an `unreachable` instruction.
+    let call_parameters = hex::decode(address_64hex.trim_start_matches("0x"))
+        .context("contract address is not hex")?
+        .encode();
+    runtime_api_bytes_over(
+        legacy,
+        request_timeout,
+        retry,
+        ZSWAP_CHAIN_STATE_ENTRY,
+        &call_parameters,
+        at_block_hash_0x,
+    )
+    .await?
+    // Global state, so an Err is the chain having no zswap state at all, never a
+    // contract this address failed to name.
+    .with_context(|| format!("midnight node has no zswap chain state at {at_block_hash_0x}"))
 }
 
 /// [`MidnightRpc::probe_archive_state`] over explicit transports: the probe needs only
@@ -566,6 +740,7 @@ mod tests {
             node_ws_url: "ws://127.0.0.1:9944".to_string(),
             central_address: "ab".repeat(32),
             network_id: "undeployed".to_string(),
+            publisher: Default::default(),
             rpc: Default::default(),
             indexer: Default::default(),
         };
@@ -862,6 +1037,204 @@ mod tests {
             2,
             "one fault, one retry, no more"
         );
+    }
+
+    // MidnightRuntimeApi reads over `state_call`.
+
+    /// A contract deployed on the chain the live answers below were measured against.
+    const DEPLOYED_ADDRESS: &str =
+        "d7b3c45da613be25050bbdf3fde4cef8f66154d3a52ca8c1edd878bd6391f169";
+    /// No contract at this one.
+    const BARE_ADDRESS: &str = "abababababababababababababababababababababababababababababababab";
+    /// What a node that cannot reach state at the requested hash answers a
+    /// `state_call` with, pruned or never known.
+    const PRUNED_STATE_CALL_MSG: &str =
+        "Client error: UnknownBlock: State already discarded for 0x5555";
+    /// `Err(LedgerApiError::ContractNotPresent)`, the whole two-byte answer node
+    /// 2.0.0-rc.4 gives `get_contract_state` for [`BARE_ADDRESS`].
+    const SCALE_ERR: &[u8] = &[0x01, 0x0b];
+
+    fn legacy_over(node: &StubNode) -> LegacyRpcMethods<SubstrateConfig> {
+        LegacyRpcMethods::<SubstrateConfig>::new(RpcClient::new(node.clone()))
+    }
+
+    /// A `state_call` reply: the runtime API's SCALE answer as the `0x` hex string
+    /// the node serializes `Bytes` to.
+    fn state_call_reply(scale: &[u8]) -> Canned {
+        json_str(&format!("0x{}", hex::encode(scale)))
+    }
+
+    /// SCALE `Ok(payload)` of a `Result<Vec<u8>, _>`: the zero variant byte, then
+    /// the payload length-prefixed.
+    fn scale_ok(payload: &[u8]) -> Vec<u8> {
+        let mut bytes = vec![0x00];
+        bytes.extend_from_slice(&scale_vec(payload));
+        bytes
+    }
+
+    #[tokio::test]
+    async fn ledger_parameters_calls_the_runtime_api_and_unwraps_the_payload() {
+        // The bare payload is what the ledger deserializer takes; handing back the
+        // SCALE envelope would put a variant byte and a length prefix in front of the
+        // tag and fail far from here. Sized to the answer node 2.0.0-rc.4 gives: a
+        // 791-byte tagged blob in a 794-byte envelope, so the compact length lands in
+        // its two-byte form and a strip that always dropped one byte is caught.
+        let mut params = b"midnight:ledger-parameters[v8]:".to_vec();
+        params.resize(791, 0x5a);
+        let envelope = scale_ok(&params);
+        assert_eq!(
+            envelope.len(),
+            794,
+            "one discriminant byte, a two-byte compact length, then the blob"
+        );
+        let node = StubNode::new([("state_call", vec![state_call_reply(&envelope)])]);
+
+        let read = ledger_parameters_over(
+            &legacy_over(&node),
+            PROBE_TIMEOUT,
+            attempts(0),
+            HEAD_HASH_HEX,
+        )
+        .await
+        .expect("an Ok answer unwraps");
+        assert_eq!(read, params);
+
+        // Spelled out rather than built from the constant, so a renamed entry point
+        // fails here instead of agreeing with itself. A nullary runtime API takes
+        // empty call parameters, and the hash is the caller's, never the best block.
+        assert_eq!(
+            node.calls_to("state_call"),
+            vec![format!(
+                "[\"MidnightRuntimeApi_get_ledger_parameters\",\"0x\",\"{HEAD_HASH_HEX}\"]"
+            )],
+        );
+    }
+
+    #[tokio::test]
+    async fn zswap_chain_state_ignores_the_address_and_returns_global_state() {
+        // Deliberate, and measured against node 2.0.0-rc.4: a deployed contract's
+        // address and 32 bytes of 0xab drew byte-identical 1588-byte payloads. The
+        // entry point declares an address and selects nothing with it, so this read is
+        // the whole chain's zswap state and has no absent case. Nobody should "fix"
+        // the caller to key zswap state by contract.
+        //
+        // Offline, the stub cannot re-prove what the node does; what it pins is this
+        // crate's half of it. Both addresses reach the wire, distinctly, so the
+        // argument is passed as the runtime API declares it, and the same answer comes
+        // back as the same bytes either way: no address-keyed handling, and no Option
+        // for a caller to read absence out of.
+        let global = b"midnight:zswap-ledger-state[v5]:global".to_vec();
+        let node = StubNode::new([("state_call", vec![state_call_reply(&scale_ok(&global))])]);
+        let legacy = legacy_over(&node);
+
+        let at_deployed = zswap_chain_state_over(
+            &legacy,
+            PROBE_TIMEOUT,
+            attempts(0),
+            DEPLOYED_ADDRESS,
+            HEAD_HASH_HEX,
+        )
+        .await
+        .expect("a served answer unwraps");
+        let at_bare = zswap_chain_state_over(
+            &legacy,
+            PROBE_TIMEOUT,
+            attempts(0),
+            BARE_ADDRESS,
+            HEAD_HASH_HEX,
+        )
+        .await
+        .expect("an address with no contract is answered just the same");
+
+        assert_eq!(at_deployed, global);
+        assert_eq!(at_deployed, at_bare);
+
+        let calls = node.calls_to("state_call");
+        assert!(calls[0].contains(DEPLOYED_ADDRESS));
+        assert!(calls[1].contains(BARE_ADDRESS));
+    }
+
+    #[tokio::test]
+    async fn a_runtime_api_err_answer_is_a_settled_fault() {
+        // Neither read here has an absent case, so an Err envelope is a fault for
+        // both. It is still the runtime's own answer rather than a transport fault:
+        // one call each, never a retry, because no number of re-asks changes it.
+        let node = StubNode::new([("state_call", vec![state_call_reply(SCALE_ERR)])]);
+        let legacy = legacy_over(&node);
+
+        ledger_parameters_over(&legacy, PROBE_TIMEOUT, attempts(2), HEAD_HASH_HEX)
+            .await
+            .expect_err("a node with no ledger parameters cannot be proved against");
+        assert_eq!(node.calls_to("state_call").len(), 1);
+
+        zswap_chain_state_over(
+            &legacy,
+            PROBE_TIMEOUT,
+            attempts(2),
+            DEPLOYED_ADDRESS,
+            HEAD_HASH_HEX,
+        )
+        .await
+        .expect_err("a chain with no zswap state cannot be proved against");
+        assert_eq!(node.calls_to("state_call").len(), 2);
+    }
+
+    #[tokio::test]
+    async fn zswap_chain_state_scale_encodes_the_address() {
+        // The entry point takes a `Vec<u8>`, so the address arrives length-prefixed.
+        // compact(32) is one byte, 32 << 2 = 0x80, hand-built so the prefix is pinned
+        // non-circularly. The bare 32 bytes do not come back as a decode error: node
+        // 2.0.0-rc.4 traps the runtime wasm on an `unreachable` instruction, which is
+        // why this is pinned at the wire rather than left to a live failure.
+        let node = StubNode::new([("state_call", vec![state_call_reply(&scale_ok(b"zswap"))])]);
+
+        let state = zswap_chain_state_over(
+            &legacy_over(&node),
+            PROBE_TIMEOUT,
+            attempts(0),
+            DEPLOYED_ADDRESS,
+            HEAD_HASH_HEX,
+        )
+        .await
+        .expect("a served answer unwraps");
+
+        assert_eq!(state, b"zswap");
+        assert_eq!(
+            node.calls_to("state_call"),
+            vec![format!(
+                "[\"MidnightRuntimeApi_get_zswap_chain_state\",\"0x80{DEPLOYED_ADDRESS}\",\"{HEAD_HASH_HEX}\"]"
+            )],
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_api_reads_spend_the_contract_state_retry_budget() {
+        // `state_call` carries no per-pallet "not present" message to tell apart, so
+        // the only classification left is the pruning signature, and like
+        // contract_state it is an Err that spends the whole budget before surfacing.
+        let node = StubNode::new([(
+            "state_call",
+            vec![Canned::NodeError(-32000, PRUNED_STATE_CALL_MSG)],
+        )]);
+        let legacy = legacy_over(&node);
+
+        let err = ledger_parameters_over(&legacy, PROBE_TIMEOUT, attempts(2), HEAD_HASH_HEX)
+            .await
+            .expect_err("a node that cannot reach the state must not answer");
+        assert!(is_state_unservable(&err), "got: {err:#}");
+        assert_eq!(node.calls_to("state_call").len(), 3);
+
+        let err = zswap_chain_state_over(
+            &legacy,
+            PROBE_TIMEOUT,
+            attempts(2),
+            DEPLOYED_ADDRESS,
+            HEAD_HASH_HEX,
+        )
+        .await
+        .expect_err("a node that cannot reach the state must not answer");
+        assert!(is_state_unservable(&err), "got: {err:#}");
+        assert_eq!(node.calls_to("state_call").len(), 6);
     }
 
     #[tokio::test]

--- a/chain-signatures/chain-midnight/tests/intent_seam.rs
+++ b/chain-signatures/chain-midnight/tests/intent_seam.rs
@@ -1,0 +1,292 @@
+//! The seam: the real Rust client drives the real TypeScript builder, and what comes
+//! back parses here as the ledger's own `Intent`. Both halves are unit-tested against
+//! stubs, which proves each one keeps its own end of the wire and nothing about the two
+//! agreeing. This is the only test where neither side's expectations were authored by
+//! the side under test.
+//!
+//! `#[ignore]`d: it runs `node dist/main.js` out of the publisher package's own
+//! installed dependencies, so `npm ci` and `npm run build` have to have run there. The
+//! midnight-publisher-ts workflow is the only place it runs.
+//!
+//! Everything the child is handed comes from committed fixtures and the ledger crate's
+//! own constants, so no node, no proof server and no wallet is involved.
+
+use std::path::{Path, PathBuf};
+
+use midnight_ledger_v9::structure::{
+    ContractAction, ContractCall, Intent, ProofPreimageMarker, Signature, INITIAL_PARAMETERS,
+};
+use midnight_onchain_state::state::ContractState;
+use midnight_storage::DefaultDB;
+use midnight_transient_crypto::commitment::PedersenRandomness;
+use mpc_chain_midnight::{IntentGen, IntentRequest, PublisherConfig, WirePoint, WireSignature};
+use tokio_util::sync::CancellationToken;
+
+/// The contract `respond-singleton-state-37571.mn` was captured from, per
+/// `tests/fixtures/README.md`. Its embedded verifier keys match the installed
+/// `@sig-net/midnight-contract`, which is what lets the entry-point lookup succeed.
+const SINGLETON: &str = "d7b3c45da613be25050bbdf3fde4cef8f66154d3a52ca8c1edd878bd6391f169";
+
+/// Minted by the real circuit on the capture chain. Any 32 bytes would do for a blind
+/// append, but a real one keeps the fixture honest.
+const REQUEST_ID: &str = "abf32e141d471192a834779b0a8960aa05a7f94534564f477420eef80f588c48";
+
+/// Deliberately all different from each other. Equal-looking components would make a
+/// transposed x and y invisible, which is the exact bug the argument assertion exists
+/// to catch: a transposed signature still produces a well-formed intent that lands
+/// under the right request id and recovers a different key.
+const BIG_R_X: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+const BIG_R_Y: &str = "2222222222222222222222222222222222222222222222222222222222222222";
+const S: &str = "3333333333333333333333333333333333333333333333333333333333333333";
+
+/// The transcript renders a trailing-zero-trimmed value, so a zero recovery id is `-`.
+const RECOVERY_ID_ZERO: &str = "-";
+
+const SINGLETON_STATE: &[u8] =
+    include_bytes!("../../midnight-publisher-ts/tests/fixtures/respond-singleton-state-37571.mn");
+
+/// The child refuses to boot without one. Nothing here encodes an address, so it only
+/// has to be a value the contract library recognises.
+const NETWORK_ID: &str = "undeployed";
+
+/// Ledger 9's own tagged reading of what the builder wrote: `signature`, `pre-proof`
+/// and `pre-binding`, the three markers the TypeScript side names when it decodes its
+/// own output.
+type ChainIntent = Intent<Signature, ProofPreimageMarker, PedersenRandomness, DefaultDB>;
+
+fn publisher_package() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../midnight-publisher-ts")
+}
+
+fn path_arg(path: &Path) -> String {
+    path.to_str()
+        .unwrap_or_else(|| panic!("{} is not valid UTF-8", path.display()))
+        .to_string()
+}
+
+/// The builder as the node runs it in production: argv straight to the built entry
+/// point, with the compiled contract assets the circuit runs against.
+fn live_config() -> PublisherConfig {
+    let package = publisher_package();
+    let entry = package.join("dist/main.js");
+    // The library resolves its own assets relative to its package, so this is the
+    // installed copy rather than anything under `tests/`.
+    let managed = package.join("node_modules/@sig-net/midnight-contract/dist/managed");
+    // Checked here rather than left to the child: a missing entry point makes `node`
+    // exit at boot, which reaches the caller as a closed pipe and reads like a protocol
+    // fault instead of an unbuilt package.
+    assert!(
+        entry.is_file(),
+        "{} is missing: run `npm ci && npm run build` in {}",
+        entry.display(),
+        package.display()
+    );
+    assert!(
+        managed.is_dir(),
+        "{} is missing: run `npm ci` in {}",
+        managed.display(),
+        package.display()
+    );
+    PublisherConfig {
+        intent_gen_command: vec!["node".to_string(), path_arg(&entry)],
+        managed_dir: path_arg(&managed),
+        ..Default::default()
+    }
+}
+
+fn signature() -> WireSignature {
+    WireSignature {
+        big_r: WirePoint {
+            x: BIG_R_X.to_string(),
+            y: BIG_R_Y.to_string(),
+        },
+        s: S.to_string(),
+        recovery_id: 0,
+    }
+}
+
+/// The parameters the chain starts on, straight out of the ledger crate. The child
+/// reads them with ledger 9's `LedgerParameters.deserialize`, so producing them here
+/// with `tagged_serialize` is a second thing this test pins: the Rust and TypeScript
+/// ledger builds still agree on that blob.
+fn initial_ledger_parameters() -> String {
+    let mut bytes = Vec::new();
+    midnight_serialize::tagged_serialize(&INITIAL_PARAMETERS, &mut bytes)
+        .expect("the ledger's own initial parameters serialize");
+    hex::encode(bytes)
+}
+
+fn respond_request() -> IntentRequest {
+    IntentRequest {
+        circuit: "respond",
+        contract_address: SINGLETON.to_string(),
+        request_id: REQUEST_ID.to_string(),
+        signature: signature(),
+        serialized_output: None,
+        output_len: None,
+        contract_state: hex::encode(SINGLETON_STATE),
+        ledger_parameters: initial_ledger_parameters(),
+        coin_public_key: "44".repeat(32),
+        ttl_seconds: 1_800_000_000,
+    }
+}
+
+/// The one call the intent carries, or a failure naming which assumption broke.
+///
+/// Decoded, never byte-compared: the builder samples a fresh communication commitment
+/// per call, deliberately, because that commitment is what unlinks a call from its
+/// caller. Only the decode is stable.
+fn sole_call(bytes: &[u8]) -> ContractCall<ProofPreimageMarker, DefaultDB> {
+    // Tagged rather than bare, so a ledger version skew fails by name here instead of
+    // as a field-shaped parse error on good bytes.
+    let intent: ChainIntent = midnight_serialize::tagged_deserialize(&mut &bytes[..])
+        .expect("the TypeScript intent deserializes as the ledger's own Intent");
+
+    let actions: Vec<_> = intent.actions.iter_deref().cloned().collect();
+    assert_eq!(actions.len(), 1, "one contract call");
+    let ContractAction::Call(call) = &actions[0] else {
+        panic!("the single action must be a Call");
+    };
+    assert_eq!(
+        hex::encode(call.address.0 .0),
+        SINGLETON,
+        "the call must name the contract the request named"
+    );
+    // Both respond circuits are blind appends with no fallible work, and the Rust half
+    // treats a built intent as final on that basis. A contract change that moves work
+    // into the fallible segment surfaces here.
+    assert!(
+        call.guaranteed_transcript.is_some(),
+        "respond runs wholly in the guaranteed phase"
+    );
+    assert!(
+        call.fallible_transcript.is_none(),
+        "nothing in respond belongs to the fallible phase"
+    );
+    (**call).clone()
+}
+
+/// The circuit's arguments as the transcript pushed them: one `pushs` op whose tuple IS
+/// the event struct, in the order the contract declared it, tagged with each field's
+/// width.
+///
+/// This is what makes the test a seam test rather than a shape check. The values only
+/// survive into the intent here, so it is the only thing that can tell a request this
+/// crate encoded correctly from one whose fields the wire transposed, dropped or
+/// zeroed. The publisher package pins the same string, but from its own TypeScript
+/// input, so it cannot see a permutation introduced on this side.
+///
+/// Both circuits end in the signature's `b32b32b32b1`, which is what distinguishes this
+/// op from the transcript's other pushes.
+fn pushed_call_args(call: &ContractCall<ProofPreimageMarker, DefaultDB>) -> String {
+    let rendered = format!(
+        "{:#?}",
+        call.guaranteed_transcript
+            .as_ref()
+            .expect("the guaranteed transcript is present")
+    );
+    let ops: Vec<&str> = rendered
+        .lines()
+        .map(|line| line.trim().trim_end_matches(','))
+        .filter(|op| op.starts_with("pushs <[") && op.ends_with("b32b32b32b1>"))
+        .collect();
+
+    assert_eq!(
+        ops.len(),
+        1,
+        "expected one argument push in the transcript: {rendered}"
+    );
+    ops[0].to_string()
+}
+
+#[tokio::test]
+#[ignore = "needs npm ci and npm run build in chain-signatures/midnight-publisher-ts"]
+async fn the_rust_client_and_the_ts_builder_agree_on_a_respond_intent() {
+    let builder = IntentGen::spawn(&live_config(), NETWORK_ID)
+        .await
+        .expect("spawn the builder");
+
+    let bytes = builder
+        .build(&respond_request(), &CancellationToken::new())
+        .await
+        .expect("the builder answers");
+
+    let call = sole_call(&bytes);
+    assert_eq!(call.entry_point.0.as_slice(), b"respond");
+    assert_eq!(
+        pushed_call_args(&call),
+        format!("pushs <[{BIG_R_X}, {BIG_R_Y}, {S}, {RECOVERY_ID_ZERO}]: b32b32b32b1>")
+    );
+}
+
+#[tokio::test]
+#[ignore = "needs npm ci and npm run build in chain-signatures/midnight-publisher-ts"]
+async fn the_rust_client_and_the_ts_builder_agree_on_a_bidirectional_intent() {
+    // The second circuit is a separate deployed operation with a wider event struct, so
+    // the unidirectional case passing says nothing about it. `output_len` is what tells
+    // a consumer how much of the fixed Bytes<128> is real return data, and it renders
+    // in hex: 0x20.
+    let output = "ab".repeat(128);
+    let builder = IntentGen::spawn(&live_config(), NETWORK_ID)
+        .await
+        .expect("spawn the builder");
+
+    let bytes = builder
+        .build(
+            &IntentRequest {
+                circuit: "respondBidirectional",
+                serialized_output: Some(output.clone()),
+                output_len: Some(32),
+                ..respond_request()
+            },
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("the builder answers");
+
+    let call = sole_call(&bytes);
+    assert_eq!(call.entry_point.0.as_slice(), b"respondBidirectional");
+    assert_eq!(
+        pushed_call_args(&call),
+        format!(
+            "pushs <[{output}, 20, {BIG_R_X}, {BIG_R_Y}, {S}, {RECOVERY_ID_ZERO}]: \
+             b128b1b32b32b32b1>"
+        )
+    );
+}
+
+#[tokio::test]
+#[ignore = "needs npm ci and npm run build in chain-signatures/midnight-publisher-ts"]
+async fn a_contract_missing_the_entry_point_arrives_as_the_child_s_own_refusal() {
+    // A contract with no operations at all stands in for the real case: a managed dir
+    // pointed at a different build than what is deployed. What is under test is that
+    // the child's own verdict survives the pipe, because a generic transport error
+    // would send an operator looking at the wire instead of at the deployment.
+    let builder = IntentGen::spawn(&live_config(), NETWORK_ID)
+        .await
+        .expect("spawn the builder");
+    let mut empty = Vec::new();
+    midnight_serialize::tagged_serialize(&ContractState::<DefaultDB>::default(), &mut empty)
+        .expect("an empty contract state serializes");
+
+    let error = builder
+        .build(
+            &IntentRequest {
+                contract_state: hex::encode(&empty),
+                ..respond_request()
+            },
+            &CancellationToken::new(),
+        )
+        .await
+        .expect_err("a contract with no respond operation cannot be answered");
+
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains("contract_mismatch"),
+        "the child's code has to survive the wire: {rendered}"
+    );
+    assert!(
+        rendered.contains("exposes no operation `respond`"),
+        "the child's message has to survive the wire: {rendered}"
+    );
+}

--- a/chain-signatures/chain-midnight/tests/respond_live.rs
+++ b/chain-signatures/chain-midnight/tests/respond_live.rs
@@ -1,0 +1,360 @@
+//! End to end, against a running chain: this crate reads the singleton, decides what to
+//! sign, builds an `Intent`, hands it to the TypeScript child to balance, prove and post,
+//! and then reads the response back through its OWN decoder.
+//!
+//! The read-back is the assertion that matters. A submit receipt only says the node
+//! accepted some bytes; decoding the singleton's respond map afterwards says the write
+//! actually happened, under the id it was posted for, carrying the signature that was
+//! posted, and that the read path and the write path agree about the same contract.
+//!
+//! `#[ignore]`d: it needs the node, the indexer and the proof server up, `npm ci && npm
+//! run build` in the publisher package, and a funding wallet with spendable DUST, and it
+//! submits a real transaction that spends real fees.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use midnight_base_crypto::fab::AlignedValue;
+use midnight_onchain_state::state::StateValue;
+use midnight_storage::DefaultDB;
+use mpc_chain_integration_core::utils::test::make_publish_action;
+use mpc_chain_integration_core::{ChainPublisher, PublishAction};
+use mpc_chain_midnight::{
+    decode_contract_state, IntentGen, MidnightChainCtx, MidnightConfig, MidnightPublisher,
+    MidnightRpc, PublisherConfig,
+};
+use mpc_primitives::{Chain, SignBidirectionalEvent, SignId, SignKind};
+use tokio_util::sync::CancellationToken;
+
+/// The deployed signet singleton on the local stack, and the one whose embedded verifier
+/// keys match the installed `@sig-net/midnight-contract`. The fixtures came from an older
+/// deploy that is also still on chain; targeting that one here would prove the write path
+/// against a contract nothing else in this deployment uses.
+const SIGNET: &str = "1bbd5a535a514a1d5946500d881f780cb6bb3a25fefcd67f750e0a83b0987070";
+
+const NODE_WS_URL: &str = "ws://127.0.0.1:9944";
+const PROOF_SERVER_URL: &str = "http://127.0.0.1:6300";
+/// The indexer is what the funding wallet syncs its spendable DUST from: no node RPC
+/// serves the ledger events that state is replayed out of, which is why a submit needs
+/// both of these and not just the node.
+const INDEXER_URL: &str = "http://127.0.0.1:8088/api/v3/graphql";
+const INDEXER_WS_URL: &str = "ws://127.0.0.1:8088/api/v3/graphql/ws";
+const NETWORK_ID: &str = "undeployed";
+
+/// The environment name this test takes the funding wallet from. Read at use and never
+/// rendered: it is a spending key, and the local stack's copy lives in the
+/// midnight-integration checkout's `.env` as `MPC_RESPONDER_SEED`.
+const FUNDING_SEED_VAR: &str = "MPC_RESPONDER_SEED";
+
+/// The request id this test posts under.
+///
+/// Arbitrary on purpose, and legitimately so: both respond circuits are blind appends
+/// that neither look up the id nor check it against a prior request, so nothing on chain
+/// has to have asked for this one. ASCII, so a human reading the singleton's respond map
+/// can tell this test's writes from a real signature at a glance, and ending in a nonzero
+/// byte so the stored key atom is not trailing-zero trimmed away from the id it names.
+const REQUEST_ID: &[u8; 32] = b"chain-midnight/respond_live 0001";
+
+/// `respondMap`, ledger field 3 of the singleton, per the contract's own
+/// `compiler/contract-info.json`: a map from `{count, requestId}` to the responded
+/// signature.
+const RESPOND_MAP_FIELD: usize = 3;
+
+/// The singleton's declared ledger field count, which is under the compact compiler's
+/// chunk arity, so the fields are the state root's own children rather than a chunk tree.
+const LEDGER_FIELDS: usize = 6;
+
+fn publisher_package() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../midnight-publisher-ts")
+}
+
+fn path_arg(path: &Path) -> String {
+    path.to_str()
+        .unwrap_or_else(|| panic!("{} is not valid UTF-8", path.display()))
+        .to_string()
+}
+
+/// The builder as the node runs it in production: argv straight to the built entry point,
+/// the compiled contract assets the circuit is proved against, and the wallet that pays.
+fn live_publisher_config() -> PublisherConfig {
+    let package = publisher_package();
+    let entry = package.join("dist/main.js");
+    // The library resolves its own assets relative to its package, so this is the
+    // installed copy rather than anything under `tests/`.
+    let managed = package.join("node_modules/@sig-net/midnight-contract/dist/managed");
+    // Checked here rather than left to the child: a missing entry point makes `node` exit
+    // at boot, which reaches the caller as a closed pipe and reads like a protocol fault
+    // instead of an unbuilt package.
+    assert!(
+        entry.is_file(),
+        "{} is missing: run `npm ci && npm run build` in {}",
+        entry.display(),
+        package.display()
+    );
+    assert!(
+        managed.is_dir(),
+        "{} is missing: run `npm ci` in {}",
+        managed.display(),
+        package.display()
+    );
+    PublisherConfig {
+        intent_gen_command: vec!["node".to_string(), path_arg(&entry)],
+        managed_dir: path_arg(&managed),
+        funding_seed: funding_seed(),
+        node_ws_url: NODE_WS_URL.to_string(),
+        proof_server_url: PROOF_SERVER_URL.to_string(),
+        indexer_url: INDEXER_URL.to_string(),
+        indexer_ws_url: INDEXER_WS_URL.to_string(),
+        ..Default::default()
+    }
+}
+
+/// The funding wallet's seed, straight out of the environment into the config that
+/// carries it. Never returned into a message and never logged: `PublisherConfig` redacts
+/// it in `Debug` and this is the only other place it is touched.
+fn funding_seed() -> String {
+    std::env::var(FUNDING_SEED_VAR).unwrap_or_else(|_| {
+        panic!(
+            "{FUNDING_SEED_VAR} is unset: export the local stack's funding wallet seed \
+             (midnight-integration's .env) before running this test"
+        )
+    })
+}
+
+fn node_config() -> MidnightConfig {
+    MidnightConfig {
+        node_ws_url: NODE_WS_URL.to_string(),
+        central_address: SIGNET.to_string(),
+        network_id: NETWORK_ID.to_string(),
+        publisher: live_publisher_config(),
+        rpc: Default::default(),
+        indexer: Default::default(),
+    }
+}
+
+/// The action the node would hand its publisher: a Midnight `SignBidirectional` whose
+/// chain context names the singleton the request was minted by.
+fn respond_action() -> PublishAction {
+    let chain_ctx = borsh::to_vec(&MidnightChainCtx {
+        central_address: SIGNET.to_string(),
+    })
+    .expect("MidnightChainCtx serializes");
+    make_publish_action(
+        Chain::Midnight,
+        SignKind::SignBidirectional(SignBidirectionalEvent {
+            sender: [0; 32],
+            serialized_transaction: vec![],
+            caip2_id: "midnight:undeployed".to_string(),
+            key_version: 1,
+            deposit: 0,
+            path: String::new(),
+            algo: String::new(),
+            dest: String::new(),
+            params: String::new(),
+            output_deserialization_schema: vec![],
+            respond_serialization_schema: vec![],
+            chain: Chain::Midnight,
+            chain_ctx: Some(chain_ctx),
+        }),
+        SignId::new(*REQUEST_ID),
+    )
+}
+
+/// One stored respond, as the four atoms the circuit pushed: the two affine coordinates
+/// of `bigR`, the scalar, and the recovery id.
+///
+/// Re-padded, because the state layer stores atoms trailing-zero trimmed: a scalar whose
+/// top bytes are zero is stored short and is still the same 32-byte value.
+#[derive(Debug, PartialEq, Eq)]
+struct StoredSignature {
+    big_r_x: [u8; 32],
+    big_r_y: [u8; 32],
+    s: [u8; 32],
+    recovery_id: u8,
+}
+
+fn padded<const N: usize>(atom: &[u8], what: &str) -> [u8; N] {
+    assert!(
+        atom.len() <= N,
+        "{what}: {} stored bytes do not fit Bytes<{N}>",
+        atom.len()
+    );
+    let mut out = [0u8; N];
+    out[..atom.len()].copy_from_slice(atom);
+    out
+}
+
+/// The signet field at `index`, off the decoded state root.
+fn ledger_field(root: &StateValue<DefaultDB>, index: usize) -> &StateValue<DefaultDB> {
+    let StateValue::Array(fields) = root else {
+        panic!("the singleton's state root is not an array of ledger fields: {root:?}");
+    };
+    assert_eq!(
+        fields.len(),
+        LEDGER_FIELDS,
+        "the singleton declares {LEDGER_FIELDS} ledger fields; a different count means the \
+         deployed contract is not the build this test reads field {index} of"
+    );
+    fields
+        .iter_deref()
+        .nth(index)
+        .unwrap_or_else(|| panic!("ledger field {index} is absent"))
+}
+
+/// Every signature filed in the singleton's respond map under `request_id`.
+///
+/// Keyed on `{count, requestId}` rather than on the id alone, so an id responded twice
+/// holds two entries. The count is the contract's own and this side does not predict it,
+/// which is why this collects rather than looks one up.
+fn responses_for(state: &[u8], request_id: &[u8; 32]) -> Vec<StoredSignature> {
+    let root = decode_contract_state(state).expect("the singleton's state decodes");
+    let field = ledger_field(&root, RESPOND_MAP_FIELD);
+    let StateValue::Map(entries) = field else {
+        panic!("ledger field {RESPOND_MAP_FIELD} is not the respond map: {field:?}");
+    };
+    entries
+        .iter()
+        .filter_map(|entry| {
+            let (key, value) = &*entry;
+            (filed_under(key) == *request_id).then(|| stored_signature(value))
+        })
+        .collect()
+}
+
+/// The `requestId` half of a `{count, requestId}` map key.
+fn filed_under(key: &AlignedValue) -> [u8; 32] {
+    let atoms = &key.value.0;
+    assert_eq!(
+        atoms.len(),
+        2,
+        "a respond map key is {{count, requestId}}, got {} atoms",
+        atoms.len()
+    );
+    padded::<32>(&atoms[1].0, "respond map key requestId")
+}
+
+fn stored_signature(value: &StateValue<DefaultDB>) -> StoredSignature {
+    let StateValue::Cell(cell) = value else {
+        panic!("a respond map value is a cell, got {value:?}");
+    };
+    let atoms = &cell.value.0;
+    assert_eq!(
+        atoms.len(),
+        4,
+        "a stored signature is bigR.x, bigR.y, s and recoveryId, got {} atoms",
+        atoms.len()
+    );
+    StoredSignature {
+        big_r_x: padded(&atoms[0].0, "bigR.x"),
+        big_r_y: padded(&atoms[1].0, "bigR.y"),
+        s: padded(&atoms[2].0, "s"),
+        // A Uint<8> is stored little-endian trimmed, so recovery id 0 is the empty atom.
+        recovery_id: padded::<1>(&atoms[3].0, "recoveryId")[0],
+    }
+}
+
+/// The signature this run posted, in the form the circuit pushed it.
+fn posted_signature(action: &PublishAction) -> StoredSignature {
+    use k256::elliptic_curve::sec1::ToEncodedPoint as _;
+
+    let encoded = action.signature.big_r.to_encoded_point(false);
+    StoredSignature {
+        big_r_x: (*encoded.x().expect("big_r has affine coordinates")).into(),
+        big_r_y: (*encoded.y().expect("big_r has affine coordinates")).into(),
+        s: action.signature.s.to_bytes().into(),
+        recovery_id: action.signature.recovery_id,
+    }
+}
+
+/// How long the read-back waits for the response to be visible at a finalized head.
+///
+/// The child already waits for the transaction's own finality before answering, so this
+/// only covers the node's finalized head catching up with it. Generous rather than tight:
+/// a timeout here is meant to end the test, never to be the thing the test measures.
+const READ_BACK_TIMEOUT: Duration = Duration::from_secs(180);
+const READ_BACK_POLL: Duration = Duration::from_secs(2);
+
+/// The singleton's contract state at the current finalized head, with the hash and height
+/// it was read at.
+async fn state_at_finalized_head(rpc: &MidnightRpc) -> (Vec<u8>, u64) {
+    let head = rpc
+        .finalized_block_ref()
+        .await
+        .expect("the node answers with its finalized head");
+    let state = rpc
+        .contract_state(SIGNET, &head.hash)
+        .await
+        .expect("the node answers a contract state read")
+        .unwrap_or_else(|| panic!("no contract lives at {SIGNET} at {}", head.hash));
+    (state, head.number)
+}
+
+#[tokio::test]
+#[ignore = "needs a live midnight node, indexer and proof server, a funded wallet, and \
+            `npm ci && npm run build` in chain-signatures/midnight-publisher-ts; submits a \
+            real transaction"]
+async fn a_respond_lands_on_chain_and_reads_back_through_this_crate_s_decoder() {
+    let config = node_config();
+    let rpc = Arc::new(
+        MidnightRpc::connect(&config)
+            .await
+            .expect("the local midnight node is reachable"),
+    );
+    let intent_gen = Arc::new(
+        IntentGen::spawn(&config.publisher, &config.network_id)
+            .await
+            .expect("the intent builder starts"),
+    );
+    let publisher = MidnightPublisher::new(
+        &config.publisher,
+        rpc.clone(),
+        intent_gen,
+        CancellationToken::new(),
+    )
+    .expect("the funding seed derives a wallet");
+
+    // What the id must NOT already hold, so the assertion below cannot be satisfied by a
+    // previous run: this run's signature is freshly minted, so an earlier entry under the
+    // same id carries a different one.
+    let action = respond_action();
+    let posted = posted_signature(&action);
+    let (before, before_height) = state_at_finalized_head(&rpc).await;
+    assert!(
+        !responses_for(&before, REQUEST_ID).contains(&posted),
+        "the singleton already holds this run's signature at height {before_height}"
+    );
+
+    publisher
+        .publish_signature(&action)
+        .await
+        .expect("the respond is built, proved, paid for and accepted by the node");
+
+    // The loop closes here and not at the submit: what the node accepted is only bytes
+    // until this crate's own reader finds them in the contract's state.
+    let deadline = Instant::now() + READ_BACK_TIMEOUT;
+    loop {
+        let (state, height) = state_at_finalized_head(&rpc).await;
+        let filed = responses_for(&state, REQUEST_ID);
+        if filed.contains(&posted) {
+            println!(
+                "midnight respond read back at finalized height {height}: {} response(s) \
+                 filed under {}",
+                filed.len(),
+                String::from_utf8_lossy(REQUEST_ID)
+            );
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the publish reported success but {READ_BACK_TIMEOUT:?} later the singleton's \
+             respond map still does not hold this run's signature under {}: {} response(s) \
+             are filed under that id at finalized height {height}, none of them this one, \
+             so either the transaction never changed the state or the read path and the \
+             write path disagree about contract {SIGNET}",
+            String::from_utf8_lossy(REQUEST_ID),
+            filed.len()
+        );
+        tokio::time::sleep(READ_BACK_POLL).await;
+    }
+}

--- a/chain-signatures/node/src/cli/args/midnight.rs
+++ b/chain-signatures/node/src/cli/args/midnight.rs
@@ -1,4 +1,5 @@
-use mpc_chain_midnight::MidnightConfig;
+use anyhow::Context as _;
+use mpc_chain_midnight::{MidnightConfig, PublisherConfig};
 
 /// CLI arguments for the Midnight indexer.
 #[derive(Debug, Clone, clap::Parser)]
@@ -28,11 +29,68 @@ pub struct MidnightArgs {
         requires = "midnight_node_ws_url"
     )]
     pub midnight_network_id: Option<String>,
+    /// Hex seed of the wallet that funds respond transactions.
+    #[arg(
+        long,
+        env("MPC_MIDNIGHT_FUNDING_SEED"),
+        requires = "midnight_node_ws_url"
+    )]
+    pub midnight_funding_seed: Option<String>,
+    /// Directory the publisher keeps its prover artifacts and wallet state in.
+    #[arg(
+        long,
+        env("MPC_MIDNIGHT_MANAGED_DIR"),
+        requires = "midnight_node_ws_url"
+    )]
+    pub midnight_managed_dir: Option<String>,
+    /// argv of the intent builder child process, JSON-encoded:
+    /// `["node","dist/main.js"]`.
+    ///
+    /// A JSON array in one clap value rather than a multi-value flag: clap's
+    /// multi-value forms keep consuming tokens until the next `--flag`, so an
+    /// argv element that itself looks like a flag would end the list and
+    /// `into_str_args` could not emit this flag ahead of another one and get
+    /// the same argv back. Delimiter splitting has the matching defect one
+    /// level down, making the delimiter unrepresentable inside an element;
+    /// JSON escapes instead of terminating, so every argv survives.
+    #[arg(
+        long,
+        env("MPC_MIDNIGHT_INTENT_GEN_COMMAND"),
+        requires = "midnight_node_ws_url"
+    )]
+    pub midnight_intent_gen_command: Option<String>,
+    /// Proof server URL. Required to respond: these contracts are zkir-v3 and
+    /// cannot be proven in process, so there is no local-proving deployment to
+    /// fall back to.
+    #[arg(
+        long,
+        env("MPC_MIDNIGHT_PROOF_SERVER_URL"),
+        requires = "midnight_node_ws_url"
+    )]
+    pub midnight_proof_server_url: Option<String>,
+    /// Indexer GraphQL URL. Required to respond: the funding wallet's spendable
+    /// DUST is only derivable by replaying every block's ledger events from
+    /// genesis, and no node RPC serves them.
+    #[arg(
+        long,
+        env("MPC_MIDNIGHT_INDEXER_URL"),
+        requires = "midnight_node_ws_url"
+    )]
+    pub midnight_indexer_url: Option<String>,
+    /// Indexer GraphQL subscription URL, the same service as above over a
+    /// websocket. Both, because the wallet catches up over one and follows over
+    /// the other.
+    #[arg(
+        long,
+        env("MPC_MIDNIGHT_INDEXER_WS_URL"),
+        requires = "midnight_node_ws_url"
+    )]
+    pub midnight_indexer_ws_url: Option<String>,
 }
 
 impl MidnightArgs {
     pub fn into_str_args(self) -> Vec<String> {
-        let mut args = Vec::with_capacity(8);
+        let mut args = Vec::with_capacity(16);
         if let Some(v) = self.midnight_node_ws_url {
             args.extend(["--midnight-node-ws-url".to_string(), v]);
         }
@@ -42,6 +100,24 @@ impl MidnightArgs {
         if let Some(v) = self.midnight_network_id {
             args.extend(["--midnight-network-id".to_string(), v]);
         }
+        if let Some(v) = self.midnight_funding_seed {
+            args.extend(["--midnight-funding-seed".to_string(), v]);
+        }
+        if let Some(v) = self.midnight_managed_dir {
+            args.extend(["--midnight-managed-dir".to_string(), v]);
+        }
+        if let Some(v) = self.midnight_intent_gen_command {
+            args.extend(["--midnight-intent-gen-command".to_string(), v]);
+        }
+        if let Some(v) = self.midnight_proof_server_url {
+            args.extend(["--midnight-proof-server-url".to_string(), v]);
+        }
+        if let Some(v) = self.midnight_indexer_url {
+            args.extend(["--midnight-indexer-url".to_string(), v]);
+        }
+        if let Some(v) = self.midnight_indexer_ws_url {
+            args.extend(["--midnight-indexer-ws-url".to_string(), v]);
+        }
         args
     }
 
@@ -49,7 +125,7 @@ impl MidnightArgs {
     /// Ethereum can validate by parsing into `Url`/`Address`/`PrivateKeySigner`,
     /// which make an invalid value unrepresentable; these fields are `String`,
     /// so the boundary check is `validate()` instead. clap's `requires_all`
-    /// only guarantees the four flags arrive together, never that
+    /// only guarantees the flags arrive together, never that
     /// `central_address` is 64 lowercase hex.
     pub fn into_config(self) -> anyhow::Result<Option<MidnightConfig>> {
         let (Some(node_ws_url), Some(central_address), Some(network_id)) = (
@@ -59,10 +135,48 @@ impl MidnightArgs {
         ) else {
             return Ok(None);
         };
+        // Start from the defaults and overwrite per supplied flag: the publisher
+        // tuning without flags (timeouts, restart backoff) has to keep its
+        // default, and an omitted flag must be indistinguishable from one.
+        let mut publisher = PublisherConfig::default();
+        // An omitted seed is legal rather than an error: Midnight runs
+        // indexer-only deployments, and forcing a read-only node to invent a
+        // credential it never spends puts a fake secret in a deployment. A
+        // seedless publisher is simply not registered.
+        if let Some(v) = self.midnight_funding_seed {
+            publisher.funding_seed = v;
+        }
+        if let Some(v) = self.midnight_managed_dir {
+            publisher.managed_dir = v;
+        }
+        if let Some(v) = self.midnight_intent_gen_command {
+            publisher.intent_gen_command = serde_json::from_str(&v).with_context(|| {
+                format!("midnight config: --midnight-intent-gen-command must be a JSON array of strings, got {v}")
+            })?;
+        }
+        if let Some(v) = self.midnight_proof_server_url {
+            publisher.proof_server_url = v;
+        }
+        if let Some(v) = self.midnight_indexer_url {
+            publisher.indexer_url = v;
+        }
+        if let Some(v) = self.midnight_indexer_ws_url {
+            publisher.indexer_ws_url = v;
+        }
+        // No flag of its own: the builder dials the same node this config already
+        // names, so a second flag would only be a second spelling of one value
+        // and a way for them to disagree. Copied only for a deployment that
+        // responds, because the child validates its submit half all-or-none, and
+        // the node URL alone would be the one value an indexer-only deployment
+        // handed it out of five.
+        if !publisher.funding_seed.is_empty() {
+            publisher.node_ws_url = node_ws_url.clone();
+        }
         let config = MidnightConfig {
             node_ws_url,
             central_address,
             network_id,
+            publisher,
             rpc: Default::default(),
             indexer: Default::default(),
         };
@@ -79,19 +193,49 @@ impl MidnightArgs {
                     node_ws_url,
                     central_address,
                     network_id,
+                    publisher,
                     rpc: _,
                     indexer: _,
                 } = c;
+                let PublisherConfig {
+                    funding_seed,
+                    managed_dir,
+                    intent_gen_command,
+                    proof_server_url,
+                    indexer_url,
+                    indexer_ws_url,
+                    // Emitted by no flag and rebuilt from `node_ws_url` above on
+                    // the way back in, which is the whole reason it has none.
+                    node_ws_url: _,
+                    request_timeout: _,
+                    restart_backoff: _,
+                    submit_timeout: _,
+                } = publisher;
                 MidnightArgs {
                     midnight_node_ws_url: Some(node_ws_url),
                     midnight_central_address: Some(central_address),
                     midnight_network_id: Some(network_id),
+                    midnight_funding_seed: Some(funding_seed),
+                    midnight_managed_dir: Some(managed_dir),
+                    midnight_intent_gen_command: Some(
+                        serde_json::to_string(&intent_gen_command)
+                            .expect("a Vec<String> always serializes"),
+                    ),
+                    midnight_proof_server_url: Some(proof_server_url),
+                    midnight_indexer_url: Some(indexer_url),
+                    midnight_indexer_ws_url: Some(indexer_ws_url),
                 }
             }
             None => MidnightArgs {
                 midnight_node_ws_url: None,
                 midnight_central_address: None,
                 midnight_network_id: None,
+                midnight_funding_seed: None,
+                midnight_managed_dir: None,
+                midnight_intent_gen_command: None,
+                midnight_proof_server_url: None,
+                midnight_indexer_url: None,
+                midnight_indexer_ws_url: None,
             },
         }
     }
@@ -103,23 +247,48 @@ mod tests {
     use clap::Parser as _;
     use mpc_chain_midnight::IndexerConfig;
 
+    /// A config whose publisher fields are all distinguishable from their
+    /// defaults, so an assertion against it cannot pass on a dropped flag.
+    fn configured() -> MidnightConfig {
+        MidnightConfig {
+            node_ws_url: "ws://127.0.0.1:9944".into(),
+            central_address: "ab".repeat(32),
+            network_id: "undeployed".into(),
+            publisher: PublisherConfig {
+                funding_seed: "0f".repeat(32),
+                managed_dir: "/var/lib/mpc/midnight".into(),
+                // A space and a leading dash in one argv, which only a
+                // structured encoding gets back out intact.
+                intent_gen_command: vec![
+                    "node".into(),
+                    "/opt/midnight publisher/dist/main.js".into(),
+                    "--managed-dir".into(),
+                ],
+                proof_server_url: "http://127.0.0.1:6300".into(),
+                indexer_url: "http://127.0.0.1:8088/api/v3/graphql".into(),
+                indexer_ws_url: "ws://127.0.0.1:8088/api/v3/graphql/ws".into(),
+                // Not a flag's doing: `into_config` copies it off
+                // `--midnight-node-ws-url`, so a fixture without it would fail
+                // the round trip on a field the CLI is right to have added.
+                node_ws_url: "ws://127.0.0.1:9944".into(),
+                ..Default::default()
+            },
+            rpc: Default::default(),
+            indexer: Default::default(),
+        }
+    }
+
     #[test]
     fn tuning_fields_do_not_survive_the_cli_round_trip() {
-        // Known limitation, pinned deliberately: only the four
-        // endpoint/identity fields have flags, so `from_config` discards the
-        // tuning sub-structs and `into_config` reinstates their defaults.
+        // Known limitation, pinned deliberately: only the endpoint/identity and
+        // publisher fields have flags, so `from_config` discards the tuning
+        // sub-structs and `into_config` reinstates their defaults.
         // `archive_probe_window` and `require_archive_state` therefore cannot
         // traverse a process restart. Adding real flags flips this into a
         // round-trip assert.
         crate::cli::tests::assert_midnight_env_unset();
 
-        let mut cfg = MidnightConfig {
-            node_ws_url: "ws://127.0.0.1:9944".into(),
-            central_address: "ab".repeat(32),
-            network_id: "undeployed".into(),
-            rpc: Default::default(),
-            indexer: Default::default(),
-        };
+        let mut cfg = configured();
         cfg.indexer.archive_probe_window = 77;
         cfg.indexer.require_archive_state = true;
         assert_ne!(
@@ -135,7 +304,7 @@ mod tests {
         .unwrap()
         .into_config()
         .expect("a valid config passes the boundary check")
-        .expect("all four flagged fields are set");
+        .expect("all the gating fields are set");
 
         assert_eq!(reparsed.node_ws_url, cfg.node_ws_url);
         assert_eq!(reparsed.central_address, cfg.central_address);
@@ -155,18 +324,123 @@ mod tests {
         // assertion would still pass.
         crate::cli::tests::assert_midnight_env_unset();
 
-        let cfg = MidnightConfig {
-            node_ws_url: "ws://127.0.0.1:9944".into(),
-            central_address: "ab".repeat(32),
-            network_id: "undeployed".into(),
-            rpc: Default::default(),
-            indexer: Default::default(),
-        };
+        let cfg = configured();
         let args = MidnightArgs::from_config(Some(cfg.clone()));
         let reparsed = MidnightArgs::try_parse_from(
             std::iter::once("test".to_string()).chain(args.clone().into_str_args()),
         )
         .unwrap();
         assert_eq!(reparsed.into_config().unwrap(), Some(cfg));
+    }
+
+    #[test]
+    fn the_publisher_flags_are_gated_on_the_node_ws_url() {
+        // Midnight is one config gate: supplying no `--midnight-*` flag means
+        // the chain never spawns. A publisher flag clap accepts on its own
+        // would let a node carry a funding seed and a proof server with no
+        // chain configured to spend them on, and nothing else here would
+        // notice, because `into_config` returns `None` on that path.
+        crate::cli::tests::assert_midnight_env_unset();
+
+        for flag in [
+            "--midnight-funding-seed",
+            "--midnight-managed-dir",
+            "--midnight-intent-gen-command",
+            "--midnight-proof-server-url",
+            "--midnight-indexer-url",
+            "--midnight-indexer-ws-url",
+        ] {
+            let err = MidnightArgs::try_parse_from(["test", flag, "x"])
+                .expect_err("clap must reject a publisher flag supplied on its own");
+            assert!(
+                err.to_string().contains("midnight-node-ws-url"),
+                "{flag} is not gated on the node ws url: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_builder_s_node_url_is_taken_from_the_one_flag_that_names_the_node() {
+        // Not a flag of its own, and this is the assertion that keeps it from
+        // becoming one: the builder dials the same node this config already
+        // names, so a second flag would be a second spelling of one value and a
+        // way for the two to disagree, which fails only on chain.
+        crate::cli::tests::assert_midnight_env_unset();
+
+        let cfg = configured();
+        let rendered = MidnightArgs::from_config(Some(cfg.clone())).into_str_args();
+        assert!(
+            !rendered.iter().any(|a| a.contains("publisher-node")),
+            "the builder's node url must render no flag of its own: {rendered:?}"
+        );
+
+        let reparsed =
+            MidnightArgs::try_parse_from(std::iter::once("test".to_string()).chain(rendered))
+                .unwrap()
+                .into_config()
+                .expect("a valid config passes the boundary check")
+                .expect("all the gating fields are set");
+        assert_eq!(reparsed.publisher.node_ws_url, cfg.node_ws_url);
+    }
+
+    #[test]
+    fn a_node_that_only_indexes_is_handed_no_endpoint_at_all() {
+        // The other half of the copy above, and the reason it is conditional.
+        // The child validates its submit half all-or-none and dies at boot on
+        // any subset, so an indexer-only deployment carrying the node url alone
+        // would be four values short of a builder that runs. It is never spawned
+        // one here, so it must not be configured for one either.
+        crate::cli::tests::assert_midnight_env_unset();
+
+        let mut cfg = configured();
+        cfg.publisher = Default::default();
+        let reparsed = MidnightArgs::try_parse_from(
+            std::iter::once("test".to_string())
+                .chain(MidnightArgs::from_config(Some(cfg.clone())).into_str_args()),
+        )
+        .unwrap()
+        .into_config()
+        .expect("a node with no seed and no endpoints is a legal deployment")
+        .expect("all the gating fields are set");
+
+        assert_eq!(reparsed.publisher, PublisherConfig::default());
+    }
+
+    #[test]
+    fn funding_seed_is_never_logged() {
+        // `cli::log_startup` prints the chain configs with `Debug`, so a seed
+        // that `Debug` renders is a seed in the node's startup log line and in
+        // every `?config` that follows.
+        let seed = "0123456789abcdef0123456789abcdef";
+        let mut cfg = configured();
+        cfg.publisher.funding_seed = seed.to_string();
+
+        let rendered = format!("{cfg:?}");
+        assert!(
+            !rendered.contains(seed),
+            "the funding seed reached Debug: {rendered}"
+        );
+        assert!(
+            rendered.contains("funding_seed"),
+            "the field must render redacted rather than vanish, or a later \
+             derive(Debug) reinstates the leak unnoticed: {rendered}"
+        );
+    }
+
+    #[test]
+    fn a_malformed_intent_gen_command_fails_at_the_config_boundary() {
+        // argv arrives as one opaque clap value, so the shape check has nowhere
+        // to happen but here; without it a typo would surface as a child
+        // process that never spawns, long after startup.
+        crate::cli::tests::assert_midnight_env_unset();
+
+        let mut args = MidnightArgs::from_config(Some(configured()));
+        args.midnight_intent_gen_command = Some("node dist/main.js".into());
+        let err = args.into_config().unwrap_err().to_string();
+
+        assert!(
+            err.contains("--midnight-intent-gen-command"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -37,7 +37,9 @@ use local_ip_address::local_ip;
 use mpc_chain_canton::{CantonClient, CantonConfig, CantonIndexer};
 use mpc_chain_ethereum::{publisher, EthConfig, EthereumIndexer};
 use mpc_chain_integration_core::ChainPublisher;
-use mpc_chain_midnight::{MidnightConfig, MidnightIndexer, MidnightPublisher};
+use mpc_chain_midnight::{
+    IntentGen, MidnightConfig, MidnightIndexer, MidnightPublisher, MidnightRpc,
+};
 use mpc_chain_near::NearClient;
 use mpc_chain_solana::{SolConfig, SolanaClient, SolanaIndexer};
 use mpc_keys::hpke;
@@ -46,6 +48,7 @@ use near_account_id::AccountId;
 use near_crypto::{InMemorySigner, PublicKey, SecretKey};
 use sha3::Digest;
 use tokio::sync::{mpsc, watch};
+use tokio_util::sync::CancellationToken;
 use url::Url;
 
 const DEFAULT_WEB_PORT: u16 = 3000;
@@ -531,15 +534,65 @@ impl ChainConfigs {
                 Err(e) => tracing::error!(%e, "failed to create canton client"),
             }
         }
-        // MidnightPublisher is a unit struct: there is no publish path yet, and
-        // its publish_signature bails so a request keeps retrying rather than
-        // settling as published.
-        if self.midnight.is_some() {
-            publishers.insert(Chain::Midnight, Arc::new(MidnightPublisher));
+        if let Some(midnight) = &self.midnight {
+            if let Some(client) = midnight_publisher(midnight).await {
+                publishers.insert(Chain::Midnight, client);
+            }
         }
 
         publishers
     }
+}
+
+/// The Midnight publisher, when this deployment has one.
+///
+/// Gated on the funding seed rather than on the chain being configured, which is the
+/// one place Midnight differs from the arms above it. `MidnightConfig::validate`
+/// deliberately accepts an empty seed: Midnight deploys indexer-only today, so every
+/// existing deployment supplies the endpoint flags and no seed, and making the seed
+/// mandatory would both break those deployments and force a node that never spends to
+/// invent a credential, putting a fake secret in a real deployment. The gate's shape is
+/// this repo's own, absent config means the component does not spawn rather than the
+/// node refuses to start.
+async fn midnight_publisher(config: &MidnightConfig) -> Option<Arc<MidnightPublisher>> {
+    if config.publisher.funding_seed.is_empty() {
+        // Loud, and at boot: an operator who meant to run a publisher and forgot the
+        // flag would otherwise learn about it from a signature that is indexed, routed
+        // and then never answered.
+        tracing::warn!(
+            "midnight is configured with no funding seed, so no midnight publisher is \
+             registered and this node will index midnight requests without answering \
+             them. Supply --midnight-funding-seed to register one."
+        );
+        return None;
+    }
+    match build_midnight_publisher(config).await {
+        Ok(publisher) => Some(Arc::new(publisher)),
+        Err(err) => {
+            tracing::error!(?err, "failed to create midnight publisher");
+            None
+        }
+    }
+}
+
+/// The publisher's own node connection and intent builder.
+///
+/// A second connection to the node the indexer also dials: `MidnightIndexer` opens its
+/// own inside `run()` and does not expose it. The builder is spawned only here, so this
+/// stays the single child process however many times it is asked for.
+async fn build_midnight_publisher(config: &MidnightConfig) -> anyhow::Result<MidnightPublisher> {
+    // Dialed before the builder is spawned, so a node this deployment cannot reach
+    // costs no child process.
+    let rpc = Arc::new(MidnightRpc::connect(config).await?);
+    let intent_gen = Arc::new(IntentGen::spawn(&config.publisher, &config.network_id).await?);
+    // This token is never cancelled. `MidnightPublisher::new` takes one so that a
+    // proving run in flight stops with the node instead of holding it open through
+    // shutdown, and THAT PROPERTY IS NOT DELIVERED HERE: the node has no process-wide
+    // shutdown token to thread in, because `run` coordinates shutdown by awaiting join
+    // handles and `run_supervised` mints a fresh token per indexer run. Delivering it
+    // means threading a real token from `run` down through `RpcHandles::new` to here.
+    // Until then a proving run in flight still runs to completion at shutdown.
+    MidnightPublisher::new(&config.publisher, rpc, intent_gen, CancellationToken::new())
 }
 
 /// Emit the single structured "starting node" banner describing this node's identity
@@ -933,6 +986,9 @@ async fn spawn_indexers(
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
+    use std::sync::Mutex;
+
+    use mpc_chain_midnight::PublisherConfig;
 
     use super::*;
 
@@ -1131,6 +1187,12 @@ mod tests {
             "MPC_MIDNIGHT_NODE_WS_URL",
             "MPC_MIDNIGHT_CENTRAL_ADDRESS",
             "MPC_MIDNIGHT_NETWORK_ID",
+            "MPC_MIDNIGHT_FUNDING_SEED",
+            "MPC_MIDNIGHT_MANAGED_DIR",
+            "MPC_MIDNIGHT_INTENT_GEN_COMMAND",
+            "MPC_MIDNIGHT_PROOF_SERVER_URL",
+            "MPC_MIDNIGHT_INDEXER_URL",
+            "MPC_MIDNIGHT_INDEXER_WS_URL",
         ] {
             assert!(
                 std::env::var_os(var).is_none(),
@@ -1150,6 +1212,8 @@ mod tests {
 
         let account_sk = SecretKey::from_seed(near_crypto::KeyType::ED25519, "test").to_string();
         let central_address = "ab".repeat(32);
+        let funding_seed = "0f".repeat(32);
+        let intent_gen_command = r#"["node","dist/main.js"]"#;
         let argv = [
             "mpc-node",
             "start",
@@ -1171,6 +1235,14 @@ mod tests {
             &central_address,
             "--midnight-network-id",
             "undeployed",
+            "--midnight-funding-seed",
+            &funding_seed,
+            "--midnight-managed-dir",
+            "/var/lib/mpc/midnight",
+            "--midnight-intent-gen-command",
+            intent_gen_command,
+            "--midnight-proof-server-url",
+            "http://127.0.0.1:6300",
         ];
         let out = Cli::try_parse_from(argv).unwrap().into_str_args();
 
@@ -1181,12 +1253,129 @@ mod tests {
             central_address.as_str(),
             "--midnight-network-id",
             "undeployed",
+            "--midnight-funding-seed",
+            funding_seed.as_str(),
+            "--midnight-managed-dir",
+            "/var/lib/mpc/midnight",
+            "--midnight-intent-gen-command",
+            intent_gen_command,
+            "--midnight-proof-server-url",
+            "http://127.0.0.1:6300",
         ] {
             assert!(
                 out.contains(&expected.to_string()),
                 "into_str_args dropped {expected}"
             );
         }
+    }
+
+    /// Never dialed: `publishers()` only stores the client in the registry.
+    fn near_client() -> NearClient {
+        let account_id = AccountId::from_str("test.near").unwrap();
+        let signer = InMemorySigner::from_secret_key(
+            account_id.clone(),
+            SecretKey::from_seed(near_crypto::KeyType::ED25519, "test"),
+        );
+        NearClient::new(
+            "http://127.0.0.1:1",
+            &account_id,
+            signer,
+            Arc::new(NodeTelemetry::new(Chain::NEAR)),
+        )
+    }
+
+    /// Collects what a `tracing` subscriber writes, so a test can assert on a startup
+    /// line. The publisher gate's whole output when it declines is that line, so
+    /// without this the decision is unobservable and only its absence from the
+    /// registry could be checked, which an unreachable node also produces.
+    #[derive(Clone, Default)]
+    struct LogSink(Arc<Mutex<Vec<u8>>>);
+
+    impl LogSink {
+        fn text(&self) -> String {
+            String::from_utf8_lossy(&self.0.lock().unwrap()).into_owned()
+        }
+    }
+
+    impl std::io::Write for LogSink {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for LogSink {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// A fully configured Midnight deployment whose publisher the caller decides. Every
+    /// other field is held equal across the tests below.
+    fn midnight_args(publisher: PublisherConfig) -> MidnightArgs {
+        MidnightArgs::from_config(Some(MidnightConfig {
+            // Port 1 is privileged and unbound, so the dial is refused rather than
+            // left to a timeout.
+            node_ws_url: "ws://127.0.0.1:1".to_string(),
+            central_address: "ab".repeat(32),
+            network_id: "undeployed".to_string(),
+            publisher,
+            rpc: Default::default(),
+            indexer: Default::default(),
+        }))
+    }
+
+    /// A node that answers as well as indexes.
+    ///
+    /// The seed does not travel alone: the child validates the seed and the endpoints
+    /// the funding wallet reaches the chain through as one all-or-none set, so this and
+    /// `PublisherConfig::default()` differ by every one of them rather than by the seed.
+    /// `node_ws_url` is absent because it has no flag to survive `from_config` in;
+    /// `into_config` copies it off the node url above.
+    fn responding_publisher() -> PublisherConfig {
+        PublisherConfig {
+            funding_seed: "0f".repeat(32),
+            proof_server_url: "http://127.0.0.1:6300".to_string(),
+            indexer_url: "http://127.0.0.1:8088/api/v3/graphql".to_string(),
+            indexer_ws_url: "ws://127.0.0.1:8088/api/v3/graphql/ws".to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// `publishers()` over a Midnight-only config, with everything it logged at WARN
+    /// or above.
+    async fn publishers_with_logs(
+        midnight: MidnightArgs,
+    ) -> (HashMap<Chain, Arc<dyn ChainPublisher>>, String) {
+        let chains = ChainConfigs::from_args(
+            EthArgs::from_config(None),
+            SolArgs::from_config(None),
+            HydrationArgs::from_config(None),
+            CantonArgs::from_config(None),
+            midnight,
+        )
+        .unwrap();
+
+        let sink = LogSink::default();
+        let publishers = {
+            // `#[tokio::test]` runs on a current-thread runtime, so the awaits below
+            // stay on the thread this thread-local guard was installed on.
+            let _guard = tracing::subscriber::set_default(
+                tracing_subscriber::fmt()
+                    .with_writer(sink.clone())
+                    .with_ansi(false)
+                    .with_max_level(tracing::Level::WARN)
+                    .finish(),
+            );
+            chains.publishers(near_client()).await
+        };
+        (publishers, sink.text())
     }
 
     /// The Midnight config gate: with no Midnight flags supplied, the chain
@@ -1211,19 +1400,7 @@ mod tests {
             "empty MidnightArgs must not produce a MidnightConfig"
         );
 
-        let account_id = AccountId::from_str("test.near").unwrap();
-        let signer = InMemorySigner::from_secret_key(
-            account_id.clone(),
-            SecretKey::from_seed(near_crypto::KeyType::ED25519, "test"),
-        );
-        // Never dialed: publishers() only stores the client in the registry.
-        let near = NearClient::new(
-            "http://127.0.0.1:1",
-            &account_id,
-            signer,
-            Arc::new(NodeTelemetry::new(Chain::NEAR)),
-        );
-        let publishers = chains.publishers(near).await;
+        let publishers = chains.publishers(near_client()).await;
 
         assert!(
             !publishers.contains_key(&Chain::Midnight),
@@ -1235,5 +1412,54 @@ mod tests {
             "with no chain configured, only the NEAR publisher must exist"
         );
         assert!(publishers.contains_key(&Chain::NEAR));
+    }
+
+    /// The publisher gate. `MidnightConfig::validate` accepts an empty funding seed
+    /// because every Midnight deployment today is indexer-only, so a seedless node is
+    /// a supported configuration and must start: it simply registers no publisher.
+    /// Nothing else in the tree pins that, and a refactor tidying the arm into
+    /// `if self.midnight.is_some()` would register a publisher with no wallet behind
+    /// it, which fails per signature instead of once at boot.
+    #[tokio::test]
+    async fn midnight_without_a_funding_seed_registers_no_publisher() {
+        assert_midnight_env_unset();
+
+        let (publishers, logs) = publishers_with_logs(midnight_args(Default::default())).await;
+
+        assert!(
+            !publishers.contains_key(&Chain::Midnight),
+            "a midnight deployment with no funding seed must register no publisher"
+        );
+        assert!(
+            logs.contains("--midnight-funding-seed"),
+            "the warning must name the flag that would enable the publisher, or an \
+             operator who forgot it learns from an unanswered signature: {logs}"
+        );
+        assert!(
+            !logs.contains("failed to create midnight publisher"),
+            "the seed is checked before anything is dialed or spawned: {logs}"
+        );
+    }
+
+    /// The other side of that gate. A seed opens it, and construction is then attempted
+    /// against the node: `MidnightRpc::connect` fetches subxt metadata at construction,
+    /// so no publisher can be built here without a running node, and the observable
+    /// difference from the seedless case is which of the two lines is logged. Building
+    /// against a live node is an integration concern.
+    #[tokio::test]
+    async fn a_funding_seed_opens_the_midnight_publisher_gate() {
+        assert_midnight_env_unset();
+
+        let (_publishers, logs) = publishers_with_logs(midnight_args(responding_publisher())).await;
+
+        assert!(
+            !logs.contains("--midnight-funding-seed"),
+            "a seeded deployment must not be told its publisher went unregistered: {logs}"
+        );
+        assert!(
+            logs.contains("failed to create midnight publisher"),
+            "a seeded deployment must go on to build the publisher, and this one has no \
+             node to build it against: {logs}"
+        );
     }
 }


### PR DESCRIPTION
The TypeScript sidecar owned the whole respond path behind an HTTP API: it read the chain, ran the circuit, proved, balanced, signed and submitted. The node reads Midnight state natively now, so most of that no longer needs a second process. Two things genuinely cannot move: running the Compact circuit to obtain its Impact transcript, because compactc emits TypeScript and nothing else, and the funding wallet, whose spendable DUST is derived by replaying every block's ledger events from genesis and which no Rust crate rebuilds. This PR makes the node own everything above that seam.

- `intent_gen.rs` is the child client: one JSON line each way over stdio, one child reused across requests, and a respawn-and-retry that applies to `build` (idempotent) and never to `submit`, because retrying a submit can put two transactions on chain for one signature.
- `publisher.rs` pins a finalized block for its reads, so the intent is built against a state the chain has agreed on, and treats the bytes the child returns as opaque rather than round-tripping them through a decoder it would then have to trust.
- `config.rs` validates the five submit settings all-or-none: a deployment that only indexes still starts, and a typo'd endpoint fails at startup rather than on the first real signature. Its `Debug` renders field names and never values, because one of the five is a spending key.
- `tests/intent_seam.rs` drives the real child and asserts on the decoded call rather than the bytes. The builder samples a fresh communication commitment per call, so its output is deliberately not byte-deterministic: a fixed commitment would be a privacy regression, not a convenience.
- `tests/respond_live.rs` files a response on a local chain and reads it back out of contract state at a finalized height.

Depends on the TypeScript half in #1058, which is where `dist/main.js` comes from.

Based on `feat/midnight-indexer` rather than `feat/midnight-publisher`: `chain-signatures/chain-midnight` does not exist on the publisher branch, so there is nothing there for this diff to modify. Retarget if the crate moves down the stack.

Two things left open for review rather than decided here: `MidnightPublisher::new` takes a `CancellationToken` that nothing ever cancels, and `publish_signature` returns `Result<()>`, so the transaction id reaches only a log line and no caller can act on it.
