### PR TITLE
feat: cap candidates set size

### DIFF
--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -63,6 +63,9 @@ pub const MAX_JOIN_URL_LEN: usize = 2048;
 /// Fixed anti-spam deposit required to join as a candidate.
 pub const REQUIRED_JOIN_DEPOSIT: NearToken = NearToken::from_near(1);
 
+/// Maximum number of candidate applications retained at a time.
+pub const MAX_CANDIDATES: usize = 10;
+
 #[near_bindgen]
 #[derive(BorshDeserialize, BorshSerialize, Debug)]
 pub enum VersionedMpcContract {
@@ -113,9 +116,13 @@ impl MpcContract {
         candidates: BTreeMap<AccountId, CandidateInfo>,
         config: Option<Config>,
     ) -> Self {
+        let mut candidate_queue = Candidates::new();
+        for (account_id, candidate_info) in candidates {
+            candidate_queue.insert(account_id, candidate_info);
+        }
         MpcContract {
             protocol_state: ProtocolContractState::Initializing(InitializingContractState {
-                candidates: Candidates { candidates },
+                candidates: candidate_queue,
                 threshold,
                 pk_votes: PkVotes::new(),
             }),
@@ -338,6 +345,7 @@ impl VersionedMpcContract {
             ProtocolContractState::Running(RunningContractState {
                 participants,
                 ref mut candidates,
+                join_votes,
                 ..
             }) => {
                 let signer_account_id = env::signer_account_id();
@@ -347,6 +355,13 @@ impl VersionedMpcContract {
                 if let Some(diff) = deposit.checked_sub(REQUIRED_JOIN_DEPOSIT) {
                     if diff > NearToken::from_yoctonear(0) {
                         Promise::new(signer_account_id.clone()).transfer(diff);
+                    }
+                }
+                if !candidates.contains_key(&signer_account_id)
+                    && candidates.len() >= MAX_CANDIDATES
+                {
+                    if let Some(oldest_candidate) = candidates.pop_front() {
+                        join_votes.remove(&oldest_candidate.account_id);
                     }
                 }
                 candidates.insert(

--- a/chain-signatures/contract/src/primitives.rs
+++ b/chain-signatures/contract/src/primitives.rs
@@ -8,7 +8,7 @@ use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{AccountId, BorshStorageKey, CryptoHash, NearToken, PublicKey};
 use signet_primitives::{borsh_scalar, SignId, Signature};
-use std::collections::{btree_map, BTreeMap, HashMap, HashSet};
+use std::collections::{btree_map, BTreeMap, HashMap, HashSet, VecDeque};
 
 pub mod hpke {
     pub type PublicKey = [u8; 32];
@@ -241,7 +241,7 @@ impl IntoIterator for Participants {
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub struct Candidates {
-    pub candidates: BTreeMap<AccountId, CandidateInfo>,
+    pub candidates: VecDeque<CandidateInfo>,
 }
 
 impl Default for Candidates {
@@ -253,32 +253,44 @@ impl Default for Candidates {
 impl Candidates {
     pub fn new() -> Self {
         Candidates {
-            candidates: BTreeMap::new(),
+            candidates: VecDeque::new(),
         }
     }
 
     pub fn contains_key(&self, account_id: &AccountId) -> bool {
-        self.candidates.contains_key(account_id)
+        self.candidates
+            .iter()
+            .any(|candidate| &candidate.account_id == account_id)
     }
 
-    pub fn insert(&mut self, account_id: AccountId, candidate: CandidateInfo) {
-        self.candidates.insert(account_id, candidate);
+    pub fn insert(&mut self, account_id: AccountId, mut candidate: CandidateInfo) {
+        candidate.account_id = account_id.clone();
+        if let Some(existing) = self
+            .candidates
+            .iter_mut()
+            .find(|candidate| candidate.account_id == account_id)
+        {
+            *existing = candidate;
+        } else {
+            self.candidates.push_back(candidate);
+        }
     }
 
     pub fn remove(&mut self, account_id: &AccountId) {
-        self.candidates.remove(account_id);
+        self.candidates
+            .retain(|candidate| &candidate.account_id != account_id);
     }
 
     pub fn get(&self, account_id: &AccountId) -> Option<&CandidateInfo> {
-        self.candidates.get(account_id)
+        self.candidates
+            .iter()
+            .find(|candidate| &candidate.account_id == account_id)
     }
 
-    pub fn iter(&self) -> btree_map::Iter<'_, AccountId, CandidateInfo> {
-        self.candidates.iter()
-    }
-
-    pub fn iter_mut(&mut self) -> btree_map::IterMut<'_, AccountId, CandidateInfo> {
-        self.candidates.iter_mut()
+    pub fn iter(&self) -> impl Iterator<Item = (&AccountId, &CandidateInfo)> {
+        self.candidates
+            .iter()
+            .map(|candidate| (&candidate.account_id, candidate))
     }
 
     pub fn len(&self) -> usize {
@@ -288,32 +300,39 @@ impl Candidates {
     pub fn is_empty(&self) -> bool {
         self.candidates.is_empty()
     }
+
+    pub fn pop_front(&mut self) -> Option<CandidateInfo> {
+        self.candidates.pop_front()
+    }
 }
 
 impl<'a> IntoIterator for &'a Candidates {
     type Item = (&'a AccountId, &'a CandidateInfo);
-    type IntoIter = btree_map::Iter<'a, AccountId, CandidateInfo>;
+    type IntoIter = std::iter::Map<
+        std::collections::vec_deque::Iter<'a, CandidateInfo>,
+        fn(&'a CandidateInfo) -> (&'a AccountId, &'a CandidateInfo),
+    >;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.candidates.iter()
-    }
-}
-
-impl<'a> IntoIterator for &'a mut Candidates {
-    type Item = (&'a AccountId, &'a mut CandidateInfo);
-    type IntoIter = btree_map::IterMut<'a, AccountId, CandidateInfo>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.candidates.iter_mut()
+        fn as_pair(candidate: &CandidateInfo) -> (&AccountId, &CandidateInfo) {
+            (&candidate.account_id, candidate)
+        }
+        self.candidates.iter().map(as_pair)
     }
 }
 
 impl IntoIterator for Candidates {
     type Item = (AccountId, CandidateInfo);
-    type IntoIter = btree_map::IntoIter<AccountId, CandidateInfo>;
+    type IntoIter = std::iter::Map<
+        std::collections::vec_deque::IntoIter<CandidateInfo>,
+        fn(CandidateInfo) -> (AccountId, CandidateInfo),
+    >;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.candidates.into_iter()
+        fn into_pair(candidate: CandidateInfo) -> (AccountId, CandidateInfo) {
+            (candidate.account_id.clone(), candidate)
+        }
+        self.candidates.into_iter().map(into_pair)
     }
 }
 

--- a/chain-signatures/contract/tests/vote.rs
+++ b/chain-signatures/contract/tests/vote.rs
@@ -134,6 +134,80 @@ async fn test_join_refunds_excess_deposit() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_join_caps_candidates_and_removes_oldest() -> anyhow::Result<()> {
+    let (worker, contract, accounts, _) = init_env().await;
+    let root = worker.root_account()?;
+    let mut candidate_ids = Vec::new();
+
+    for i in 0..mpc_contract::MAX_CANDIDATES {
+        let candidate = root
+            .create_subaccount(&format!("candidate-{i:02}"))
+            .initial_balance(NearToken::from_near(2))
+            .transact()
+            .await?
+            .into_result()?;
+        candidate_ids.push(candidate.id().clone());
+
+        let execution = candidate
+            .call(contract.id(), "join")
+            .args_json(json!({
+                "url": "127.0.0.1",
+                "cipher_pk": vec![1u8; 32],
+                "sign_pk": "ed25519:J75xXmF7WUPS3xCm3hy2tgwLCKdYM1iJd4BWF8sWVnae",
+            }))
+            .deposit(NearToken::from_near(1))
+            .transact()
+            .await?;
+        assert!(execution.is_success());
+    }
+
+    let oldest_candidate = candidate_ids[0].clone();
+    let execution = accounts[0]
+        .call(contract.id(), "vote_join")
+        .args_json(json!({
+            "candidate": oldest_candidate,
+        }))
+        .transact()
+        .await?;
+    assert!(execution.is_success());
+
+    let newest_candidate = root
+        .create_subaccount("candidate-10")
+        .initial_balance(NearToken::from_near(2))
+        .transact()
+        .await?
+        .into_result()?;
+    let execution = newest_candidate
+        .call(contract.id(), "join")
+        .args_json(json!({
+            "url": "127.0.0.1",
+            "cipher_pk": vec![1u8; 32],
+            "sign_pk": "ed25519:J75xXmF7WUPS3xCm3hy2tgwLCKdYM1iJd4BWF8sWVnae",
+        }))
+        .deposit(NearToken::from_near(1))
+        .transact()
+        .await?;
+    assert!(execution.is_success());
+
+    let state: mpc_contract::ProtocolContractState =
+        contract.view("state").await.unwrap().json().unwrap();
+    match state {
+        mpc_contract::ProtocolContractState::Running(r) => {
+            assert_eq!(r.candidates.len(), mpc_contract::MAX_CANDIDATES);
+            assert!(!r.candidates.contains_key(&candidate_ids[0]));
+            assert!(!r.join_votes.contains_key(&candidate_ids[0]));
+            for candidate_id in &candidate_ids[1..] {
+                assert!(r.candidates.contains_key(candidate_id));
+            }
+            assert!(r.candidates.contains_key(newest_candidate.id()));
+        }
+        _ => panic!("should be in running state"),
+    };
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_remove_candidacy() -> anyhow::Result<()> {
     let (worker, contract, accounts, _) = init_env().await;
 

--- a/chain-signatures/node/src/protocol/contract/primitives.rs
+++ b/chain-signatures/node/src/protocol/contract/primitives.rs
@@ -3,7 +3,7 @@ use mpc_keys::hpke;
 use near_primitives::{borsh::BorshDeserialize, types::AccountId};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashSet, VecDeque},
     hash::Hash,
     str::FromStr,
 };
@@ -80,12 +80,12 @@ impl From<Candidates> for Participants {
                 .candidates
                 .into_iter()
                 .enumerate()
-                .map(|(participant_id, (account_id, candidate_info))| {
+                .map(|(participant_id, candidate_info)| {
                     (
                         Participant::from(participant_id as ParticipantId),
                         ParticipantInfo {
                             id: participant_id as ParticipantId,
-                            account_id,
+                            account_id: candidate_info.account_id,
                             url: candidate_info.url,
                             cipher_pk: candidate_info.cipher_pk,
                             sign_pk: candidate_info.sign_pk,
@@ -235,28 +235,34 @@ pub struct CandidateInfo {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct Candidates {
-    pub candidates: BTreeMap<AccountId, CandidateInfo>,
+    pub candidates: VecDeque<CandidateInfo>,
 }
 
 impl Candidates {
     pub fn get(&self, id: &AccountId) -> Option<&CandidateInfo> {
-        self.candidates.get(id)
+        self.candidates
+            .iter()
+            .find(|candidate| &candidate.account_id == id)
     }
 
     pub fn contains_key(&self, id: &AccountId) -> bool {
-        self.candidates.contains_key(id)
+        self.get(id).is_some()
     }
 
     pub fn keys(&self) -> impl Iterator<Item = &AccountId> {
-        self.candidates.keys()
+        self.candidates
+            .iter()
+            .map(|candidate| &candidate.account_id)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&AccountId, &CandidateInfo)> {
-        self.candidates.iter()
+        self.candidates
+            .iter()
+            .map(|candidate| (&candidate.account_id, candidate))
     }
 
     pub fn find_candidate(&self, account_id: &AccountId) -> Option<&CandidateInfo> {
-        self.candidates.get(account_id)
+        self.get(account_id)
     }
 }
 
@@ -266,20 +272,12 @@ impl From<mpc_contract::primitives::Candidates> for Candidates {
             candidates: contract_candidates
                 .candidates
                 .into_iter()
-                .map(|(account_id, candidate_info)| {
-                    (
-                        AccountId::from_str(account_id.as_ref()).unwrap(),
-                        CandidateInfo {
-                            account_id: AccountId::from_str(candidate_info.account_id.as_ref())
-                                .unwrap(),
-                            url: candidate_info.url,
-                            cipher_pk: hpke::PublicKey::from_bytes(&candidate_info.cipher_pk),
-                            sign_pk: BorshDeserialize::try_from_slice(
-                                candidate_info.sign_pk.as_bytes(),
-                            )
-                            .unwrap(),
-                        },
-                    )
+                .map(|candidate_info| CandidateInfo {
+                    account_id: AccountId::from_str(candidate_info.account_id.as_ref()).unwrap(),
+                    url: candidate_info.url,
+                    cipher_pk: hpke::PublicKey::from_bytes(&candidate_info.cipher_pk),
+                    sign_pk: BorshDeserialize::try_from_slice(candidate_info.sign_pk.as_bytes())
+                        .unwrap(),
                 })
                 .collect(),
         }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -509,10 +509,11 @@ pub async fn docker(spawner: &mut ClusterSpawner) -> anyhow::Result<Nodes> {
 
     if let Some(public_key) = spawner.pregenerated_keys.public_key() {
         // Use init_running to skip key generation
-        let participants =
-            mpc_contract::primitives::Participants::from(mpc_contract::primitives::Candidates {
-                candidates: candidates.clone().into_iter().collect(),
-            });
+        let mut candidates_struct = mpc_contract::primitives::Candidates::new();
+        for (account_id, candidate_info) in candidates.clone() {
+            candidates_struct.insert(account_id, candidate_info);
+        }
+        let participants = mpc_contract::primitives::Participants::from(candidates_struct);
         use k256::elliptic_curve::sec1::ToEncodedPoint;
         let near_pk = near_crypto::PublicKey::SECP256K1(
             near_crypto::Secp256K1PublicKey::try_from(
@@ -646,9 +647,10 @@ pub async fn host(spawner: &mut ClusterSpawner) -> anyhow::Result<Nodes> {
     let init_contract_start = std::time::Instant::now();
     if let Some(public_key) = spawner.pregenerated_keys.public_key() {
         // Use init_running to skip key generation
-        let candidates_struct = mpc_contract::primitives::Candidates {
-            candidates: candidates.clone().into_iter().collect(),
-        };
+        let mut candidates_struct = mpc_contract::primitives::Candidates::new();
+        for (account_id, candidate_info) in candidates.clone() {
+            candidates_struct.insert(account_id, candidate_info);
+        }
         let participants = mpc_contract::primitives::Participants::from(candidates_struct);
         // Convert secp256k1 public key to NEAR public key format (secp256k1)
         use k256::elliptic_curve::sec1::ToEncodedPoint;


### PR DESCRIPTION
part 3 of fixing https://github.com/sig-net/mpc-private/issues/33
Purpose:
To limit the possibility of join() attack, we've so far added url size cap and requiring non-refundable 1N deposit when calling join(). With those, it is still possible to bloat our payload by joining with 2000 accounts if the attacker is willing to spend money (2000N). 
This PR aims to cap the number of candidates to 10, and on a new join(), evict the oldest candidate if already at 10. This will make sure the payload cannot be bloated and genuine nodes can still join.
Now there's no way to bloat the contract state. But it is still possible for attacker to stop genuine nodes from joining participants by joining with new accounts to push the genuine nodes out. However they'd need to continuously do that to permanently stop a genuine node, which will be costly. But if they have some kind of bot out to get us, well, it's not good, but they spend 10x than us in this race.

I also thought about vote_remove_candidates and an admin method like clear_candidates. Latter is centralized and former basically ask node operators to be part of managing candidates, a bit weird too.

What changed:
1. candidates changed from btreemap to VecDeque so that it naturally preserves order. The lookup would now be O(candidates_set_size) but since it's capped at 10, it's quite small. Thought about adding an order: VecDeque<AccountId>, that's ugly; also maybe using an ordered map type, but seems to add unnecessary imports to the wasm.
2. evict oldest candidate in join() when candidates size already 10

Note even if old candidate have some votes, they will be evicted. Reason is our assumption is attacker haven't controlled >= T nodes, but we do not assume they control no nodes. So if they control some nodes already, but not >= T yet, then we'd still be able to have genuine nodes join.