### PR TITLE
feat(config): add `trace_timeout` for `debug_traceTransaction` RPC calls

### DIFF
--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -428,9 +428,8 @@ impl EthereumClient {
         &self,
         tx_hash: alloy::primitives::B256,
     ) -> anyhow::Result<Option<alloy::primitives::Bytes>> {
-        // TODO: trace_transaction_output can be slow, consider a longer timeout than the configured RPC timeout if necessary
         retry_rpc_gated!(
-            self.rpc.timeout,
+            self.rpc.trace_timeout,
             self.rpc.retry,
             self.shared_backoff,
             "trace_transaction_output",

--- a/chain-signatures/chain-ethereum/src/config.rs
+++ b/chain-signatures/chain-ethereum/src/config.rs
@@ -12,6 +12,8 @@ pub struct RpcConfig {
     pub timeout: Duration,
     /// Timeout for batched RPC requests
     pub batch_timeout: Duration,
+    /// Timeout for `debug_traceTransaction` (slower than other RPC calls)
+    pub trace_timeout: Duration,
     /// Retry strategy shared by all RPC calls
     pub retry: RetryConfig,
 }
@@ -21,6 +23,7 @@ impl Default for RpcConfig {
         Self {
             timeout: Duration::from_secs(2),
             batch_timeout: Duration::from_secs(5),
+            trace_timeout: Duration::from_secs(30),
             retry: RetryConfig {
                 min_delay: Duration::from_millis(500),
                 max_delay: Duration::from_secs(10),

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -409,7 +409,7 @@ async fn test_threshold_change_via_mpc_governance() {
     // Sign a request end-to-end to prove the network still produces valid
     // signatures after the threshold-change resharing.
     network
-        .assert_presignatures(1, Duration::from_secs(60))
+        .assert_presignatures(1, Duration::from_secs(120))
         .await;
     let request = sign_request(88);
     for node in &network.nodes {


### PR DESCRIPTION
Introduce `trace_timeout` for `debug_traceTransaction` method to separate it from other RPC calls, which are faster.