### PR TITLE
fix(mesh): authenticate /sync and make the active-participant view self-correcting

### DIFF
--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -293,12 +293,15 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             } = MeshHandles::new(message_options, mesh_options, &account_id);
 
             let chains = ChainConfigs::from_args(eth, sol, hydration, canton, midnight)?;
+            // Cloned into the sync task and the web server: both ends of `/sync`
+            // seal and sign with these keys.
             let network = NetworkConfig { cipher_sk, sign_sk };
             let signer = match InMemorySigner::from_secret_key(account_id.clone(), account_sk) {
                 near_crypto::Signer::InMemory(s) => s,
                 _ => unreachable!(),
             };
 
+            let web_network = network.clone();
             let RpcHandles {
                 near_client,
                 near_governance_client,
@@ -321,6 +324,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 mesh_state.clone(),
                 contract_watcher.clone(),
                 synced_peer_tx,
+                network.clone(),
             );
 
             log_startup(
@@ -380,6 +384,8 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 sync_channel,
                 account_id,
                 backlog.clone(),
+                contract_watcher.clone(),
+                web_network,
             ));
 
             spawn_indexers(

--- a/chain-signatures/node/src/lib.rs
+++ b/chain-signatures/node/src/lib.rs
@@ -1,6 +1,15 @@
 /// Version of the protocol (triples, presignatures, signatures) messages
 /// that the node can currently work with.
-pub const PROTOCOL_VERSION: u64 = 1;
+///
+/// Bump this whenever the peer wire format changes. The mesh marks any peer
+/// reporting a different version as `Offline`, which is what keeps a mixed
+/// version deployment from half-working: without a bump, a node speaking the new
+/// `/sync` envelope to an old node would just fail to decode on every round, and
+/// the peer would sit in `need_sync` (and out of `active`) indefinitely with only
+/// a decode warning to show for it.
+///
+/// - 2: `/sync` carries a signed, sealed envelope instead of a bare `SyncUpdate`.
+pub const PROTOCOL_VERSION: u64 = 2;
 /// Version of the checkpoint data that the node can work with.
 pub const CHECKPOINT_VERSION: u64 = 0;
 /// Redis namespace version for persisted checkpoints.

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -1,14 +1,16 @@
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::time::Duration;
 
 use cait_sith::protocol::Participant;
 use near_account_id::AccountId;
-use tokio::sync::{broadcast, watch};
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::WatchStream;
 use tokio_stream::{StreamExt, StreamMap};
 
+use crate::metrics::mesh as metrics;
 use crate::node_client::NodeClient;
 use crate::protocol::contract::primitives::Participants;
 use crate::protocol::state::NodeStatus as OtherNodeStatus;
@@ -110,9 +112,13 @@ impl NodeConnection {
                         Ok(status) => status,
                         Err(err) => {
                             tracing::warn!(?node, ?err, "checking /status failed");
-                            status_tx.send_if_modified(|(status, _)| {
+                            if status_tx.send_if_modified(|(status, _)| {
                                 std::mem::replace(status, NodeStatus::Offline) != NodeStatus::Offline
-                            });
+                            }) {
+                                metrics::MESH_PEER_OFFLINE
+                                    .with_label_values(&[metrics::OFFLINE_UNREACHABLE])
+                                    .inc();
+                            }
                             continue;
                         }
                     };
@@ -124,9 +130,13 @@ impl NodeConnection {
                             peer_version = resp.protocol_version,
                             "protocol version mismatch"
                         );
-                        status_tx.send_if_modified(|(status, _)| {
+                        if status_tx.send_if_modified(|(status, _)| {
                             std::mem::replace(status, NodeStatus::Offline) != NodeStatus::Offline
-                        });
+                        }) {
+                            metrics::MESH_PEER_OFFLINE
+                                .with_label_values(&[metrics::OFFLINE_VERSION_MISMATCH])
+                                .inc();
+                        }
                         continue;
                     }
 
@@ -173,6 +183,14 @@ impl Drop for NodeConnection {
     }
 }
 
+/// Snapshot of the pool's current connections, keyed by participant.
+///
+/// Published as a whole rather than as a stream of add/remove events. The set is
+/// state, not a sequence: a watcher only ever needs the latest version of it, and
+/// publishing the set means a slow watcher converges on the truth instead of
+/// missing an event and diverging from it permanently.
+type ConnectionSet = Arc<HashMap<Participant, watch::Receiver<(NodeStatus, ParticipantInfo)>>>;
+
 /// Pool that manages connections to nodes in the network. It is responsible for
 /// connecting to nodes, checking their status, and dropping connections that are
 /// no longer within the network.
@@ -189,30 +207,27 @@ pub struct Pool {
     /// Account id of this node. Used to avoid creating self connections.
     node_account_id: AccountId,
 
-    conn_update_tx: broadcast::Sender<ConnectionUpdate>,
-    conn_update_rx: broadcast::Receiver<ConnectionUpdate>,
+    conns_tx: watch::Sender<ConnectionSet>,
 }
 
 impl Pool {
     pub fn new(client: &NodeClient, node_account_id: &AccountId, ping_interval: Duration) -> Self {
         tracing::info!("creating new connection pool");
-        let (conn_update_tx, conn_update_rx) = broadcast::channel(256);
+        let (conns_tx, _) = watch::channel(Arc::new(HashMap::new()));
         Self {
             client: client.clone(),
             ping_interval,
             connections: HashMap::new(),
             node_account_id: node_account_id.clone(),
-
-            conn_update_tx,
-            conn_update_rx,
+            conns_tx,
         }
     }
 
-    pub async fn connect(&mut self, contract: ProtocolState) {
+    pub async fn connect(&mut self, contract: &ProtocolState) {
         let mut seen = HashSet::new();
         match contract {
             ProtocolState::Initializing(init) => {
-                let participants: Participants = init.candidates.into();
+                let participants: Participants = init.candidates.clone().into();
                 self.connect_nodes(&participants, &mut seen).await;
             }
             ProtocolState::Running(running) => {
@@ -241,17 +256,11 @@ impl Pool {
         participants: &Participants,
         seen: &mut HashSet<Participant>,
     ) {
+        let mut changed = false;
         for (&participant, info) in participants.iter() {
             if info.account_id == self.node_account_id {
                 tracing::debug!(?participant, "skipping self connection");
-                if self.connections.remove(&participant).is_some()
-                    && self
-                        .conn_update_tx
-                        .send(ConnectionUpdate::Drop(participant))
-                        .is_err()
-                {
-                    tracing::warn!(?participant, "unable to send drop for self connection");
-                }
+                changed |= self.connections.remove(&participant).is_some();
                 continue;
             }
 
@@ -267,51 +276,47 @@ impl Pool {
                 }
                 Entry::Vacant(conn) => {
                     tracing::info!(?node, "node connection created");
-                    let conn = conn.insert(NodeConnection::spawn(
+                    conn.insert(NodeConnection::spawn(
                         &self.client,
                         participant,
                         info,
                         self.ping_interval,
                     ));
-
-                    let watcher = conn.status_rx.clone();
-                    if self
-                        .conn_update_tx
-                        .send(ConnectionUpdate::New(participant, watcher))
-                        .is_err()
-                    {
-                        tracing::warn!(?node, "failed to send new connection");
-                    }
+                    changed = true;
                 }
             }
+        }
+
+        if changed {
+            self.publish();
         }
     }
 
     /// Drop connections that are not in the active connections list. Dropped connections
     /// are no longer polled for their status.
     fn drop_connections(&mut self, active_conn: HashSet<Participant>) {
-        let mut remove = Vec::new();
-        for participant in self.connections.keys() {
-            if !active_conn.contains(participant) {
-                remove.push(*participant);
-            }
-        }
-
-        for participant in remove {
-            let removed = self.connections.remove(&participant).is_some();
-            if removed
-                && self
-                    .conn_update_tx
-                    .send(ConnectionUpdate::Drop(participant))
-                    .is_err()
-            {
-                tracing::warn!(?participant, "unable to send update for drop participant");
-            }
+        let before = self.connections.len();
+        self.connections
+            .retain(|participant, _| active_conn.contains(participant));
+        if self.connections.len() != before {
+            self.publish();
         }
     }
 
+    /// Publish the current connection set to all watchers.
+    fn publish(&self) {
+        let set: ConnectionSet = Arc::new(
+            self.connections
+                .iter()
+                .map(|(p, conn)| (*p, conn.status_rx.clone()))
+                .collect(),
+        );
+        // No receivers is normal: the mesh may not be watching yet.
+        let _ = self.conns_tx.send(set);
+    }
+
     /// Update the node state after synchronization was successful.
-    pub async fn report_node_synced(&self, participant: Participant) {
+    pub fn report_node_synced(&self, participant: Participant) {
         if let Some(conn) = self.connections.get(&participant) {
             tracing::info!(?participant, "reporting node synced");
             conn.status_tx.send_if_modified(|(status, _)| {
@@ -326,56 +331,93 @@ impl Pool {
     }
 
     pub fn watch(&self) -> ConnectionWatcher {
-        ConnectionWatcher::new(self.conn_update_rx.resubscribe())
+        ConnectionWatcher::new(self.conns_tx.subscribe())
     }
 }
 
-#[derive(Clone)]
-pub enum ConnectionUpdate {
-    New(Participant, watch::Receiver<(NodeStatus, ParticipantInfo)>),
-    Drop(Participant),
+/// A change observed by a [`ConnectionWatcher`].
+pub enum MeshUpdate {
+    /// A connection reported a new status.
+    Status(Participant, NodeStatus, ParticipantInfo),
+    /// The participant left the connection set and is no longer polled.
+    ///
+    /// Carries no [`ParticipantInfo`]: there is none to report, and inventing a
+    /// placeholder only works for as long as every consumer happens to ignore it.
+    Dropped(Participant),
 }
 
 pub struct ConnectionWatcher {
-    /// Watch for new connections and dropped connections from the pool. This
-    /// is so that we can update our watchers when the pool changes.
-    // NOTE: this is a broadcast channel so that we can get a series of updates, and
-    // not just the latest entry with watcher channel.
-    conn_update: broadcast::Receiver<ConnectionUpdate>,
-    /// Set of active connections that we are watching.
+    /// Latest connection set published by the pool.
+    conns: watch::Receiver<ConnectionSet>,
+    /// Per-connection status streams, kept in step with `conns`.
     watchers: StreamMap<Participant, WatchStream<(NodeStatus, ParticipantInfo)>>,
+    /// Drops found by the last reconcile, still to be reported.
+    dropped: Vec<Participant>,
 }
 
 impl ConnectionWatcher {
-    fn new(conn_update: broadcast::Receiver<ConnectionUpdate>) -> Self {
+    fn new(conns: watch::Receiver<ConnectionSet>) -> Self {
         Self {
-            conn_update,
+            conns,
             watchers: StreamMap::new(),
+            dropped: Vec::new(),
         }
     }
 
-    pub async fn next(&mut self) -> (Participant, NodeStatus, ParticipantInfo) {
+    /// Next change, or `None` once the pool is gone and no further updates can
+    /// arrive. Callers must treat `None` as terminal: continuing to use the last
+    /// mesh state would be acting on a snapshot that can no longer be corrected.
+    pub async fn next(&mut self) -> Option<MeshUpdate> {
         loop {
+            if let Some(participant) = self.dropped.pop() {
+                return Some(MeshUpdate::Dropped(participant));
+            }
+
             tokio::select! {
-                // Update our watchers if the connections changed.
-                Ok(update) = self.conn_update.recv() => {
-                    match update {
-                        ConnectionUpdate::New(participant, rx) => {
-                            tracing::debug!(?participant, "adding new watcher");
-                            self.watchers.insert(participant, WatchStream::new(rx));
-                        }
-                        ConnectionUpdate::Drop(participant) => {
-                            tracing::debug!(?participant, "dropping watcher");
-                            self.watchers.remove(&participant);
-                            return (participant, NodeStatus::Offline, ParticipantInfo::new(u32::MAX));
-                        }
+                // Both branches are cancel-safe, and `changed()` erroring is the
+                // only way out, so this select can never end up with every branch
+                // disabled.
+                changed = self.conns.changed() => {
+                    if changed.is_err() {
+                        tracing::warn!("connection pool dropped; connection watcher stopping");
+                        return None;
                     }
+                    self.reconcile();
                 }
-                // NOTE: if watchers.next() return None, it means that the connection is dropped
-                // or that the StreamMap is empty. In that case, we should just continue
+                // `watchers.next()` yields `None` while the map is empty, which
+                // just disables this branch until the set changes.
                 Some((p, (status, info))) = self.watchers.next() => {
-                    return (p, status, info);
+                    return Some(MeshUpdate::Status(p, status, info));
                 }
+            }
+        }
+    }
+
+    /// Bring the status streams in line with the latest published set.
+    ///
+    /// Re-inserted connections re-emit their current status, because
+    /// `WatchStream` yields the present value on creation. That is what makes a
+    /// missed intermediate state self-correcting rather than permanent.
+    fn reconcile(&mut self) {
+        let set = self.conns.borrow_and_update().clone();
+
+        let gone: Vec<Participant> = self
+            .watchers
+            .keys()
+            .filter(|p| !set.contains_key(p))
+            .copied()
+            .collect();
+        for participant in gone {
+            tracing::debug!(?participant, "dropping watcher");
+            self.watchers.remove(&participant);
+            self.dropped.push(participant);
+        }
+
+        for (participant, rx) in set.iter() {
+            if !self.watchers.contains_key(participant) {
+                tracing::debug!(?participant, "adding new watcher");
+                self.watchers
+                    .insert(*participant, WatchStream::new(rx.clone()));
             }
         }
     }

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -1,6 +1,8 @@
+use std::collections::BTreeSet;
 use std::time::Duration;
 
 use crate::mesh::connection::NodeStatus;
+use crate::metrics::mesh as metrics;
 use crate::node_client::NodeClient;
 use crate::protocol::contract::primitives::Participants;
 use crate::protocol::ParticipantInfo;
@@ -71,14 +73,37 @@ impl Mesh {
     pub async fn run(mut self, mut contract: ContractStateWatcher) {
         let state_tx = self.state_tx.clone();
         let mut conn_update = self.connections.watch();
-        tokio::spawn(async move {
-            loop {
-                let (p, status, info) = conn_update.next().await;
-                tracing::info!(?p, ?status, "mesh connection status changed");
-                state_tx.send_modify(|state| {
-                    state.update(p, status, info);
-                });
+        // Deliberately not detached-and-forgotten: if this loop ever ends, the
+        // mesh state freezes at its last value while the node keeps reporting
+        // healthy, and every `wait_threshold_active` downstream would go on
+        // succeeding against a stale snapshot. Say so loudly.
+        let mut updater = tokio::spawn(async move {
+            while let Some(update) = conn_update.next().await {
+                match update {
+                    connection::MeshUpdate::Status(p, status, info) => {
+                        tracing::info!(?p, ?status, "mesh connection status changed");
+                        metrics::MESH_STATUS_TRANSITIONS
+                            .with_label_values(&[status_label(status)])
+                            .inc();
+                        state_tx.send_modify(|state| state.update(p, status, info));
+                    }
+                    connection::MeshUpdate::Dropped(p) => {
+                        tracing::info!(?p, "mesh connection dropped");
+                        metrics::MESH_STATUS_TRANSITIONS
+                            .with_label_values(&["dropped"])
+                            .inc();
+                        state_tx.send_modify(|state| state.remove(p));
+                    }
+                }
+                let state = state_tx.borrow();
+                metrics::MESH_PARTICIPANTS
+                    .with_label_values(&["active"])
+                    .set(state.active().len() as i64);
+                metrics::MESH_PARTICIPANTS
+                    .with_label_values(&["need_sync"])
+                    .set(state.need_sync().len() as i64);
             }
+            tracing::error!("mesh connection watcher stopped; mesh state is now frozen");
         });
 
         loop {
@@ -95,8 +120,13 @@ impl Mesh {
                             ProtocolState::Initializing(_) | ProtocolState::Resharing(_) => NodeStatus::Inactive,
                             ProtocolState::Running(_) => NodeStatus::Active,
                         };
-                        self.connections.connect(contract).await;
+                        self.connections.connect(&contract).await;
+                        // The contract is the authority on membership, so take
+                        // the participant set from it rather than waiting for a
+                        // drop to arrive per departed peer.
+                        let members = Self::members(&contract);
                         self.state_tx.send_modify(|state| {
+                            state.retain(|p| members.contains(p) || *p == participant);
                             // if the previous me is different from the current me, remove the
                             // previous me from the MeshState.
                             if let Some(previous_me) = previous_me.filter(|old| *old != participant) {
@@ -117,8 +147,31 @@ impl Mesh {
                         tracing::warn!(?participant, "ignoring self sync report");
                         continue;
                     }
-                    self.connections.report_node_synced(participant).await;
+                    self.connections.report_node_synced(participant);
                 }
+                // The updater outlives the pool it watches, so reaching this arm
+                // means it panicked or the pool was torn down. Either way the mesh
+                // state can no longer be corrected; stop rather than serve a
+                // snapshot that will silently go stale.
+                result = &mut updater => {
+                    tracing::error!(?result, "mesh connection updater exited; stopping mesh");
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Participants the contract currently recognizes for this node's epoch.
+    fn members(contract: &ProtocolState) -> BTreeSet<Participant> {
+        match contract {
+            ProtocolState::Initializing(init) => {
+                let participants: Participants = init.candidates.clone().into();
+                participants.keys().copied().collect()
+            }
+            ProtocolState::Running(running) => running.participants.keys().copied().collect(),
+            // Matches `Pool::connect`: only the new set operates under the new epoch.
+            ProtocolState::Resharing(resharing) => {
+                resharing.new_participants.keys().copied().collect()
             }
         }
     }
@@ -140,6 +193,15 @@ impl Mesh {
                 .find(&self.my_id)
                 .map(|(p, info)| (*p, info.clone())),
         }
+    }
+}
+
+const fn status_label(status: NodeStatus) -> &'static str {
+    match status {
+        NodeStatus::Active => "active",
+        NodeStatus::Syncing => "syncing",
+        NodeStatus::Inactive => "inactive",
+        NodeStatus::Offline => "offline",
     }
 }
 
@@ -166,6 +228,36 @@ mod tests {
     use test_log::test;
 
     const PING_INTERVAL: Duration = Duration::from_millis(10);
+    /// Generous on purpose: these tests assert what the mesh converges to, not
+    /// how fast. A wall-clock bound only needs to be long enough that a loaded
+    /// machine does not read as a failure.
+    const SETTLE_TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// Poll until `cond` holds, instead of sleeping for a fixed multiple of the
+    /// ping interval and hoping the mesh got there.
+    async fn wait_until(
+        state: &watch::Receiver<MeshState>,
+        what: &str,
+        cond: impl Fn(&MeshState) -> bool,
+    ) {
+        let deadline = tokio::time::Instant::now() + SETTLE_TIMEOUT;
+        loop {
+            {
+                let current = state.borrow();
+                if cond(&current) {
+                    return;
+                }
+                if tokio::time::Instant::now() >= deadline {
+                    panic!(
+                        "timed out waiting for {what}; active={:?} need_sync={:?}",
+                        current.active().keys_vec(),
+                        current.need_sync().keys_vec(),
+                    );
+                }
+            }
+            tokio::time::sleep(PING_INTERVAL).await;
+        }
+    }
 
     async fn expect_status(
         watcher: &mut connection::ConnectionWatcher,
@@ -173,15 +265,43 @@ mod tests {
         expected: NodeStatus,
     ) {
         for _ in 0..20 {
-            if let Ok((p, status, _info)) =
-                tokio::time::timeout(Duration::from_millis(500), watcher.next()).await
-            {
-                if p == participant && status == expected {
-                    return;
+            match tokio::time::timeout(Duration::from_millis(500), watcher.next()).await {
+                Ok(Some(connection::MeshUpdate::Status(p, status, _info)))
+                    if p == participant && status == expected =>
+                {
+                    return
                 }
+                Ok(None) => panic!("connection watcher ended while waiting for {participant:?}"),
+                _ => continue,
             }
         }
         panic!("timed out waiting for {participant:?} to become {expected:?}");
+    }
+
+    /// Collect statuses from the watcher until every peer in `expect` has
+    /// reported `status`, so the test asserts the set it cares about rather than
+    /// a fixed number of arbitrary updates.
+    async fn expect_all(
+        watcher: &mut connection::ConnectionWatcher,
+        mut expect: HashSet<Participant>,
+        status: NodeStatus,
+    ) {
+        let deadline = tokio::time::Instant::now() + SETTLE_TIMEOUT;
+        while !expect.is_empty() {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out waiting for {status:?} from {expect:?}"
+            );
+            match tokio::time::timeout(remaining, watcher.next()).await {
+                Ok(Some(connection::MeshUpdate::Status(p, got, _))) if got == status => {
+                    expect.remove(&p);
+                }
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("connection watcher ended waiting for {status:?}"),
+                Err(_) => panic!("timed out waiting for {status:?} from {expect:?}"),
+            }
+        }
     }
 
     #[test(tokio::test)]
@@ -195,39 +315,49 @@ mod tests {
         let mut watcher = pool.watch();
         pool.connect_nodes(&participants, &mut HashSet::new()).await;
 
-        // We do not sync with ourselves, so only expect 1..num_nodes
-        tokio::time::sleep(PING_INTERVAL * 3).await;
-        let mut syncing = HashSet::new();
-        for i in 1..num_nodes {
-            match tokio::time::timeout(Duration::from_millis(100), watcher.next()).await {
-                Ok((participant, status, _info)) => {
-                    tracing::info!(?participant, ?status, "got connection update for syncing");
-                    if matches!(status, NodeStatus::Syncing) {
-                        syncing.insert(participant);
-                    }
-                }
-                Err(_) => {
-                    panic!("timed out waiting for syncing nodes idx={i}");
-                }
-            }
-        }
-        for i in 1..num_nodes {
-            pool.report_node_synced(servers[i].id()).await;
-        }
+        // We never connect to ourselves, so servers[0] is not expected here.
+        let peers: HashSet<Participant> = (1..num_nodes).map(|i| servers[i].id()).collect();
 
-        // Same with active. We only expect 1..num_nodes for new statuses
-        tokio::time::sleep(PING_INTERVAL * 3).await;
-        for i in 1..num_nodes {
-            match tokio::time::timeout(Duration::from_millis(100), watcher.next()).await {
-                Ok((participant, status, _info)) => {
-                    tracing::info!(?participant, ?status, "got connection update for active");
-                    if matches!(status, NodeStatus::Active) {
-                        syncing.insert(participant);
-                    }
+        expect_all(&mut watcher, peers.clone(), NodeStatus::Syncing).await;
+        for &peer in &peers {
+            pool.report_node_synced(peer);
+        }
+        expect_all(&mut watcher, peers, NodeStatus::Active).await;
+    }
+
+    /// A peer leaving the connection set must reach the watcher as a drop even
+    /// though it never reports a status again.
+    #[test(tokio::test)]
+    async fn test_pool_reports_dropped_connections() {
+        let num_nodes = 2;
+        let servers = MockServers::run(num_nodes).await;
+        let my_id = servers[0].account_id().clone();
+
+        let mut pool = Pool::new(&servers.client(), &my_id, PING_INTERVAL);
+        let mut watcher = pool.watch();
+        pool.connect_nodes(&servers.participants(), &mut HashSet::new())
+            .await;
+
+        let peer = servers[1].id();
+        expect_status(&mut watcher, peer, NodeStatus::Syncing).await;
+
+        pool.disconnect_all();
+
+        let deadline = tokio::time::Instant::now() + SETTLE_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out waiting for drop of {peer:?}"
+            );
+            match tokio::time::timeout(remaining, watcher.next()).await {
+                Ok(Some(connection::MeshUpdate::Dropped(p))) => {
+                    assert_eq!(p, peer);
+                    return;
                 }
-                Err(_) => {
-                    panic!("timed out waiting for active nodes idx={i}");
-                }
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("connection watcher ended before reporting the drop"),
+                Err(_) => panic!("timed out waiting for drop of {peer:?}"),
             }
         }
     }
@@ -261,61 +391,63 @@ mod tests {
             sync_rx,
         );
 
-        let mut mesh_state = mesh.watch();
+        let mesh_state = mesh.watch();
         let mesh_task = tokio::spawn(mesh.run(contract_watcher));
 
         // check that the mesh state is updated.
         {
-            tokio::time::sleep(PING_INTERVAL * 3).await;
-            let state = mesh_state.borrow();
-            assert!(state.active().contains_key(&me));
-            drop(state);
+            wait_until(&mesh_state, "self to be active", |state| {
+                state.active().contains_key(&me)
+            })
+            .await;
 
             for idx in 0..num_nodes {
                 sync_tx.send(servers[idx].id()).await.unwrap();
             }
-            tokio::time::sleep(PING_INTERVAL * 3).await;
+            wait_until(&mesh_state, "all nodes to be active", |state| {
+                state.active().len() == num_nodes && state.need_sync().is_empty()
+            })
+            .await;
 
             let state = mesh_state.borrow();
-            assert_eq!(state.active().len(), num_nodes);
             assert_eq!(state.active(), &expected_participants);
-            assert!(state.need_sync().is_empty());
             for idx in 0..num_nodes {
                 assert!(state.active().contains_key(&servers[idx].id()));
             }
-            assert!(state.active().contains_key(&me));
         }
 
         // check that the mesh state is updated when a participant goes offline
         {
             servers[1].make_offline().await;
-            tokio::time::sleep(PING_INTERVAL * 3).await;
+            wait_until(&mesh_state, "offline node to leave active", |state| {
+                !state.active().contains_key(&servers[1].id())
+            })
+            .await;
 
             let state = mesh_state.borrow();
             assert_eq!(state.active().len(), num_nodes - 1);
             assert!(state.active().contains_key(&me));
             assert!(state.active().contains_key(&servers[0].id()));
-            assert!(!state.active().contains_key(&servers[1].id()));
             assert!(state.active().contains_key(&servers[2].id()));
         }
 
         // check that the mesh state is updated when a participant goes back online.
         {
             servers[1].make_online().await;
-            tokio::time::sleep(PING_INTERVAL * 3).await;
-
             // Node is now syncing: should be in need_sync but not in active yet.
-            let state = mesh_state.borrow_and_update().clone();
-            assert_eq!(state.active().len(), num_nodes - 1);
-            assert!(!state.active().contains_key(&servers[1].id()));
-            assert!(state.need_sync().contains_key(&servers[1].id()));
+            wait_until(&mesh_state, "returning node to need sync", |state| {
+                state.need_sync().contains_key(&servers[1].id())
+            })
+            .await;
+            assert!(!mesh_state.borrow().active().contains_key(&servers[1].id()));
 
             sync_tx.send(servers[1].id()).await.unwrap();
-            tokio::time::sleep(PING_INTERVAL).await;
+            wait_until(&mesh_state, "synced node to become active", |state| {
+                state.active().len() == num_nodes && state.need_sync().is_empty()
+            })
+            .await;
 
-            let state = mesh_state.borrow_and_update().clone();
-            assert_eq!(state.active().len(), num_nodes);
-            assert!(state.need_sync().is_empty());
+            let state = mesh_state.borrow();
             for idx in 0..num_nodes {
                 assert!(state.active().contains_key(&servers[idx].id()));
             }
@@ -368,16 +500,20 @@ mod tests {
 
             // Wait for the mesh to process the contract update and connect the new participant
             let expected_participants = servers.participants();
-            tokio::time::sleep(PING_INTERVAL * 3).await;
+            wait_until(&mesh_state, "new participant to be tracked", |state| {
+                state.active().len() + state.need_sync().len() == num_nodes
+            })
+            .await;
             for i in 0..num_nodes {
                 sync_tx.send(servers[i].id()).await.unwrap();
             }
 
-            tokio::time::sleep(PING_INTERVAL * 3).await;
+            wait_until(&mesh_state, "new participant to become active", |state| {
+                state.active().len() == num_nodes && state.need_sync().is_empty()
+            })
+            .await;
             let state = mesh_state.borrow();
 
-            assert!(state.active().len() == num_nodes);
-            assert!(state.need_sync().is_empty());
             for i in 0..num_nodes {
                 assert!(
                     state.active().contains_key(&servers[i].id()),
@@ -402,11 +538,12 @@ mod tests {
 
             // Wait for the mesh to process the contract update and remove the participant
             let expected_participants = servers.participants();
-            tokio::time::sleep(PING_INTERVAL * 3).await;
+            wait_until(&mesh_state, "removed participant to be dropped", |state| {
+                state.active().len() == num_nodes && state.need_sync().is_empty()
+            })
+            .await;
             let state = mesh_state.borrow();
 
-            assert!(state.need_sync().is_empty());
-            assert!(state.active().len() == num_nodes);
             for i in 0..num_nodes {
                 assert!(
                     state.active().contains_key(&servers[i].id()),
@@ -433,7 +570,7 @@ mod tests {
         let remote_id = servers[1].id();
 
         expect_status(&mut watcher, remote_id, NodeStatus::Syncing).await;
-        pool.report_node_synced(remote_id).await;
+        pool.report_node_synced(remote_id);
         expect_status(&mut watcher, remote_id, NodeStatus::Active).await;
 
         servers[1].set_protocol_version(None).await;
@@ -441,7 +578,7 @@ mod tests {
 
         servers[1].make_online().await;
         expect_status(&mut watcher, remote_id, NodeStatus::Syncing).await;
-        pool.report_node_synced(remote_id).await;
+        pool.report_node_synced(remote_id);
         expect_status(&mut watcher, remote_id, NodeStatus::Active).await;
 
         servers[1].set_protocol_version(Some(0)).await;

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -259,6 +259,50 @@ mod tests {
         }
     }
 
+    /// Keep reporting `peers` synced until `cond` holds.
+    ///
+    /// A single report races the first ping. `report_node_synced` only promotes
+    /// a peer that is already `Syncing`, so a report arriving while the peer is
+    /// still `Offline` is dropped, and nothing re-sends it: the peer then sits in
+    /// `need_sync` forever. Waiting for the peer to reach `need_sync` first
+    /// narrows that window but does not close it, because a ping that fails under
+    /// load knocks it back to `Offline` before the report lands.
+    ///
+    /// `SyncTask` does not have this problem: it re-reads `need_sync()` every
+    /// 200ms and re-broadcasts, so a dropped report costs one round rather than
+    /// the peer. Tests have to drive it the same way to be testing the real
+    /// behaviour.
+    async fn sync_until(
+        state: &watch::Receiver<MeshState>,
+        sync_tx: &mpsc::Sender<Participant>,
+        peers: &[Participant],
+        what: &str,
+        cond: impl Fn(&MeshState) -> bool,
+    ) {
+        let deadline = tokio::time::Instant::now() + SETTLE_TIMEOUT;
+        loop {
+            {
+                let current = state.borrow();
+                if cond(&current) {
+                    return;
+                }
+                if tokio::time::Instant::now() >= deadline {
+                    panic!(
+                        "timed out waiting for {what}; active={:?} need_sync={:?}",
+                        current.active().keys_vec(),
+                        current.need_sync().keys_vec(),
+                    );
+                }
+            }
+            for &peer in peers {
+                // A full channel means the mesh has not drained yet; the next
+                // iteration retries anyway, so dropping this report is harmless.
+                let _ = sync_tx.try_send(peer);
+            }
+            tokio::time::sleep(PING_INTERVAL).await;
+        }
+    }
+
     async fn expect_status(
         watcher: &mut connection::ConnectionWatcher,
         participant: Participant,
@@ -401,12 +445,19 @@ mod tests {
             })
             .await;
 
-            for idx in 0..num_nodes {
-                sync_tx.send(servers[idx].id()).await.unwrap();
-            }
-            wait_until(&mesh_state, "all nodes to be active", |state| {
-                state.active().len() == num_nodes && state.need_sync().is_empty()
-            })
+            // Note this says nothing about the peers: self is marked active by
+            // the contract arm, not by a ping, so it lands before the peers'
+            // first ping has even completed.
+            let peers = (0..num_nodes)
+                .map(|idx| servers[idx].id())
+                .collect::<Vec<_>>();
+            sync_until(
+                &mesh_state,
+                &sync_tx,
+                &peers,
+                "all nodes to be active",
+                |state| state.active().len() == num_nodes && state.need_sync().is_empty(),
+            )
             .await;
 
             let state = mesh_state.borrow();
@@ -441,10 +492,13 @@ mod tests {
             .await;
             assert!(!mesh_state.borrow().active().contains_key(&servers[1].id()));
 
-            sync_tx.send(servers[1].id()).await.unwrap();
-            wait_until(&mesh_state, "synced node to become active", |state| {
-                state.active().len() == num_nodes && state.need_sync().is_empty()
-            })
+            sync_until(
+                &mesh_state,
+                &sync_tx,
+                &[servers[1].id()],
+                "synced node to become active",
+                |state| state.active().len() == num_nodes && state.need_sync().is_empty(),
+            )
             .await;
 
             let state = mesh_state.borrow();
@@ -504,13 +558,15 @@ mod tests {
                 state.active().len() + state.need_sync().len() == num_nodes
             })
             .await;
-            for i in 0..num_nodes {
-                sync_tx.send(servers[i].id()).await.unwrap();
-            }
 
-            wait_until(&mesh_state, "new participant to become active", |state| {
-                state.active().len() == num_nodes && state.need_sync().is_empty()
-            })
+            let peers = (0..num_nodes).map(|i| servers[i].id()).collect::<Vec<_>>();
+            sync_until(
+                &mesh_state,
+                &sync_tx,
+                &peers,
+                "new participant to become active",
+                |state| state.active().len() == num_nodes && state.need_sync().is_empty(),
+            )
             .await;
             let state = mesh_state.borrow();
 

--- a/chain-signatures/node/src/mesh/state.rs
+++ b/chain-signatures/node/src/mesh/state.rs
@@ -45,6 +45,17 @@ impl MeshState {
         self.need_sync.remove(&participant);
     }
 
+    /// Drop every participant failing `keep`.
+    ///
+    /// Membership changes are driven by the contract, but removals otherwise
+    /// only reach this state as per-connection drop events. This is the
+    /// reconciling path: it lets the caller assert the whole set against the
+    /// contract instead of trusting that one event per departed peer arrived.
+    pub fn retain(&mut self, keep: impl Fn(&Participant) -> bool) {
+        self.active.participants.retain(|p, _| keep(p));
+        self.need_sync.participants.retain(|p, _| keep(p));
+    }
+
     pub fn clear(&mut self) {
         self.active.clear();
         self.need_sync.clear();
@@ -54,6 +65,81 @@ impl MeshState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn participant(id: u32) -> (Participant, ParticipantInfo) {
+        (Participant::from(id), ParticipantInfo::new(id))
+    }
+
+    /// `retain` is the reconciling path against the contract, so it has to clear
+    /// both sets. A participant left behind in `need_sync` would keep drawing
+    /// sync broadcasts after the contract dropped it.
+    #[test]
+    fn retain_drops_participants_from_both_sets() {
+        let (active, active_info) = participant(1);
+        let (syncing, syncing_info) = participant(2);
+        let (kept, kept_info) = participant(3);
+        let mut state = MeshState::default();
+
+        state.update(active, NodeStatus::Active, active_info);
+        state.update(syncing, NodeStatus::Syncing, syncing_info);
+        state.update(kept, NodeStatus::Active, kept_info);
+
+        state.retain(|p| *p == kept);
+
+        assert!(state.active().contains_key(&kept));
+        assert!(!state.active().contains_key(&active));
+        assert!(!state.need_sync().contains_key(&syncing));
+        assert_eq!(state.active().len(), 1);
+        assert!(state.need_sync().is_empty());
+    }
+
+    /// A participant re-added under a different index must not linger under the
+    /// old one: that is what leaves a departed peer selectable for signing.
+    #[test]
+    fn remove_then_readd_under_new_index_leaves_no_stale_entry() {
+        let (old_index, old_info) = participant(4);
+        let (new_index, new_info) = participant(5);
+        let mut state = MeshState::default();
+
+        state.update(old_index, NodeStatus::Active, old_info);
+        state.remove(old_index);
+        state.update(new_index, NodeStatus::Active, new_info);
+
+        assert!(!state.active().contains_key(&old_index));
+        assert!(state.active().contains_key(&new_index));
+        assert_eq!(state.active().len(), 1);
+    }
+
+    #[test]
+    fn clear_empties_both_sets() {
+        let (active, active_info) = participant(6);
+        let (syncing, syncing_info) = participant(7);
+        let mut state = MeshState::default();
+
+        state.update(active, NodeStatus::Active, active_info);
+        state.update(syncing, NodeStatus::Syncing, syncing_info);
+        state.clear();
+
+        assert!(state.active().is_empty());
+        assert!(state.need_sync().is_empty());
+    }
+
+    /// Both offline reasons must evict from `need_sync` too, or a peer that goes
+    /// down mid-sync keeps being broadcast to forever.
+    #[test]
+    fn offline_and_inactive_clear_pending_sync() {
+        for status in [NodeStatus::Offline, NodeStatus::Inactive] {
+            let (p, info) = participant(8);
+            let mut state = MeshState::default();
+
+            state.update(p, NodeStatus::Syncing, info.clone());
+            assert!(state.need_sync().contains_key(&p));
+
+            state.update(p, status, info);
+            assert!(!state.need_sync().contains_key(&p), "{status:?}");
+            assert!(!state.active().contains_key(&p), "{status:?}");
+        }
+    }
 
     #[test]
     fn syncing_moves_participant_out_of_active_until_reactivated() {

--- a/chain-signatures/node/src/metrics/mesh.rs
+++ b/chain-signatures/node/src/metrics/mesh.rs
@@ -1,0 +1,54 @@
+//! Metrics for the mesh's view of peer liveness.
+//!
+//! Every wait in the signing path is gated on the size of the active set, and
+//! those waits are unbounded, so "why is this node not signing" is almost always
+//! "how big was the active set, and why". Without these, that question can only
+//! be answered from logs.
+
+use std::sync::LazyLock;
+
+use prometheus::{CounterVec, IntGaugeVec};
+
+use super::{
+    try_create_counter_vec_with_node_account_id, try_create_int_gauge_vec_with_node_account_id,
+};
+
+/// Size of each mesh participant set. Label `state` is `active` or `need_sync`.
+pub(crate) static MESH_PARTICIPANTS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    try_create_int_gauge_vec_with_node_account_id(
+        "multichain_mesh_participants",
+        "number of participants in each mesh set as seen by this node",
+        &["state"],
+    )
+    .unwrap()
+});
+
+/// Peer status transitions observed by this node, labelled by the new status.
+pub(crate) static MESH_STATUS_TRANSITIONS: LazyLock<CounterVec> = LazyLock::new(|| {
+    try_create_counter_vec_with_node_account_id(
+        "multichain_mesh_status_transitions_total",
+        "peer connection status transitions observed by this node",
+        &["status"],
+    )
+    .unwrap()
+});
+
+/// Why a peer was marked offline.
+///
+/// Both reasons collapse to [`NodeStatus::Offline`] because neither is usable in
+/// a protocol, but they call for opposite responses: `version_mismatch` across a
+/// rollout is expected and self-resolving, `unreachable` is not. The status alone
+/// cannot tell an operator which one they are looking at.
+///
+/// [`NodeStatus::Offline`]: crate::mesh::connection::NodeStatus::Offline
+pub(crate) static MESH_PEER_OFFLINE: LazyLock<CounterVec> = LazyLock::new(|| {
+    try_create_counter_vec_with_node_account_id(
+        "multichain_mesh_peer_offline_total",
+        "times a peer was marked offline, by reason",
+        &["reason"],
+    )
+    .unwrap()
+});
+
+pub(crate) const OFFLINE_UNREACHABLE: &str = "unreachable";
+pub(crate) const OFFLINE_VERSION_MISMATCH: &str = "version_mismatch";

--- a/chain-signatures/node/src/metrics/mod.rs
+++ b/chain-signatures/node/src/metrics/mod.rs
@@ -8,6 +8,7 @@ use prometheus::{HistogramOpts, HistogramVec, Opts, Result};
 
 pub mod hardware;
 pub mod indexers;
+pub mod mesh;
 pub mod messaging;
 pub mod nodes;
 pub mod protocols;

--- a/chain-signatures/node/src/node_client.rs
+++ b/chain-signatures/node/src/node_client.rs
@@ -1,6 +1,5 @@
 use crate::backlog::Checkpoint;
 use crate::protocol::message::cbor_to_bytes;
-use crate::protocol::sync::SyncUpdate;
 use crate::protocol::Chain;
 use crate::web::{CheckpointResponse, StateView, StatusResponse};
 
@@ -232,11 +231,15 @@ impl NodeClient {
         Ok(resp.json().await?)
     }
 
+    /// Exchange sealed sync envelopes. Both directions carry a [`SignedMessage`],
+    /// so neither side has to trust a sender claim made in the payload.
+    ///
+    /// [`SignedMessage`]: crate::protocol::message::SignedMessage
     pub async fn sync(
         &self,
         base: impl IntoUrl,
-        update: &SyncUpdate,
-    ) -> Result<SyncUpdate, RequestError> {
+        update: &Ciphered,
+    ) -> Result<Ciphered, RequestError> {
         let mut url = base.into_url()?;
         url.set_path("sync");
         self.post_cbor_response(

--- a/chain-signatures/node/src/protocol/sync/mod.rs
+++ b/chain-signatures/node/src/protocol/sync/mod.rs
@@ -6,12 +6,14 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::{JoinHandle, JoinSet};
 
+use crate::config::NetworkConfig;
 use crate::mesh::MeshState;
 use crate::node_client::NodeClient;
 use crate::rpc::ContractStateWatcher;
 use crate::storage::{PresignatureStorage, StorageError, TripleStorage};
 
-use super::contract::primitives::ParticipantInfo;
+use super::contract::primitives::{ParticipantInfo, ParticipantMap};
+use super::message::SignedMessage;
 use super::presignature::PresignatureId;
 use super::triple::TripleId;
 
@@ -66,6 +68,11 @@ impl SyncUpdate {
 }
 
 pub struct SyncRequest {
+    /// Sender proven by the envelope signature. This, and never the payload's
+    /// `from`, is what may reach storage: `remove_outdated` deletes every
+    /// artifact we hold for the owner it is given, so an unverified owner is a
+    /// remote delete primitive.
+    pub from: Participant,
     pub update: SyncUpdate,
     pub response_tx: oneshot::Sender<Result<SyncUpdate, StorageError>>,
 }
@@ -80,7 +87,7 @@ impl SyncRequest {
         let start = Instant::now();
 
         let outdated_triples = match triples
-            .remove_outdated(self.update.from, &self.update.triples)
+            .remove_outdated(self.from, &self.update.triples)
             .await
         {
             Ok(result) => result,
@@ -90,7 +97,7 @@ impl SyncRequest {
             }
         };
         let outdated_presignatures = match presignatures
-            .remove_outdated(self.update.from, &self.update.presignatures)
+            .remove_outdated(self.from, &self.update.presignatures)
             .await
         {
             Ok(result) => result,
@@ -131,6 +138,7 @@ pub struct SyncTask {
     contract: ContractStateWatcher,
     requests: SyncRequestReceiver,
     synced_peer_tx: mpsc::Sender<Participant>,
+    network: NetworkConfig,
 }
 
 // TODO: add a watch channel for mesh active participants.
@@ -142,6 +150,7 @@ impl SyncTask {
         mesh_state: watch::Receiver<MeshState>,
         contract: ContractStateWatcher,
         synced_peer_tx: mpsc::Sender<Participant>,
+        network: NetworkConfig,
     ) -> (SyncChannel, Self) {
         let (requests, channel) = SyncChannel::new();
         let task = Self {
@@ -152,6 +161,7 @@ impl SyncTask {
             contract,
             requests,
             synced_peer_tx,
+            network,
         };
         (channel, task)
     }
@@ -200,6 +210,8 @@ impl SyncTask {
                         update,
                         receivers.into_iter(),
                         me,
+                        self.network.clone(),
+                        self.contract.participant_map().await,
                     ));
                     broadcast = Some((start, task));
                 }
@@ -346,27 +358,65 @@ impl SyncTask {
 /// Broadcast an update to all participants specified by `receivers`.
 /// Returns results for all peers that complete within BROADCAST_TIMEOUT.
 /// Peers that don't respond are not included in results and will be retried later.
+///
+/// Each update is sealed to the recipient's `cipher_pk` and signed with our
+/// `sign_sk`, and each response is verified to be signed by the peer we actually
+/// contacted. A response drives `remove_holder_and_prune` locally, so accepting
+/// one from an unverified sender would let any host prune our artifacts.
 async fn broadcast_sync(
     client: NodeClient,
     update: SyncUpdate,
     receivers: impl Iterator<Item = (Participant, ParticipantInfo)>,
     me: Participant,
+    network: NetworkConfig,
+    participants: ParticipantMap,
 ) -> Vec<(Participant, SyncPeerResponse)> {
     let mut tasks = JoinSet::new();
     let update = Arc::new(update);
+    let participants = Arc::new(participants);
 
     for (p, info) in receivers {
         let client = client.clone();
         let update = update.clone();
+        let network = network.clone();
+        let participants = participants.clone();
         let url = info.url;
         tasks.spawn(async move {
-            let sync_result = if p != me {
-                match client.sync(&url, &update).await {
-                    Ok(response) => SyncPeerResponse::Success(response),
-                    Err(err) => SyncPeerResponse::Failed(err.to_string()),
+            if p == me {
+                return (p, SyncPeerResponse::SelfPeer);
+            }
+
+            let sealed =
+                match SignedMessage::encrypt(&*update, me, &network.sign_sk, &info.cipher_pk) {
+                    Ok(sealed) => sealed,
+                    Err(err) => {
+                        return (
+                            p,
+                            SyncPeerResponse::Failed(format!("encrypt failed: {err}")),
+                        )
+                    }
+                };
+
+            let sync_result = match client.sync(&url, &sealed).await {
+                Ok(sealed) => {
+                    match SignedMessage::decrypt_with::<SyncUpdate, _>(
+                        &sealed,
+                        &network.cipher_sk,
+                        &participants,
+                        |_| Ok(()),
+                    ) {
+                        // A peer must not be able to answer for another peer:
+                        // the pruning below is applied against `p`.
+                        Ok((signer, _)) if signer != p => SyncPeerResponse::Failed(format!(
+                            "response signed by {signer:?}, expected {p:?}"
+                        )),
+                        Ok((_, response)) => SyncPeerResponse::Success(response),
+                        Err(err) => {
+                            SyncPeerResponse::Failed(format!("response verify failed: {err}"))
+                        }
+                    }
                 }
-            } else {
-                SyncPeerResponse::SelfPeer
+                Err(err) => SyncPeerResponse::Failed(err.to_string()),
             };
             (p, sync_result)
         });
@@ -424,10 +474,17 @@ impl SyncChannel {
         (requests, channel)
     }
 
-    pub async fn request_update(&self, update: SyncUpdate) -> Result<SyncUpdate, SyncError> {
+    /// `from` must be the sender authenticated by the transport envelope, not a
+    /// value taken from the payload.
+    pub async fn request_update(
+        &self,
+        from: Participant,
+        update: SyncUpdate,
+    ) -> Result<SyncUpdate, SyncError> {
         let (response_tx, response_rx) = oneshot::channel();
         let request = SyncRequest {
-            update: update.clone(),
+            from,
+            update,
             response_tx,
         };
 
@@ -450,5 +507,94 @@ impl SyncChannel {
             tracing::debug!(?err, "sync processing failed in storage layer");
             SyncError::ResponseFailed
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::contract::primitives::Participants;
+    use crate::protocol::ParticipantInfo;
+
+    fn keyed_participant(id: u32, seed: &str) -> (ParticipantInfo, near_crypto::SecretKey) {
+        let sign_sk = near_crypto::SecretKey::from_seed(near_crypto::KeyType::ED25519, seed);
+        let (_, cipher_pk) = mpc_keys::hpke::generate();
+        let mut info = ParticipantInfo::new(id);
+        info.sign_pk = sign_sk.public_key();
+        info.cipher_pk = cipher_pk;
+        (info, sign_sk)
+    }
+
+    /// The `/sync` handler feeds `remove_outdated`, which deletes every artifact
+    /// we hold for the owner it is handed. That owner must come from the
+    /// envelope signature, never from the payload, or any caller could name a
+    /// victim. Lock in that the two are distinguishable: a forged payload `from`
+    /// does not change who the envelope proves sent it.
+    #[test]
+    fn payload_from_cannot_impersonate_another_participant() {
+        let attacker = Participant::from(1u32);
+        let victim = Participant::from(2u32);
+
+        let (attacker_info, attacker_sk) = keyed_participant(1, "sync-attacker");
+        let (victim_info, _victim_sk) = keyed_participant(2, "sync-victim");
+        let (recipient_cipher_sk, recipient_cipher_pk) = mpc_keys::hpke::generate();
+
+        let mut participants = Participants::default();
+        participants.insert(&attacker, attacker_info);
+        participants.insert(&victim, victim_info);
+        let participants = ParticipantMap::One(participants);
+
+        // The attacker signs with its own key but claims to be the victim in
+        // the payload, which is what would reach storage if it were trusted.
+        let forged = SyncUpdate {
+            from: victim,
+            triples: Vec::new(),
+            presignatures: Vec::new(),
+        };
+        let sealed =
+            SignedMessage::encrypt(&forged, attacker, &attacker_sk, &recipient_cipher_pk).unwrap();
+
+        let (signer, update) = SignedMessage::decrypt_with::<SyncUpdate, _>(
+            &sealed,
+            &recipient_cipher_sk,
+            &participants,
+            |_| Ok(()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            signer, attacker,
+            "the authenticated sender must be the signer"
+        );
+        assert_eq!(
+            update.from, victim,
+            "the payload still carries the forged claim, so it must never be used as the owner"
+        );
+        assert_ne!(signer, update.from);
+    }
+
+    /// A participant absent from the contract set cannot be authenticated at all,
+    /// so an outside caller never reaches storage.
+    #[test]
+    fn unknown_sender_is_rejected() {
+        let outsider = Participant::from(9u32);
+        let (_outsider_info, outsider_sk) = keyed_participant(9, "sync-outsider");
+        let (recipient_cipher_sk, recipient_cipher_pk) = mpc_keys::hpke::generate();
+
+        let update = SyncUpdate {
+            from: outsider,
+            triples: Vec::new(),
+            presignatures: Vec::new(),
+        };
+        let sealed =
+            SignedMessage::encrypt(&update, outsider, &outsider_sk, &recipient_cipher_pk).unwrap();
+
+        let result = SignedMessage::decrypt_with::<SyncUpdate, _>(
+            &sealed,
+            &recipient_cipher_sk,
+            &ParticipantMap::One(Participants::default()),
+            |_| Ok(()),
+        );
+        assert!(result.is_err(), "unknown participant must not authenticate");
     }
 }

--- a/chain-signatures/node/src/web/error.rs
+++ b/chain-signatures/node/src/web/error.rs
@@ -26,6 +26,11 @@ pub enum Error {
     Sync(#[from] SyncError),
     #[error("invalid parameters: {0}")]
     InvalidParameters(String),
+    /// Sender could not be authenticated against the contract participant set.
+    /// Deliberately carries no detail: the caller is unauthenticated, so the
+    /// reason is only logged server-side.
+    #[error("unauthorized")]
+    Unauthorized,
 }
 
 impl Error {
@@ -38,6 +43,7 @@ impl Error {
             Error::Rpc(_) => StatusCode::BAD_REQUEST,
             Error::InvalidParameters(_) => StatusCode::BAD_REQUEST,
             Error::Sync(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Error::Unauthorized => StatusCode::UNAUTHORIZED,
         }
     }
 }

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -8,13 +8,26 @@ pub mod debug;
 
 use self::error::Error;
 use crate::backlog::{Backlog, Checkpoint};
+use crate::config::NetworkConfig;
 use crate::metrics::messaging::WEB_ENDPOINT_LATENCY;
+use crate::protocol::message::SignedMessage;
 use crate::protocol::state::{NodeStateWatcher, NodeStatus, ResharingStatus};
 use crate::protocol::sync::{SyncChannel, SyncUpdate};
 use crate::protocol::{Chain, MessageChannel};
+use crate::rpc::ContractStateWatcher;
 use crate::storage::{PresignatureStorage, TripleStorage};
 use crate::web::cbor::Cbor;
 use crate::web::error::Result;
+
+/// Upper bound on a `/sync` body.
+///
+/// A sync update carries one id per artifact the sender owns. With the contract
+/// defaults (`max_triples` = 1024 * 32 * 128, `max_presignatures` half that,
+/// ids being CBOR-encoded `u64`s) a single owner holding the entire network-wide
+/// pool lands in the tens of megabytes, so this is a real ceiling rather than a
+/// tight bound. It is only a backstop against oversized bodies: authenticity is
+/// enforced by the signed envelope in [`sync`], not by this limit.
+const MAX_SYNC_BODY_BYTES: usize = 20 * 1024 * 1024;
 
 use anyhow::Context;
 use axum::body::Body;
@@ -45,6 +58,8 @@ struct AxumState {
     #[allow(dead_code)] // used by debug-page
     my_account_id: AccountId,
     backlog: Backlog,
+    contract: ContractStateWatcher,
+    network: NetworkConfig,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -57,6 +72,8 @@ pub async fn run(
     sync_channel: SyncChannel,
     my_account_id: AccountId,
     backlog: Backlog,
+    contract: ContractStateWatcher,
+    network: NetworkConfig,
 ) {
     tracing::info!("starting web server");
     let axum_state = AxumState {
@@ -67,12 +84,16 @@ pub async fn run(
         sync_channel,
         my_account_id,
         backlog,
+        contract,
+        network,
     };
 
-    // Sync can be a large payload, so we set a higher limit for payload.
+    // A sync update carries one id per artifact we own, so the payload scales
+    // with the artifact cap rather than being bounded by a fixed guess. The
+    // limit is the last line before decryption, so keep it tight.
     let sync = Router::new()
         .route("/sync", post(sync))
-        .layer(DefaultBodyLimit::max(20 * 1024 * 1024));
+        .layer(DefaultBodyLimit::max(MAX_SYNC_BODY_BYTES));
 
     let mut router = Router::new()
         // healthcheck endpoint
@@ -304,17 +325,57 @@ async fn bench_metrics() -> Json<BenchMetrics> {
     })
 }
 
+/// Peer state sync.
+///
+/// The request is a [`SignedMessage`]: sealed to our `cipher_pk` and signed by
+/// the sender, so the sender is authenticated against the contract's participant
+/// set before any storage work happens. This is load-bearing, not defence in
+/// depth. The handler feeds `remove_outdated`, which deletes every artifact we
+/// hold for the owner it is given; trusting a `from` taken from the payload
+/// would make this endpoint a remote "delete all presignatures owned by P"
+/// primitive for any unauthenticated caller.
+///
+/// The response is sealed and signed the same way, so the peer can likewise
+/// verify it is acting on our answer and not an interposed one.
+///
+/// [`SignedMessage`]: crate::protocol::message::SignedMessage
 #[tracing::instrument(level = "debug", skip_all)]
 async fn sync(
     Extension(state): Extension<Arc<AxumState>>,
-    WithRejection(Cbor(update), _): WithRejection<Cbor<SyncUpdate>, Error>,
-) -> Result<Cbor<SyncUpdate>> {
+    WithRejection(Cbor(sealed), _): WithRejection<Cbor<Ciphered>, Error>,
+) -> Result<Cbor<Ciphered>> {
     let start = Instant::now();
-    let response = state.sync_channel.request_update(update).await?;
+
+    let participants = state.contract.participant_map().await;
+    let (from, update) = SignedMessage::decrypt_with::<SyncUpdate, _>(
+        &sealed,
+        &state.network.cipher_sk,
+        &participants,
+        |_| Ok(()),
+    )
+    .map_err(|err| {
+        tracing::warn!(?err, "rejecting unverified sync request");
+        Error::Unauthorized
+    })?;
+
+    let response = state.sync_channel.request_update(from, update).await?;
+
+    // `SyncRequest::process` stamps the response with our own participant id.
+    let me = response.from;
+    let peer = participants.get(&from).ok_or_else(|| {
+        tracing::warn!(?from, "no participant info to seal sync response to");
+        Error::Unauthorized
+    })?;
+    let sealed = SignedMessage::encrypt(&response, me, &state.network.sign_sk, &peer.cipher_pk)
+        .map_err(|err| {
+            tracing::warn!(?err, ?from, "failed to seal sync response");
+            Error::Unauthorized
+        })?;
+
     WEB_ENDPOINT_LATENCY
         .with_label_values(&["sync"])
         .observe(start.elapsed().as_millis() as f64);
-    Ok(Cbor(response))
+    Ok(Cbor(sealed))
 }
 
 type ChainAndDigest = (Chain, Option<[u8; 32]>);

--- a/integration-tests/benches/store.rs
+++ b/integration-tests/benches/store.rs
@@ -129,6 +129,13 @@ fn env() -> (Runtime, SyncEnv) {
             mesh.watch(),
             contract_watcher,
             synced_peer_tx,
+            mpc_node::config::NetworkConfig {
+                sign_sk: near_crypto::SecretKey::from_seed(
+                    near_crypto::KeyType::ED25519,
+                    "bench-sync",
+                ),
+                cipher_sk: mpc_keys::hpke::SecretKey::from_bytes(&[0u8; 32]),
+            },
         );
 
         SyncEnv {

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -543,6 +543,7 @@ impl MpcFixtureNodeBuilder {
         let (rpc_tx, rpc_rx) = mpsc::channel(MAX_CONCURRENT_RPC_REQUESTS);
         let rpc_channel = RpcChannel { tx: rpc_tx };
         let (mesh_tx, mesh_rx) = watch::channel(context.init_mesh.clone());
+        let network = self.config.local.network.clone();
         let (config_tx, config_rx) = watch::channel(self.config);
 
         let channels = protocol::test_setup::TestProtocolChannels {
@@ -618,12 +619,15 @@ impl MpcFixtureNodeBuilder {
             triple_storage.clone(),
             presignature_storage.clone(),
             mesh_rx.clone(),
-            context.contract_state,
+            context.contract_state.clone(),
             mpc_node::protocol::sync::SyncTask::synced_nodes_channel().0,
+            network.clone(),
         );
         tokio::spawn(sync_task.run());
 
         let mut node = MpcFixtureNode {
+            contract: context.contract_state,
+            network,
             me: self.me,
             account_id: self.participant_info.account_id.clone(),
             state: node_state,

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -50,6 +50,10 @@ pub struct MpcFixtureNode {
 
     pub sync_channel: mpc_node::protocol::sync::SyncChannel,
     pub web_handle: Option<tokio::task::JoinHandle<()>>,
+
+    /// Needed by the web interface to authenticate `/sync` peers.
+    pub contract: mpc_node::rpc::ContractStateWatcher,
+    pub network: mpc_node::config::NetworkConfig,
 }
 
 /// Logs for reading outputs after a test run for assertions and debugging.
@@ -308,8 +312,9 @@ impl MpcFixtureNode {
             triples,
             presignatures,
         };
+        // Stands in for the sender the web layer authenticates from the envelope.
         self.sync_channel
-            .request_update(update)
+            .request_update(from, update)
             .await
             .expect("sync_channel request_update failed")
     }
@@ -386,6 +391,8 @@ impl MpcFixtureNode {
             SyncChannel::new().1,
             account_id,
             self.backlog.clone(),
+            self.contract.clone(),
+            self.network.clone(),
         );
         self.web_handle = Some(tokio::spawn(task));
         Some(web_port)


### PR DESCRIPTION
Authenticates `POST /sync` and makes the mesh's active-participant view
self-correcting.

## Rollout: needs a coordinated restart

`PROTOCOL_VERSION` goes 1 -> 2 because the `/sync` wire format changed. Old and
new nodes cannot sync, so a mixed-version window costs signing capacity while it
lasts. The bump makes that a clean partition instead of a silent one: the mesh
already marks version-mismatched peers `Offline`, where without it a peer sits
in `need_sync` indefinitely behind a decode warning.

## What changed

- **`/sync` is authenticated.** Both directions use the `SignedMessage` envelope
  `/msg` already uses, so storage keys off the verified signer rather than a
  sender id taken from the payload. A response is rejected unless signed by the
  peer we contacted, since it drives local pruning.
- **The connection set is published over a `watch` channel** instead of streamed
  as add/remove events over `broadcast`. A lag silently dropped events, so a
  dropped `New(p)` left `p` unable to become active again; with the channel
  closed and no watchers the loop panicked, freezing mesh state while `/status`
  still reported healthy. Drops now fall out of a set difference.
- **`MeshState` is reconciled against the contract** on every update. A departed
  participant could previously linger in `active()` and be selected for signing.
- **Mesh metrics:** set-size gauges, a status-transition counter, and an offline
  counter split by `unreachable` vs `version_mismatch`, which call for opposite
  operator responses.
- **Tests:** condition waits instead of sleeps, plus coverage for drops,
  `retain`, `clear`, re-add under a new index, and sync eviction.
  `test_pool_update`'s second phase never asserted any node reached `Active`.

## Worth a close look

- `decrypt_with(.., |_| Ok(()))` passes a no-op closure, so participant-set
  membership is the only check on the caller.
- During resharing `participant_map()` is `Two(new, old)`, so a departing
  participant keeps `/sync` access for that window.
- The lookup that seals the response runs against the snapshot `decrypt_with`
  already validated, so its `Unauthorized` branch is unreachable.

## Left for later

- The body is buffered before the caller is authenticated, so an unauthenticated
  caller can still allocate `MAX_SYNC_BODY_BYTES` per request, uncapped in
  flight. Authentication closed the storage half, not this one.
- Authentication bounds the caller to the participant set; a member can still
  drive pruning.
- The single global broadcast slot can park a peer in `need_sync` for up to
  `BROADCAST_TIMEOUT`.
- A node exempts itself from the liveness checks it applies to peers, inflating
  `active().len()` by one at startup. The fix is not circular (checked) but
  changes when a node considers itself usable, so it wants its own PR and soak.
