### PR TITLE
Carry the rejector's round inside StaleRound instead of the reject id

### DIFF
--- a/chain-signatures/node/src/protocol/message/crypto.rs
+++ b/chain-signatures/node/src/protocol/message/crypto.rs
@@ -333,6 +333,119 @@ mod tests {
         );
     }
 
+    /// `PositMessage::stale_round` lets a `StaleRound` reject carry the
+    /// rejector's round without changing `PositRejectReason`'s wire shape.
+    /// Prove the property that motivated it: the field is compatible in both
+    /// directions, and a message bundled *after* the posit in the same batch
+    /// still decodes.
+    #[test]
+    fn test_posit_stale_round_field_is_wire_compatible() {
+        use crate::protocol::message::{PositMessage, PositProtocolId};
+        use crate::protocol::posit::{PositAction, PositRejectReason};
+
+        /// Mirrors `PositMessage`'s shape before `stale_round` was added.
+        #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        struct OldPositMessage {
+            id: PositProtocolId,
+            from: Participant,
+            action: PositAction,
+        }
+
+        #[derive(Debug, Serialize, Deserialize)]
+        enum OldMessage {
+            Posit(OldPositMessage),
+            Generating(GeneratingMessage),
+        }
+
+        impl PartialEq<Message> for OldMessage {
+            fn eq(&self, other: &Message) -> bool {
+                match (self, other) {
+                    (OldMessage::Posit(a), Message::Posit(b)) => {
+                        a.id == b.id && a.from == b.from && a.action == b.action
+                    }
+                    (OldMessage::Generating(a), Message::Generating(b)) => a == b,
+                    _ => false,
+                }
+            }
+        }
+
+        let from = Participant::from(7);
+        let (cipher_sk, cipher_pk) = mpc_keys::hpke::generate();
+        let sign_sk =
+            near_crypto::SecretKey::from_seed(near_crypto::KeyType::ED25519, "sign-stale-round");
+        let mut participants = Participants::default();
+        participants.insert(
+            &from,
+            ParticipantInfo {
+                sign_pk: sign_sk.public_key(),
+                cipher_pk: cipher_pk.clone(),
+                id: from.into(),
+                url: "http://localhost:3030".to_string(),
+                account_id: "test.near".parse().unwrap(),
+            },
+        );
+        let participants = ParticipantMap::One(participants);
+        let sign_id = SignId::new([9; 32]);
+
+        // Forward compatibility: a new node sends a `StaleRound` reject with
+        // `stale_round` set, bundled with an unrelated trailing message. An
+        // old node without the field still decodes the whole batch — it
+        // simply never learns the rejector's round.
+        let new_batch = vec![
+            Message::Posit(PositMessage {
+                id: PositProtocolId::Signature(sign_id, 1, 2),
+                from,
+                action: PositAction::RejectWithReason(PositRejectReason::StaleRound),
+                stale_round: Some(5),
+            }),
+            Message::Generating(GeneratingMessage {
+                from,
+                data: vec![1, 2, 3],
+            }),
+        ];
+        let encrypted = SignedMessage::encrypt(&new_batch, from, &sign_sk, &cipher_pk).unwrap();
+        let old_decoded: Vec<OldMessage> =
+            SignedMessage::decrypt(&encrypted, &cipher_sk, &participants).unwrap();
+        assert_eq!(
+            old_decoded.len(),
+            2,
+            "old node must still see both messages in the batch, not just the posit"
+        );
+        assert_eq!(old_decoded, new_batch);
+
+        // Backward compatibility: an old node's `StaleRound` reject (no
+        // `stale_round` field at all) is decoded by new code as `None`, and
+        // the trailing message still decodes.
+        let old_batch = vec![
+            OldMessage::Posit(OldPositMessage {
+                id: PositProtocolId::Signature(sign_id, 1, 2),
+                from,
+                action: PositAction::RejectWithReason(PositRejectReason::StaleRound),
+            }),
+            OldMessage::Generating(GeneratingMessage {
+                from,
+                data: vec![4, 5, 6],
+            }),
+        ];
+        let encrypted = SignedMessage::encrypt(&old_batch, from, &sign_sk, &cipher_pk).unwrap();
+        let new_decoded: Vec<Message> =
+            SignedMessage::decrypt(&encrypted, &cipher_sk, &participants).unwrap();
+        assert_eq!(
+            new_decoded.len(),
+            2,
+            "new node must still see both messages in the batch, not just the posit"
+        );
+        let Message::Posit(posit) = &new_decoded[0] else {
+            panic!("expected a posit message");
+        };
+        assert_eq!(posit.stale_round, None);
+        assert!(matches!(
+            posit.action,
+            PositAction::RejectWithReason(PositRejectReason::StaleRound)
+        ));
+        assert_eq!(old_batch[1], new_decoded[1]);
+    }
+
     #[test]
     fn test_encrypt_size() {
         let epoch = 1;

--- a/chain-signatures/node/src/protocol/message/inbox.rs
+++ b/chain-signatures/node/src/protocol/message/inbox.rs
@@ -76,7 +76,14 @@ pub struct MessageInbox {
     /// Protocol messages per running signature generation.
     signature: HashMap<(SignId, PresignatureId), Subscriber<SignatureMessage>>,
     /// Posit conversations for all sign requests; demuxed per sign_id by the SignatureSpawner.
-    signature_posit: Subscriber<(SignId, PresignatureId, Round, Participant, PositAction)>,
+    signature_posit: Subscriber<(
+        SignId,
+        PresignatureId,
+        Round,
+        Participant,
+        PositAction,
+        Option<Round>,
+    )>,
 }
 
 impl MessageInbox {
@@ -139,6 +146,7 @@ impl MessageInbox {
                         round,
                         message.from,
                         message.action,
+                        message.stale_round,
                     ));
                     self.signature_posit.report_capacity_global();
                 }
@@ -789,6 +797,7 @@ mod tests {
                 id: PositProtocolId::Signature(sign_id, 77, round),
                 from,
                 action: PositAction::Accept,
+                stale_round: None,
             }));
         }
         messages.push(Message::Ready(ReadyMessage {

--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -291,7 +291,14 @@ impl MessageChannel {
 
     pub async fn subscribe_signature_posit(
         &self,
-    ) -> mpsc::Receiver<(SignId, PresignatureId, Round, Participant, PositAction)> {
+    ) -> mpsc::Receiver<(
+        SignId,
+        PresignatureId,
+        Round,
+        Participant,
+        PositAction,
+        Option<Round>,
+    )> {
         self.subscribe_or_closed(SubscribeId::SignaturePosit, "signature posit")
             .await
     }

--- a/chain-signatures/node/src/protocol/message/sub.rs
+++ b/chain-signatures/node/src/protocol/message/sub.rs
@@ -43,7 +43,16 @@ pub enum SubscribeResponse {
     Presignature(mpsc::Receiver<PresignatureMessage>),
     PresignaturePosit(mpsc::Receiver<(FullPresignatureId, Participant, PositAction)>),
     Signature(mpsc::Receiver<SignatureMessage>),
-    SignaturePosit(mpsc::Receiver<(SignId, PresignatureId, Round, Participant, PositAction)>),
+    SignaturePosit(
+        mpsc::Receiver<(
+            SignId,
+            PresignatureId,
+            Round,
+            Participant,
+            PositAction,
+            Option<Round>,
+        )>,
+    ),
 }
 
 /// Ties a message type to the `SubscribeResponse` variant carrying its receiver.
@@ -73,7 +82,7 @@ impl_subscription_message! {
     PresignatureMessage => Presignature,
     (FullPresignatureId, Participant, PositAction) => PresignaturePosit,
     SignatureMessage => Signature,
-    (SignId, PresignatureId, Round, Participant, PositAction) => SignaturePosit,
+    (SignId, PresignatureId, Round, Participant, PositAction, Option<Round>) => SignaturePosit,
 }
 
 pub enum SubscribeRequestAction {

--- a/chain-signatures/node/src/protocol/message/types.rs
+++ b/chain-signatures/node/src/protocol/message/types.rs
@@ -36,6 +36,10 @@ pub struct PositMessage {
     pub id: PositProtocolId,
     pub from: Participant,
     pub action: PositAction,
+    /// The rejector's own round, set only alongside a `StaleRound` reject so
+    /// the sender can catch up in one bump.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stale_round: Option<Round>,
 }
 
 impl PositMessage {

--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -57,19 +57,19 @@ pub enum PositAction {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Copy, Hash)]
 pub enum PositRejectReason {
-    Unknown = 0,
+    Unknown,
     /// The node is already participating in a generation, or has already
     /// finished generation.
-    AlreadyGenerating = 1,
+    AlreadyGenerating,
     /// The node cannot participate because it doesn't have the required
     /// artifact.
-    MissingArtifact = 2,
+    MissingArtifact,
     /// The posit message is invalid, usually because of bad timing leading to
     /// round / proposer mismatches.
-    InvalidRequest = 3,
-    /// The sender's round is behind the rejector's current round. The reject
-    /// carries the rejector's round so the sender can catch up in one bump.
-    StaleRound = 4,
+    InvalidRequest,
+    /// The message's round is behind the rejector's current round, carried
+    /// here so the sender can catch up in one bump.
+    StaleRound(usize),
 }
 
 impl PositAction {

--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -68,8 +68,8 @@ pub enum PositRejectReason {
     /// round / proposer mismatches.
     InvalidRequest,
     /// The message's round is behind the rejector's current round, carried
-    /// here so the sender can catch up in one bump.
-    StaleRound(usize),
+    /// in `PositMessage::stale_round` so the sender can catch up in one bump.
+    StaleRound,
 }
 
 impl PositAction {

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -469,6 +469,7 @@ impl PresignatureSpawner {
                             id: PositProtocolId::Presignature(id),
                             from: self.me,
                             action,
+                            stale_round: None,
                         },
                     )
                     .await;
@@ -534,6 +535,7 @@ impl PresignatureSpawner {
                         id: PositProtocolId::Presignature(id),
                         from: self.me,
                         action: PositAction::Propose,
+                        stale_round: None,
                     },
                 )
                 .await;
@@ -697,6 +699,7 @@ impl PresignatureSpawner {
                             id: PositProtocolId::Presignature(id),
                             from: self.me,
                             action: PositAction::Start(participants.clone()),
+                            stale_round: None,
                         },
                     )
                     .await;

--- a/chain-signatures/node/src/protocol/request/mailbox.rs
+++ b/chain-signatures/node/src/protocol/request/mailbox.rs
@@ -14,6 +14,8 @@ pub(crate) struct SignPositMessage {
     pub round: usize,
     pub from: Participant,
     pub action: PositAction,
+    /// The rejector's own round, set only alongside a `StaleRound` reject.
+    pub stale_round: Option<usize>,
 }
 
 /// Mailbox holding the latest posit message per sending participant.
@@ -103,6 +105,7 @@ mod tests {
             round,
             from: Participant::from(from),
             action,
+            stale_round: None,
         }
     }
 

--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -279,6 +279,7 @@ impl SignatureSpawner {
         round: usize,
         from: Participant,
         action: PositAction,
+        stale_round: Option<usize>,
     ) {
         // Drop late-arriving posits for already-completed/aborted sign IDs
         // to prevent re-creating orphan mailboxes.
@@ -293,6 +294,7 @@ impl SignatureSpawner {
                 round,
                 from,
                 action,
+                stale_round,
             });
     }
 
@@ -431,8 +433,8 @@ impl SignatureSpawner {
                     };
                     self.handle_sign(&governance, sign, &protocol);
                 }
-                Some((sign_id, presignature_id, round, from, action)) = posits.recv() => {
-                    self.handle_posit(sign_id, presignature_id, round, from, action);
+                Some((sign_id, presignature_id, round, from, action, stale_round)) = posits.recv() => {
+                    self.handle_posit(sign_id, presignature_id, round, from, action, stale_round);
                 }
                 Some(result) = self.tasks.join_next(), if !self.tasks.is_empty() => {
                     self.handle_task_exit(result);
@@ -654,7 +656,14 @@ mod tests {
         assert!(spawner.test_dead_ids_contains(&sign_id));
 
         // Step 3: Late posit → dropped (dead_id check), mailbox NOT recreated
-        spawner.handle_posit(sign_id, 0, 0, Participant::from(1), PositAction::Propose);
+        spawner.handle_posit(
+            sign_id,
+            0,
+            0,
+            Participant::from(1),
+            PositAction::Propose,
+            None,
+        );
         assert!(!spawner.test_posit_mailboxes_contains(&sign_id));
 
         // Step 4: Re-spawn → dead cleared, request retained again
@@ -663,7 +672,14 @@ mod tests {
         assert!(!spawner.test_dead_ids_contains(&sign_id));
 
         // Step 5: Posit after re-spawn → accepted, mailbox re-created
-        spawner.handle_posit(sign_id, 0, 0, Participant::from(1), PositAction::Propose);
+        spawner.handle_posit(
+            sign_id,
+            0,
+            0,
+            Participant::from(1),
+            PositAction::Propose,
+            None,
+        );
         assert!(spawner.test_posit_mailboxes_contains(&sign_id));
 
         // Step 6: Governance respawn → task swapped in place, nothing retired,

--- a/chain-signatures/node/src/protocol/request/organize.rs
+++ b/chain-signatures/node/src/protocol/request/organize.rs
@@ -190,6 +190,7 @@ impl OrganizingPhase {
                             id: PositProtocolId::Signature(sign_id, presignature_id, state.round()),
                             from: ctx.governance.me,
                             action: PositAction::Propose,
+                            stale_round: None,
                         },
                     )
                     .await;

--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -44,7 +44,7 @@ impl PositPhase {
                     Some(peer_current),
                 ) = (action, stale_round)
                 {
-                    state.highest_seen_round = state.highest_seen_round.max(*peer_current);
+                    state.record_peer_round(*peer_current);
                 }
 
                 // Nothing else to do with a Reject: a deliberator has sent
@@ -278,7 +278,7 @@ impl PositPhase {
                     // A StaleRound reject carries the rejector's current round;
                     // remember it so our next bump catches up in one step.
                     if let (PositAction::RejectWithReason(PositRejectReason::StaleRound), Some(peer_current)) = (&task_msg.action, task_msg.stale_round) {
-                        state.highest_seen_round = state.highest_seen_round.max(peer_current);
+                        state.record_peer_round(peer_current);
                     }
 
                     // Ignore messages for older rounds

--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -36,6 +36,21 @@ impl PositPhase {
                     round: peer_round,
                 } = &task_msg;
 
+                // A StaleRound reject carries the rejector's current round;
+                // remember it so our next bump catches up in one step.
+                if let PositAction::RejectWithReason(PositRejectReason::StaleRound(peer_current)) =
+                    action
+                {
+                    state.highest_seen_round = state.highest_seen_round.max(*peer_current);
+                }
+
+                // Nothing else to do with a Reject: a deliberator has sent
+                // nothing that could be rejected, and answering one would
+                // ping-pong rejects between two nodes.
+                if matches!(action, PositAction::RejectWithReason(_)) {
+                    continue;
+                }
+
                 // reject any messages with a different round than ours
                 //
                 // note: Rejecting messages of older rounds is always the right
@@ -44,19 +59,27 @@ impl PositPhase {
                 // that higher round, or else any peer could force themselves to
                 // be the proposer every time.
                 if state.round() > *peer_round {
+                    tracing::info!(
+                        ?from,
+                        peer_round,
+                        my_round = state.round(),
+                        "Rejecting message from older round, as deliberator",
+                    );
                     ctx.msg
                         .send(
                             ctx.governance.me,
                             *from,
                             PositMessage {
+                                // The id echoes the rejected message so the
+                                // sender knows which attempt we are answering.
                                 id: PositProtocolId::Signature(
                                     sign_id,
                                     *presignature_id,
-                                    state.round(),
+                                    *peer_round,
                                 ),
                                 from: ctx.governance.me,
                                 action: PositAction::RejectWithReason(
-                                    PositRejectReason::StaleRound,
+                                    PositRejectReason::StaleRound(state.round()),
                                 ),
                             },
                         )
@@ -245,6 +268,12 @@ impl PositPhase {
                 task_msg = mailbox.recv() => {
                     let SignPositMessage { round: peer_round , ..} = task_msg;
 
+                    // A StaleRound reject carries the rejector's current round;
+                    // remember it so our next bump catches up in one step.
+                    if let PositAction::RejectWithReason(PositRejectReason::StaleRound(peer_current)) = &task_msg.action {
+                        state.highest_seen_round = state.highest_seen_round.max(*peer_current);
+                    }
+
                     // Ignore messages for older rounds
                     if state.round() > peer_round {
                         continue;
@@ -411,10 +440,11 @@ mod tests {
     use deadpool_redis::Runtime;
     use mpc_primitives::SignKind;
 
-    /// A deliberator that rejects a Propose from a *behind* proposer must stamp
-    /// the reject with its own (higher) round, not echo the sender's round.
-    /// Otherwise the behind proposer never learns it is behind and climbs one
-    /// round per attempt instead of catching up in a single `bump_round`.
+    /// A deliberator that rejects a Propose from a *behind* proposer echoes the
+    /// rejected round in the id (so the reject reaches the sender's current
+    /// conversation) and carries its own round inside `StaleRound` — otherwise
+    /// the behind proposer never learns it is behind and climbs one round per
+    /// attempt instead of catching up in a single `bump_round`.
     #[tokio::test]
     async fn reject_of_older_round_carries_rejectors_round() {
         let me = Participant::from(1);
@@ -505,11 +535,11 @@ mod tests {
         let PositProtocolId::Signature(_, _, reject_round) = posit.id else {
             panic!("expected a signature posit id");
         };
-        // The reject carries our round (5), not the sender's echoed round (2).
-        assert_eq!(reject_round, 5);
+        // The id echoes the rejected round (2); our round (5) rides in the reason.
+        assert_eq!(reject_round, 2);
         assert!(matches!(
             posit.action,
-            PositAction::RejectWithReason(PositRejectReason::StaleRound)
+            PositAction::RejectWithReason(PositRejectReason::StaleRound(5))
         ));
     }
 }

--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -434,51 +434,48 @@ impl PositPhase {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::contract::primitives::{ParticipantInfo, Participants};
-    use crate::protocol::message::Message;
+    use crate::protocol::message::{Message, MessageInbox, MessageOutbox};
     use crate::protocol::presignature::Presignature;
+    use crate::rpc::RpcAction;
     use deadpool_redis::Runtime;
     use mpc_primitives::SignKind;
 
-    /// A deliberator that rejects a Propose from a *behind* proposer echoes the
-    /// rejected round in the id (so the reject reaches the sender's current
-    /// conversation) and carries its own round inside `StaleRound` — otherwise
-    /// the behind proposer never learns it is behind and climbs one round per
-    /// attempt instead of catching up in a single `bump_round`.
-    #[tokio::test]
-    async fn reject_of_older_round_carries_rejectors_round() {
-        let me = Participant::from(1);
-        let proposer = Participant::from(0);
+    /// A `wait_for_propose` harness; the unused channel ends are held alive so
+    /// sends keep working.
+    struct TestSetup {
+        ctx: SignTask,
+        state: SignState,
+        outbox: MessageOutbox,
+        _inbox: MessageInbox,
+        _rpc_rx: mpsc::Receiver<RpcAction>,
+        _mesh_tx: watch::Sender<MeshState>,
+    }
 
+    fn setup(me: Participant, other: Participant) -> TestSetup {
         let account_id: near_account_id::AccountId = "p-1".parse().unwrap();
-        let mut participants = Participants::default();
-        participants.insert(&proposer, ParticipantInfo::new(0));
-        participants.insert(&me, ParticipantInfo::new(1));
-
         let governance = GovernanceInfo {
             me,
             threshold: 1,
             epoch: 0,
             public_key: k256::AffinePoint::default(),
-            participants: [proposer, me].into_iter().collect(),
+            participants: [other, me].into_iter().collect(),
             is_running: true,
         };
 
         let redis_cfg = deadpool_redis::Config::from_url("redis://127.0.0.1/");
         let pool = redis_cfg.create_pool(Some(Runtime::Tokio1)).unwrap();
-        // The reject path never touches presignatures, so the lazy pool is
-        // never actually connected.
+        // These tests never touch presignatures, so the lazy pool is never
+        // actually connected.
         let presignatures = Presignature::storage(&pool, &account_id);
-        let (_inbox, mut outbox, msg_channel) = MessageChannel::new();
+        let (_inbox, outbox, msg_channel) = MessageChannel::new();
         let (rpc_tx, _rpc_rx) = mpsc::channel(1);
-        let rpc_channel = RpcChannel { tx: rpc_tx };
 
-        let mut ctx = SignTask {
+        let ctx = SignTask {
             governance,
             sign_id: SignId::new([0u8; 32]),
             presignatures,
             msg: msg_channel,
-            rpc: rpc_channel,
+            rpc: RpcChannel { tx: rpc_tx },
             backlog: Backlog::new(),
             cfg: ProtocolConfig::default(),
             is_proposer: Arc::new(AtomicBool::new(false)),
@@ -501,28 +498,53 @@ mod tests {
             SignKind::Sign,
         );
         let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
-        let mut state = SignState::new(request, mesh_rx, Arc::new(AtomicUsize::new(0)));
+        let state = SignState::new(request, mesh_rx, Arc::clone(&ctx.round));
 
-        // We are ahead of the proposer: our round is 5, the incoming Propose is
-        // for round 2. Give the round a short budget so `wait_for_propose`
-        // times out and returns shortly after emitting the reject.
-        state.set_round(5);
-        state.budget.reset(Duration::from_millis(200));
+        TestSetup {
+            ctx,
+            state,
+            outbox,
+            _inbox,
+            _rpc_rx,
+            _mesh_tx,
+        }
+    }
+
+    /// A deliberator that rejects a Propose from a *behind* proposer echoes the
+    /// rejected round in the id (so the reject reaches the sender's current
+    /// conversation) and carries its own round inside `StaleRound` — otherwise
+    /// the behind proposer never learns it is behind and climbs one round per
+    /// attempt instead of catching up in a single `bump_round`.
+    #[tokio::test]
+    async fn reject_of_older_round_carries_rejectors_round() {
+        let me = Participant::from(1);
+        let proposer = Participant::from(0);
+        let mut t = setup(me, proposer);
+
+        // We are ahead of the proposer. Give the round a short budget so
+        // `wait_for_propose` times out and returns shortly after emitting the
+        // reject.
+        let our_round = 5;
+        let propose_round = 2;
+        t.state.set_round(our_round);
+        t.state.budget.reset(Duration::from_millis(200));
 
         let mailbox = PositMailbox::new();
         mailbox.push(SignPositMessage {
             presignature_id: 42,
-            round: 2,
+            round: propose_round,
             from: proposer,
             action: PositAction::Propose,
         });
 
         // Behind-proposer Propose is rejected; the call then times out waiting
         // for a valid one and reorganizes.
-        let phase = PositPhase::wait_for_propose(&mut ctx, &mut state, &mailbox, proposer).await;
+        let phase =
+            PositPhase::wait_for_propose(&mut t.ctx, &mut t.state, &mailbox, proposer).await;
         assert!(matches!(phase, Err(SignPhase::Organizing(_))));
 
-        let sent = outbox
+        let sent = t
+            .outbox
             .intercept_outgoing_messages()
             .try_recv()
             .expect("a reject should have been sent to the behind proposer");
@@ -535,11 +557,48 @@ mod tests {
         let PositProtocolId::Signature(_, _, reject_round) = posit.id else {
             panic!("expected a signature posit id");
         };
-        // The id echoes the rejected round (2); our round (5) rides in the reason.
-        assert_eq!(reject_round, 2);
-        assert!(matches!(
-            posit.action,
-            PositAction::RejectWithReason(PositRejectReason::StaleRound(5))
-        ));
+        // The id echoes the round of the message being rejected.
+        assert_eq!(reject_round, propose_round);
+        let PositAction::RejectWithReason(PositRejectReason::StaleRound(rejectors_round)) =
+            posit.action
+        else {
+            panic!("expected a StaleRound reject");
+        };
+        // Our round rides in the reason so the sender can catch up in one bump.
+        assert_eq!(rejectors_round, our_round);
+    }
+
+    /// Receiving side of the same contract: the rejector's round carried in
+    /// `StaleRound` is recorded and the reject itself never answered, so the
+    /// next bump jumps straight to that round instead of climbing one round
+    /// per attempt.
+    #[tokio::test]
+    async fn received_stale_round_reject_catches_up_in_one_bump() {
+        let me = Participant::from(1);
+        let peer = Participant::from(0);
+        let mut t = setup(me, peer);
+
+        // We are behind at round 2; a peer at round 5 rejected our message,
+        // echoing our round in the id and carrying its own in the payload.
+        t.state.set_round(2);
+        t.state.budget.reset(Duration::from_millis(200));
+
+        let mailbox = PositMailbox::new();
+        mailbox.push(SignPositMessage {
+            presignature_id: 42,
+            round: 2,
+            from: peer,
+            action: PositAction::RejectWithReason(PositRejectReason::StaleRound(5)),
+        });
+
+        // No Propose ever arrives, so the wait times out and reorganizes,
+        // bumping the round with the recorded rejector's round.
+        let phase = PositPhase::wait_for_propose(&mut t.ctx, &mut t.state, &mailbox, peer).await;
+        assert!(matches!(phase, Err(SignPhase::Organizing(_))));
+
+        // Caught up in one bump: max(2 + 1, 5) = 5.
+        assert_eq!(t.state.round(), 5);
+        // A reject is never answered — replying would ping-pong rejects.
+        assert!(t.outbox.intercept_outgoing_messages().try_recv().is_err());
     }
 }

--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -34,12 +34,15 @@ impl PositPhase {
                     from,
                     action,
                     round: peer_round,
+                    stale_round,
                 } = &task_msg;
 
                 // A StaleRound reject carries the rejector's current round;
                 // remember it so our next bump catches up in one step.
-                if let PositAction::RejectWithReason(PositRejectReason::StaleRound(peer_current)) =
-                    action
+                if let (
+                    PositAction::RejectWithReason(PositRejectReason::StaleRound),
+                    Some(peer_current),
+                ) = (action, stale_round)
                 {
                     state.highest_seen_round = state.highest_seen_round.max(*peer_current);
                 }
@@ -79,8 +82,9 @@ impl PositPhase {
                                 ),
                                 from: ctx.governance.me,
                                 action: PositAction::RejectWithReason(
-                                    PositRejectReason::StaleRound(state.round()),
+                                    PositRejectReason::StaleRound,
                                 ),
+                                stale_round: Some(state.round()),
                             },
                         )
                         .await;
@@ -139,6 +143,7 @@ impl PositPhase {
                                     action: PositAction::RejectWithReason(
                                         PositRejectReason::MissingArtifact,
                                     ),
+                                    stale_round: None,
                                 },
                             )
                             .await;
@@ -168,6 +173,7 @@ impl PositPhase {
                                 action: PositAction::RejectWithReason(
                                     PositRejectReason::InvalidRequest,
                                 ),
+                                stale_round: None,
                             },
                         )
                         .await;
@@ -195,6 +201,7 @@ impl PositPhase {
                     id: PositProtocolId::Signature(sign_id, presignature_id, state.round()),
                     from: ctx.governance.me,
                     action: PositAction::Accept,
+                    stale_round: None,
                 },
             )
             .await;
@@ -270,8 +277,8 @@ impl PositPhase {
 
                     // A StaleRound reject carries the rejector's current round;
                     // remember it so our next bump catches up in one step.
-                    if let PositAction::RejectWithReason(PositRejectReason::StaleRound(peer_current)) = &task_msg.action {
-                        state.highest_seen_round = state.highest_seen_round.max(*peer_current);
+                    if let (PositAction::RejectWithReason(PositRejectReason::StaleRound), Some(peer_current)) = (&task_msg.action, task_msg.stale_round) {
+                        state.highest_seen_round = state.highest_seen_round.max(peer_current);
                     }
 
                     // Ignore messages for older rounds
@@ -293,7 +300,7 @@ impl PositPhase {
                         continue;
                     }
 
-                    let SignPositMessage { presignature_id: _, round: _peer_round, from, action } = task_msg;
+                    let SignPositMessage { presignature_id: _, round: _peer_round, from, action, stale_round: _ } = task_msg;
 
                     if is_deliberator {
                         if let PositAction::Start(participants) = action {
@@ -423,6 +430,7 @@ impl PositPhase {
                         id: PositProtocolId::Signature(sign_id, presignature_id, state.round()),
                         from: ctx.governance.me,
                         action: PositAction::Start(participants.clone()),
+                        stale_round: None,
                     },
                 )
                 .await;
@@ -535,6 +543,7 @@ mod tests {
             round: propose_round,
             from: proposer,
             action: PositAction::Propose,
+            stale_round: None,
         });
 
         // Behind-proposer Propose is rejected; the call then times out waiting
@@ -559,13 +568,12 @@ mod tests {
         };
         // The id echoes the round of the message being rejected.
         assert_eq!(reject_round, propose_round);
-        let PositAction::RejectWithReason(PositRejectReason::StaleRound(rejectors_round)) =
-            posit.action
-        else {
-            panic!("expected a StaleRound reject");
-        };
-        // Our round rides in the reason so the sender can catch up in one bump.
-        assert_eq!(rejectors_round, our_round);
+        assert!(matches!(
+            posit.action,
+            PositAction::RejectWithReason(PositRejectReason::StaleRound)
+        ));
+        // Our round rides in `stale_round` so the sender can catch up in one bump.
+        assert_eq!(posit.stale_round, Some(our_round));
     }
 
     /// Receiving side of the same contract: the rejector's round carried in
@@ -588,7 +596,8 @@ mod tests {
             presignature_id: 42,
             round: 2,
             from: peer,
-            action: PositAction::RejectWithReason(PositRejectReason::StaleRound(5)),
+            action: PositAction::RejectWithReason(PositRejectReason::StaleRound),
+            stale_round: Some(5),
         });
 
         // No Propose ever arrives, so the wait times out and reorganizes,

--- a/chain-signatures/node/src/protocol/request/state.rs
+++ b/chain-signatures/node/src/protocol/request/state.rs
@@ -88,6 +88,15 @@ impl SignState {
         tracing::debug!(prev_round, new_round = self.round, "bumped round");
     }
 
+    /// Record a peer's round learned from a `StaleRound` reject so the next
+    /// bump catches up in one step.
+    pub fn record_peer_round(&mut self, peer_round: usize) {
+        if peer_round > self.highest_seen_round {
+            self.highest_seen_round = peer_round;
+            self.buffered_messages.clear();
+        }
+    }
+
     /// Buffer a posit message for a future round until that round is reached.
     pub fn buffer_future_posit_message(&mut self, msg: SignPositMessage) {
         let SignPositMessage {

--- a/chain-signatures/node/src/protocol/request/task.rs
+++ b/chain-signatures/node/src/protocol/request/task.rs
@@ -128,6 +128,7 @@ impl GeneratingPhase {
             round,
             from,
             action,
+            ..
         } = task_msg;
         if !matches!(action, PositAction::Propose) {
             return;
@@ -147,6 +148,7 @@ impl GeneratingPhase {
                     id: PositProtocolId::Signature(ctx.sign_id, presignature_id, round),
                     from: me,
                     action: PositAction::RejectWithReason(PositRejectReason::AlreadyGenerating),
+                    stale_round: None,
                 },
             )
             .await;

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -434,6 +434,7 @@ impl TripleSpawner {
                             id: PositProtocolId::Triple(id),
                             from: self.me,
                             action,
+                            stale_round: None,
                         },
                     )
                     .await;
@@ -462,6 +463,7 @@ impl TripleSpawner {
                         id: PositProtocolId::Triple(pair_id),
                         from: self.me,
                         action: PositAction::Propose,
+                        stale_round: None,
                     },
                 )
                 .await;
@@ -488,6 +490,7 @@ impl TripleSpawner {
                             id: PositProtocolId::Triple(id),
                             from: self.me,
                             action: PositAction::Start(participants.clone()),
+                            stale_round: None,
                         },
                     )
                     .await;


### PR DESCRIPTION
Reshapes the `StaleRound` reject introduced in #1048:

- The reject's id now echoes the rejected message's round (an address, not
  content); the rejector's current round rides inside `StaleRound(usize)`