### PR TITLE
fix(bidirectional): surface ethereum output extraction failures (#1090)

### DIFF
--- a/chain-signatures/chain-ethereum/src/execution_watcher.rs
+++ b/chain-signatures/chain-ethereum/src/execution_watcher.rs
@@ -17,7 +17,7 @@ use alloy::network::TransactionResponse;
 use alloy::primitives::{Address, B256};
 use alloy::rpc::types::{Block, BlockId, BlockTransactions, TransactionReceipt};
 use futures_util::{stream, StreamExt};
-use mpc_chain_integration_core::StateManager;
+use mpc_chain_integration_core::{ChainTelemetry, ExtractionFailureKind, StateManager};
 use mpc_primitives::{
     BidirectionalTx, BidirectionalTxId, Chain, ChainConfig as _, ChainEvent, ExecutionOutcome,
     SignId,
@@ -47,37 +47,82 @@ type WatcherReceipt = (
     anyhow::Result<BackfillOutcome>,
 );
 
-/// Result of a `backfill_execution_confirmation`. `Observed` carries an
-/// optional event; the staleness check skips observed watchers so a mined tx
-/// with a failed extraction can stay pending for retry. `NotObserved` covers
-/// "no receipt yet" (pending or replaced).
+/// Result of a `backfill_execution_confirmation`. `Observed` carries the
+/// confirmation for a mined tx; the staleness check skips observed watchers so
+/// a mined tx whose extraction must be retried can stay pending. `NotObserved`
+/// covers "no receipt yet" (pending or replaced).
 #[allow(clippy::large_enum_variant)] // value is consumed in one match arm; never stored.
 enum BackfillOutcome {
     NotObserved,
-    Observed { event: Option<ChainEvent> },
+    Observed { confirmation: ConfirmationOutcome },
+}
+
+/// Result of resolving a mined transaction into an execution confirmation.
+#[allow(clippy::large_enum_variant)] // value is consumed in one match arm; never stored.
+enum ConfirmationOutcome {
+    /// The execution resolved to a definite outcome.
+    Confirmed(ChainEvent),
+    /// Output extraction failed for a node-local reason. No event is emitted;
+    /// the watcher is re-attempted on the next block.
+    RetryExtraction,
+}
+
+/// A failed output extraction, classified by whether resolving the execution
+/// from it would be consensus-safe.
+///
+/// Only failures that are a pure function of on-chain data and the request's
+/// own schemas are [`Terminal`](ExtractionFailure::Terminal): every node
+/// derives them identically, so failing the request cannot make one node
+/// disagree with its peers. Anything that depends on *this* node's RPC
+/// endpoint — transport errors, missing `debug_traceTransaction` support, a
+/// malformed provider response — is
+/// [`Retryable`](ExtractionFailure::Retryable), because a peer with a healthy
+/// endpoint would extract an output just fine and unilaterally failing here
+/// would stall signing on divergent responses.
+enum ExtractionFailure {
+    Retryable(anyhow::Error),
+    Terminal(anyhow::Error),
+}
+
+impl ExtractionFailure {
+    fn kind(&self) -> ExtractionFailureKind {
+        match self {
+            Self::Retryable(_) => ExtractionFailureKind::Retryable,
+            Self::Terminal(_) => ExtractionFailureKind::Terminal,
+        }
+    }
+}
+
+/// RPC-acquired inputs to deterministic output interpretation.
+struct ExtractionInputs {
+    is_contract_call: bool,
+    trace_output: TraceOutput,
 }
 
 /// Borrow-based view over the indexer's dependencies used to resolve execution
-/// confirmations for a single block. Cheap to construct (four shared refs).
-pub(crate) struct ExecutionWatcher<'a, S: StateManager> {
+/// confirmations for a single block. Cheap to construct (five shared refs).
+pub(crate) struct ExecutionWatcher<'a, S: StateManager, T: ChainTelemetry> {
     client: &'a EthereumClient,
     state_manager: &'a S,
     config: &'a IndexerConfig,
     gate: &'a Mutex<WatcherGateState>,
+    telemetry: &'a T,
 }
 
-impl<'a, S: StateManager> ExecutionWatcher<'a, S> {
+impl<'a, S: StateManager, T: ChainTelemetry> ExecutionWatcher<'a, S, T> {
     pub(crate) fn new(
         client: &'a EthereumClient,
         state_manager: &'a S,
         config: &'a IndexerConfig,
         gate: &'a Mutex<WatcherGateState>,
+        telemetry: &'a T,
     ) -> Self {
         Self {
             client,
             state_manager,
             config,
             gate,
+            telemetry,
         }
     }
 
@@ -165,18 +210,33 @@ impl<'a, S: StateManager> ExecutionWatcher<'a, S> {
         (new_watchers, gate.retry.clone())
     }
 
-    /// Extract the output of a successful transaction, either from the trace or from the receipt.
-    async fn extract_success_tx_output(
+    /// Fetch the RPC-derived inputs to output extraction: the transaction
+    /// itself and, for contract calls, its `debug_traceTransaction` return
+    /// data. Every failure here is node-local, so all are retryable — except a
+    /// `CREATE` transaction, which is a property of the transaction itself and
+    /// can never be extracted by any node.
+    async fn fetch_extraction_inputs(
         &self,
         tx_id: alloy::primitives::B256,
-        tx: &BidirectionalTx,
-    ) -> anyhow::Result<Vec<u8>> {
-        let Some(tx_info) = self.client.get_transaction_by_hash(tx_id).await? else {
-            anyhow::bail!("Failed to fetch transaction {tx_id:?}");
+    ) -> Result<ExtractionInputs, ExtractionFailure> {
+        let tx_info = match self.client.get_transaction_by_hash(tx_id).await {
+            Ok(Some(tx_info)) => tx_info,
+            Ok(None) => {
+                return Err(ExtractionFailure::Retryable(anyhow::anyhow!(
+                    "transaction {tx_id:?} not found by the rpc endpoint"
+                )))
+            }
+            Err(err) => {
+                return Err(ExtractionFailure::Retryable(
+                    err.context(format!("failed to fetch transaction {tx_id:?}")),
+                ))
+            }
         };
 
         if tx_info.inner.to().is_none() {
-            anyhow::bail!("unsupported contract deployment (CREATE): {tx_id:?}");
+            return Err(ExtractionFailure::Terminal(anyhow::anyhow!(
+                "unsupported contract deployment (CREATE): {tx_id:?}"
+            )));
         }
 
         let data = tx_info.inner.input().clone();
@@ -187,30 +247,66 @@ impl<'a, S: StateManager> ExecutionWatcher<'a, S> {
                 ?tx_id,
                 "Extracting transaction output via debug_traceTransaction"
             );
-            match self.client.trace_transaction_output(tx_id).await? {
-                Some(output) => TraceOutput::Output(output),
-                None => {
+            match self.client.trace_transaction_output(tx_id).await {
+                Ok(Some(output)) => TraceOutput::Output(output),
+                Ok(None) => {
                     tracing::warn!(
                         ?tx_id,
                         "debug_traceTransaction returned no return data for a call frame"
                     );
                     TraceOutput::NoReturnData
                 }
+                // Transport errors, endpoints without trace support, and
+                // malformed trace envelopes are all indistinguishable
+                // node-local problems here: a peer on a healthy endpoint still
+                // extracts an output, so never resolve the request from one.
+                Err(err) => {
+                    return Err(ExtractionFailure::Retryable(
+                        err.context(format!("debug_traceTransaction failed for {tx_id:?}")),
+                    ))
+                }
             }
         } else {
             TraceOutput::NotTraced
         };
 
-        build_serialized_output(
+        Ok(ExtractionInputs {
             is_contract_call,
-            &tx.output_deserialization_schema,
             trace_output,
+        })
+    }
+
+    /// Extract the output of a successful transaction, either from the trace or from the receipt.
+    ///
+    /// Splits into an RPC acquisition phase and a deterministic interpretation
+    /// phase so failures can be classified for consensus safety; see
+    /// [`ExtractionFailure`].
+    async fn extract_success_tx_output(
+        &self,
+        tx_id: alloy::primitives::B256,
+        tx: &BidirectionalTx,
+    ) -> Result<Vec<u8>, ExtractionFailure> {
+        let inputs = self.fetch_extraction_inputs(tx_id).await?;
+
+        // Deterministic from here on: on-chain data decoded against the
+        // request's own schemas, identically on every node.
+        build_serialized_output(
+            inputs.is_contract_call,
+            &tx.output_deserialization_schema,
+            inputs.trace_output,
             tx.source_chain.respond_serialization_format(),
             &tx.respond_serialization_schema,
         )
+        .map_err(ExtractionFailure::Terminal)
     }
 
-    /// Construct a `ChainEvent::ExecutionConfirmed` for a mined transaction, if possible.
+    /// Construct a `ChainEvent::ExecutionConfirmed` for a mined transaction.
+    ///
+    /// A terminal extraction failure resolves the execution as
+    /// [`ExecutionOutcome::Failed`] rather than dropping the event, so the
+    /// bidirectional request completes with an explicit failure instead of
+    /// staying pending forever. A retryable one emits nothing and asks for
+    /// another attempt on the next block.
     async fn execution_confirmed_event(
         &self,
         tx_id: BidirectionalTxId,
@@ -218,7 +314,7 @@ impl<'a, S: StateManager> ExecutionWatcher<'a, S> {
         pending_tx: &BidirectionalTx,
         block_number: u64,
         receipt: &TransactionReceipt,
-    ) -> Option<ChainEvent> {
+    ) -> ConfirmationOutcome {
         let receipt_succeeded = receipt.status();
 
         tracing::info!(
@@ -243,25 +339,37 @@ impl<'a, S: StateManager> ExecutionWatcher<'a, S> {
                         output: serialized_output,
                     }
                 }
-                Err(err) => {
-                    tracing::error!(
-                        ?tx_id,
-                        ?sign_id,
-                        ?err,
-                        "Failed to extract transaction output"
-                    );
-                    // TODO: Surface unrecoverable extraction failures as telemetry
-                    // or an explicit failed execution outcome. Returning `None`
-                    // drops the event, which can leave the bidirectional request
-                    // pending with only this log as evidence.
-                    return None;
+                Err(failure) => {
+                    self.telemetry
+                        .bidirectional_extraction_failed(failure.kind());
+                    match failure {
+                        ExtractionFailure::Retryable(err) => {
+                            tracing::warn!(
+                                ?tx_id,
+                                ?sign_id,
+                                ?err,
+                                "failed to extract transaction output; retrying on the next block"
+                            );
+                            return ConfirmationOutcome::RetryExtraction;
+                        }
+                        ExtractionFailure::Terminal(err) => {
+                            tracing::error!(
+                                ?tx_id,
+                                ?sign_id,
+                                ?err,
+                                "unrecoverable transaction output extraction failure; \
+                                 resolving bidirectional execution as failed"
+                            );
+                            ExecutionOutcome::Failed
+                        }
+                    }
                 }
             }
         } else {
             ExecutionOutcome::Failed
         };
 
-        Some(ChainEvent::ExecutionConfirmed {
+        ConfirmationOutcome::Confirmed(ChainEvent::ExecutionConfirmed {
             tx_id,
             sign_id,
             source_chain: pending_tx.source_chain,
@@ -311,10 +419,10 @@ impl<'a, S: StateManager> ExecutionWatcher<'a, S> {
             "backfilled execution confirmation for late ethereum watcher"
         );
 
-        let event = self
+        let confirmation = self
             .execution_confirmed_event(tx_id, sign_id, pending_tx, mined_block_number, &receipt)
             .await;
-        Ok(BackfillOutcome::Observed { event })
+        Ok(BackfillOutcome::Observed { confirmation })
     }
 
     /// Fetches receipts for a batch of watchers with bounded concurrency,
@@ -380,11 +488,16 @@ impl<'a, S: StateManager> ExecutionWatcher<'a, S> {
             self.fetch_watcher_receipts(mined, block_number).await
         {
             match result {
-                Ok(BackfillOutcome::Observed { event }) => {
+                Ok(BackfillOutcome::Observed { confirmation }) => {
+                    // The tx mined regardless of extraction outcome, so its
+                    // nonce slot is consumed either way.
                     consumed_slots
                         .insert((Address::from(pending_tx.from_address), pending_tx.nonce));
-                    if let Some(event) = event {
-                        events.push(event);
+                    match confirmation {
+                        ConfirmationOutcome::Confirmed(event) => events.push(event),
+                        ConfirmationOutcome::RetryExtraction => {
+                            failed.insert(tx_id);
+                        }
                     }
                 }
                 Ok(BackfillOutcome::NotObserved) => {}
@@ -491,11 +604,12 @@ impl<'a, S: StateManager> ExecutionWatcher<'a, S> {
             .await
         {
             match result {
-                Ok(BackfillOutcome::Observed { event }) => {
-                    if let Some(event) = event {
-                        events.push(event); // Late watcher pickup
+                Ok(BackfillOutcome::Observed { confirmation }) => match confirmation {
+                    ConfirmationOutcome::Confirmed(event) => events.push(event), // Late watcher pickup
+                    ConfirmationOutcome::RetryExtraction => {
+                        failed.insert(tx_id);
                     }
-                }
+                },
                 Ok(BackfillOutcome::NotObserved) => {
                     tracing::warn!(
                         ?tx_id,
@@ -1418,6 +1532,449 @@ mod tests {
 
         nonce_mock.assert_async().await;
         receipt_mock.assert_async().await;
+    }
+
+    /// A successful receipt for a tx mined in `block_number`.
+    fn success_receipt(
+        tx_hash: alloy::primitives::B256,
+        from_address: alloy::primitives::Address,
+        block_number: u64,
+    ) -> serde_json::Value {
+        let block_hash = b256!("6e4e53d1de650d5a5ebed19b38321db369ef1dc357904284ecf4d89b8834969c");
+        json!({
+            "transactionHash": format!("{tx_hash:#x}"),
+            "blockHash": format!("{block_hash:#x}"),
+            "blockNumber": format!("0x{block_number:x}"),
+            "transactionIndex": "0x0",
+            "from": format!("{from_address:#x}"),
+            "to": format!("{from_address:#x}"),
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x3a29f0f8",
+            "contractAddress": null,
+            "logsBloom": format!("0x{}", "0".repeat(512)),
+            "cumulativeGasUsed": "0x5208",
+            "type": "0x2",
+            "logs": [],
+            "status": "0x1"
+        })
+    }
+
+    /// A contract-call transaction body (non-empty calldata) for
+    /// `eth_getTransactionByHash`, so extraction takes the trace path.
+    fn contract_call_transaction(
+        tx_hash: alloy::primitives::B256,
+        from_address: alloy::primitives::Address,
+        to_address: alloy::primitives::Address,
+    ) -> serde_json::Value {
+        let block_hash = b256!("6e4e53d1de650d5a5ebed19b38321db369ef1dc357904284ecf4d89b8834969c");
+        json!({
+            "hash": format!("{tx_hash:#x}"),
+            "blockHash": format!("{block_hash:#x}"),
+            "blockNumber": "0x5",
+            "transactionIndex": "0x0",
+            "from": format!("{from_address:#x}"),
+            "to": format!("{to_address:#x}"),
+            "value": "0x0",
+            "gas": "0x5208",
+            "gasPrice": "0x3a29f0f8",
+            "input": "0xa9059cbb00",
+            "nonce": "0x0",
+            "type": "0x0",
+            "v": "0x1b",
+            "r": format!("{block_hash:#x}"),
+            "s": format!("{block_hash:#x}"),
+        })
+    }
+
+    /// Watcher tx with an empty output schema: any trace return data then
+    /// contradicts the declared schema, which is a deterministic (terminal)
+    /// extraction failure.
+    fn empty_output_schema_tx(
+        tx_hash: alloy::primitives::B256,
+        from_address: alloy::primitives::Address,
+    ) -> BidirectionalTx {
+        BidirectionalTx {
+            id: BidirectionalTxId(tx_hash.0),
+            sender: [0u8; 32],
+            serialized_transaction: vec![],
+            source_chain: Chain::Solana,
+            target_chain: Chain::Ethereum,
+            caip2_id: "eip155:31337".to_string(),
+            key_version: LATEST_MPC_KEY_VERSION,
+            deposit: 0,
+            path: "m/44'/60'/0'/0/0".to_string(),
+            algo: "secp256k1".to_string(),
+            dest: Chain::Ethereum.to_string(),
+            params: "{}".to_string(),
+            output_deserialization_schema: b"[]".to_vec(),
+            respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
+            request_id: tx_hash.0,
+            from_address: **from_address,
+            nonce: 0,
+        }
+    }
+
+    /// A deterministic extraction failure — trace return data that contradicts
+    /// the declared output schema — resolves the execution as failed instead of
+    /// silently dropping the event and wedging the request.
+    #[tokio::test]
+    async fn terminal_extraction_failure_emits_failed_event() {
+        let mut server = Server::new_async().await;
+
+        let from_address = address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+        let to_address = address!("5fbdb2315678afecb367f032d93f642f64180aa3");
+        let tx_hash = b256!("9999999999999999999999999999999999999999999999999999999999999999");
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionReceipt",
+                "params": [format!("{tx_hash:#x}")]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({ "jsonrpc": "2.0", "id": 1, "result": success_receipt(tx_hash, from_address, 5) })
+                    .to_string(),
+            )
+            .create_async()
+            .await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionByHash",
+                "params": [format!("{tx_hash:#x}")]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": contract_call_transaction(tx_hash, from_address, to_address),
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        // Trace returns 32 bytes of return data while the tx declares an empty
+        // output schema: unrecoverable for every node, not just this one.
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "debug_traceTransaction",
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "type": "CALL",
+                        "output": format!("0x{}", "0".repeat(63) + "1"),
+                    },
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let harness = test_utils::WatcherHarness::new(&server.url()).await;
+        harness
+            .state_manager
+            .watch_execution(
+                Chain::Ethereum,
+                SignId::new([9; 32]),
+                empty_output_schema_tx(tx_hash, from_address),
+            )
+            .await;
+
+        let mut block: Block = Block::default();
+        block.header.number = 5;
+        block.transactions = BlockTransactions::Hashes(vec![tx_hash]);
+
+        let events = harness
+            .watcher()
+            .collect(&block)
+            .await
+            .expect("should succeed");
+
+        assert_eq!(events.len(), 1, "terminal failure emits exactly one event");
+        match &events[0] {
+            ChainEvent::ExecutionConfirmed {
+                tx_id,
+                block_height,
+                result,
+                ..
+            } => {
+                assert_eq!(tx_id.0, tx_hash.0);
+                assert_eq!(*block_height, 5, "event height is the mined block");
+                assert!(matches!(result, ExecutionOutcome::Failed));
+            }
+            other => panic!("expected ExecutionConfirmed, got {other:?}"),
+        }
+
+        assert_eq!(harness.telemetry.terminal_failures(), 1);
+        assert_eq!(harness.telemetry.retryable_failures(), 0);
+    }
+
+    /// A trace RPC failure is node-local: emit nothing (a peer with a healthy
+    /// endpoint still resolves the execution) and retry on the very next block
+    /// rather than waiting for the slow sweep.
+    #[tokio::test]
+    async fn retryable_extraction_failure_retries_next_block() {
+        let mut server = Server::new_async().await;
+
+        let from_address = address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+        let to_address = address!("5fbdb2315678afecb367f032d93f642f64180aa3");
+        let tx_hash = b256!("aaaa000000000000000000000000000000000000000000000000000000000000");
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionReceipt",
+                "params": [format!("{tx_hash:#x}")]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({ "jsonrpc": "2.0", "id": 1, "result": success_receipt(tx_hash, from_address, 5) })
+                    .to_string(),
+            )
+            .create_async()
+            .await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionByHash",
+                "params": [format!("{tx_hash:#x}")]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": contract_call_transaction(tx_hash, from_address, to_address),
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        // Phase 1 (block 5): the trace endpoint is down.
+        let failing_trace_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "debug_traceTransaction",
+            })))
+            .with_status(500)
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        let harness = test_utils::WatcherHarness::new(&server.url()).await;
+        harness
+            .state_manager
+            .watch_execution(
+                Chain::Ethereum,
+                SignId::new([0xaa; 32]),
+                empty_output_schema_tx(tx_hash, from_address),
+            )
+            .await;
+
+        let mut block5: Block = Block::default();
+        block5.header.number = 5;
+        block5.transactions = BlockTransactions::Hashes(vec![tx_hash]);
+
+        let events = harness
+            .watcher()
+            .collect(&block5)
+            .await
+            .expect("trace failure should not fail block processing");
+
+        assert!(events.is_empty(), "a node-local failure emits no event");
+        assert_eq!(harness.telemetry.retryable_failures(), 1);
+        assert_eq!(harness.telemetry.terminal_failures(), 0);
+        assert!(
+            harness
+                .state_manager
+                .get_execution_watchers(Chain::Ethereum)
+                .await
+                .contains_key(&BidirectionalTxId(tx_hash.0)),
+            "watcher stays pending for retry"
+        );
+        failing_trace_mock.assert_async().await;
+        failing_trace_mock.remove_async().await;
+
+        // Phase 2 (block 6, NOT a sweep tick): the retry set drives a fresh
+        // attempt; the trace now succeeds with the empty return data the
+        // schema declares.
+        let nonce_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionCount",
+                "params": [format!("{from_address:#x}"), "0x6"]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({ "jsonrpc": "2.0", "id": 1, "result": "0x1" }).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let trace_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "debug_traceTransaction",
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": { "type": "CALL", "output": "0x" },
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut block6: Block = Block::default();
+        block6.header.number = 6;
+        block6.transactions = BlockTransactions::Hashes(Vec::new());
+
+        let events = harness
+            .watcher()
+            .collect(&block6)
+            .await
+            .expect("should succeed");
+
+        assert_eq!(events.len(), 1, "the retry resolves the execution");
+        match &events[0] {
+            ChainEvent::ExecutionConfirmed {
+                tx_id,
+                block_height,
+                result,
+                ..
+            } => {
+                assert_eq!(tx_id.0, tx_hash.0);
+                assert_eq!(*block_height, 5, "event height is the mined block");
+                assert!(matches!(result, ExecutionOutcome::Success { .. }));
+            }
+            other => panic!("expected ExecutionConfirmed, got {other:?}"),
+        }
+        assert_eq!(
+            harness.telemetry.retryable_failures(),
+            1,
+            "no further failures once the endpoint recovers"
+        );
+
+        nonce_mock.assert_async().await;
+        trace_mock.assert_async().await;
+    }
+
+    /// A malformed `debug_traceTransaction` payload is provider output, not
+    /// on-chain data: two nodes can see different responses, so it must take
+    /// the retryable path rather than unilaterally failing the request.
+    #[tokio::test]
+    async fn malformed_trace_response_is_retryable() {
+        let mut server = Server::new_async().await;
+
+        let from_address = address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+        let to_address = address!("5fbdb2315678afecb367f032d93f642f64180aa3");
+        let tx_hash = b256!("bbbb000000000000000000000000000000000000000000000000000000000000");
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionReceipt",
+                "params": [format!("{tx_hash:#x}")]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({ "jsonrpc": "2.0", "id": 1, "result": success_receipt(tx_hash, from_address, 5) })
+                    .to_string(),
+            )
+            .create_async()
+            .await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getTransactionByHash",
+                "params": [format!("{tx_hash:#x}")]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": contract_call_transaction(tx_hash, from_address, to_address),
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        // Not a call frame at all.
+        let trace_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "debug_traceTransaction",
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({ "jsonrpc": "2.0", "id": 1, "result": "not-a-call-frame" }).to_string(),
+            )
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        let harness = test_utils::WatcherHarness::new(&server.url()).await;
+        harness
+            .state_manager
+            .watch_execution(
+                Chain::Ethereum,
+                SignId::new([0xbb; 32]),
+                empty_output_schema_tx(tx_hash, from_address),
+            )
+            .await;
+
+        let mut block: Block = Block::default();
+        block.header.number = 5;
+        block.transactions = BlockTransactions::Hashes(vec![tx_hash]);
+
+        let events = harness
+            .watcher()
+            .collect(&block)
+            .await
+            .expect("malformed trace should not fail block processing");
+
+        assert!(
+            events.is_empty(),
+            "malformed provider output emits no event"
+        );
+        assert_eq!(harness.telemetry.retryable_failures(), 1);
+        assert_eq!(harness.telemetry.terminal_failures(), 0);
+        assert!(
+            harness
+                .state_manager
+                .get_execution_watchers(Chain::Ethereum)
+                .await
+                .contains_key(&BidirectionalTxId(tx_hash.0)),
+            "watcher stays pending for retry"
+        );
+        trace_mock.assert_async().await;
     }
 
     #[tokio::test]

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -219,6 +219,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             &self.state_manager,
             &self.eth.indexer,
             &self.watcher_gate,
+            &self.telemetry,
         );
         let exec_events = watcher.collect(block).await?;
 

--- a/chain-signatures/chain-ethereum/src/test_utils.rs
+++ b/chain-signatures/chain-ethereum/src/test_utils.rs
@@ -6,7 +6,10 @@ use crate::EthConfig;
 use alloy::primitives::{Address, Bloom};
 use alloy::rpc::types::{Block, Log};
 use mpc_chain_integration_core::utils::retry::RetryConfig;
-use mpc_chain_integration_core::{MockStateManager, NoopChainTelemetry};
+use mpc_chain_integration_core::{
+    ChainTelemetry, ExtractionFailureKind, MockStateManager, NoopChainTelemetry,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -123,6 +126,46 @@ pub struct WatcherHarness {
     pub state_manager: MockStateManager,
     pub config: IndexerConfig,
     gate: Mutex<WatcherGateState>,
+    pub telemetry: CountingChainTelemetry,
+}
+
+/// `ChainTelemetry` that counts bidirectional extraction failures by kind, so
+/// tests can assert how a failure was classified.
+#[derive(Clone, Default)]
+pub struct CountingChainTelemetry {
+    counts: Arc<ExtractionFailureCounts>,
+}
+
+#[derive(Default)]
+struct ExtractionFailureCounts {
+    retryable: AtomicUsize,
+    terminal: AtomicUsize,
+}
+
+impl CountingChainTelemetry {
+    pub fn retryable_failures(&self) -> usize {
+        self.counts.retryable.load(Ordering::Relaxed)
+    }
+
+    pub fn terminal_failures(&self) -> usize {
+        self.counts.terminal.load(Ordering::Relaxed)
+    }
+}
+
+impl ChainTelemetry for CountingChainTelemetry {
+    fn block_indexed(&self, _block_number: u64) {}
+    fn block_finalized(&self, _block_number: u64) {}
+    fn checkpoint_created(&self, _block_number: u64) {}
+    fn request_indexed_at(&self, _block_timestamp: u64) {}
+    fn request_indexed(&self) {}
+
+    fn bidirectional_extraction_failed(&self, kind: ExtractionFailureKind) {
+        let counter = match kind {
+            ExtractionFailureKind::Retryable => &self.counts.retryable,
+            ExtractionFailureKind::Terminal => &self.counts.terminal,
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 impl WatcherHarness {
@@ -134,16 +177,18 @@ impl WatcherHarness {
             state_manager: MockStateManager::new(),
             config: IndexerConfig::default(),
             gate: Mutex::new(WatcherGateState::default()),
+            telemetry: CountingChainTelemetry::default(),
         }
     }
 
     /// Construct an [`ExecutionWatcher`] borrowing this harness's dependencies.
-    pub fn watcher(&self) -> ExecutionWatcher<'_, MockStateManager> {
+    pub fn watcher(&self) -> ExecutionWatcher<'_, MockStateManager, CountingChainTelemetry> {
         ExecutionWatcher::new(
             self.client.as_ref(),
             &self.state_manager,
             &self.config,
             &self.gate,
+            &self.telemetry,
         )
     }
 }

--- a/chain-signatures/chain-integration-core/src/lib.rs
+++ b/chain-signatures/chain-integration-core/src/lib.rs
@@ -10,7 +10,8 @@ pub use indexer::ChainIndexer;
 pub use publish::{ChainPublisher, PublishAction};
 pub use state::{MockStateManager, StateManager};
 pub use telemetry::{
-    ChainTelemetry, NoopChainTelemetry, NoopPublisherTelemetry, PublisherTelemetry,
+    ChainTelemetry, ExtractionFailureKind, NoopChainTelemetry, NoopPublisherTelemetry,
+    PublisherTelemetry,
 };
 
 // Re-export backon because `retry_rpc!` uses `Retryable` trait internally

--- a/chain-signatures/chain-integration-core/src/telemetry.rs
+++ b/chain-signatures/chain-integration-core/src/telemetry.rs
@@ -16,6 +16,34 @@ pub trait ChainTelemetry: Send + Sync + Clone + 'static {
 
     /// Report that a request was indexed without a block timestamp (faster chains, e.g. for Solana, Canton, or Hydration)
     fn request_indexed(&self);
+
+    /// Records a failed attempt to extract the output of a bidirectional
+    /// execution on this chain. Counts *attempts*: a retryable failure on the
+    /// same transaction increments once per retry.
+    fn bidirectional_extraction_failed(&self, kind: ExtractionFailureKind);
+}
+
+/// Consensus-safety classification of a bidirectional output extraction
+/// failure, used as a metric label.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExtractionFailureKind {
+    /// Node-local failure (RPC transport, missing trace support, malformed
+    /// provider response). Another node may well succeed, so the watcher is
+    /// retried rather than resolved.
+    Retryable,
+    /// Deterministic failure of on-chain data against the request's schemas.
+    /// Every node observes it identically, so the execution is resolved as
+    /// failed.
+    Terminal,
+}
+
+impl ExtractionFailureKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Retryable => "retryable",
+            Self::Terminal => "terminal",
+        }
+    }
 }
 
 /// No-op implementation for tests
@@ -28,6 +56,7 @@ impl ChainTelemetry for NoopChainTelemetry {
     fn checkpoint_created(&self, _block_number: u64) {}
     fn request_indexed_at(&self, _block_timestamp: u64) {}
     fn request_indexed(&self) {}
+    fn bidirectional_extraction_failed(&self, _kind: ExtractionFailureKind) {}
 }
 
 /// Interface for the chain clients to record telemetry data during publishing signatures to the chain.

--- a/chain-signatures/node/src/metrics/indexers.rs
+++ b/chain-signatures/node/src/metrics/indexers.rs
@@ -1,7 +1,9 @@
-use prometheus::IntGaugeVec;
+use prometheus::{CounterVec, IntGaugeVec};
 use std::sync::LazyLock;
 
-use super::try_create_int_gauge_vec_with_node_account_id;
+use super::{
+    try_create_counter_vec_with_node_account_id, try_create_int_gauge_vec_with_node_account_id,
+};
 
 /// Possible status options:
 ///     - "indexed" - latest block number seen by the indexer
@@ -12,6 +14,25 @@ pub static LATEST_BLOCK_NUMBER: LazyLock<IntGaugeVec> = LazyLock::new(|| {
         "multichain_latest_block_number",
         "Latest block number seen by the node",
         &["chain", "status"],
+    )
+    .unwrap()
+});
+
+/// Failed attempts to extract the output of a bidirectional execution on the
+/// target chain, labelled by `kind`:
+///     - "retryable" - node-local failure (RPC transport, missing trace support,
+///       malformed provider response); the watcher stays pending and is retried
+///     - "terminal" - deterministic failure of on-chain data against the
+///       request schemas; the execution is resolved as failed
+///
+/// Counts attempts, not transactions: one retryable transaction increments this
+/// once per retry, so a rising "retryable" rate with no matching resolution is
+/// the signal that a node's RPC endpoint cannot extract outputs.
+pub static BIDIRECTIONAL_EXTRACTION_FAILURES: LazyLock<CounterVec> = LazyLock::new(|| {
+    try_create_counter_vec_with_node_account_id(
+        "multichain_bidirectional_extraction_failures",
+        "Failed bidirectional execution output extraction attempts",
+        &["chain", "kind"],
     )
     .unwrap()
 });

--- a/chain-signatures/node/src/metrics/telemetry.rs
+++ b/chain-signatures/node/src/metrics/telemetry.rs
@@ -1,8 +1,10 @@
-use mpc_chain_integration_core::{ChainTelemetry, PublishAction, PublisherTelemetry};
+use mpc_chain_integration_core::{
+    ChainTelemetry, ExtractionFailureKind, PublishAction, PublisherTelemetry,
+};
 use mpc_primitives::{Chain, ChainConfig as _};
 
 use super::{
-    indexers::LATEST_BLOCK_NUMBER,
+    indexers::{BIDIRECTIONAL_EXTRACTION_FAILURES, LATEST_BLOCK_NUMBER},
     requests::{record_indexing_step_reached, record_request_latency_since, SignRequestStep},
 };
 
@@ -68,5 +70,11 @@ impl ChainTelemetry for NodeTelemetry {
 
     fn request_indexed(&self) {
         record_indexing_step_reached(self.chain);
+    }
+
+    fn bidirectional_extraction_failed(&self, kind: ExtractionFailureKind) {
+        BIDIRECTIONAL_EXTRACTION_FAILURES
+            .with_label_values(&[self.chain.as_str(), kind.as_str()])
+            .inc();
     }
 }


### PR DESCRIPTION
## Summary

  Fixes #1090. Ethereum bidirectional response handling dropped `ExecutionConfirmed` events whenever output extraction
  failed: `execution_confirmed_event` logged an error and returned `None`, leaving the request pending indefinitely with no
  failure outcome, no retry marker, and no metric.

  Extraction is now split into an RPC acquisition phase (tx lookup + `debug_traceTransaction`) and a deterministic
  interpretation phase, and failures are classified by consensus safety:

  - **Terminal** — `CREATE` transactions and `build_serialized_output` errors. These are a pure function of on-chain data and
  the request's own schemas, so every node derives them identically. The execution now resolves as
  `ExecutionOutcome::Failed` at the mined block height instead of being dropped.
  - **Retryable** — RPC transport errors, endpoints without trace support, malformed trace responses. These are node-local: a
  peer on a healthy endpoint still extracts an output, so failing the request here would stall signing on divergent
  responses. No event is emitted; the watcher is instead marked for a fresh attempt on the **next** block rather than waiting
  for `watcher_slow_sweep_interval`.

  Adds the `multichain_bidirectional_extraction_failures` counter, labelled by `chain` and `kind` (`retryable`/`terminal`).
  It counts *attempts*, so a rising `retryable` rate with no resolution is the signal that a node's RPC endpoint cannot
  extract outputs.

  ## Testing

  New tests in `execution_watcher.rs`:
  - trace output contradicting the declared output schema → exactly one `Failed` event at the mined block, terminal counter
  incremented
  - trace RPC failure → no event, watcher stays pending, resolves on the next block (not a sweep tick, so only the retry set
  could have driven it)
  - malformed trace response → retryable path, no event, watcher stays pending