### PR TITLE
fix: cap candidate join url length

### DIFF
--- a/chain-signatures/contract/src/errors/impls.rs
+++ b/chain-signatures/contract/src/errors/impls.rs
@@ -72,6 +72,15 @@ impl From<JoinError> for Error {
     }
 }
 
+impl JoinError {
+    pub(crate) fn message<T>(self, msg: T) -> Error
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        Error::message(ErrorKind::Join(self), msg)
+    }
+}
+
 impl From<PublicKeyError> for Error {
     fn from(code: PublicKeyError) -> Self {
         Self::simple(ErrorKind::PublicKey(code))

--- a/chain-signatures/contract/src/errors/mod.rs
+++ b/chain-signatures/contract/src/errors/mod.rs
@@ -35,6 +35,8 @@ pub enum JoinError {
     JoinAlreadyParticipant,
     #[error("Account to revoke is not in the candidate set.")]
     RevokeNotCandidate,
+    #[error("Candidate URL is too long.")]
+    UrlTooLong,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, thiserror::Error)]

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -57,6 +57,9 @@ const UPDATE_CONFIG_GAS: Gas = Gas::from_tgas(5);
 // Maximum number of concurrent requests
 const MAX_CONCURRENT_REQUESTS: u32 = 128;
 
+/// Maximum accepted byte length for a candidate node URL.
+pub const MAX_JOIN_URL_LEN: usize = 2048;
+
 #[near_bindgen]
 #[derive(BorshDeserialize, BorshSerialize, Debug)]
 pub enum VersionedMpcContract {
@@ -303,6 +306,14 @@ impl VersionedMpcContract {
         cipher_pk: primitives::hpke::PublicKey,
         sign_pk: PublicKey,
     ) -> Result<(), Error> {
+        let url_len = url.len();
+        if url_len > MAX_JOIN_URL_LEN {
+            return Err(JoinError::UrlTooLong.message(format!(
+                "Provided {}, maximum {}",
+                url_len, MAX_JOIN_URL_LEN,
+            )));
+        }
+
         log!(
             "join: signer={}, url={}, cipher_pk={:?}, sign_pk={:?}",
             env::signer_account_id(),

--- a/chain-signatures/contract/tests/vote.rs
+++ b/chain-signatures/contract/tests/vote.rs
@@ -57,6 +57,25 @@ async fn test_join() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_join_rejects_oversized_url() -> anyhow::Result<()> {
+    let (worker, contract, _, _) = init_env().await;
+    let alice = worker.dev_create_account().await?;
+
+    let execution = alice
+        .call(contract.id(), "join")
+        .args_json(json!({
+            "url": "a".repeat(mpc_contract::MAX_JOIN_URL_LEN + 1),
+            "cipher_pk": vec![1u8; 32],
+            "sign_pk": "ed25519:J75xXmF7WUPS3xCm3hy2tgwLCKdYM1iJd4BWF8sWVnae",
+        }))
+        .transact()
+        .await?;
+
+    assert!(execution.is_failure());
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_remove_candidacy() -> anyhow::Result<()> {
     let (worker, contract, accounts, _) = init_env().await;
 


### PR DESCRIPTION
part 1 of fixing https://github.com/sig-net/mpc-private/issues/33
another PR with vote_remove_candidates that can restore our contract state and storage stake will come in a separate PR