### PR TITLE
Collapses the two posit buffers + refactoring

### DIFF
--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -57,19 +57,19 @@ pub enum PositAction {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Copy, Hash)]
 pub enum PositRejectReason {
-    Unknown = 0,
+    Unknown,
     /// The node is already participating in a generation, or has already
     /// finished generation.
-    AlreadyGenerating = 1,
+    AlreadyGenerating,
     /// The node cannot participate because it doesn't have the required
     /// artifact.
-    MissingArtifact = 2,
+    MissingArtifact,
     /// The posit message is invalid, usually because of bad timing leading to
     /// round / proposer mismatches.
-    InvalidRequest = 3,
-    /// The sender's round is behind the rejector's current round. The reject
-    /// carries the rejector's round so the sender can catch up in one bump.
-    StaleRound = 4,
+    InvalidRequest,
+    /// The message's round is behind the rejector's current round, carried
+    /// here so the sender can catch up in one bump.
+    StaleRound(usize),
 }
 
 impl PositAction {

--- a/chain-signatures/node/src/protocol/request/mailbox.rs
+++ b/chain-signatures/node/src/protocol/request/mailbox.rs
@@ -86,7 +86,7 @@ mod tests {
         mailbox.push(posit(1, 0, PositAction::Propose));
         mailbox.push(posit(2, 3, PositAction::Accept));
 
-        let mut got = vec![
+        let mut got = [
             mailbox.try_recv().expect("sender 1"),
             mailbox.try_recv().expect("sender 2"),
         ];

--- a/chain-signatures/node/src/protocol/request/mailbox.rs
+++ b/chain-signatures/node/src/protocol/request/mailbox.rs
@@ -8,17 +8,15 @@ use std::sync::Arc;
 use cait_sith::protocol::Participant;
 use tokio::sync::Notify;
 
-/// Posit messages routed to a running signature task.
-pub(crate) enum SignTaskMessage {
-    PositMessage {
-        presignature_id: PresignatureId,
-        round: usize,
-        from: Participant,
-        action: PositAction,
-    },
+/// A posit message routed to a signature task.
+pub(crate) struct SignPositMessage {
+    pub presignature_id: PresignatureId,
+    pub round: usize,
+    pub from: Participant,
+    pub action: PositAction,
 }
 
-/// Work queue for posit messages, keyed by sending participant.
+/// Mailbox holding the latest posit message per sending participant.
 ///
 /// A message for round N from sender P replaces any earlier message from P.
 ///
@@ -29,13 +27,13 @@ pub(crate) enum SignTaskMessage {
 ///   here. But we can't get a `Start` message for a round that we haven't already
 ///   responded to a `Propose` message. Therefore, one message per round is all we
 ///   need to buffer.
-pub(crate) struct SignPositWorkQueue {
+pub(crate) struct PositMailbox {
     // using std Mutex here, do not hold across .await
-    messages: std::sync::Mutex<HashMap<Participant, SignTaskMessage>>,
+    messages: std::sync::Mutex<HashMap<Participant, SignPositMessage>>,
     notify: Notify,
 }
 
-impl SignPositWorkQueue {
+impl PositMailbox {
     pub(crate) fn new() -> Arc<Self> {
         Arc::new(Self {
             messages: std::sync::Mutex::new(HashMap::new()),
@@ -45,8 +43,8 @@ impl SignPositWorkQueue {
 
     /// Buffer `msg` in its sender's slot, overwriting when its round is `>=` the
     /// buffered one, then wake one consumer.
-    pub(crate) fn push(&self, msg: SignTaskMessage) {
-        let SignTaskMessage::PositMessage {
+    pub(crate) fn push(&self, msg: SignPositMessage) {
+        let SignPositMessage {
             from,
             round: new_round,
             ..
@@ -55,7 +53,7 @@ impl SignPositWorkQueue {
         let mut inserted = false;
         match guard.entry(from) {
             Entry::Occupied(mut occupied_entry) => {
-                let SignTaskMessage::PositMessage {
+                let SignPositMessage {
                     round: existing, ..
                 } = occupied_entry.get();
 
@@ -76,14 +74,14 @@ impl SignPositWorkQueue {
         }
     }
 
-    fn try_recv(&self) -> Option<SignTaskMessage> {
+    fn try_recv(&self) -> Option<SignPositMessage> {
         let mut guard = self.messages.lock().unwrap();
         let key = guard.keys().next().copied()?;
         guard.remove(&key)
     }
 
     /// Wait for the next available posit message.
-    pub(crate) async fn recv(&self) -> SignTaskMessage {
+    pub(crate) async fn recv(&self) -> SignPositMessage {
         loop {
             // Register for wakeup BEFORE checking to avoid races with a push.
             let notified = self.notify.notified();

--- a/chain-signatures/node/src/protocol/request/mailbox.rs
+++ b/chain-signatures/node/src/protocol/request/mailbox.rs
@@ -1,7 +1,6 @@
 use crate::protocol::posit::PositAction;
 use crate::protocol::presignature::PresignatureId;
 
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -16,17 +15,11 @@ pub(crate) struct SignPositMessage {
     pub action: PositAction,
 }
 
-/// Mailbox holding the latest posit message per sending participant.
+/// Mailbox holding the latest posit message per sending participant — a
+/// sender's newest message supersedes its previous one.
 ///
-/// A message for round N from sender P replaces any earlier message from P.
-///
-/// Only a single message per round and sender buffered. This is enough because:
-///
-/// - When we are proposer for a round, only Reject or Accept will be sent to us.
-/// - When we are deliberator, we can only receive `Propose` or `Start` messages
-///   here. But we can't get a `Start` message for a round that we haven't already
-///   responded to a `Propose` message. Therefore, one message per round is all we
-///   need to buffer.
+/// Deliberately round-agnostic: arrival order decides, never rounds (which can
+/// legitimately go down after a reset). Round classification is the task's job.
 pub(crate) struct PositMailbox {
     // using std Mutex here, do not hold across .await
     messages: std::sync::Mutex<HashMap<Participant, SignPositMessage>>,
@@ -41,37 +34,12 @@ impl PositMailbox {
         })
     }
 
-    /// Buffer `msg` in its sender's slot, overwriting when its round is `>=` the
-    /// buffered one, then wake one consumer.
+    /// Store `msg` in its sender's slot — last arrived wins — then wake one
+    /// consumer.
     pub(crate) fn push(&self, msg: SignPositMessage) {
-        let SignPositMessage {
-            from,
-            round: new_round,
-            ..
-        } = msg;
-        let mut guard = self.messages.lock().unwrap();
-        let mut inserted = false;
-        match guard.entry(from) {
-            Entry::Occupied(mut occupied_entry) => {
-                let SignPositMessage {
-                    round: existing, ..
-                } = occupied_entry.get();
-
-                if new_round >= *existing {
-                    occupied_entry.insert(msg);
-                    inserted = true;
-                }
-            }
-            Entry::Vacant(vacant_entry) => {
-                vacant_entry.insert(msg);
-                inserted = true;
-            }
-        }
-        drop(guard);
+        self.messages.lock().unwrap().insert(msg.from, msg);
         // Wake up potential work consumers. (after releasing the lock)
-        if inserted {
-            self.notify.notify_one();
-        }
+        self.notify.notify_one();
     }
 
     fn try_recv(&self) -> Option<SignPositMessage> {
@@ -90,5 +58,59 @@ impl PositMailbox {
             }
             notified.await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn posit(from: u32, round: usize, action: PositAction) -> SignPositMessage {
+        SignPositMessage {
+            presignature_id: 0,
+            round,
+            from: Participant::from(from),
+            action,
+        }
+    }
+
+    /// One slot per sender, last arrived wins — regardless of rounds. A lower
+    /// round can legitimately arrive after a higher one (peers restart at
+    /// round 0 after a governance change) and must not be silenced; judging
+    /// rounds is the task's job.
+    #[test]
+    fn one_slot_per_sender_last_arrived_wins() {
+        let mailbox = PositMailbox::new();
+        mailbox.push(posit(1, 5, PositAction::Propose));
+        mailbox.push(posit(1, 5, PositAction::Accept));
+        mailbox.push(posit(1, 0, PositAction::Propose));
+        mailbox.push(posit(2, 3, PositAction::Accept));
+
+        let mut got = vec![
+            mailbox.try_recv().expect("sender 1"),
+            mailbox.try_recv().expect("sender 2"),
+        ];
+        got.sort_by_key(|msg| u32::from(msg.from));
+        assert!(matches!(got[0].action, PositAction::Propose));
+        assert_eq!(got[0].round, 0, "round 0 must replace the round-5 slot");
+        assert_eq!(got[1].round, 3);
+        assert!(mailbox.try_recv().is_none());
+    }
+
+    #[tokio::test]
+    async fn recv_wakes_on_push() {
+        let mailbox = PositMailbox::new();
+        let consumer = {
+            let mailbox = Arc::clone(&mailbox);
+            tokio::spawn(async move { mailbox.recv().await })
+        };
+        tokio::task::yield_now().await;
+        mailbox.push(posit(3, 1, PositAction::Accept));
+
+        let got = tokio::time::timeout(std::time::Duration::from_secs(1), consumer)
+            .await
+            .expect("recv should wake on push")
+            .unwrap();
+        assert_eq!(got.from, Participant::from(3));
     }
 }

--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -32,17 +32,17 @@ use tokio::sync::{mpsc, watch, OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinHandle;
 
 mod limiter;
+mod mailbox;
 mod metrics;
 mod organize;
 mod posit;
 mod state;
 mod task;
-mod work_queue;
 
 use limiter::SignLimiter;
 use task::SignTask;
 
-pub(crate) use work_queue::{SignPositWorkQueue, SignTaskMessage};
+pub(crate) use mailbox::{PositMailbox, SignPositMessage};
 
 /// How many rounds ahead the organizing phase searches for an active proposer.
 const PROPOSER_SEARCH_WINDOW: usize = 512;
@@ -62,7 +62,7 @@ const ORGANIZE_POSIT_TIMEOUT: Duration = Duration::from_secs(if cfg!(feature = "
 const ACCEPT_POSIT_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Upper bound on the number of recently-completed/aborted sign IDs we remember
-/// so that late-arriving peer posit messages do not re-create orphan queues.
+/// so that late-arriving peer posit messages do not re-create orphan mailboxes.
 const MAX_DEAD_IDS: usize = 4096;
 
 /// A retained in-flight request. `is_proposer` is shared with the current
@@ -73,7 +73,7 @@ struct SignEntry {
 }
 
 /// Router and lifecycle owner for all in-flight sign tasks: one task per
-/// `sign_id`, plus the posit queues, delayed-response watchers, and dedup state
+/// `sign_id`, plus the posit mailboxes, delayed-response watchers, and dedup state
 /// that outlive individual tasks. (TODO: needs refactoring)
 pub struct SignatureSpawner {
     contract: ContractStateWatcher,
@@ -81,14 +81,14 @@ pub struct SignatureSpawner {
     presignatures: PresignatureStorage,
     /// Consolidated signature tasks - one per sign_id, each task is an async task handling complete lifecycle
     tasks: JoinMap<SignId, Result<(), SignError>>,
-    /// Per-sign posit queues; also buffer messages that arrive before their
+    /// Per-sign posit mailboxes; also buffer messages that arrive before their
     /// task spawns.
-    posit_queues: HashMap<SignId, Arc<SignPositWorkQueue>>,
+    posit_mailboxes: HashMap<SignId, Arc<PositMailbox>>,
     /// Watchers that increment the delayed metric when response time exceeds expected.
     delayed_watchers: HashMap<SignId, JoinHandle<()>>,
     /// In-flight requests: enables chain-scoped abort and respawning.
     requests: HashMap<SignId, SignEntry>,
-    /// Recently completed/aborted sign IDs; prevents late peer posit messages from recreating orphan queues.
+    /// Recently completed/aborted sign IDs; prevents late peer posit messages from recreating orphan mailboxes.
     dead_ids: LruCache<SignId, ()>,
     mesh_state: watch::Receiver<MeshState>,
     /// Caps concurrent sign-task progress so requests don't flood the system's compute.
@@ -181,12 +181,12 @@ impl SignatureSpawner {
             .map(|entry| Arc::clone(&entry.is_proposer))
             .expect("sign request entry must exist when spawning its task");
 
-        // Take (or create) the posit queue; it may already hold messages
+        // Take (or create) the posit mailbox; it may already hold messages
         // that arrived before this task spawned.
-        let posit_queue = Arc::clone(
-            self.posit_queues
+        let mailbox = Arc::clone(
+            self.posit_mailboxes
                 .entry(sign_id)
-                .or_insert_with(SignPositWorkQueue::new),
+                .or_insert_with(PositMailbox::new),
         );
 
         let task = SignTask {
@@ -203,14 +203,12 @@ impl SignatureSpawner {
         };
 
         // Spawn the async task with organizing loop
-        self.tasks.spawn(
-            sign_id,
-            task.run(request, self.mesh_state.clone(), posit_queue),
-        );
+        self.tasks
+            .spawn(sign_id, task.run(request, self.mesh_state.clone(), mailbox));
     }
 
     /// Spawn a fresh incarnation for every retained request; the caller must
-    /// have aborted previous incarnations. Not a retirement: queues,
+    /// have aborted previous incarnations. Not a retirement: mailboxes,
     /// watchers, and dedup state survive.
     fn spawn_tasks(&mut self, governance: &GovernanceInfo, cfg: &ProtocolConfig) {
         let requests: Vec<IndexedSignRequest> = self
@@ -237,14 +235,14 @@ impl SignatureSpawner {
         action: PositAction,
     ) {
         // Drop late-arriving posits for already-completed/aborted sign IDs
-        // to prevent re-creating orphan queues.
+        // to prevent re-creating orphan mailboxes.
         if self.dead_ids.contains(&sign_id) {
             return;
         }
-        self.posit_queues
+        self.posit_mailboxes
             .entry(sign_id)
-            .or_insert_with(SignPositWorkQueue::new)
-            .push(SignTaskMessage::PositMessage {
+            .or_insert_with(PositMailbox::new)
+            .push(SignPositMessage {
                 presignature_id,
                 round,
                 from,
@@ -285,7 +283,7 @@ impl SignatureSpawner {
     }
 
     /// Record a sign ID as dead so that late-arriving peer posits are dropped
-    /// instead of recreating an orphan queue. Automatically LRU-evicts the
+    /// instead of recreating an orphan mailbox. Automatically LRU-evicts the
     /// stalest entry when the cache exceeds [`MAX_DEAD_IDS`].
     fn mark_dead(&mut self, sign_id: SignId) {
         self.dead_ids.put(sign_id, ());
@@ -301,12 +299,12 @@ impl SignatureSpawner {
         }
     }
 
-    /// Common teardown when a sign task ends: forget the id, drop its queue and
+    /// Common teardown when a sign task ends: forget the id, drop its mailbox and
     /// its delayed watcher. Does not touch `tasks` (aborting varies per caller).
     fn retire_task(&mut self, sign_id: SignId, reason: &str) {
         self.mark_dead(sign_id);
         self.requests.remove(&sign_id);
-        self.posit_queues.remove(&sign_id);
+        self.posit_mailboxes.remove(&sign_id);
         self.abort_delayed_watcher(sign_id, reason);
     }
 
@@ -324,7 +322,7 @@ impl SignatureSpawner {
                 let sign_id = request.id;
 
                 // Skip requests we already track. Use the request map rather than
-                // the queue map, which may already hold buffered messages (e.g. a
+                // the mailbox map, which may already hold buffered messages (e.g. a
                 // Propose arriving before the indexer notifies us), and rather than
                 // the task map, which is empty while requests are held for governance.
                 if self.requests.contains_key(&sign_id) {
@@ -422,8 +420,8 @@ impl SignatureSpawner {
         self.dead_ids.contains(sign_id)
     }
 
-    fn test_posit_queues_contains(&self, sign_id: &SignId) -> bool {
-        self.posit_queues.contains_key(sign_id)
+    fn test_posit_mailboxes_contains(&self, sign_id: &SignId) -> bool {
+        self.posit_mailboxes.contains_key(sign_id)
     }
 
     fn test_tasks_contains(&self, sign_id: SignId) -> bool {
@@ -462,7 +460,7 @@ impl SignatureSpawnerTask {
         let spawner = SignatureSpawner {
             contract,
             tasks: JoinMap::new(),
-            posit_queues: HashMap::new(),
+            posit_mailboxes: HashMap::new(),
             delayed_watchers: HashMap::new(),
             requests: HashMap::new(),
             dead_ids: LruCache::new(NonZeroUsize::new(MAX_DEAD_IDS).unwrap()),
@@ -541,7 +539,7 @@ mod tests {
             contract,
             presignatures,
             tasks: JoinMap::new(),
-            posit_queues: HashMap::new(),
+            posit_mailboxes: HashMap::new(),
             delayed_watchers: HashMap::new(),
             requests: HashMap::new(),
             dead_ids: LruCache::new(NonZeroUsize::new(MAX_DEAD_IDS).unwrap()),
@@ -564,39 +562,39 @@ mod tests {
         };
         let request = IndexedSignRequest::sign(sign_id, args, Chain::Solana, 0);
 
-        // Step 1: Spawn → queue created, request retained, not dead
+        // Step 1: Spawn → mailbox created, request retained, not dead
         spawner.add_request(&governance, request.clone(), cfg.clone());
         assert!(spawner.test_tasks_contains(sign_id));
-        assert!(spawner.test_posit_queues_contains(&sign_id));
+        assert!(spawner.test_posit_mailboxes_contains(&sign_id));
         assert!(spawner.test_requests_contains(&sign_id));
         assert!(!spawner.test_dead_ids_contains(&sign_id));
 
-        // Step 2: Abort chain → queue removed, request dropped, marked dead
+        // Step 2: Abort chain → mailbox removed, request dropped, marked dead
         spawner.handle_sign(&governance, SignCommand::AbortChain(Chain::Solana), &cfg);
         assert!(!spawner.test_tasks_contains(sign_id));
-        assert!(!spawner.test_posit_queues_contains(&sign_id));
+        assert!(!spawner.test_posit_mailboxes_contains(&sign_id));
         assert!(!spawner.test_requests_contains(&sign_id));
         assert!(spawner.test_dead_ids_contains(&sign_id));
 
-        // Step 3: Late posit → dropped (dead_id check), queue NOT recreated
+        // Step 3: Late posit → dropped (dead_id check), mailbox NOT recreated
         spawner.handle_posit(sign_id, 0, 0, Participant::from(1), PositAction::Propose);
-        assert!(!spawner.test_posit_queues_contains(&sign_id));
+        assert!(!spawner.test_posit_mailboxes_contains(&sign_id));
 
         // Step 4: Re-spawn → dead cleared, request retained again
         spawner.add_request(&governance, request, cfg.clone());
         assert!(spawner.test_tasks_contains(sign_id));
         assert!(!spawner.test_dead_ids_contains(&sign_id));
 
-        // Step 5: Posit after re-spawn → accepted, queue re-created
+        // Step 5: Posit after re-spawn → accepted, mailbox re-created
         spawner.handle_posit(sign_id, 0, 0, Participant::from(1), PositAction::Propose);
-        assert!(spawner.test_posit_queues_contains(&sign_id));
+        assert!(spawner.test_posit_mailboxes_contains(&sign_id));
 
         // Step 6: Governance respawn → task swapped in place, nothing retired.
         spawner.tasks.abort_all();
         spawner.spawn_tasks(&governance, &cfg);
         assert!(spawner.test_tasks_contains(sign_id));
         assert!(spawner.test_requests_contains(&sign_id));
-        assert!(spawner.test_posit_queues_contains(&sign_id));
+        assert!(spawner.test_posit_mailboxes_contains(&sign_id));
         assert!(!spawner.test_dead_ids_contains(&sign_id));
     }
 }

--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -36,6 +36,21 @@ impl PositPhase {
                     round: peer_round,
                 } = &task_msg;
 
+                // A StaleRound reject carries the rejector's current round;
+                // remember it so our next bump catches up in one step.
+                if let PositAction::RejectWithReason(PositRejectReason::StaleRound(peer_current)) =
+                    action
+                {
+                    state.highest_seen_round = state.highest_seen_round.max(*peer_current);
+                }
+
+                // Nothing else to do with a Reject: a deliberator has sent
+                // nothing that could be rejected, and answering one would
+                // ping-pong rejects between two nodes.
+                if matches!(action, PositAction::RejectWithReason(_)) {
+                    continue;
+                }
+
                 // reject any messages with a different round than ours
                 //
                 // note: Rejecting messages of older rounds is always the right
@@ -44,19 +59,27 @@ impl PositPhase {
                 // that higher round, or else any peer could force themselves to
                 // be the proposer every time.
                 if state.round > *peer_round {
+                    tracing::info!(
+                        ?from,
+                        peer_round,
+                        my_round = state.round,
+                        "Rejecting message from older round, as deliberator",
+                    );
                     ctx.msg
                         .send(
                             ctx.governance.me,
                             *from,
                             PositMessage {
+                                // The id echoes the rejected message so the
+                                // sender knows which attempt we are answering.
                                 id: PositProtocolId::Signature(
                                     sign_id,
                                     *presignature_id,
-                                    state.round,
+                                    *peer_round,
                                 ),
                                 from: ctx.governance.me,
                                 action: PositAction::RejectWithReason(
-                                    PositRejectReason::StaleRound,
+                                    PositRejectReason::StaleRound(state.round),
                                 ),
                             },
                         )
@@ -243,7 +266,13 @@ impl PositPhase {
         let accepted_participants = loop {
             tokio::select! {
                 task_msg = mailbox.recv() => {
-                    let SignPositMessage { round: peer_round , ..} = task_msg;
+                    let SignPositMessage { presignature_id, round: peer_round, from, action } = task_msg;
+
+                    // A StaleRound reject carries the rejector's current round;
+                    // remember it so our next bump catches up in one step.
+                    if let PositAction::RejectWithReason(PositRejectReason::StaleRound(peer_current)) = &action {
+                        state.highest_seen_round = state.highest_seen_round.max(*peer_current);
+                    }
 
                     // Ignore messages for older rounds
                     if state.round > peer_round {
@@ -260,11 +289,14 @@ impl PositPhase {
                             my_round = state.round,
                             "Storing message for future round",
                         );
-                        state.buffer_future_posit_message(task_msg);
+                        state.buffer_future_posit_message(SignPositMessage {
+                            presignature_id,
+                            round: peer_round,
+                            from,
+                            action,
+                        });
                         continue;
                     }
-
-                    let SignPositMessage { presignature_id: _, round: _peer_round, from, action } = task_msg;
 
                     if is_deliberator {
                         if let PositAction::Start(participants) = action {
@@ -410,10 +442,11 @@ mod tests {
     use crate::protocol::presignature::Presignature;
     use deadpool_redis::Runtime;
 
-    /// A deliberator that rejects a Propose from a *behind* proposer must stamp
-    /// the reject with its own (higher) round, not echo the sender's round.
-    /// Otherwise the behind proposer never learns it is behind and climbs one
-    /// round per attempt instead of catching up in a single `bump_round`.
+    /// A deliberator that rejects a Propose from a *behind* proposer echoes the
+    /// rejected round in the id (so the reject reaches the sender's current
+    /// conversation) and carries its own round inside `StaleRound` — otherwise
+    /// the behind proposer never learns it is behind and climbs one round per
+    /// attempt instead of catching up in a single `bump_round`.
     #[tokio::test]
     async fn reject_of_older_round_carries_rejectors_round() {
         let me = Participant::from(1);
@@ -503,11 +536,11 @@ mod tests {
         let PositProtocolId::Signature(_, _, reject_round) = posit.id else {
             panic!("expected a signature posit id");
         };
-        // The reject carries our round (5), not the sender's echoed round (2).
-        assert_eq!(reject_round, 5);
+        // The id echoes the rejected round (2); our round (5) rides in the reason.
+        assert_eq!(reject_round, 2);
         assert!(matches!(
             posit.action,
-            PositAction::RejectWithReason(PositRejectReason::StaleRound)
+            PositAction::RejectWithReason(PositRejectReason::StaleRound(5))
         ));
     }
 }

--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -274,8 +274,33 @@ impl PositPhase {
                         state.highest_seen_round = state.highest_seen_round.max(*peer_current);
                     }
 
-                    // Ignore messages for older rounds
+                    // Reject messages for older rounds so the sender learns our
+                    // round and can catch up in one bump.
                     if state.round > peer_round {
+                        // Never answer a stale Reject: a reject needs no reply,
+                        // and replying would ping-pong rejects between nodes.
+                        if matches!(action, PositAction::RejectWithReason(_)) {
+                            continue;
+                        }
+                        tracing::info!(
+                            ?from,
+                            peer_round,
+                            my_round = state.round,
+                            "Rejecting message from older round",
+                        );
+                        ctx.msg
+                            .send(
+                                ctx.governance.me,
+                                from,
+                                PositMessage {
+                                    // The id echoes the rejected message so the
+                                    // sender knows which attempt we answer.
+                                    id: PositProtocolId::Signature(sign_id, presignature_id, peer_round),
+                                    from: ctx.governance.me,
+                                    action: PositAction::RejectWithReason(PositRejectReason::StaleRound(state.round)),
+                                },
+                            )
+                            .await;
                         continue;
                     }
 

--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -1,6 +1,6 @@
+use super::mailbox::PositMailbox;
 use super::state::SignState;
 use super::task::{GeneratingPhase, SignPhase};
-use super::work_queue::SignPositWorkQueue;
 use super::*;
 
 /// Posit phase — see [`super::task::SignPhase::Posit`].
@@ -16,7 +16,7 @@ impl PositPhase {
     async fn wait_for_propose(
         ctx: &mut SignTask,
         state: &mut SignState,
-        posit_queue: &SignPositWorkQueue,
+        mailbox: &PositMailbox,
         proposer: Participant,
     ) -> Result<PresignatureId, SignPhase> {
         let sign_id = ctx.sign_id;
@@ -26,10 +26,10 @@ impl PositPhase {
                 // Prioritize buffered messages for the current round.
                 let task_msg = match state.take_buffered_posit_message() {
                     Some(buffered) => buffered,
-                    None => posit_queue.recv().await,
+                    None => mailbox.recv().await,
                 };
 
-                let SignTaskMessage::PositMessage {
+                let SignPositMessage {
                     presignature_id,
                     from,
                     action,
@@ -185,7 +185,7 @@ impl PositPhase {
         &mut self,
         ctx: &mut SignTask,
         state: &mut SignState,
-        posit_queue: &SignPositWorkQueue,
+        mailbox: &PositMailbox,
     ) -> SignPhase {
         let proposer = self.proposer;
         let active = self.active.clone();
@@ -213,8 +213,7 @@ impl PositPhase {
                 "deliberator waiting for Propose"
             );
 
-            presignature_id = match Self::wait_for_propose(ctx, state, posit_queue, proposer).await
-            {
+            presignature_id = match Self::wait_for_propose(ctx, state, mailbox, proposer).await {
                 Ok(id) => id,
                 Err(phase) => return phase,
             }
@@ -243,8 +242,8 @@ impl PositPhase {
 
         let accepted_participants = loop {
             tokio::select! {
-                task_msg = posit_queue.recv() => {
-                    let SignTaskMessage::PositMessage { round: peer_round , ..} = task_msg;
+                task_msg = mailbox.recv() => {
+                    let SignPositMessage { round: peer_round , ..} = task_msg;
 
                     // Ignore messages for older rounds
                     if state.round > peer_round {
@@ -265,7 +264,7 @@ impl PositPhase {
                         continue;
                     }
 
-                    let SignTaskMessage::PositMessage { presignature_id: _, round: _peer_round, from, action } = task_msg;
+                    let SignPositMessage { presignature_id: _, round: _peer_round, from, action } = task_msg;
 
                     if is_deliberator {
                         if let PositAction::Start(participants) = action {
@@ -478,8 +477,8 @@ mod tests {
         state.round = 5;
         state.budget.reset(Duration::from_millis(200));
 
-        let posit_queue = SignPositWorkQueue::new();
-        posit_queue.push(SignTaskMessage::PositMessage {
+        let mailbox = PositMailbox::new();
+        mailbox.push(SignPositMessage {
             presignature_id: 42,
             round: 2,
             from: proposer,
@@ -488,8 +487,7 @@ mod tests {
 
         // Behind-proposer Propose is rejected; the call then times out waiting
         // for a valid one and reorganizes.
-        let phase =
-            PositPhase::wait_for_propose(&mut ctx, &mut state, &posit_queue, proposer).await;
+        let phase = PositPhase::wait_for_propose(&mut ctx, &mut state, &mailbox, proposer).await;
         assert!(matches!(phase, Err(SignPhase::Organizing(_))));
 
         let sent = outbox

--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -23,11 +23,7 @@ impl PositPhase {
         let remaining = state.budget.remaining();
         let outcome = tokio::time::timeout(remaining, async {
             loop {
-                // Prioritize buffered messages for the current round.
-                let task_msg = match state.take_buffered_posit_message() {
-                    Some(buffered) => buffered,
-                    None => mailbox.recv().await,
-                };
+                let task_msg = mailbox.recv().await;
 
                 let SignPositMessage {
                     presignature_id,
@@ -51,13 +47,8 @@ impl PositPhase {
                     continue;
                 }
 
-                // reject any messages with a different round than ours
-                //
-                // note: Rejecting messages of older rounds is always the right
-                // choice. But for newer messages, we could buffer them and try
-                // that round later. What we must not do is immediately jump to
-                // that higher round, or else any peer could force themselves to
-                // be the proposer every time.
+                // Reject messages from older rounds so the sender learns our
+                // round and can catch up in one bump.
                 if state.round > *peer_round {
                     tracing::info!(
                         ?from,
@@ -87,17 +78,16 @@ impl PositPhase {
                     continue;
                 }
 
-                // Message can't be processed now but is crucial to make progress later.
-                // Note that we must first try and finish the current round and
-                // not immediately jump to that higher round. Otherwise, any peer
-                // could force themselves to be the proposer every time.
+                // A future round means we are behind; remember it for the next
+                // bump but finish the current round first — jumping right away
+                // would let any peer force themselves to be the proposer.
                 if state.round < *peer_round {
                     tracing::info!(
                         peer_round,
                         my_round = state.round,
-                        "Storing message for future round, as deliberator",
+                        "Dropping message from future round, as deliberator",
                     );
-                    state.buffer_future_posit_message(task_msg);
+                    state.highest_seen_round = state.highest_seen_round.max(*peer_round);
                     continue;
                 }
 
@@ -304,22 +294,17 @@ impl PositPhase {
                         continue;
                     }
 
-                    // Message can't be processed now but is crucial to make progress later.
-                    // Note that we must first try and finish the current round and
-                    // not immediately jump to that higher round. Otherwise, any peer
-                    // could force themselves to be the proposer every time.
+                    // A future round means we are behind; remember it for the
+                    // next bump but finish the current round first — jumping
+                    // right away would let any peer force themselves to be the
+                    // proposer.
                     if state.round < peer_round {
                         tracing::info!(
                             peer_round,
                             my_round = state.round,
-                            "Storing message for future round",
+                            "Dropping message from future round",
                         );
-                        state.buffer_future_posit_message(SignPositMessage {
-                            presignature_id,
-                            round: peer_round,
-                            from,
-                            action,
-                        });
+                        state.highest_seen_round = state.highest_seen_round.max(peer_round);
                         continue;
                     }
 

--- a/chain-signatures/node/src/protocol/request/state.rs
+++ b/chain-signatures/node/src/protocol/request/state.rs
@@ -20,7 +20,7 @@ pub struct SignState {
     ///
     /// INVARIANT: All messages stored here are for `highest_seen_round`. Must
     /// be cleared when `highest_seen_round` changes. One slot per sender.
-    pub buffered_messages: HashMap<Participant, SignTaskMessage>,
+    pub buffered_messages: HashMap<Participant, SignPositMessage>,
     /// When Some, another group is already generating this signature.
     /// The timestamp is when proposing can be resumed.
     pub pause_proposing_until: Option<std::time::Instant>,
@@ -68,8 +68,8 @@ impl SignState {
     }
 
     /// Buffer a posit message for a future round until that round is reached.
-    pub fn buffer_future_posit_message(&mut self, msg: SignTaskMessage) {
-        let SignTaskMessage::PositMessage {
+    pub fn buffer_future_posit_message(&mut self, msg: SignPositMessage) {
+        let SignPositMessage {
             round: peer_round,
             from,
             ..
@@ -87,7 +87,7 @@ impl SignState {
     }
 
     /// Take a buffered message to process, if one exists for the current round.
-    pub fn take_buffered_posit_message(&mut self) -> Option<SignTaskMessage> {
+    pub fn take_buffered_posit_message(&mut self) -> Option<SignPositMessage> {
         if self.highest_seen_round == self.round {
             let key = self.buffered_messages.keys().next().copied()?;
             self.buffered_messages.remove(&key)

--- a/chain-signatures/node/src/protocol/request/state.rs
+++ b/chain-signatures/node/src/protocol/request/state.rs
@@ -10,17 +10,10 @@ pub struct SignState {
     /// Budget for the current organizing+posit attempt.
     pub budget: TimeoutBudget,
     pub permit: Option<SignPermit>,
-    /// The highest round sent by a peer
+    /// Highest round seen from peers — via future-round messages or the round
+    /// carried in `StaleRound` rejects. `bump_round` jumps straight here so a
+    /// behind node catches up in one bump.
     pub highest_seen_round: usize,
-    /// Posit message for `highest_seen_round` round.
-    ///
-    /// These are later processed, if the task reaches the `highest_seen_round`
-    /// as a deliberator. Proposers do not reprocess old messages. A valid peer
-    /// would not have sent a posit message before the proposer proposes.
-    ///
-    /// INVARIANT: All messages stored here are for `highest_seen_round`. Must
-    /// be cleared when `highest_seen_round` changes. One slot per sender.
-    pub buffered_messages: HashMap<Participant, SignPositMessage>,
     /// When Some, another group is already generating this signature.
     /// The timestamp is when proposing can be resumed.
     pub pause_proposing_until: Option<std::time::Instant>,
@@ -35,7 +28,6 @@ impl SignState {
             budget: TimeoutBudget::new(ORGANIZE_POSIT_TIMEOUT),
             permit: None,
             highest_seen_round: 0,
-            buffered_messages: HashMap::new(),
             pause_proposing_until: None,
         }
     }
@@ -65,34 +57,5 @@ impl SignState {
         self.budget.reset(ORGANIZE_POSIT_TIMEOUT);
         self.permit = None;
         tracing::debug!(prev_round, new_round = self.round, "bumped round");
-    }
-
-    /// Buffer a posit message for a future round until that round is reached.
-    pub fn buffer_future_posit_message(&mut self, msg: SignPositMessage) {
-        let SignPositMessage {
-            round: peer_round,
-            from,
-            ..
-        } = msg;
-
-        if peer_round < self.highest_seen_round {
-            return;
-        }
-        if peer_round > self.highest_seen_round {
-            self.highest_seen_round = peer_round;
-            self.buffered_messages.clear();
-        }
-        // One slot per sender, keep only the latest round.
-        self.buffered_messages.insert(from, msg);
-    }
-
-    /// Take a buffered message to process, if one exists for the current round.
-    pub fn take_buffered_posit_message(&mut self) -> Option<SignPositMessage> {
-        if self.highest_seen_round == self.round {
-            let key = self.buffered_messages.keys().next().copied()?;
-            self.buffered_messages.remove(&key)
-        } else {
-            None
-        }
     }
 }

--- a/chain-signatures/node/src/protocol/request/task.rs
+++ b/chain-signatures/node/src/protocol/request/task.rs
@@ -1,10 +1,10 @@
 //! Per-request driver: the `SignPhase` state machine and the `SignTask` that owns it.
 
+use super::mailbox::PositMailbox;
 use super::metrics::PhaseDurations;
 use super::organize::OrganizingPhase;
 use super::posit::PositPhase;
 use super::state::SignState;
-use super::work_queue::SignPositWorkQueue;
 use super::*;
 
 /// Generating phase — see [`SignPhase::Generating`].
@@ -35,12 +35,12 @@ impl SignPhase {
         &mut self,
         ctx: &mut SignTask,
         state: &mut SignState,
-        posit_queue: &SignPositWorkQueue,
+        mailbox: &PositMailbox,
     ) -> SignPhase {
         match self {
             SignPhase::Organizing(phase) => phase.advance(ctx, state).await,
-            SignPhase::Posit(phase) => phase.advance(ctx, state, posit_queue).await,
-            SignPhase::Generating(phase) => phase.advance(ctx, state, posit_queue).await,
+            SignPhase::Posit(phase) => phase.advance(ctx, state, mailbox).await,
+            SignPhase::Generating(phase) => phase.advance(ctx, state, mailbox).await,
             SignPhase::Complete(result) => SignPhase::Complete(*result),
         }
     }
@@ -51,7 +51,7 @@ impl GeneratingPhase {
         &mut self,
         ctx: &SignTask,
         state: &mut SignState,
-        posit_queue: &SignPositWorkQueue,
+        mailbox: &PositMailbox,
     ) -> SignPhase {
         // We successfully committed to generating; future rounds should be unrestricted.
         state.pause_proposing_until = None;
@@ -108,7 +108,7 @@ impl GeneratingPhase {
         let result = loop {
             tokio::select! {
                 result = &mut generation => break result,
-                task_msg = posit_queue.recv() => {
+                task_msg = mailbox.recv() => {
                     Self::reject_late_propose(ctx, task_msg).await;
                 }
             }
@@ -122,8 +122,8 @@ impl GeneratingPhase {
 
     /// Reject a `Propose` that arrives while we are already generating; drop
     /// stale Accept/Reject/Start messages.
-    async fn reject_late_propose(ctx: &SignTask, task_msg: SignTaskMessage) {
-        let SignTaskMessage::PositMessage {
+    async fn reject_late_propose(ctx: &SignTask, task_msg: SignPositMessage) {
+        let SignPositMessage {
             presignature_id,
             round,
             from,
@@ -173,7 +173,7 @@ impl SignTask {
         mut self,
         request: IndexedSignRequest,
         mesh_state: watch::Receiver<MeshState>,
-        posit_queue: Arc<SignPositWorkQueue>,
+        mailbox: Arc<PositMailbox>,
     ) -> Result<(), SignError> {
         let sign_id = self.sign_id;
         tracing::info!(?sign_id, governance = ?self.governance, "signature task starting...");
@@ -193,7 +193,7 @@ impl SignTask {
                 SignPhase::Complete(_) => None,
             };
 
-            let new_phase = phase.advance(&mut self, &mut state, &posit_queue).await;
+            let new_phase = phase.advance(&mut self, &mut state, &mailbox).await;
             if let Some(step) = current_phase_step {
                 durations.add(step, phase_start.elapsed());
                 if matches!(&new_phase, SignPhase::Organizing(_)) {


### PR DESCRIPTION
This PR is mixing a couple of changes, but the goal is to have simpler, straightforward logic. I recommend reviewing commit by commit.

### [work queue -> mailbox renamings](https://github.com/sig-net/mpc/commit/2550fa61bed588d85def688edc75430dad348fbc)
Pure rename: `work_queue.rs` → `mailbox.rs`, `SignPositWorkQueue` → `PositMailbox`,
`SignTaskMessage` → `SignPositMessage`.

### [do not filter posit messages based on posit rounds in mailbox](https://github.com/sig-net/mpc/commit/a565cf86d2bdb1e66487c084e553054ed201e26d)
One slot per sender, last-arrived-wins (was: higher-round-wins). Rounds can
legitimately go down after a governance respawn, so the mailbox stays
round-agnostic and round judgment is the task's job.

### [carry the rejector's round inside StaleRound instead of the reject id](https://github.com/sig-net/mpc/commit/baa32d24389db629664c616202af326fbed5035d)
- The reject's id echoes the rejected message's round; the rejector's round
  rides in `StaleRound(usize)`. Receivers harvest it into `highest_seen_round`,
  keeping one-bump catch-up, and rejects feed `enough_rejects` naturally.
- A deliberator drops incoming Rejects: it has sent nothing that could be
  rejected, and answering one would ping-pong rejects between two nodes.

### [Reject messages for older rounds in advance()](https://github.com/sig-net/mpc/commit/b657a80410b6099626d7718ddb63b7eccbc44276)
The deliberation loop now also answers stale messages with `StaleRound` (was:
silent drop), so a behind peer catches up no matter which phase it hits.

### [drop future-round buffering, keep only the highest round](https://github.com/sig-net/mpc/commit/e3b6d15c29e28cc0d335e369ff3cbd7def00ce8c)
`SignState.buffered_messages` and its helpers are deleted: a future round is
remembered in `highest_seen_round` and the message dropped — `bump_round`
already jumps to the high-water. The high-water resets on governance respawn by
construction (`SignState` is rebuilt per task incarnation).