### PR TITLE
fix(stream): adjust Sign request metric

### DIFF
--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -89,18 +89,20 @@ pub(crate) async fn handle_chain_event<T: ChainTelemetry>(
             request,
             block_timestamp,
         } => {
-            // Handle metrics reporting for the sign request event
-            if let Some(ts) = block_timestamp {
-                // Report the request was indexed at the given block timestamp is currently used for Ethereum due to ~15 min finality delay
-                telemetry.request_indexed_at(ts);
-            } else {
-                // Other faster chains (e.g. for Solana, Canton, or Hydration) report that a request was indexed without a block timestamp
-                telemetry.request_indexed();
-            }
-
-            process_sign_request(request, ctx)
+            // Record the request's indexed timestamp if it's a new request
+            let is_new = process_sign_request(request, ctx)
                 .await
                 .context("failed to process sign request")?;
+
+            if is_new {
+                if let Some(ts) = block_timestamp {
+                    // Ethereum (~15 min finality) reports the block timestamp.
+                    telemetry.request_indexed_at(ts);
+                } else {
+                    // Faster chains (Solana, Canton, Hydration) report no timestamp.
+                    telemetry.request_indexed();
+                }
+            }
         }
         ChainEvent::Respond(ev) => {
             process_respond_event(ev, ctx, root_pk)

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -14,7 +14,7 @@ use mpc_primitives::{
 pub(crate) async fn process_sign_request(
     sign_request: IndexedSignRequest,
     ctx: &StreamContext,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<bool> {
     if matches!(sign_request.kind, SignKind::RespondBidirectional(_)) {
         anyhow::bail!("Unexpected sign request kind");
     }
@@ -33,11 +33,12 @@ pub(crate) async fn process_sign_request(
         }
     }
 
-    ctx.backlog.insert(sign_request.clone()).await;
+    // `Backlog::insert` returns `None` if the request is new, or `Some(_)` if it was already present.
+    let is_new = ctx.backlog.insert(sign_request.clone()).await.is_none();
 
     ctx.try_enqueue(SignCommand::Request(sign_request)).await?;
 
-    Ok(())
+    Ok(is_new)
 }
 
 pub(crate) async fn requeue_pending_sign_requests(

--- a/chain-signatures/node/src/stream/ops_tests.rs
+++ b/chain-signatures/node/src/stream/ops_tests.rs
@@ -570,6 +570,70 @@ async fn process_sign_request_rejects_empty_bidirectional_serialized_transaction
 }
 
 #[tokio::test]
+async fn process_sign_request_duplicate_is_idempotent() {
+    let backlog = Backlog::new();
+    let sign_id = SignId::new([9u8; 32]);
+    let request = test_indexed_request(
+        sign_id,
+        Chain::Ethereum,
+        test_sign_args(9),
+        current_unix_timestamp(),
+        SignKind::Sign,
+    );
+
+    let (sign_tx, mut sign_rx) = mpsc::channel(4);
+    let ctx = make_test_stream_context_with_generator_pk(backlog.clone(), sign_tx, false);
+
+    // First emission inserts a new entry.
+    let was_new = process_sign_request(request.clone(), &ctx)
+        .await
+        .expect("first sign request should be accepted");
+    assert!(was_new, "first insert must report a new entry");
+    assert_eq!(backlog.len(), 1);
+
+    // Replay: the indexer re-emitted the same SignId
+    // backlog.insert is keyed on SignId, so the replay is absorbed, not duplicated.
+    let is_new = process_sign_request(request.clone(), &ctx)
+        .await
+        .expect("replayed sign request should be accepted");
+    assert!(!is_new, "replayed insert must report an existing entry");
+    assert_eq!(
+        backlog.len(),
+        1,
+        "replaying the same SignId must not grow the backlog"
+    );
+
+    // No sign command was enqueued during catchup
+    assert!(
+        timeout(Duration::from_millis(100), sign_rx.recv())
+            .await
+            .is_err(),
+        "no sign command should be enqueued during catchup"
+    );
+
+    // After catchup, the backlog is re-queued to the sign queue.
+    requeue_pending_sign_requests(&ctx, Chain::Ethereum)
+        .await
+        .expect("requeue should succeed");
+
+    // The re-queued request should be sent to the sign queue.
+    match timeout(Duration::from_secs(1), sign_rx.recv())
+        .await
+        .expect("requeue should enqueue the pending request")
+        .expect("sign channel open")
+    {
+        SignCommand::Request(req) => assert_eq!(req.id, sign_id),
+        other => panic!("expected a single requeued request, got {other:?}"),
+    }
+    assert!(
+        timeout(Duration::from_millis(100), sign_rx.recv())
+            .await
+            .is_err(),
+        "the replayed duplicate must not produce a second command"
+    );
+}
+
+#[tokio::test]
 async fn process_respond_event_rejects_invalid_signature() {
     let backlog = Backlog::new();
     let sign_id = SignId::new([15u8; 32]);


### PR DESCRIPTION
Currently `SignRequest` arm in `handle_chain_event` (`chain-signatures/node/src/stream/mod.rs`) records telemetry before dedup - every restart / replay inflates the metric. This PR fixes metric pollution by tracking if as Sign request is new (not already present in the `Backlog`).

Changes:

- Update `process_sign_request` to return `anyhow::Result<bool>` - `true` for new entry, `false` when replay was absorbed
- `request_indexed_at/request_indexed` metrics are only updated if request `is_new`
- Add `process_sign_request_duplicate_is_idempotent` test to verify exactly one command is emitted after catchup and replay