### PR TITLE
refactor(ethereum): introduce unified finalized-head-gated mechanism for catchup and live phases

### DIFF
--- a/chain-signatures/chain-ethereum/src/config.rs
+++ b/chain-signatures/chain-ethereum/src/config.rs
@@ -129,8 +129,6 @@ impl Default for PublisherConfig {
 pub struct IndexerConfig {
     /// Blocks per catchup batch (`eth_getBlockByNumber` JSON-RPC batch)
     pub catchup_block_batch_size: u64,
-    /// Capacity of the live-block channel
-    pub live_block_buffer: usize,
     /// Consecutive `get_block(Finalized)` failures after which the finalized-head
     /// watcher escalates its retry warning (it never gives up)
     pub max_finalized_failures: u32,
@@ -147,7 +145,6 @@ impl Default for IndexerConfig {
     fn default() -> Self {
         Self {
             catchup_block_batch_size: 32,
-            live_block_buffer: 16384,
             max_finalized_failures: 20,
             stall_rewarn_secs: 300,
             max_concurrent_watcher_rpcs: 8,

--- a/chain-signatures/chain-ethereum/src/finalized_head.rs
+++ b/chain-signatures/chain-ethereum/src/finalized_head.rs
@@ -95,11 +95,11 @@ impl FinalizedHeadTracker {
 
     /// Construct a finalized-head tracker for unit tests, with a short refresh interval and no optimistic mode.
     #[cfg(test)]
-    pub(crate) fn new_for_test() -> Self {
+    fn new_for_test() -> Self {
         let indexer = IndexerConfig::default();
         Self {
             head: watch::channel(0).0,
-            optimistic: false,
+            optimistic: false, // existing unit tests assume finalized mode
             refresh_interval: Duration::from_millis(100),
             max_failures: indexer.max_finalized_failures,
             stall_rewarn_secs: indexer.stall_rewarn_secs,
@@ -117,10 +117,11 @@ impl FinalizedHeadTracker {
         self.head.send_replace(n);
     }
 
-    /// Blocks until the cached finalized head covers `block_number`. Returns
-    /// immediately in optimistic mode (dev chains never report finality).
+    /// Blocks until the cached head covers `block_number`. In production the
+    /// head tracks the finalized block; in optimistic mode it tracks the latest
+    /// tip (the watcher polls `Latest`).
     pub async fn wait_for(&self, block_number: u64) -> anyhow::Result<()> {
-        if self.optimistic || *self.head.borrow() >= block_number {
+        if *self.head.borrow() >= block_number {
             return Ok(());
         }
 
@@ -138,39 +139,37 @@ impl FinalizedHeadTracker {
         }
     }
 
-    /// Spawn the background finalized-head watcher that maintains the cached
-    /// head. Returns a guard whose drop aborts the task, or `None` in
-    /// optimistic mode (dev chains never report a finalized head).
+    /// Spawn the background watcher that maintains the cached head. Returns a guard whose drop aborts the task.
     pub fn spawn_watcher(
         &self,
         client: Arc<EthereumClient>,
         cancel: CancellationToken,
-    ) -> Option<AbortOnDrop> {
-        if self.optimistic {
-            return None;
-        }
-        Some(AbortOnDrop(tokio::spawn(Self::watch_finalized_head(
+    ) -> AbortOnDrop {
+        AbortOnDrop(tokio::spawn(Self::watch_head(
             client,
             self.head.clone(),
             self.refresh_interval,
             self.max_failures,
             self.stall_rewarn_secs,
+            self.optimistic,
             cancel,
-        ))))
+        )))
     }
 
     // TODO: Currently if this dies silently we have to wait 35 min for the stream supervisor to restart it. Implement faster failure detection and restart.
-    /// Background task maintaining the cached finalized head.
+    /// Background task maintaining the cached head.
     ///
-    /// Polls `eth_getBlockByNumber(Finalized)` on the configured interval and
-    /// publishes advances over the `watch` channel. Retries forever; the stream
-    /// supervisor watchdog remains the escape hatch.
-    async fn watch_finalized_head(
+    /// Polls `eth_getBlockByNumber(Finalized)` (production) or `(Latest)`
+    /// (optimistic dev mode) on the configured interval and publishes advances
+    /// over the `watch` channel. Retries forever; the stream supervisor
+    /// watchdog remains the escape hatch.
+    async fn watch_head(
         client: Arc<EthereumClient>,
         head: watch::Sender<u64>,
         refresh_interval: Duration,
         max_failures: u32,
         stall_rewarn_secs: u64,
+        optimistic: bool,
         cancel: CancellationToken,
     ) {
         let mut stall = FinalizedHeadStall::new(
@@ -179,13 +178,15 @@ impl FinalizedHeadTracker {
         );
         let mut failures = 0u32;
 
-        tracing::info!("ethereum finalized-head watcher started");
+        tracing::info!(optimistic, "ethereum head watcher started");
 
         loop {
-            match client
-                .get_block(BlockId::Number(BlockNumberOrTag::Finalized))
-                .await
-            {
+            let block_id = BlockId::Number(if optimistic {
+                BlockNumberOrTag::Latest
+            } else {
+                BlockNumberOrTag::Finalized
+            });
+            match client.get_block(block_id).await {
                 Ok(Some(block)) => {
                     failures = 0;
                     let new_final = block.header.number;
@@ -201,7 +202,7 @@ impl FinalizedHeadTracker {
                 }
                 Ok(None) => {
                     tracing::warn!(
-                        "ethereum get_block(Finalized) returned no block; watcher keeps retrying"
+                        "ethereum get_block(head) returned no block; watcher keeps retrying"
                     );
                 }
                 Err(err) => {
@@ -210,7 +211,7 @@ impl FinalizedHeadTracker {
                         ?err,
                         failures,
                         max_failures,
-                        "ethereum get_block(Finalized) failed; watcher keeps retrying"
+                        "ethereum get_block(head) failed; watcher keeps retrying"
                     );
                 }
             }

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -4,14 +4,13 @@ use crate::event_parsing::{emit_respond_events, parse_filtered_logs};
 use crate::execution_watcher::{ExecutionWatcher, WatcherGateState};
 use crate::finalized_head::FinalizedHeadTracker;
 use crate::EthConfig;
-use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::Address;
-use alloy::rpc::types::{Block, BlockId, Log};
+use alloy::rpc::types::{Block, Log};
 use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use async_trait::async_trait;
-use futures_util::{stream, Stream, StreamExt};
-use mpc_chain_integration_core::utils::task::{retry_until_ok, AbortOnDrop, CancellationTokenExt};
+use futures_util::{stream, Stream};
+use mpc_chain_integration_core::utils::task::{retry_until_ok, retry_until_some, AbortOnDrop};
 use mpc_chain_integration_core::{ChainIndexer, ChainTelemetry, StateManager};
 use mpc_primitives::{Chain, ChainEvent, IndexedSignRequest};
 use std::sync::{Arc, Mutex};
@@ -21,10 +20,8 @@ use tokio_util::sync::CancellationToken;
 
 pub struct BlockAndRequests {
     block_number: u64,
-    block_hash: alloy::primitives::B256,
-    /// Block timestamp captured from the block we already fetched, so
-    /// `emit_processed_block` doesn't need to re-fetch the block just to read
-    /// it back. Used for `ChainEvent::SignRequest`'s `block_timestamp` field.
+    /// Block timestamp captured from the fetched block, used for
+    /// `ChainEvent::SignRequest`'s `block_timestamp` field.
     block_timestamp: u64,
     indexed_requests: Vec<IndexedSignRequest>,
     respond_logs: Vec<Log>,
@@ -34,7 +31,6 @@ pub struct BlockAndRequests {
 impl BlockAndRequests {
     fn new(
         block_number: u64,
-        block_hash: alloy::primitives::B256,
         block_timestamp: u64,
         indexed_requests: Vec<IndexedSignRequest>,
         respond_logs: Vec<Log>,
@@ -42,7 +38,6 @@ impl BlockAndRequests {
     ) -> Self {
         Self {
             block_number,
-            block_hash,
             block_timestamp,
             indexed_requests,
             respond_logs,
@@ -57,8 +52,7 @@ pub struct EthereumIndexer<S: StateManager, T: ChainTelemetry> {
     telemetry: T,
     client: Arc<EthereumClient>,
     contract_address: Address,
-    /// Cached finalized head, maintained by a background watcher and consulted by
-    /// `emit_processed_block` so each block need not poll finality independently.
+    /// Finalized head tracker and watcher task, used to gate catchup and live tail processing.
     finalized_head: FinalizedHeadTracker,
     /// Watcher nonce-gate scheduling state (first-appearance checks + retries).
     watcher_gate: Mutex<WatcherGateState>,
@@ -114,41 +108,6 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             .spawn_watcher(self.client.clone(), cancel)
     }
 
-    /// Track the chain tip and forward each new block number to the channel.
-    async fn track_chain_tip(
-        client: Arc<EthereumClient>,
-        start_block_number: u64,
-        block_numbers: mpsc::Sender<u64>,
-    ) {
-        tracing::info!("tracking ethereum chain tip starting at block {start_block_number}");
-
-        let mut current_block_number = start_block_number;
-
-        // Missing ticks is what we want due to retrying on transient errors
-        let mut interval = tokio::time::interval(Self::RETRY_DELAY);
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-
-        loop {
-            interval.tick().await;
-
-            let latest_block_number = match client.get_latest_block_number().await {
-                Ok(Some(number)) => number,
-                Ok(None) => continue,
-                Err(err) => {
-                    tracing::warn!(?err, "ethereum latest block fetch failed");
-                    continue;
-                }
-            };
-
-            while current_block_number <= latest_block_number {
-                if block_numbers.send(current_block_number).await.is_err() {
-                    return;
-                }
-                current_block_number = current_block_number.saturating_add(1);
-            }
-        }
-    }
-
     /// Fetch the contract-relevant logs for a single `block`, gated by its
     /// bloom filter.
     async fn fetch_block_logs(&self, block: &Block) -> anyhow::Result<Vec<Log>> {
@@ -171,10 +130,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
 
         // Log progress every 10 blocks
         if block_number.is_multiple_of(10) {
-            tracing::info!(
-                height = block_number,
-                "processed ethereum catchup block attempt"
-            );
+            tracing::info!(height = block_number, "processed ethereum block");
         }
 
         #[cfg(feature = "bench")]
@@ -182,7 +138,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
 
         self.telemetry.block_indexed(block_number);
         let parsed = self.parse_block(block, relevant_logs).await?;
-        self.emit_processed_block(events_tx, parsed).await?;
+        self.emit_block_events(events_tx, parsed).await?;
 
         #[cfg(feature = "bench")]
         {
@@ -237,7 +193,6 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         // `ChainEvent::Block` even when there are no relevant contract logs.
         Ok(BlockAndRequests::new(
             block_number,
-            block_hash,
             block.header.timestamp,
             sign_requests,
             respond_logs,
@@ -245,48 +200,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         ))
     }
 
-    /// Emits the processed block in-order once we reach finality for it.
-    async fn emit_processed_block(
-        &self,
-        events_tx: &mpsc::Sender<ChainEvent>,
-        parsed: BlockAndRequests,
-    ) -> anyhow::Result<()> {
-        // Wait for the finalized head to reach this block number before emitting.
-        // Non-optimistic in production - the block is guaranteed to be canonical.
-        self.finalized_head.wait_for(parsed.block_number).await?;
-
-        // Reorg hash-check: only for blocks not covered by the finalized head.
-        // Always false in production because the finalized head is guaranteed to be canonical
-        // TODO: move optimistic policy into FinalizedHeadTracker so the indexer becomes mode-agnostic and the branch disappears (larger refactor)
-        if self.finalized_head.current() < parsed.block_number {
-            let block = self
-                .client
-                .as_ref()
-                .get_block(BlockId::Number(BlockNumberOrTag::Number(
-                    parsed.block_number,
-                )))
-                .await?
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "ethereum block {} not found during emission",
-                        parsed.block_number
-                    )
-                })?;
-
-            if block.header.hash != parsed.block_hash {
-                // The block was reorged after `parse_block` produced this payload.
-                // Do not emit stale events for a different canonical block, but also do
-                // not return an error that would cause the catchup path to retry this
-                // same stale payload forever.
-                return Ok(());
-            }
-        }
-
-        self.emit_block_events(events_tx, parsed).await
-    }
-
-    /// Emit the parsed block's events.
-    /// Used directly by the live path, which fetches the block post-finality.
+    /// Emit the parsed block's events in order.
     async fn emit_block_events(
         &self,
         events_tx: &mpsc::Sender<ChainEvent>,
@@ -296,7 +210,6 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             indexed_requests,
             respond_logs,
             execution_events,
-            ..
         }: BlockAndRequests,
     ) -> anyhow::Result<()> {
         for event in execution_events {
@@ -404,25 +317,80 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         }
     }
 
-    /// Process a block number: wait for finality, fetch the
-    /// canonical block, parse and emit events.
-    async fn process_finalized_block(
+    /// The catchup-live anchor: the startup tip + 1 (exclusive catchup end and
+    /// first live block), retrying until the tip is available.
+    /// Returns `None` on cancellation.
+    async fn sample_anchor(&self, cancel: &CancellationToken) -> Option<u64> {
+        retry_until_some(
+            cancel,
+            Self::RETRY_DELAY,
+            "ethereum latest block",
+            || async { self.client.get_latest_block_number().await },
+        )
+        .await
+        .map(|tip| tip.saturating_add(1))
+    }
+
+    /// Wait until the next block is processable, either by waiting for the finalized head to reach it, or by polling the latest tip in optimistic mode.
+    async fn wait_processable_bound(
+        &self,
+        next: u64,
+        cancel: &CancellationToken,
+    ) -> anyhow::Result<Option<u64>> {
+        // TODO: clean up next
+        if self.eth.optimistic_requests {
+            Ok(
+                retry_until_some(cancel, Self::RETRY_DELAY, "ethereum latest tip", || async {
+                    Ok(self
+                        .client
+                        .get_latest_block_number()
+                        .await?
+                        .filter(|&latest| latest >= next))
+                })
+                .await,
+            )
+        } else {
+            tokio::select! {
+                _ = cancel.cancelled() => Ok(None),
+                res = self.finalized_head.wait_for(next) => {
+                    res?;
+                    Ok(Some(self.finalized_head.current()))
+                }
+            }
+        }
+    }
+
+    /// Batch-fetch `[start, end)` via `CatchupIter` and process each item,
+    /// retrying transient failures. Returns early on cancellation.
+    async fn process_range(
         &self,
         events_tx: &mpsc::Sender<ChainEvent>,
-        block_number: u64,
+        start: u64,
+        end: u64,
+        cancel: &CancellationToken,
     ) -> anyhow::Result<()> {
-        self.finalized_head.wait_for(block_number).await?;
-
-        let block = self
-            .client
-            .get_block(BlockId::Number(BlockNumberOrTag::Number(block_number)))
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("ethereum finalized block {block_number} not found"))?;
-        let logs = self.fetch_block_logs(&block).await?;
-
-        self.telemetry.block_indexed(block_number);
-        let parsed = self.parse_block(&block, &logs).await?;
-        self.emit_block_events(events_tx, parsed).await
+        let mut iter = CatchupIter::new(
+            self.client.clone(),
+            start,
+            end,
+            self.contract_address,
+            self.eth.indexer.catchup_block_batch_size,
+        );
+        loop {
+            let item = tokio::select! {
+                _ = cancel.cancelled() => return Ok(()),
+                item = iter.next() => item,
+            };
+            let Some(item) = item else { break };
+            retry_until_ok(
+                cancel,
+                Self::RETRY_DELAY,
+                "ethereum block processing",
+                || async { self.process_catchup_item(events_tx, &item).await },
+            )
+            .await;
+        }
+        Ok(())
     }
 }
 
@@ -435,74 +403,54 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
         events_tx: mpsc::Sender<ChainEvent>,
         cancel: CancellationToken,
     ) -> anyhow::Result<()> {
-        // Anchor: the live task starts here once catchup reaches it.
-        let anchor_height = loop {
-            if cancel.is_cancelled() {
-                return Ok(());
-            }
-            match self.client.get_latest_block_number().await {
-                Ok(Some(latest)) => break latest.saturating_add(1),
-                Ok(None) => {}
-                Err(err) => {
-                    tracing::warn!(?err, "ethereum latest block fetch failed");
-                }
-            }
-            if cancel.cancelled_within(Self::RETRY_DELAY).await {
-                return Ok(());
-            }
-        };
-
         // Spawn the finalized head watcher.
         let _finalized_watcher = self
             .finalized_head
             .spawn_watcher(self.client.clone(), cancel.clone());
 
-        let mut catchup_iter = self.catchup_blocks(anchor_height).await;
-        loop {
-            let item = tokio::select! {
-                _ = cancel.cancelled() => return Ok(()),
-                item = catchup_iter.next() => item,
+        // Anchor = tip-at-startup + 1: the catchup-live boundary.
+        let Some(anchor) = self.sample_anchor(&cancel).await else {
+            return Ok(()); // cancelled while waiting for anchor
+        };
+
+        // Next block to process, starting from the last processed block + 1
+        // Or start from the anchor if no blocks have been processed yet.
+        let mut next = self
+            .state_manager
+            .get_processed_block(Chain::Ethereum)
+            .await
+            .map(|n| n.saturating_add(1))
+            .unwrap_or(anchor);
+        next = self.client.clamp_oldest_supported(next, anchor);
+
+        // Catchup: process all blocks up to the anchor, then emit a CatchupCompleted event.
+        while next < anchor {
+            // Wait for the next block to be processable
+            let Some(upper) = self.wait_processable_bound(next, &cancel).await? else {
+                return Ok(()); // cancelled while waiting
             };
-            let Some(item) = item else { break };
-            retry_until_ok(
-                &cancel,
-                Self::RETRY_DELAY,
-                "ethereum catchup block processing",
-                || async { self.process_catchup_item(&events_tx, &item).await },
-            )
-            .await;
+            // Clamp the upper bound to the anchor so we don't process beyond it.
+            let end = upper.min(anchor.saturating_sub(1)) + 1;
+            self.process_range(&events_tx, next, end, &cancel).await?;
+            next = end;
         }
 
+        if cancel.is_cancelled() {
+            return Ok(());
+        }
         events_tx
             .send(ChainEvent::CatchupCompleted)
             .await
             .context("failed to send catchup completed event")?;
 
-        // Spawned only after catchup: no catchup/live coordination needed, and
-        // the abort-on-drop guard ties the task's lifetime to this `run()`.
-        let (block_numbers_tx, mut block_numbers_rx) =
-            mpsc::channel(self.eth.indexer.live_block_buffer);
-        let _live_task = AbortOnDrop(tokio::spawn(Self::track_chain_tip(
-            self.client.clone(),
-            anchor_height,
-            block_numbers_tx,
-        )));
-
+        // Live tail: process each block as it becomes processable, waiting for the finalized head to reach it.
         loop {
-            let number = tokio::select! {
-                _ = cancel.cancelled() => return Ok(()),
-                number = block_numbers_rx.recv() => number,
+            let Some(upper) = self.wait_processable_bound(next, &cancel).await? else {
+                return Ok(()); // cancelled while waiting
             };
-            let Some(number) = number else {
-                anyhow::bail!("ethereum chain tip tracker terminated at block {anchor_height}");
-            };
-            retry_until_ok(
-                &cancel,
-                Self::RETRY_DELAY,
-                "ethereum live block processing",
-                || async { self.process_finalized_block(&events_tx, number).await },
-            )
-            .await;
+            self.process_range(&events_tx, next, upper + 1, &cancel)
+                .await?;
+            next = upper + 1;
         }
     }
 }
@@ -602,8 +550,6 @@ mod tests {
             .build()
             .await;
         let (events_tx, mut events_rx) = chain_event_channel();
-        // Ensure blocks are considered finalized to avoid reorg-check refetches in process_catchup
-        indexer.finalized_head.set_head(100);
 
         let mut iter = crate::client::CatchupIter::new(
             indexer.client.clone(),
@@ -664,7 +610,6 @@ mod tests {
             .build()
             .await;
         let (events_tx, mut events_rx) = chain_event_channel();
-        indexer.finalized_head.set_head(100);
 
         let mut iter = crate::client::CatchupIter::new(
             indexer.client.clone(),
@@ -703,8 +648,7 @@ mod tests {
         let mut server = Server::new_async().await;
         let block_number = 12;
 
-        // One Missing in the batch;
-        // assert process_catchup does 1 get_block + 1 single eth_getBlockReceipts for that block.
+        // One Missing item: process_catchup refetches the block once by number.
         let block_mock = server
             .mock("POST", "/")
             .match_body(Matcher::PartialJson(json!({
@@ -714,7 +658,7 @@ mod tests {
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(test_utils::block_response(1, block_number).to_string())
-            .expect(1) // Should only be fetched once because we consider it finalized
+            .expect(1) // refetched exactly once by the Missing path
             .create_async()
             .await;
 
@@ -732,9 +676,6 @@ mod tests {
             .build()
             .await;
         let (events_tx, mut events_rx) = chain_event_channel();
-
-        // Ensure block is considered finalized to avoid the reorg-check refetch
-        indexer.finalized_head.set_head(100);
 
         let item = CatchupItem::Missing(BlockId::Number(BlockNumberOrTag::Number(block_number)));
         indexer
@@ -781,8 +722,6 @@ mod tests {
             .build()
             .await;
         let (events_tx, mut events_rx) = chain_event_channel();
-        // Ensure block is considered finalized to avoid the reorg-check refetch
-        indexer.finalized_head.set_head(100);
 
         let mut iter = crate::client::CatchupIter::new(
             indexer.client.clone(),
@@ -805,55 +744,6 @@ mod tests {
 
         blocks_mock.assert_async().await;
         logs_mock.assert_async().await;
-    }
-
-    #[tokio::test]
-    async fn live_fetches_finalized_block_after_finality() {
-        let mut server = Server::new_async().await;
-        let block_number = 42;
-
-        // Empty-bloom block: the bloom gate skips eth_getLogs entirely.
-        let logs_mock = server
-            .mock("POST", "/")
-            .match_body(Matcher::Regex("eth_getLogs".to_string()))
-            .expect(0)
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body("[]")
-            .create_async()
-            .await;
-
-        // Post-finality block fetch by number
-        let block_mock = server
-            .mock("POST", "/")
-            .match_body(Matcher::PartialJson(json!({
-                "method": "eth_getBlockByNumber",
-                "params": [format!("0x{block_number:x}"), false]
-            })))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(test_utils::block_response(2, block_number).to_string())
-            .expect(1)
-            .create_async()
-            .await;
-
-        let indexer = test_utils::TestIndexerBuilder::new(server.url())
-            .build()
-            .await;
-        let (events_tx, mut events_rx) = chain_event_channel();
-
-        indexer
-            .process_finalized_block(&events_tx, block_number)
-            .await
-            .expect("live process should succeed");
-
-        assert!(matches!(
-            events_rx.recv().await,
-            Some(ChainEvent::Block(n)) if n == block_number
-        ));
-
-        logs_mock.assert_async().await;
-        block_mock.assert_async().await;
     }
 
     #[tokio::test]
@@ -908,7 +798,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn catchup_finalized_block_does_not_refetch_for_emission() {
+    async fn catchup_emits_block_without_refetching() {
         let mut server = Server::new_async().await;
 
         let item = test_utils::batch_block(42, vec![]);
@@ -917,9 +807,8 @@ mod tests {
         };
         let block_number = block.header.number;
 
-        // `eth_getBlockByNumber(Number)` for the same block — must NEVER be hit,
-        // because this catchup block is at or below the finalized head sampled at
-        // catchup start, so the reorg check is skipped.
+        // `process_block` emits directly from the batch-supplied block; it must
+        // never re-fetch the same block by number.
         let block_by_number_mock = server
             .mock("POST", "/")
             .match_body(Matcher::PartialJson(json!({
@@ -933,65 +822,15 @@ mod tests {
             .create_async()
             .await;
 
-        // Optimistic mode (default) so the finalized-head wait is skipped.
         let indexer = test_utils::TestIndexerBuilder::new(server.url())
             .build()
             .await;
         let (events_tx, mut events_rx) = chain_event_channel();
-        // Block 42 was finalized at fetch time (head sampled at 100), so the
-        // re-fetch + reorg check is skipped.
-        indexer.finalized_head.set_head(100);
 
         indexer
             .process_catchup_item(&events_tx, &item)
             .await
-            .expect("catchup over a present finalized block should succeed");
-
-        block_by_number_mock.assert_async().await;
-
-        // The block event must still be emitted.
-        assert!(matches!(
-            events_rx.recv().await,
-            Some(ChainEvent::Block(n)) if n == block_number
-        ));
-    }
-
-    #[tokio::test]
-    async fn catchup_unfinalized_block_keeps_reorg_check() {
-        let mut server = Server::new_async().await;
-
-        let item = test_utils::batch_block(42, vec![]);
-        let CatchupItem::BatchBlock { block, .. } = &item else {
-            unreachable!("test_utils::batch_block returns CatchupItem::BatchBlock")
-        };
-        let block_number = block.header.number;
-
-        // `eth_getBlockByNumber(Number)` — expected once: block 42 is above the
-        // sampled finalized head (10), so the check runs. Matching hash → emit.
-        let block_by_number_mock = server
-            .mock("POST", "/")
-            .match_body(Matcher::PartialJson(json!({
-                "method": "eth_getBlockByNumber",
-                "params": [format!("0x{block_number:x}"), false]
-            })))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(test_utils::block_response(3, block_number).to_string())
-            .expect(1)
-            .create_async()
-            .await;
-
-        let indexer = test_utils::TestIndexerBuilder::new(server.url())
-            .build()
-            .await;
-        let (events_tx, mut events_rx) = chain_event_channel();
-        // Finalized head sampled at 10 → block 42 is unfinalized at fetch time.
-        indexer.finalized_head.set_head(10);
-
-        indexer
-            .process_catchup_item(&events_tx, &item)
-            .await
-            .expect("catchup over an unfinalized block should succeed");
+            .expect("catchup over a present block should succeed");
 
         block_by_number_mock.assert_async().await;
 
@@ -1017,9 +856,6 @@ mod tests {
     struct RunFixture {
         _server: mockito::ServerGuard,
         latest: Arc<AtomicU64>,
-        /// Highest block number fetched by number, used to detect producer
-        /// activity after cancellation.
-        max_requested_block: Arc<AtomicU64>,
         cancel: CancellationToken,
         run_handle: tokio::task::JoinHandle<anyhow::Result<()>>,
         events_rx: mpsc::Receiver<ChainEvent>,
@@ -1029,7 +865,6 @@ mod tests {
         async fn spawn(processed: u64, latest: u64) -> Self {
             let mut server = Server::new_async().await;
             let latest = Arc::new(AtomicU64::new(latest));
-            let max_requested_block = Arc::new(AtomicU64::new(0));
 
             // Anchor sampling + live head polling.
             server
@@ -1037,23 +872,6 @@ mod tests {
                 .match_body(Matcher::PartialJson(json!({
                     "method": "eth_getBlockByNumber",
                     "params": ["latest", false]
-                })))
-                .with_status(200)
-                .with_header("content-type", "application/json")
-                .with_body_from_request({
-                    let latest = latest.clone();
-                    move |req| block_reply(req, latest.load(Ordering::Relaxed))
-                })
-                .create_async()
-                .await;
-
-            // Finalized head sampled once at catchup start; tracking `latest`
-            // means catchup blocks skip the reorg refetch.
-            server
-                .mock("POST", "/")
-                .match_body(Matcher::PartialJson(json!({
-                    "method": "eth_getBlockByNumber",
-                    "params": ["finalized", false]
                 })))
                 .with_status(200)
                 .with_header("content-type", "application/json")
@@ -1092,31 +910,6 @@ mod tests {
                 .create_async()
                 .await;
 
-            // Single-block fetches by number (live fetch + reorg refetch).
-            server
-                .mock("POST", "/")
-                .match_body(Matcher::Regex(r#"^\{.*"params":\["0x"#.to_string()))
-                .with_status(200)
-                .with_header("content-type", "application/json")
-                .with_body_from_request({
-                    let max_requested_block = max_requested_block.clone();
-                    move |req| {
-                        let body: serde_json::Value =
-                            serde_json::from_slice(req.body().expect("request body"))
-                                .expect("json body");
-                        let id = body["id"].as_u64().expect("request id");
-                        let hex = body["params"][0].as_str().expect("block number param");
-                        let number = u64::from_str_radix(hex.trim_start_matches("0x"), 16)
-                            .expect("hex block number");
-                        max_requested_block.fetch_max(number, Ordering::Relaxed);
-                        test_utils::block_response(id, number)
-                            .to_string()
-                            .into_bytes()
-                    }
-                })
-                .create_async()
-                .await;
-
             let builder = test_utils::TestIndexerBuilder::new(server.url());
             builder
                 .state_manager
@@ -1134,7 +927,6 @@ mod tests {
             Self {
                 _server: server,
                 latest,
-                max_requested_block,
                 cancel,
                 run_handle,
                 events_rx,
@@ -1207,7 +999,57 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancel_aborts_chain_tip_tracker() {
+    async fn wait_processable_bound_polls_latest_in_optimistic_mode() {
+        let mut server = Server::new_async().await;
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockByNumber",
+                "params": ["latest", false]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(test_utils::block_response(1, 10).to_string())
+            .create_async()
+            .await;
+
+        // Optimistic mode is the TestIndexerBuilder default.
+        let indexer = test_utils::TestIndexerBuilder::new(server.url())
+            .build()
+            .await;
+        let cancel = CancellationToken::new();
+
+        let upper = indexer
+            .wait_processable_bound(5, &cancel)
+            .await
+            .expect("optimistic wait_processable_bound resolves once latest >= next");
+        assert_eq!(upper, Some(10));
+    }
+
+    #[tokio::test]
+    async fn wait_processable_bound_waits_for_finalized_head() {
+        // Non-optimistic mode: wait_processable_bound blocks on the cached finalized
+        // head, so no RPC is needed.
+        let mut builder = test_utils::TestIndexerBuilder::new("http://127.0.0.1:1");
+        builder.eth.optimistic_requests = false;
+        let indexer = builder.build().await;
+        let cancel = CancellationToken::new();
+
+        let head = indexer.finalized_head.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            head.set_head(100);
+        });
+
+        let upper = indexer
+            .wait_processable_bound(50, &cancel)
+            .await
+            .expect("wait_processable_bound resolves once the head covers next");
+        assert_eq!(upper, Some(100));
+    }
+
+    #[tokio::test]
+    async fn cancel_stops_block_processing_after_catchup() {
         let mut f = RunFixture::spawn(9, 9).await;
         assert!(matches!(f.next_event().await, ChainEvent::CatchupCompleted));
 
@@ -1216,14 +1058,12 @@ mod tests {
 
         f.cancel_and_join().await;
 
-        // Check that the live block producer did not advance after cancellation.
-        let max_at_cancel = f.max_requested_block.load(Ordering::Relaxed);
+        // After cancellation, advancing the tip must not produce any more blocks.
         f.latest.store(11, Ordering::Relaxed);
         tokio::time::sleep(Duration::from_millis(1200)).await;
-        assert_eq!(
-            f.max_requested_block.load(Ordering::Relaxed),
-            max_at_cancel,
-            "live block producer survived run() cancellation"
+        assert!(
+            f.events_rx.try_recv().is_err(),
+            "block processing continued after run() cancellation"
         );
     }
 }

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -385,12 +385,13 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
 impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> {
     const CHAIN: Chain = Chain::Ethereum;
 
-    // TODO: add tracing
     async fn run(
         &self,
         events_tx: mpsc::Sender<ChainEvent>,
         cancel: CancellationToken,
     ) -> anyhow::Result<()> {
+        tracing::info!("ethereum indexer started");
+
         // Spawn the finalized head watcher.
         let _finalized_watcher = self
             .finalized_head
@@ -398,7 +399,8 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
 
         // Anchor = tip-at-startup + 1: the catchup-live boundary.
         let Some(anchor) = self.sample_anchor(&cancel).await else {
-            return Ok(()); // cancelled while waiting for anchor
+            tracing::debug!("ethereum indexer cancelled before the startup tip was sampled");
+            return Ok(());
         };
 
         // Next block to process, starting from the last processed block + 1
@@ -410,6 +412,20 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
             .map(|n| n.saturating_add(1))
             .unwrap_or(anchor);
         next = self.client.clamp_oldest_supported(next, anchor);
+
+        if next < anchor {
+            tracing::info!(
+                start = next,
+                tip = anchor.saturating_sub(1),
+                blocks = anchor - next,
+                "ethereum indexer starting catchup"
+            );
+        } else {
+            tracing::info!(
+                height = next,
+                "ethereum indexer already caught up; skipping catchup"
+            );
+        }
 
         // Catchup: process all blocks up to the anchor, then emit a CatchupCompleted event.
         while next < anchor {
@@ -424,8 +440,13 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
         }
 
         if cancel.is_cancelled() {
+            tracing::debug!("ethereum indexer cancelled after catchup; skipping CatchupCompleted");
             return Ok(());
         }
+        tracing::info!(
+            height = next,
+            "ethereum catchup complete; entering live tail"
+        );
         events_tx
             .send(ChainEvent::CatchupCompleted)
             .await

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -167,11 +167,30 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         block: &Block,
         relevant_logs: &[Log],
     ) -> anyhow::Result<()> {
-        // Emit telemetry for the indexed block number
-        self.telemetry.block_indexed(block.header.number);
+        let block_number = block.header.number;
 
-        let processed = self.parse_block(block, relevant_logs).await?;
-        self.emit_processed_block(events_tx, processed).await?;
+        // Log progress every 10 blocks
+        if block_number.is_multiple_of(10) {
+            tracing::info!(
+                height = block_number,
+                "processed ethereum catchup block attempt"
+            );
+        }
+
+        #[cfg(feature = "bench")]
+        let start = std::time::Instant::now();
+
+        self.telemetry.block_indexed(block_number);
+        let parsed = self.parse_block(block, relevant_logs).await?;
+        self.emit_processed_block(events_tx, parsed).await?;
+
+        #[cfg(feature = "bench")]
+        {
+            crate::bench::add_process_time(start.elapsed());
+            if crate::bench::inc_block() % 100 == 0 {
+                crate::bench::report_metrics("catchup_progress");
+            }
+        }
 
         Ok(())
     }
@@ -191,27 +210,18 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
             block_hash
         );
 
-        let mut sign_requests = Vec::new();
-
-        let (respond_logs, potential_request_logs): (Vec<Log>, Vec<Log>) =
-            relevant_logs.iter().cloned().partition(|log| {
-                log.topic0().is_some_and(|topic| {
-                    *topic == ChainSignatures::SignatureResponded::SIGNATURE_HASH
-                })
-            });
-
-        let request_logs: Vec<Log> = potential_request_logs
-            .into_iter()
-            .filter(|log| {
-                log.topic0().is_some_and(|topic| {
-                    *topic == ChainSignatures::SignatureRequested::SIGNATURE_HASH
-                })
-            })
+        // Filter relevant logs into request and respond categories
+        let request_logs: Vec<Log> = relevant_logs
+            .iter()
+            .filter(|l| l.topic0() == Some(&ChainSignatures::SignatureRequested::SIGNATURE_HASH))
+            .cloned()
             .collect();
-
-        if !request_logs.is_empty() {
-            sign_requests.extend(parse_filtered_logs(request_logs));
-        }
+        let respond_logs: Vec<Log> = relevant_logs
+            .iter()
+            .filter(|l| l.topic0() == Some(&ChainSignatures::SignatureResponded::SIGNATURE_HASH))
+            .cloned()
+            .collect();
+        let sign_requests = parse_filtered_logs(request_logs);
 
         // Collect execution confirmations (if any) and emit ExecutionConfirmed events
         let watcher = ExecutionWatcher::new(
@@ -366,14 +376,10 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         events_tx: &mpsc::Sender<ChainEvent>,
         item: &CatchupItem,
     ) -> anyhow::Result<()> {
-        // NOTE: oh rust: needed otherwise the block gets dropped before we can use
-        // it, since it `block` is of reference type. Maybe the language will let
-        // us elide this in the future, but for now we need to introduce a new var.
-        let _block;
-        let _logs;
-
-        let (block, logs) = match item {
-            CatchupItem::BatchBlock { block, logs } => (block, logs.as_slice()),
+        match item {
+            CatchupItem::BatchBlock { block, logs } => {
+                self.process_block(events_tx, block, logs).await
+            }
             CatchupItem::Missing(block_id) => {
                 tracing::warn!(
                     ?block_id,
@@ -383,42 +389,19 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
                 #[cfg(feature = "bench")]
                 let start = std::time::Instant::now();
 
-                // Refetch the block, then bloom-gate a single-block `eth_getLogs`.
                 let block = self.client.get_block(*block_id).await?.ok_or_else(|| {
                     anyhow::anyhow!(
                         "ethereum catchup block {block_id:?} is still unavailable after refetch"
                     )
                 })?;
-                let l = self.fetch_block_logs(&block).await?;
+                let logs = self.fetch_block_logs(&block).await?;
 
                 #[cfg(feature = "bench")]
                 crate::bench::add_refetch_time(start.elapsed());
 
-                _block = block;
-                _logs = l;
-                (&_block, _logs.as_slice())
-            }
-        };
-
-        let height = block.header.number;
-        if height.is_multiple_of(10) {
-            tracing::info!(height, "processed ethereum catchup block attempt");
-        }
-
-        #[cfg(feature = "bench")]
-        let start_process = std::time::Instant::now();
-
-        self.process_block(events_tx, block, logs).await?;
-
-        #[cfg(feature = "bench")]
-        {
-            crate::bench::add_process_time(start_process.elapsed());
-            if crate::bench::inc_block() % 100 == 0 {
-                crate::bench::report_metrics("catchup_progress");
+                self.process_block(events_tx, &block, &logs).await
             }
         }
-
-        Ok(())
     }
 
     /// Process a block number: wait for finality, fetch the

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -100,9 +100,8 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         }
     }
 
-    /// Spawn the background finalized-head watcher. Returns a guard whose drop
-    /// aborts the task, or `None` in optimistic mode (dev chains never report a
-    /// finalized head).
+    /// Spawn the background head watcher (`Finalized` in production, `Latest` in
+    /// optimistic dev mode). Returns a guard whose drop aborts the task.
     pub fn spawn_finalized_head_watcher(&self, cancel: CancellationToken) -> AbortOnDrop {
         self.finalized_head
             .spawn_watcher(self.client.clone(), cancel)
@@ -189,8 +188,8 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         );
         let exec_events = watcher.collect(block).await?;
 
-        // Always forward the processed block to the "finalization" stage so it can emit
-        // `ChainEvent::Block` even when there are no relevant contract logs.
+        // Always produce a payload so `ChainEvent::Block` is emitted even when
+        // the block has no relevant contract logs.
         Ok(BlockAndRequests::new(
             block_number,
             block.header.timestamp,
@@ -241,9 +240,8 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         Ok(())
     }
 
-    /// Catchup blocks in `[processed + 1, anchor_height)` fetched in batches.
-    /// Samples the finalized head once at catchup start, so blocks at or below
-    /// it can skip the per-block re-fetch + reorg hash check.
+    /// Catchup blocks in `[processed + 1, anchor_height)` fetched in batches,
+    /// clamped to the RPC's supported historical window.
     pub async fn catchup_blocks(
         &self,
         anchor_height: u64,

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -103,7 +103,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
     /// Spawn the background finalized-head watcher. Returns a guard whose drop
     /// aborts the task, or `None` in optimistic mode (dev chains never report a
     /// finalized head).
-    pub fn spawn_finalized_head_watcher(&self, cancel: CancellationToken) -> Option<AbortOnDrop> {
+    pub fn spawn_finalized_head_watcher(&self, cancel: CancellationToken) -> AbortOnDrop {
         self.finalized_head
             .spawn_watcher(self.client.clone(), cancel)
     }
@@ -331,31 +331,18 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         .map(|tip| tip.saturating_add(1))
     }
 
-    /// Wait until the next block is processable, either by waiting for the finalized head to reach it, or by polling the latest tip in optimistic mode.
+    /// Wait until `next` is processable (the head covers it), returning the
+    /// ready upper bound. Returns `None` on cancellation.
     async fn wait_processable_bound(
         &self,
         next: u64,
         cancel: &CancellationToken,
     ) -> anyhow::Result<Option<u64>> {
-        // TODO: clean up next
-        if self.eth.optimistic_requests {
-            Ok(
-                retry_until_some(cancel, Self::RETRY_DELAY, "ethereum latest tip", || async {
-                    Ok(self
-                        .client
-                        .get_latest_block_number()
-                        .await?
-                        .filter(|&latest| latest >= next))
-                })
-                .await,
-            )
-        } else {
-            tokio::select! {
-                _ = cancel.cancelled() => Ok(None),
-                res = self.finalized_head.wait_for(next) => {
-                    res?;
-                    Ok(Some(self.finalized_head.current()))
-                }
+        tokio::select! {
+            _ = cancel.cancelled() => Ok(None),
+            res = self.finalized_head.wait_for(next) => {
+                res?;
+                Ok(Some(self.finalized_head.current()))
             }
         }
     }
@@ -398,6 +385,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
 impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> {
     const CHAIN: Chain = Chain::Ethereum;
 
+    // TODO: add tracing
     async fn run(
         &self,
         events_tx: mpsc::Sender<ChainEvent>,
@@ -996,34 +984,6 @@ mod tests {
     async fn run_stops_promptly_on_cancel_during_catchup() {
         let mut f = RunFixture::spawn(0, 500).await;
         f.cancel_and_join().await;
-    }
-
-    #[tokio::test]
-    async fn wait_processable_bound_polls_latest_in_optimistic_mode() {
-        let mut server = Server::new_async().await;
-        server
-            .mock("POST", "/")
-            .match_body(Matcher::PartialJson(json!({
-                "method": "eth_getBlockByNumber",
-                "params": ["latest", false]
-            })))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(test_utils::block_response(1, 10).to_string())
-            .create_async()
-            .await;
-
-        // Optimistic mode is the TestIndexerBuilder default.
-        let indexer = test_utils::TestIndexerBuilder::new(server.url())
-            .build()
-            .await;
-        let cancel = CancellationToken::new();
-
-        let upper = indexer
-            .wait_processable_bound(5, &cancel)
-            .await
-            .expect("optimistic wait_processable_bound resolves once latest >= next");
-        assert_eq!(upper, Some(10));
     }
 
     #[tokio::test]

--- a/chain-signatures/chain-integration-core/src/utils/task.rs
+++ b/chain-signatures/chain-integration-core/src/utils/task.rs
@@ -89,16 +89,6 @@ mod tests {
     };
 
     #[tokio::test]
-    async fn retry_until_some_returns_value_when_ready() {
-        let cancel = CancellationToken::new();
-        let val = retry_until_some(&cancel, Duration::from_millis(1), "test", || async {
-            Ok::<_, anyhow::Error>(Some(42u64))
-        })
-        .await;
-        assert_eq!(val, Some(42));
-    }
-
-    #[tokio::test]
     async fn retry_until_some_retries_on_none_then_yields_value() {
         let cancel = CancellationToken::new();
         let count = Arc::new(AtomicU32::new(0));
@@ -150,5 +140,101 @@ mod tests {
         })
         .await;
         assert!(val.is_none());
+    }
+
+    #[tokio::test]
+    async fn retry_until_ok_retries_on_error_then_succeeds() {
+        let cancel = CancellationToken::new();
+        let count = Arc::new(AtomicU32::new(0));
+        let count_clone = count.clone();
+        retry_until_ok(&cancel, Duration::from_millis(1), "test", move || {
+            let count = count_clone.clone();
+            async move {
+                if count.fetch_add(1, Ordering::Relaxed) == 0 {
+                    Err(anyhow::anyhow!("boom"))
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .await;
+        assert_eq!(count.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn retry_until_ok_stops_on_cancel() {
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        let count = Arc::new(AtomicU32::new(0));
+        let count_clone = count.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            cancel_clone.cancel();
+        });
+        retry_until_ok(&cancel, Duration::from_millis(50), "test", move || {
+            let count = count_clone.clone();
+            async move {
+                count.fetch_add(1, Ordering::Relaxed);
+                Err::<(), anyhow::Error>(anyhow::anyhow!("always fails"))
+            }
+        })
+        .await;
+        // The task should have been retried at least once before cancellation.
+        assert!(count.load(Ordering::Relaxed) >= 1);
+    }
+
+    #[tokio::test]
+    async fn cancelled_within_returns_false_when_duration_elapses() {
+        let cancel = CancellationToken::new();
+        let started = std::time::Instant::now();
+        let cancelled = cancel.cancelled_within(Duration::from_millis(30)).await;
+        assert!(!cancelled);
+        // `sleep` never returns early, so the full duration must have elapsed.
+        assert!(started.elapsed() >= Duration::from_millis(30));
+    }
+
+    #[tokio::test]
+    async fn cancelled_within_returns_true_when_cancelled_during_wait() {
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            cancel_clone.cancel();
+        });
+        let started = std::time::Instant::now();
+        let cancelled = cancel.cancelled_within(Duration::from_millis(500)).await;
+        assert!(cancelled);
+        assert!(started.elapsed() < Duration::from_millis(200));
+    }
+
+    #[tokio::test]
+    async fn abort_on_drop_aborts_the_wrapped_task() {
+        let count = Arc::new(AtomicU32::new(0));
+        let count_clone = count.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                count_clone.fetch_add(1, Ordering::Relaxed);
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        });
+
+        {
+            let guard = AbortOnDrop(handle);
+            tokio::time::sleep(Duration::from_millis(35)).await;
+            assert!(
+                count.load(Ordering::Relaxed) >= 2,
+                "task should have incremented before drop"
+            );
+            drop(guard);
+        }
+
+        // After dropping the guard, the wrapped task must stop running.
+        let after_drop = count.load(Ordering::Relaxed);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            count.load(Ordering::Relaxed),
+            after_drop,
+            "wrapped task kept running after AbortOnDrop was dropped"
+        );
     }
 }

--- a/chain-signatures/chain-integration-core/src/utils/task.rs
+++ b/chain-signatures/chain-integration-core/src/utils/task.rs
@@ -40,21 +40,12 @@ pub async fn retry_until_ok<F, Fut>(
     F: Fn() -> Fut,
     Fut: Future<Output = anyhow::Result<()>>,
 {
-    loop {
-        tokio::select! {
-            _ = cancel.cancelled() => return,
-            result = process() => match result {
-                Ok(()) => return,
-                Err(err) => tracing::warn!(?err, "{label} failed; retrying"),
-            },
-        }
-        if cancel.cancelled_within(delay).await {
-            return;
-        }
-    }
+    // `Ok(())` -> `Some(())` (done), `Err` retries with backoff.
+    retry_until_some(cancel, delay, label, || async { process().await.map(Some) }).await;
 }
 
-/// Same as `retry_until_ok`, but returns Option<T> when the operation returns `Ok(Some(T))`, and continues retrying on `Ok(None)`.
+/// Retries `poll` with `delay` backoff until it returns `Ok(Some(T))` or `cancel`
+/// fires. Each failure is logged at WARN with `label` identifying the operation.
 pub async fn retry_until_some<T, F, Fut>(
     cancel: &CancellationToken,
     delay: Duration,
@@ -71,7 +62,7 @@ where
             result = poll() => match result {
                 Ok(Some(value)) => return Some(value),
                 Ok(None) => {}
-                Err(err) => tracing::warn!(?err, "{label} not ready; retrying"),
+                Err(err) => tracing::warn!(?err, "{label} failed; retrying"),
             },
         }
         if cancel.cancelled_within(delay).await {

--- a/chain-signatures/chain-integration-core/src/utils/task.rs
+++ b/chain-signatures/chain-integration-core/src/utils/task.rs
@@ -53,3 +53,102 @@ pub async fn retry_until_ok<F, Fut>(
         }
     }
 }
+
+/// Same as `retry_until_ok`, but returns Option<T> when the operation returns `Ok(Some(T))`, and continues retrying on `Ok(None)`.
+pub async fn retry_until_some<T, F, Fut>(
+    cancel: &CancellationToken,
+    delay: Duration,
+    label: &str,
+    poll: F,
+) -> Option<T>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = anyhow::Result<Option<T>>>,
+{
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => return None,
+            result = poll() => match result {
+                Ok(Some(value)) => return Some(value),
+                Ok(None) => {}
+                Err(err) => tracing::warn!(?err, "{label} not ready; retrying"),
+            },
+        }
+        if cancel.cancelled_within(delay).await {
+            return None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    };
+
+    #[tokio::test]
+    async fn retry_until_some_returns_value_when_ready() {
+        let cancel = CancellationToken::new();
+        let val = retry_until_some(&cancel, Duration::from_millis(1), "test", || async {
+            Ok::<_, anyhow::Error>(Some(42u64))
+        })
+        .await;
+        assert_eq!(val, Some(42));
+    }
+
+    #[tokio::test]
+    async fn retry_until_some_retries_on_none_then_yields_value() {
+        let cancel = CancellationToken::new();
+        let count = Arc::new(AtomicU32::new(0));
+        let count_clone = count.clone();
+        let val = retry_until_some(&cancel, Duration::from_millis(1), "test", move || {
+            let count = count_clone.clone();
+            async move {
+                if count.fetch_add(1, Ordering::Relaxed) < 2 {
+                    Ok(None)
+                } else {
+                    Ok(Some(7u64))
+                }
+            }
+        })
+        .await;
+        assert_eq!(val, Some(7));
+        assert_eq!(count.load(Ordering::Relaxed), 3);
+    }
+
+    #[tokio::test]
+    async fn retry_until_some_retries_on_error() {
+        let cancel = CancellationToken::new();
+        let count = Arc::new(AtomicU32::new(0));
+        let count_clone = count.clone();
+        let val = retry_until_some(&cancel, Duration::from_millis(1), "test", move || {
+            let count = count_clone.clone();
+            async move {
+                if count.fetch_add(1, Ordering::Relaxed) == 0 {
+                    Err(anyhow::anyhow!("boom"))
+                } else {
+                    Ok(Some(1u64))
+                }
+            }
+        })
+        .await;
+        assert_eq!(val, Some(1));
+    }
+
+    #[tokio::test]
+    async fn retry_until_some_returns_none_on_cancel() {
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            cancel_clone.cancel();
+        });
+        let val = retry_until_some(&cancel, Duration::from_millis(50), "test", || async {
+            Ok::<_, anyhow::Error>(None::<u64>)
+        })
+        .await;
+        assert!(val.is_none());
+    }
+}


### PR DESCRIPTION
Long-term fix for #1094 I previously mentioned in #1101 (fixed the live phase)

This PR makes both catchup and live phases use the same finalized-head-gated mechanism ensuring finality for all blocks.

Main changes:

- Indexer: 
  - Add new methods: 
    - `sample_anchor` (returns tip + 1)
    - `wait_processable_bound` (waits till ceiling is ready, used to gate processable range) 
    - `process_range` (batch fetch and process)
  - Update `run` method: both catchup and live loops now use the same primitives (`wait_processable_bound` + `process_range`). Difference between the two is trivial: catchup is bounded, live is uncapped. `ChainEvent::CatchupCompleted` emission is preserved. 
  - Transition to a single mechanism for both phases enabled a significant cleanup:
    - reorg hash-check (dead code in production)
    - per-block finality wait - `wait_processable_bound` guarantees all blocks are finalized
    - internal `mpsc` channel to track tip of the chain
    - `process_finalized_block` and `emit_processed_block` methods
    - `block_hash` field in `BlockAndRequests`
    - `live_block_buffer` field in `IndexerConfig`
  - Add more tracing to log how far behind it is at startup and when it transitions to the live tail
  
- `FinalizedHeadTracker` now encapsulates optimistic mode: watcher polls `eth_getBlockByNumber(Latest)` for optimistic mode and `eth_getBlockByNumber(Finalized)` in production. Indexer becomes mode-agnostic.
- Minor readability changes:
  - `parse_block`: replace `partition`+`filter`+`is_some_and` chain with two `topic0()` filters
  - `process_catchup_item`: replace `_block` and `_logs` lifetime workaround
- New shared helper and new unit tests in `chain-integration-core/src/utils/task.rs`:
  -  `retry_until_some` - similar to existing `retry_until_ok`, but returns `Option`, used for `sample_anchor` method
  - 8 unit tests covering: `retry_until_ok`, `retry_until_some`, `cancelled_within`, `AbortOnDrop`
