### PR TITLE
fix(request): carry posit round across respawns

### DIFF
--- a/chain-signatures/node/src/protocol/request/mailbox.rs
+++ b/chain-signatures/node/src/protocol/request/mailbox.rs
@@ -18,7 +18,7 @@ pub(crate) struct SignPositMessage {
 
 /// Mailbox holding the latest posit message per sending participant.
 ///
-/// A message for round N from sender P replaces messages from P for earlier rounds.
+/// A message for round N from sender P replaces messages from P for earlier or equal rounds.
 ///
 /// Only a single message per round and sender buffered. This is enough because:
 ///

--- a/chain-signatures/node/src/protocol/request/mailbox.rs
+++ b/chain-signatures/node/src/protocol/request/mailbox.rs
@@ -18,7 +18,12 @@ pub(crate) struct SignPositMessage {
 
 /// Mailbox holding the latest posit message per sending participant.
 ///
-/// A message for round N from sender P replaces any earlier message from P.
+/// Ordered by round, not by arrival: messages travel as independent HTTP
+/// requests with their own retries, so a stale one can land after a fresher
+/// one and must not overwrite it. Rounds normally only go up per sender (they
+/// are carried across task respawns); after the rare reset (process restart,
+/// retire and re-add) fresh low-round messages may be dropped while an old
+/// one sits unread — the task's StaleRound rejects drive catch-up instead.
 ///
 /// Only a single message per round and sender buffered. This is enough because:
 ///
@@ -90,5 +95,41 @@ impl PositMailbox {
             }
             notified.await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn posit(from: u32, round: usize, action: PositAction) -> SignPositMessage {
+        SignPositMessage {
+            presignature_id: 0,
+            round,
+            from: Participant::from(from),
+            action,
+        }
+    }
+
+    /// One slot per sender, highest round wins. An equal round still
+    /// overwrites: that is a sender superseding its own message (Propose then
+    /// Accept), not a reordering.
+    #[test]
+    fn one_slot_per_sender_highest_round_wins() {
+        let mailbox = PositMailbox::new();
+        mailbox.push(posit(1, 5, PositAction::Propose));
+        mailbox.push(posit(1, 5, PositAction::Accept));
+        mailbox.push(posit(1, 2, PositAction::Propose));
+        mailbox.push(posit(2, 3, PositAction::Accept));
+
+        let mut got = [
+            mailbox.try_recv().expect("first message"),
+            mailbox.try_recv().expect("second message"),
+        ];
+        got.sort_by_key(|msg| u32::from(msg.from));
+        assert!(matches!(got[0].action, PositAction::Accept));
+        assert_eq!(got[0].round, 5, "the round-2 straggler must not win");
+        assert_eq!(got[1].round, 3);
+        assert!(mailbox.try_recv().is_none());
     }
 }

--- a/chain-signatures/node/src/protocol/request/mailbox.rs
+++ b/chain-signatures/node/src/protocol/request/mailbox.rs
@@ -18,12 +18,7 @@ pub(crate) struct SignPositMessage {
 
 /// Mailbox holding the latest posit message per sending participant.
 ///
-/// Ordered by round, not by arrival: messages travel as independent HTTP
-/// requests with their own retries, so a stale one can land after a fresher
-/// one and must not overwrite it. Rounds normally only go up per sender (they
-/// are carried across task respawns); after the rare reset (process restart,
-/// retire and re-add) fresh low-round messages may be dropped while an old
-/// one sits unread — the task's StaleRound rejects drive catch-up instead.
+/// A message for round N from sender P replaces messages from P for earlier rounds.
 ///
 /// Only a single message per round and sender buffered. This is enough because:
 ///

--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -22,7 +22,7 @@ use mpc_contract::config::ProtocolConfig;
 use mpc_primitives::{ChainConfig as _, IndexedSignRequest, SignCommand, SignId};
 use std::collections::{BTreeSet, HashMap};
 use std::num::NonZeroUsize;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, watch, OwnedSemaphorePermit, Semaphore};
@@ -111,10 +111,12 @@ fn round_timeout(round: usize) -> Duration {
 const MAX_DEAD_IDS: usize = 4096;
 
 /// A retained in-flight request. `is_proposer` is shared with the current
-/// task incarnation and read by the deadline watcher.
+/// task incarnation and read by the deadline watcher; `round` carries the
+/// posit round across respawns.
 struct SignEntry {
     request: IndexedSignRequest,
     is_proposer: Arc<AtomicBool>,
+    round: Arc<AtomicUsize>,
 }
 
 /// Router and lifecycle owner for all in-flight sign tasks: one task per
@@ -168,6 +170,7 @@ impl SignatureSpawner {
             SignEntry {
                 request: request.clone(),
                 is_proposer: Arc::clone(&is_proposer),
+                round: Arc::new(AtomicUsize::new(0)),
             },
         );
 
@@ -217,10 +220,10 @@ impl SignatureSpawner {
         let sign_id = request.id;
         tracing::info!(?sign_id, "spawning signature task");
 
-        let is_proposer = self
+        let (is_proposer, round) = self
             .requests
             .get(&sign_id)
-            .map(|entry| Arc::clone(&entry.is_proposer))
+            .map(|entry| (Arc::clone(&entry.is_proposer), Arc::clone(&entry.round)))
             .expect("sign request entry must exist when spawning its task");
 
         // Take (or create) the posit mailbox; it may already hold messages
@@ -240,6 +243,7 @@ impl SignatureSpawner {
             backlog: self.backlog.clone(),
             cfg,
             is_proposer,
+            round,
             limiter: self.limiter.clone(),
             node_account_id: self.node_account_id.clone(),
         };
@@ -624,6 +628,7 @@ mod tests {
             SignEntry {
                 request: probe_request,
                 is_proposer: Arc::new(AtomicBool::new(false)),
+                round: Arc::new(AtomicUsize::new(0)),
             },
         );
         spawner.tasks.spawn(probe_id, async move {
@@ -661,13 +666,21 @@ mod tests {
         spawner.handle_posit(sign_id, 0, 0, Participant::from(1), PositAction::Propose);
         assert!(spawner.test_posit_mailboxes_contains(&sign_id));
 
-        // Step 6: Governance respawn → task swapped in place, nothing retired.
+        // Step 6: Governance respawn → task swapped in place, nothing retired,
+        // and the new incarnation resumes from the entry's carried round.
+        let carried = Arc::new(AtomicUsize::new(7));
+        spawner.requests.get_mut(&sign_id).unwrap().round = Arc::clone(&carried);
         spawner.tasks.abort_all();
         spawner.spawn_tasks(&governance, &cfg);
         assert!(spawner.test_tasks_contains(sign_id));
         assert!(spawner.test_requests_contains(&sign_id));
         assert!(spawner.test_posit_mailboxes_contains(&sign_id));
         assert!(!spawner.test_dead_ids_contains(&sign_id));
+        assert!(
+            Arc::strong_count(&carried) >= 3,
+            "respawned task must share the entry's round, not a fresh one"
+        );
+        assert!(carried.load(Ordering::Relaxed) >= 7);
     }
 
     #[test]

--- a/chain-signatures/node/src/protocol/request/organize.rs
+++ b/chain-signatures/node/src/protocol/request/organize.rs
@@ -74,7 +74,7 @@ impl OrganizingPhase {
 
         ctx.is_proposer.store(false, Ordering::Relaxed);
 
-        tracing::info!(?sign_id, round = ?state.round, "entering organizing phase");
+        tracing::info!(?sign_id, round = ?state.round(), "entering organizing phase");
         let (active, proposer, is_proposer) = {
             let Some(active) = self
                 .wait_for_active_participants(ctx, state, threshold)
@@ -86,7 +86,7 @@ impl OrganizingPhase {
             // Elect from inputs every node shares (round, membership, entropy), no
             // local-only information: filtering by the local active set makes nodes
             // elect different proposers and diverge permanently (#907).
-            let proposer = Self::proposer_per_round(state.round, &participants, &entropy);
+            let proposer = Self::proposer_per_round(state.round(), &participants, &entropy);
 
             // If proposing is paused (generating already ongoing), we act as if we weren't a proposer.
             let skip_proposing = state
@@ -97,7 +97,7 @@ impl OrganizingPhase {
 
             tracing::info!(
                 ?sign_id,
-                round = ?state.round,
+                round = ?state.round(),
                 ?proposer,
                 ?me,
                 is_proposer,
@@ -113,7 +113,7 @@ impl OrganizingPhase {
             let remaining = state.budget.remaining();
             tracing::info!(
                 ?sign_id,
-                round = ?state.round,
+                round = ?state.round(),
                 timeout = ?remaining,
                 limit = ctx.limiter.limit(),
                 "proposer waiting for concurrency slot"
@@ -136,7 +136,7 @@ impl OrganizingPhase {
         }
 
         let (presignature_id, presignature, active) = if is_proposer {
-            tracing::info!(?sign_id, round = ?state.round, "proposer waiting for presignature");
+            tracing::info!(?sign_id, round = ?state.round(), "proposer waiting for presignature");
             let active = active.iter().copied().collect::<Vec<_>>();
             let remaining = state.budget.remaining();
             let fetch = tokio::time::timeout(remaining, async {
@@ -187,7 +187,7 @@ impl OrganizingPhase {
                         ctx.governance.me,
                         p,
                         PositMessage {
-                            id: PositProtocolId::Signature(sign_id, presignature_id, state.round),
+                            id: PositProtocolId::Signature(sign_id, presignature_id, state.round()),
                             from: ctx.governance.me,
                             action: PositAction::Propose,
                         },

--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -43,7 +43,7 @@ impl PositPhase {
                 // that round later. What we must not do is immediately jump to
                 // that higher round, or else any peer could force themselves to
                 // be the proposer every time.
-                if state.round > *peer_round {
+                if state.round() > *peer_round {
                     ctx.msg
                         .send(
                             ctx.governance.me,
@@ -52,7 +52,7 @@ impl PositPhase {
                                 id: PositProtocolId::Signature(
                                     sign_id,
                                     *presignature_id,
-                                    state.round,
+                                    state.round(),
                                 ),
                                 from: ctx.governance.me,
                                 action: PositAction::RejectWithReason(
@@ -68,10 +68,10 @@ impl PositPhase {
                 // Note that we must first try and finish the current round and
                 // not immediately jump to that higher round. Otherwise, any peer
                 // could force themselves to be the proposer every time.
-                if state.round < *peer_round {
+                if state.round() < *peer_round {
                     tracing::info!(
                         peer_round,
-                        my_round = state.round,
+                        my_round = state.round(),
                         "Storing message for future round, as deliberator",
                     );
                     state.buffer_future_posit_message(task_msg);
@@ -110,7 +110,7 @@ impl PositPhase {
                                     id: PositProtocolId::Signature(
                                         sign_id,
                                         *presignature_id,
-                                        state.round,
+                                        state.round(),
                                     ),
                                     from: ctx.governance.me,
                                     action: PositAction::RejectWithReason(
@@ -139,7 +139,7 @@ impl PositPhase {
                                 id: PositProtocolId::Signature(
                                     sign_id,
                                     *presignature_id,
-                                    state.round,
+                                    state.round(),
                                 ),
                                 from: ctx.governance.me,
                                 action: PositAction::RejectWithReason(
@@ -169,7 +169,7 @@ impl PositPhase {
                 ctx.governance.me,
                 proposer,
                 PositMessage {
-                    id: PositProtocolId::Signature(sign_id, presignature_id, state.round),
+                    id: PositProtocolId::Signature(sign_id, presignature_id, state.round()),
                     from: ctx.governance.me,
                     action: PositAction::Accept,
                 },
@@ -193,7 +193,7 @@ impl PositPhase {
         let presignature = self.presignature.take();
 
         let sign_id = ctx.sign_id;
-        let round = state.round;
+        let round = state.round();
         let is_proposer = proposer == ctx.governance.me;
         let is_deliberator = !is_proposer;
 
@@ -246,7 +246,7 @@ impl PositPhase {
                     let SignPositMessage { round: peer_round , ..} = task_msg;
 
                     // Ignore messages for older rounds
-                    if state.round > peer_round {
+                    if state.round() > peer_round {
                         continue;
                     }
 
@@ -254,10 +254,10 @@ impl PositPhase {
                     // Note that we must first try and finish the current round and
                     // not immediately jump to that higher round. Otherwise, any peer
                     // could force themselves to be the proposer every time.
-                    if state.round < peer_round {
+                    if state.round() < peer_round {
                         tracing::info!(
                             peer_round,
-                            my_round = state.round,
+                            my_round = state.round(),
                             "Storing message for future round",
                         );
                         state.buffer_future_posit_message(task_msg);
@@ -380,7 +380,7 @@ impl PositPhase {
         presignature_id: PresignatureId,
     ) -> Vec<Participant> {
         let participants = counter.accepts.into_iter().collect::<Vec<_>>();
-        tracing::info!(?sign_id, round=?state.round, me = ?ctx.governance.me, ?participants, "proposer broadcasting Start");
+        tracing::info!(?sign_id, round=?state.round(), me = ?ctx.governance.me, ?participants, "proposer broadcasting Start");
 
         for &p in &participants {
             if p == ctx.governance.me {
@@ -391,7 +391,7 @@ impl PositPhase {
                     ctx.governance.me,
                     p,
                     PositMessage {
-                        id: PositProtocolId::Signature(sign_id, presignature_id, state.round),
+                        id: PositProtocolId::Signature(sign_id, presignature_id, state.round()),
                         from: ctx.governance.me,
                         action: PositAction::Start(participants.clone()),
                     },
@@ -452,6 +452,7 @@ mod tests {
             backlog: Backlog::new(),
             cfg: ProtocolConfig::default(),
             is_proposer: Arc::new(AtomicBool::new(false)),
+            round: Arc::new(AtomicUsize::new(0)),
             limiter: SignLimiter::new(1),
             node_account_id: account_id,
         };
@@ -470,12 +471,12 @@ mod tests {
             SignKind::Sign,
         );
         let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
-        let mut state = SignState::new(request, mesh_rx);
+        let mut state = SignState::new(request, mesh_rx, Arc::new(AtomicUsize::new(0)));
 
         // We are ahead of the proposer: our round is 5, the incoming Propose is
         // for round 2. Give the round a short budget so `wait_for_propose`
         // times out and returns shortly after emitting the reject.
-        state.round = 5;
+        state.set_round(5);
         state.budget.reset(Duration::from_millis(200));
 
         let mailbox = PositMailbox::new();

--- a/chain-signatures/node/src/protocol/request/state.rs
+++ b/chain-signatures/node/src/protocol/request/state.rs
@@ -4,7 +4,7 @@ use super::task::SignPhase;
 use super::*;
 
 pub struct SignState {
-    pub round: usize,
+    round: usize,
     pub request: IndexedSignRequest,
     pub mesh_state: watch::Receiver<MeshState>,
     /// Budget for the current organizing+posit attempt.
@@ -24,12 +24,19 @@ pub struct SignState {
     /// When Some, another group is already generating this signature.
     /// The timestamp is when proposing can be resumed.
     pub pause_proposing_until: Option<std::time::Instant>,
+    /// Shared with `SignEntry` so a respawn resumes at the round it left off;
+    /// peers rely on our rounds never going down.
+    carried_round: Arc<AtomicUsize>,
 }
 
 impl SignState {
-    pub fn new(request: IndexedSignRequest, mesh_state: watch::Receiver<MeshState>) -> Self {
+    pub fn new(
+        request: IndexedSignRequest,
+        mesh_state: watch::Receiver<MeshState>,
+        carried_round: Arc<AtomicUsize>,
+    ) -> Self {
         Self {
-            round: 0,
+            round: carried_round.load(Ordering::Relaxed),
             request,
             mesh_state,
             budget: TimeoutBudget::new(round_timeout(0)),
@@ -37,7 +44,18 @@ impl SignState {
             highest_seen_round: 0,
             buffered_messages: HashMap::new(),
             pause_proposing_until: None,
+            carried_round,
         }
+    }
+
+    pub fn round(&self) -> usize {
+        self.round
+    }
+
+    /// Sole write path for `round`; keeps the carried value in step.
+    pub fn set_round(&mut self, round: usize) {
+        self.round = round;
+        self.carried_round.store(round, Ordering::Relaxed);
     }
 
     pub fn request(&self) -> &IndexedSignRequest {
@@ -61,7 +79,10 @@ impl SignState {
 
     fn bump_round(&mut self) {
         let prev_round = self.round;
-        self.round = std::cmp::max(self.round.saturating_add(1), self.highest_seen_round);
+        self.set_round(std::cmp::max(
+            self.round.saturating_add(1),
+            self.highest_seen_round,
+        ));
         self.budget.reset(round_timeout(self.round));
         self.permit = None;
         tracing::debug!(prev_round, new_round = self.round, "bumped round");
@@ -94,5 +115,44 @@ impl SignState {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request() -> IndexedSignRequest {
+        IndexedSignRequest::sign(
+            SignId::new([0u8; 32]),
+            mpc_primitives::SignArgs {
+                entropy: [0u8; 32],
+                epsilon: k256::Scalar::from(1u64),
+                payload: k256::Scalar::from(2u64),
+                path: "test".to_string(),
+                key_version: 0,
+            },
+            Chain::Ethereum,
+            0,
+        )
+    }
+
+    /// A respawn rebuilds `SignState`; the round must resume from the carried
+    /// value, not restart at 0 — peers read a round reset as time travel.
+    #[test]
+    fn round_survives_a_respawn() {
+        let carried = Arc::new(AtomicUsize::new(0));
+        let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
+
+        let mut state = SignState::new(request(), mesh_rx.clone(), Arc::clone(&carried));
+        state.reorganize("test");
+        state.highest_seen_round = 9;
+        state.reorganize("test");
+        assert_eq!(state.round(), 9);
+
+        // The task is aborted and a new incarnation takes over.
+        drop(state);
+        let respawned = SignState::new(request(), mesh_rx, carried);
+        assert_eq!(respawned.round(), 9);
     }
 }

--- a/chain-signatures/node/src/protocol/request/task.rs
+++ b/chain-signatures/node/src/protocol/request/task.rs
@@ -163,6 +163,8 @@ pub struct SignTask {
     pub backlog: Backlog,
     pub cfg: ProtocolConfig,
     pub is_proposer: Arc<AtomicBool>,
+    /// Posit round, shared with `SignEntry` so it survives a respawn.
+    pub round: Arc<AtomicUsize>,
     pub limiter: SignLimiter,
     pub node_account_id: near_account_id::AccountId,
 }
@@ -178,7 +180,7 @@ impl SignTask {
         let sign_id = self.sign_id;
         tracing::info!(?sign_id, governance = ?self.governance, "signature task starting...");
 
-        let mut state = SignState::new(request, mesh_state);
+        let mut state = SignState::new(request, mesh_state, Arc::clone(&self.round));
         let mut phase = SignPhase::Organizing(OrganizingPhase);
 
         // Sum per-phase time across loop attempts; emit on Complete(Ok) only.


### PR DESCRIPTION
## Problem

A respawned sign task (`spawn_tasks` on a governance change) rebuilds `SignState` and restarted at round 0, while its `SignEntry`, its mailbox, and every peer kept the old round. Two symptoms:

- Peers' mailboxes silently drop the fresh low-round messages: the `PositMailbox` slot keeps the highest round per sender, so a leftover pre-respawn message wins over a legitimate new round-0 Propose.
- Leftover high-round messages get harvested into `highest_seen_round`, sending nodes to a round nobody else is in.

## Fix

Carry the round in `SignEntry` (which already outlives incarnations, like `is_proposer`) via an `Arc<AtomicUsize>`, threaded through `SignTask` into `SignState::new`. The `round` field is now private; `set_round()` is the sole write path and keeps the carried value in step.

This makes per-sender rounds monotonic for the life of an entry — the invariant the mailbox's highest-round-wins slot already relies on: the outbox spawns an independent retry loop per encrypted partition (`outbox.rs`), so a stale message can arrive after a fresher one and arrival order alone is not trustworthy. This is also the reason **not** to make the mailbox round-agnostic (#1079, second commit): last-arrived-wins would let a retried stale message overwrite a fresh one, which is never retransmitted at the posit level.

## Tests

- `round_survives_a_respawn` (state.rs): a rebuilt `SignState` resumes from the carried value.
- Lifecycle test step 6 (mod.rs): the respawned incarnation shares the entry's round (Arc identity), rather than minting a fresh one.
- `one_slot_per_sender_highest_round_wins` (mailbox.rs): pins the guard, which previously had no test.

`cargo test -p mpc-node --lib` 159/0, clippy and fmt clean.

## Known limits (deliberate)

- A full reset (process restart, or retire + re-add after chain abort) still starts at 0; recovery there runs via StaleRound rejects, as today. The mailbox doc comment states this.
- `highest_seen_round` and the future-round buffer are intentionally not carried; a respawn costs at most one extra reorganize before re-harvesting.
- Respawn no longer acts as an accidental round re-sync across nodes. Round convergence rests on StaleRound harvesting (ahead nodes advance +1, behind nodes jump); the deterministic rotation + growing round timeouts in #1051 further break lockstep divergence.