### PR TITLE
refactor(integration tests): reduce `MpcFixture` boilerplate and busy-polling

### DIFF
--- a/integration-tests/src/actions/wait.rs
+++ b/integration-tests/src/actions/wait.rs
@@ -429,18 +429,21 @@ async fn require_checkpoint(
     chain: Chain,
     block_height: u64,
 ) -> anyhow::Result<Checkpoint> {
-    tokio::time::timeout(Duration::from_secs(10), async move {
-        loop {
-            let checkpoints = nodes.fetch_checkpoints(id).await?;
-            if let Some(checkpoint) = checkpoints.get(&chain) {
-                if checkpoint.block_height >= block_height {
-                    return Ok(checkpoint.clone());
-                }
+    let is_ready = || async {
+        let checkpoints = nodes.fetch_checkpoints(id).await?;
+        if let Some(checkpoint) = checkpoints.get(&chain) {
+            if checkpoint.block_height >= block_height {
+                return Ok(checkpoint.clone());
             }
-
-            tokio::time::sleep(Duration::from_secs(1)).await;
         }
+        anyhow::bail!("node(id={id}) {chain:?} checkpoint not yet at height {block_height}");
+    };
+
+    let strategy = ConstantBuilder::default()
+        .with_delay(Duration::from_secs(1))
+        .with_max_times(10);
+
+    is_ready.retry(&strategy).await.with_context(|| {
+        format!("node {id} did not reach {chain:?} checkpoint >= {block_height} in time")
     })
-    .await
-    .unwrap()
 }

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -274,11 +274,14 @@ impl MpcFixture {
 
 impl MpcFixtureNode {
     pub async fn wait_for_running(&self) {
+        let mut watcher = self.state.clone();
         loop {
-            if matches!(self.state.status(), NodeStatus::Running { .. }) {
+            if matches!(watcher.status(), NodeStatus::Running { .. }) {
                 return;
             }
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            if watcher.changed().await.is_err() {
+                return;
+            }
         }
     }
 

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -21,7 +21,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
-use tokio::sync::{watch, Mutex};
+use tokio::sync::{watch, Mutex, Notify};
 
 pub struct MpcFixture {
     pub nodes: Vec<MpcFixtureNode>,
@@ -56,6 +56,9 @@ pub struct MpcFixtureNode {
 pub struct SharedOutput {
     pub msg_log: Arc<Mutex<dyn CollectMessages + Send>>,
     pub rpc_actions: Arc<Mutex<HashSet<String>>>,
+    /// Signaled whenever an RPC action is recorded, so `wait_for_actions`
+    /// reacts on the event instead of polling.
+    pub actions_changed: Arc<Notify>,
 }
 
 impl MpcFixture {
@@ -175,8 +178,6 @@ impl MpcFixture {
     }
 
     pub async fn wait_for_actions(&self, threshold: usize) -> HashSet<String> {
-        let interval = Duration::from_millis(100);
-
         loop {
             let actions = self.output.rpc_actions.lock().await;
 
@@ -185,7 +186,9 @@ impl MpcFixture {
             }
 
             drop(actions);
-            tokio::time::sleep(interval).await;
+
+            // Wait for a notification that the RPC actions changed
+            self.output.actions_changed.notified().await;
         }
     }
 
@@ -418,6 +421,7 @@ impl SharedOutput {
         Self {
             msg_log: Arc::new(Mutex::new(M::default())),
             rpc_actions: Arc::new(Mutex::new(HashSet::new())),
+            actions_changed: Arc::new(Notify::new()),
         }
     }
 }
@@ -427,6 +431,7 @@ impl Default for SharedOutput {
         Self {
             msg_log: Arc::new(Mutex::new(MessagePrinter)),
             rpc_actions: Default::default(),
+            actions_changed: Arc::new(Notify::new()),
         }
     }
 }

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -276,6 +276,7 @@ impl MpcFixtureNode {
     pub async fn wait_for_running(&self) {
         let mut watcher = self.state.clone();
         loop {
+            // watcher.status() parks the task until the status changes, so this only resumes when the status changes.
             if matches!(watcher.status(), NodeStatus::Running { .. }) {
                 return;
             }

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -218,6 +218,13 @@ impl MpcFixture {
         result.expect("should produce enough signatures")
     }
 
+    /// Send the same `SignCommand` to every node's `sign_tx`.
+    pub async fn broadcast(&self, request: &SignCommand) {
+        for node in &self.nodes {
+            node.sign_tx.send(request.clone()).await.unwrap();
+        }
+    }
+
     pub async fn print_triples(&self) {
         for node in &self.nodes {
             let id = node.me;

--- a/integration-tests/src/mpc_fixture/fixture_tasks.rs
+++ b/integration-tests/src/mpc_fixture/fixture_tasks.rs
@@ -36,6 +36,7 @@ pub(super) fn test_mock_network(
 ) -> JoinHandle<()> {
     let msg_log = Arc::clone(&shared_output.msg_log);
     let rpc_actions = Arc::clone(&shared_output.rpc_actions);
+    let actions_changed = Arc::clone(&shared_output.actions_changed);
     // Participant info as of network start, consulted for recipient's encryption key
     let initial_participants = mesh.borrow().active().clone();
 
@@ -99,6 +100,7 @@ pub(super) fn test_mock_network(
                     let mut actions_log = rpc_actions.lock().await;
                     actions_log.insert(action_str);
                     drop(actions_log);
+                    actions_changed.notify_one();
 
                     if let Some(chain) = &mock_chain {
                         chain.on_rpc_publish(&rpc).await;

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -216,10 +216,7 @@ async fn test_basic_sign() {
         .await;
 
     tracing::info!("sending requests now");
-    let request = sign_request(0);
-    network[0].sign_tx.send(request.clone()).await.unwrap();
-    network[1].sign_tx.send(request.clone()).await.unwrap();
-    network[2].sign_tx.send(request.clone()).await.unwrap();
+    network.broadcast(&sign_request(0)).await;
 
     let timeout = Duration::from_secs(10);
 
@@ -248,10 +245,7 @@ async fn test_sign_task_survives_resharing() {
         .assert_presignatures(1, Duration::from_secs(5))
         .await;
 
-    let request = sign_request(7);
-    for node in &network.nodes {
-        node.sign_tx.send(request.clone()).await.unwrap();
-    }
+    network.broadcast(&sign_request(7)).await;
 
     network.trigger_resharing();
     tokio::time::sleep(Duration::from_millis(200)).await;
@@ -279,10 +273,7 @@ async fn test_sign_request_during_resharing() {
     network.trigger_resharing();
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let request = sign_request(8);
-    for node in &network.nodes {
-        node.sign_tx.send(request.clone()).await.unwrap();
-    }
+    network.broadcast(&sign_request(8)).await;
 
     tokio::time::sleep(Duration::from_millis(100)).await;
     network.complete_resharing();
@@ -411,10 +402,7 @@ async fn test_threshold_change_via_mpc_governance() {
     network
         .assert_presignatures(1, Duration::from_secs(60))
         .await;
-    let request = sign_request(88);
-    for node in &network.nodes {
-        node.sign_tx.send(request.clone()).await.unwrap();
-    }
+    network.broadcast(&sign_request(88)).await;
     let actions = network.assert_actions(1, Duration::from_secs(30)).await;
     assert_eq!(actions.len(), 1);
     assert!(actions
@@ -490,10 +478,7 @@ async fn test_sign_adequate_stockpile() {
     // Send sign requests to all nodes concurrently
     tracing::info!(NUM_SIGN_REQUESTS, "sending sign requests");
     for seed in 0..NUM_SIGN_REQUESTS {
-        let request = sign_request(seed);
-        for node in &network.nodes {
-            node.sign_tx.send(request.clone()).await.unwrap();
-        }
+        network.broadcast(&sign_request(seed)).await;
     }
 
     // Wait for all signatures to be produced
@@ -568,10 +553,7 @@ async fn test_sign_limited_stockpile_contention() {
     // Send all requests at once to maximize contention
     tracing::info!(NUM_SIGN_REQUESTS, "sending sign requests simultaneously");
     for seed in 0..NUM_SIGN_REQUESTS {
-        let request = sign_request(seed);
-        for node in &network.nodes {
-            node.sign_tx.send(request.clone()).await.unwrap();
-        }
+        network.broadcast(&sign_request(seed)).await;
     }
 
     // We expect to complete at least as many signatures as we have presignatures.
@@ -660,10 +642,7 @@ async fn test_sign_requests_wait_for_presignatures() {
     // Send ALL sign requests at once - more than we have presignatures for
     tracing::info!(TOTAL_SIGN_REQUESTS, "sending all sign requests");
     for seed in 0..TOTAL_SIGN_REQUESTS {
-        let request = sign_request(seed);
-        for node in &network.nodes {
-            node.sign_tx.send(request.clone()).await.unwrap();
-        }
+        network.broadcast(&sign_request(seed)).await;
     }
 
     // First batch: wait for as many signatures as we initially have presignatures
@@ -772,10 +751,7 @@ async fn test_sign_contention_5_nodes() {
 
     // Send sign requests to all nodes concurrently (simulates real network conditions)
     for seed in 0..NUM_SIGN_REQUESTS {
-        let request = sign_request(seed);
-        for node in &network.nodes {
-            node.sign_tx.send(request.clone()).await.unwrap();
-        }
+        network.broadcast(&sign_request(seed)).await;
     }
 
     // Wait for all signatures - allow more time for 5-node consensus
@@ -947,10 +923,7 @@ async fn test_sign_no_presignature_waste() {
     );
 
     for seed in 0..initial_presignatures {
-        let request = sign_request(seed as u8);
-        for node in &network.nodes {
-            node.sign_tx.send(request.clone()).await.unwrap();
-        }
+        network.broadcast(&sign_request(seed as u8)).await;
     }
 
     let actions = network
@@ -1094,10 +1067,7 @@ async fn test_sign_missing_presignature() {
 
     // Now we submit the request
     tracing::info!("sending requests now");
-    let request = sign_request(0);
-    for node in &network.nodes {
-        node.sign_tx.send(request.clone()).await.unwrap();
-    }
+    network.broadcast(&sign_request(0)).await;
 
     // give 2 minutes to resolve the problem
     // expectation: the node without the presignature will reject a posit, or if
@@ -1155,10 +1125,7 @@ async fn test_sign_missing_presignature_after_posits() {
 
     // Now we submit the request
     tracing::info!("sending requests now");
-    let request = sign_request(0);
-    for node in &network.nodes {
-        node.sign_tx.send(request.clone()).await.unwrap();
-    }
+    network.broadcast(&sign_request(0)).await;
 
     // Wait for first round of posits to go through.
     tokio::time::timeout(Duration::from_millis(5000), rx)
@@ -1303,12 +1270,8 @@ async fn test_non_participants_pause_posits() {
     // Node 2's Accept to node 1's Propose is dropped, so generation is {0, 1}.
     // After ORGANIZE_POSIT_TIMEOUT, node 2 becomes round-1 proposer and
     // receives AlreadyGenerating from nodes 0 and 1.
-    let request = sign_request(0);
-
     // Send the request to all three nodes.
-    network[0].sign_tx.send(request.clone()).await.unwrap();
-    network[1].sign_tx.send(request.clone()).await.unwrap();
-    network[2].sign_tx.send(request.clone()).await.unwrap();
+    network.broadcast(&sign_request(0)).await;
 
     // Wait for node 2 to propose once, sending a message to both other nodes.
     // Should happen after ~1 ORGANIZE_POSIT_TIMEOUT (5s for tests)


### PR DESCRIPTION
A couple of improvements for integration tests to reduce duplication, replace busy-polling with events and improve consistency.

- Add `MpcFixture::broadcast` helper to send `SignCommand` to every node. Replaces manual loops in tests
- Update `wait_for_actions` method to use `Notify` instead of polling every 100 ms
- Update `wait_for_running` method to use existing `NodeStateWatcher::changed()` instead of 50 ms polling
- Update `require_checkpoint` in `actions/wait.rs` to use `backon` retry same as sibling methods