### PR TITLE
docs(mesh): document the active-participant state machine

### DIFF
--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -293,12 +293,15 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
             } = MeshHandles::new(message_options, mesh_options, &account_id);
 
             let chains = ChainConfigs::from_args(eth, sol, hydration, canton, midnight)?;
+            // Cloned into the sync task and the web server: both ends of `/sync`
+            // seal and sign with these keys.
             let network = NetworkConfig { cipher_sk, sign_sk };
             let signer = match InMemorySigner::from_secret_key(account_id.clone(), account_sk) {
                 near_crypto::Signer::InMemory(s) => s,
                 _ => unreachable!(),
             };
 
+            let web_network = network.clone();
             let RpcHandles {
                 near_client,
                 near_governance_client,
@@ -321,6 +324,7 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 mesh_state.clone(),
                 contract_watcher.clone(),
                 synced_peer_tx,
+                network.clone(),
             );
 
             log_startup(
@@ -380,6 +384,8 @@ pub async fn run(cmd: Cli) -> anyhow::Result<()> {
                 sync_channel,
                 account_id,
                 backlog.clone(),
+                contract_watcher.clone(),
+                web_network,
             ));
 
             spawn_indexers(

--- a/chain-signatures/node/src/lib.rs
+++ b/chain-signatures/node/src/lib.rs
@@ -1,6 +1,15 @@
 /// Version of the protocol (triples, presignatures, signatures) messages
 /// that the node can currently work with.
-pub const PROTOCOL_VERSION: u64 = 1;
+///
+/// Bump this whenever the peer wire format changes. The mesh marks any peer
+/// reporting a different version as `Offline`, which is what keeps a mixed
+/// version deployment from half-working: without a bump, a node speaking the new
+/// `/sync` envelope to an old node would just fail to decode on every round, and
+/// the peer would sit in `need_sync` (and out of `active`) indefinitely with only
+/// a decode warning to show for it.
+///
+/// - 2: `/sync` carries a signed, sealed envelope instead of a bare `SyncUpdate`.
+pub const PROTOCOL_VERSION: u64 = 2;
 /// Version of the checkpoint data that the node can work with.
 pub const CHECKPOINT_VERSION: u64 = 0;
 /// Redis namespace version for persisted checkpoints.

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -1,14 +1,16 @@
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::time::Duration;
 
 use cait_sith::protocol::Participant;
 use near_account_id::AccountId;
-use tokio::sync::{broadcast, watch};
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::WatchStream;
 use tokio_stream::{StreamExt, StreamMap};
 
+use crate::metrics::mesh as metrics;
 use crate::node_client::NodeClient;
 use crate::protocol::contract::primitives::Participants;
 use crate::protocol::state::NodeStatus as OtherNodeStatus;
@@ -110,9 +112,13 @@ impl NodeConnection {
                         Ok(status) => status,
                         Err(err) => {
                             tracing::warn!(?node, ?err, "checking /status failed");
-                            status_tx.send_if_modified(|(status, _)| {
+                            if status_tx.send_if_modified(|(status, _)| {
                                 std::mem::replace(status, NodeStatus::Offline) != NodeStatus::Offline
-                            });
+                            }) {
+                                metrics::MESH_PEER_OFFLINE
+                                    .with_label_values(&[metrics::OFFLINE_UNREACHABLE])
+                                    .inc();
+                            }
                             continue;
                         }
                     };
@@ -124,9 +130,13 @@ impl NodeConnection {
                             peer_version = resp.protocol_version,
                             "protocol version mismatch"
                         );
-                        status_tx.send_if_modified(|(status, _)| {
+                        if status_tx.send_if_modified(|(status, _)| {
                             std::mem::replace(status, NodeStatus::Offline) != NodeStatus::Offline
-                        });
+                        }) {
+                            metrics::MESH_PEER_OFFLINE
+                                .with_label_values(&[metrics::OFFLINE_VERSION_MISMATCH])
+                                .inc();
+                        }
                         continue;
                     }
 
@@ -173,6 +183,14 @@ impl Drop for NodeConnection {
     }
 }
 
+/// Snapshot of the pool's current connections, keyed by participant.
+///
+/// Published as a whole rather than as a stream of add/remove events. The set is
+/// state, not a sequence: a watcher only ever needs the latest version of it, and
+/// publishing the set means a slow watcher converges on the truth instead of
+/// missing an event and diverging from it permanently.
+type ConnectionSet = Arc<HashMap<Participant, watch::Receiver<(NodeStatus, ParticipantInfo)>>>;
+
 /// Pool that manages connections to nodes in the network. It is responsible for
 /// connecting to nodes, checking their status, and dropping connections that are
 /// no longer within the network.
@@ -189,30 +207,27 @@ pub struct Pool {
     /// Account id of this node. Used to avoid creating self connections.
     node_account_id: AccountId,
 
-    conn_update_tx: broadcast::Sender<ConnectionUpdate>,
-    conn_update_rx: broadcast::Receiver<ConnectionUpdate>,
+    conns_tx: watch::Sender<ConnectionSet>,
 }
 
 impl Pool {
     pub fn new(client: &NodeClient, node_account_id: &AccountId, ping_interval: Duration) -> Self {
         tracing::info!("creating new connection pool");
-        let (conn_update_tx, conn_update_rx) = broadcast::channel(256);
+        let (conns_tx, _) = watch::channel(Arc::new(HashMap::new()));
         Self {
             client: client.clone(),
             ping_interval,
             connections: HashMap::new(),
             node_account_id: node_account_id.clone(),
-
-            conn_update_tx,
-            conn_update_rx,
+            conns_tx,
         }
     }
 
-    pub async fn connect(&mut self, contract: ProtocolState) {
+    pub async fn connect(&mut self, contract: &ProtocolState) {
         let mut seen = HashSet::new();
         match contract {
             ProtocolState::Initializing(init) => {
-                let participants: Participants = init.candidates.into();
+                let participants: Participants = init.candidates.clone().into();
                 self.connect_nodes(&participants, &mut seen).await;
             }
             ProtocolState::Running(running) => {
@@ -241,17 +256,11 @@ impl Pool {
         participants: &Participants,
         seen: &mut HashSet<Participant>,
     ) {
+        let mut changed = false;
         for (&participant, info) in participants.iter() {
             if info.account_id == self.node_account_id {
                 tracing::debug!(?participant, "skipping self connection");
-                if self.connections.remove(&participant).is_some()
-                    && self
-                        .conn_update_tx
-                        .send(ConnectionUpdate::Drop(participant))
-                        .is_err()
-                {
-                    tracing::warn!(?participant, "unable to send drop for self connection");
-                }
+                changed |= self.connections.remove(&participant).is_some();
                 continue;
             }
 
@@ -267,51 +276,47 @@ impl Pool {
                 }
                 Entry::Vacant(conn) => {
                     tracing::info!(?node, "node connection created");
-                    let conn = conn.insert(NodeConnection::spawn(
+                    conn.insert(NodeConnection::spawn(
                         &self.client,
                         participant,
                         info,
                         self.ping_interval,
                     ));
-
-                    let watcher = conn.status_rx.clone();
-                    if self
-                        .conn_update_tx
-                        .send(ConnectionUpdate::New(participant, watcher))
-                        .is_err()
-                    {
-                        tracing::warn!(?node, "failed to send new connection");
-                    }
+                    changed = true;
                 }
             }
+        }
+
+        if changed {
+            self.publish();
         }
     }
 
     /// Drop connections that are not in the active connections list. Dropped connections
     /// are no longer polled for their status.
     fn drop_connections(&mut self, active_conn: HashSet<Participant>) {
-        let mut remove = Vec::new();
-        for participant in self.connections.keys() {
-            if !active_conn.contains(participant) {
-                remove.push(*participant);
-            }
-        }
-
-        for participant in remove {
-            let removed = self.connections.remove(&participant).is_some();
-            if removed
-                && self
-                    .conn_update_tx
-                    .send(ConnectionUpdate::Drop(participant))
-                    .is_err()
-            {
-                tracing::warn!(?participant, "unable to send update for drop participant");
-            }
+        let before = self.connections.len();
+        self.connections
+            .retain(|participant, _| active_conn.contains(participant));
+        if self.connections.len() != before {
+            self.publish();
         }
     }
 
+    /// Publish the current connection set to all watchers.
+    fn publish(&self) {
+        let set: ConnectionSet = Arc::new(
+            self.connections
+                .iter()
+                .map(|(p, conn)| (*p, conn.status_rx.clone()))
+                .collect(),
+        );
+        // No receivers is normal: the mesh may not be watching yet.
+        let _ = self.conns_tx.send(set);
+    }
+
     /// Update the node state after synchronization was successful.
-    pub async fn report_node_synced(&self, participant: Participant) {
+    pub fn report_node_synced(&self, participant: Participant) {
         if let Some(conn) = self.connections.get(&participant) {
             tracing::info!(?participant, "reporting node synced");
             conn.status_tx.send_if_modified(|(status, _)| {
@@ -326,56 +331,93 @@ impl Pool {
     }
 
     pub fn watch(&self) -> ConnectionWatcher {
-        ConnectionWatcher::new(self.conn_update_rx.resubscribe())
+        ConnectionWatcher::new(self.conns_tx.subscribe())
     }
 }
 
-#[derive(Clone)]
-pub enum ConnectionUpdate {
-    New(Participant, watch::Receiver<(NodeStatus, ParticipantInfo)>),
-    Drop(Participant),
+/// A change observed by a [`ConnectionWatcher`].
+pub enum MeshUpdate {
+    /// A connection reported a new status.
+    Status(Participant, NodeStatus, ParticipantInfo),
+    /// The participant left the connection set and is no longer polled.
+    ///
+    /// Carries no [`ParticipantInfo`]: there is none to report, and inventing a
+    /// placeholder only works for as long as every consumer happens to ignore it.
+    Dropped(Participant),
 }
 
 pub struct ConnectionWatcher {
-    /// Watch for new connections and dropped connections from the pool. This
-    /// is so that we can update our watchers when the pool changes.
-    // NOTE: this is a broadcast channel so that we can get a series of updates, and
-    // not just the latest entry with watcher channel.
-    conn_update: broadcast::Receiver<ConnectionUpdate>,
-    /// Set of active connections that we are watching.
+    /// Latest connection set published by the pool.
+    conns: watch::Receiver<ConnectionSet>,
+    /// Per-connection status streams, kept in step with `conns`.
     watchers: StreamMap<Participant, WatchStream<(NodeStatus, ParticipantInfo)>>,
+    /// Drops found by the last reconcile, still to be reported.
+    dropped: Vec<Participant>,
 }
 
 impl ConnectionWatcher {
-    fn new(conn_update: broadcast::Receiver<ConnectionUpdate>) -> Self {
+    fn new(conns: watch::Receiver<ConnectionSet>) -> Self {
         Self {
-            conn_update,
+            conns,
             watchers: StreamMap::new(),
+            dropped: Vec::new(),
         }
     }
 
-    pub async fn next(&mut self) -> (Participant, NodeStatus, ParticipantInfo) {
+    /// Next change, or `None` once the pool is gone and no further updates can
+    /// arrive. Callers must treat `None` as terminal: continuing to use the last
+    /// mesh state would be acting on a snapshot that can no longer be corrected.
+    pub async fn next(&mut self) -> Option<MeshUpdate> {
         loop {
+            if let Some(participant) = self.dropped.pop() {
+                return Some(MeshUpdate::Dropped(participant));
+            }
+
             tokio::select! {
-                // Update our watchers if the connections changed.
-                Ok(update) = self.conn_update.recv() => {
-                    match update {
-                        ConnectionUpdate::New(participant, rx) => {
-                            tracing::debug!(?participant, "adding new watcher");
-                            self.watchers.insert(participant, WatchStream::new(rx));
-                        }
-                        ConnectionUpdate::Drop(participant) => {
-                            tracing::debug!(?participant, "dropping watcher");
-                            self.watchers.remove(&participant);
-                            return (participant, NodeStatus::Offline, ParticipantInfo::new(u32::MAX));
-                        }
+                // Both branches are cancel-safe, and `changed()` erroring is the
+                // only way out, so this select can never end up with every branch
+                // disabled.
+                changed = self.conns.changed() => {
+                    if changed.is_err() {
+                        tracing::warn!("connection pool dropped; connection watcher stopping");
+                        return None;
                     }
+                    self.reconcile();
                 }
-                // NOTE: if watchers.next() return None, it means that the connection is dropped
-                // or that the StreamMap is empty. In that case, we should just continue
+                // `watchers.next()` yields `None` while the map is empty, which
+                // just disables this branch until the set changes.
                 Some((p, (status, info))) = self.watchers.next() => {
-                    return (p, status, info);
+                    return Some(MeshUpdate::Status(p, status, info));
                 }
+            }
+        }
+    }
+
+    /// Bring the status streams in line with the latest published set.
+    ///
+    /// Re-inserted connections re-emit their current status, because
+    /// `WatchStream` yields the present value on creation. That is what makes a
+    /// missed intermediate state self-correcting rather than permanent.
+    fn reconcile(&mut self) {
+        let set = self.conns.borrow_and_update().clone();
+
+        let gone: Vec<Participant> = self
+            .watchers
+            .keys()
+            .filter(|p| !set.contains_key(p))
+            .copied()
+            .collect();
+        for participant in gone {
+            tracing::debug!(?participant, "dropping watcher");
+            self.watchers.remove(&participant);
+            self.dropped.push(participant);
+        }
+
+        for (participant, rx) in set.iter() {
+            if !self.watchers.contains_key(participant) {
+                tracing::debug!(?participant, "adding new watcher");
+                self.watchers
+                    .insert(*participant, WatchStream::new(rx.clone()));
             }
         }
     }

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -16,10 +16,16 @@ use crate::protocol::contract::primitives::Participants;
 use crate::protocol::state::NodeStatus as OtherNodeStatus;
 use crate::protocol::{ParticipantInfo, ProtocolState};
 
+/// Status of a single connection, as seen by this node.
+///
+/// See the [module docs](crate::mesh) for how these map onto the two
+/// [`MeshState`](crate::mesh::MeshState) sets and what drives each transition.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum NodeStatus {
     /// The connected node responds and is actively participating in the MPC
     /// network.
+    ///
+    /// Reachable only via [`Pool::report_node_synced`]; no ping sets this.
     Active,
     /// State sync is running for node in this state.
     ///

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -1,3 +1,96 @@
+//! Which participants this node considers usable right now.
+//!
+//! The mesh answers one question for the rest of the node: of the participants
+//! the contract recognizes, which ones are reachable, running a compatible
+//! protocol version, and synced with us. That answer is [`MeshState`], published
+//! over a `watch` channel and read by signing, triple and presignature
+//! generation, indexer hydration and backlog recovery.
+//!
+//! Everything here is one node's local view. Two nodes will disagree about who
+//! is active, and that is expected: the view is built from this node's own pings
+//! and its own sync progress. Anything that needs agreement across nodes (such
+//! as electing a proposer) must not be derived from it, see `#907`.
+//!
+//! # States
+//!
+//! [`NodeStatus`] is per connection. [`MeshState`] keeps two sets, and the
+//! status decides which one a participant lands in:
+//!
+//! | [`NodeStatus`] | set in [`MeshState`] | meaning |
+//! |----------------|----------------------|---------|
+//! | `Active`       | `active()`           | reachable, running, synced with us |
+//! | `Syncing`      | `need_sync()`        | reachable and running, sync outstanding |
+//! | `Inactive`     | neither              | reachable, but not running the protocol |
+//! | `Offline`      | neither              | unreachable, or on a different protocol version |
+//!
+//! Only `active()` may be used to pick peers for a protocol. `need_sync()` is
+//! the work queue the sync task consumes, not a set of usable peers.
+//!
+//! # Transitions
+//!
+//! The graph is close to complete, so the rules are clearer than a drawing.
+//! Each ping outcome determines the next status from the current one:
+//!
+//! | current | ping fails, or version differs | peer not `Running` | peer `Running` |
+//! |---------|-------------------------------|--------------------|----------------|
+//! | `Offline`  | `Offline`  | `Inactive` | **`Syncing`** |
+//! | `Inactive` | `Offline`  | `Inactive` | **`Syncing`** |
+//! | `Syncing`  | `Offline`  | `Inactive` | `Syncing`     |
+//! | `Active`   | `Offline`  | `Inactive` | `Active`      |
+//!
+//! Plus the one transition no ping performs:
+//!
+//! ```text
+//!   Syncing ──[ sync task reports success ]──> Active
+//! ```
+//!
+//! A new connection starts `Offline` and is promoted only once a ping succeeds.
+//!
+//! Two things are worth reading off that table. First, the missing edge: no ping
+//! moves a peer to `Active`. A peer reporting `Running` from `Offline`,
+//! `Inactive` or `Syncing` is written as `Syncing`, because a reachable peer is
+//! not yet a peer holding the same view of the artifacts we own. `Active` is
+//! reachable only through [`connection::Pool::report_node_synced`]. Second, an
+//! `Active` peer that keeps reporting `Running` stays put, so the sync cost is
+//! paid on entry rather than on every ping.
+//!
+//! Any momentary drop to `Offline` or `Inactive` therefore costs a full re-sync
+//! before the peer counts toward threshold again.
+//!
+//! # Who drives them
+//!
+//! Four writers, and they are the whole story:
+//!
+//! 1. **The per-peer ping loop** (`NodeConnection::run`) polls `/status` every
+//!    `ping_interval`. It sets `Offline`, `Inactive` and `Syncing`. It never
+//!    sets `Active`.
+//! 2. **The sync task**, via `synced_peer_rx` into
+//!    [`connection::Pool::report_node_synced`], performs the single
+//!    `Syncing -> Active` transition. It is deliberately conditional: a peer
+//!    that fell out of `Syncing` in the meantime is left alone rather than
+//!    activated on the strength of a stale success. A report for a participant
+//!    with no connection is a no-op.
+//! 3. **The contract**, through [`Mesh::run`], sets this node's own status and
+//!    reconciles the whole set with [`MeshState::retain`]. The contract is the
+//!    authority on membership.
+//! 4. **The pool**, through [`connection::Pool::connect`], adds and drops
+//!    connections, publishing the set that [`connection::ConnectionWatcher`]
+//!    turns into [`connection::MeshUpdate::Dropped`] for departed peers.
+//!
+//! There is a liveness dependency in (2) that is easy to miss: `Syncing` is not
+//! a state a peer leaves on its own. If the sync task stops draining
+//! `need_sync()`, peers stay there forever, `active()` shrinks below threshold,
+//! and signing stalls with every peer looking reachable.
+//!
+//! # This node
+//!
+//! A node does not ping itself. [`Mesh::run`] writes its own entry directly from
+//! the contract state: `Active` under a `Running` contract, `Inactive` under
+//! `Initializing` or `Resharing`. So the local entry in `active()` reflects what
+//! the contract says this node should be doing, not whether it is in fact
+//! able to do it, and unlike every peer it is never gated on sync. See S6 in
+//! `doc/MESH_ACTIVE_REVIEW.md`.
+
 use std::collections::BTreeSet;
 use std::time::Duration;
 

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -1,6 +1,8 @@
+use std::collections::BTreeSet;
 use std::time::Duration;
 
 use crate::mesh::connection::NodeStatus;
+use crate::metrics::mesh as metrics;
 use crate::node_client::NodeClient;
 use crate::protocol::contract::primitives::Participants;
 use crate::protocol::ParticipantInfo;
@@ -71,14 +73,37 @@ impl Mesh {
     pub async fn run(mut self, mut contract: ContractStateWatcher) {
         let state_tx = self.state_tx.clone();
         let mut conn_update = self.connections.watch();
-        tokio::spawn(async move {
-            loop {
-                let (p, status, info) = conn_update.next().await;
-                tracing::info!(?p, ?status, "mesh connection status changed");
-                state_tx.send_modify(|state| {
-                    state.update(p, status, info);
-                });
+        // Deliberately not detached-and-forgotten: if this loop ever ends, the
+        // mesh state freezes at its last value while the node keeps reporting
+        // healthy, and every `wait_threshold_active` downstream would go on
+        // succeeding against a stale snapshot. Say so loudly.
+        let mut updater = tokio::spawn(async move {
+            while let Some(update) = conn_update.next().await {
+                match update {
+                    connection::MeshUpdate::Status(p, status, info) => {
+                        tracing::info!(?p, ?status, "mesh connection status changed");
+                        metrics::MESH_STATUS_TRANSITIONS
+                            .with_label_values(&[status_label(status)])
+                            .inc();
+                        state_tx.send_modify(|state| state.update(p, status, info));
+                    }
+                    connection::MeshUpdate::Dropped(p) => {
+                        tracing::info!(?p, "mesh connection dropped");
+                        metrics::MESH_STATUS_TRANSITIONS
+                            .with_label_values(&["dropped"])
+                            .inc();
+                        state_tx.send_modify(|state| state.remove(p));
+                    }
+                }
+                let state = state_tx.borrow();
+                metrics::MESH_PARTICIPANTS
+                    .with_label_values(&["active"])
+                    .set(state.active().len() as i64);
+                metrics::MESH_PARTICIPANTS
+                    .with_label_values(&["need_sync"])
+                    .set(state.need_sync().len() as i64);
             }
+            tracing::error!("mesh connection watcher stopped; mesh state is now frozen");
         });
 
         loop {
@@ -95,8 +120,13 @@ impl Mesh {
                             ProtocolState::Initializing(_) | ProtocolState::Resharing(_) => NodeStatus::Inactive,
                             ProtocolState::Running(_) => NodeStatus::Active,
                         };
-                        self.connections.connect(contract).await;
+                        self.connections.connect(&contract).await;
+                        // The contract is the authority on membership, so take
+                        // the participant set from it rather than waiting for a
+                        // drop to arrive per departed peer.
+                        let members = Self::members(&contract);
                         self.state_tx.send_modify(|state| {
+                            state.retain(|p| members.contains(p) || *p == participant);
                             // if the previous me is different from the current me, remove the
                             // previous me from the MeshState.
                             if let Some(previous_me) = previous_me.filter(|old| *old != participant) {
@@ -117,8 +147,31 @@ impl Mesh {
                         tracing::warn!(?participant, "ignoring self sync report");
                         continue;
                     }
-                    self.connections.report_node_synced(participant).await;
+                    self.connections.report_node_synced(participant);
                 }
+                // The updater outlives the pool it watches, so reaching this arm
+                // means it panicked or the pool was torn down. Either way the mesh
+                // state can no longer be corrected; stop rather than serve a
+                // snapshot that will silently go stale.
+                result = &mut updater => {
+                    tracing::error!(?result, "mesh connection updater exited; stopping mesh");
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Participants the contract currently recognizes for this node's epoch.
+    fn members(contract: &ProtocolState) -> BTreeSet<Participant> {
+        match contract {
+            ProtocolState::Initializing(init) => {
+                let participants: Participants = init.candidates.clone().into();
+                participants.keys().copied().collect()
+            }
+            ProtocolState::Running(running) => running.participants.keys().copied().collect(),
+            // Matches `Pool::connect`: only the new set operates under the new epoch.
+            ProtocolState::Resharing(resharing) => {
+                resharing.new_participants.keys().copied().collect()
             }
         }
     }
@@ -140,6 +193,15 @@ impl Mesh {
                 .find(&self.my_id)
                 .map(|(p, info)| (*p, info.clone())),
         }
+    }
+}
+
+const fn status_label(status: NodeStatus) -> &'static str {
+    match status {
+        NodeStatus::Active => "active",
+        NodeStatus::Syncing => "syncing",
+        NodeStatus::Inactive => "inactive",
+        NodeStatus::Offline => "offline",
     }
 }
 
@@ -166,6 +228,36 @@ mod tests {
     use test_log::test;
 
     const PING_INTERVAL: Duration = Duration::from_millis(10);
+    /// Generous on purpose: these tests assert what the mesh converges to, not
+    /// how fast. A wall-clock bound only needs to be long enough that a loaded
+    /// machine does not read as a failure.
+    const SETTLE_TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// Poll until `cond` holds, instead of sleeping for a fixed multiple of the
+    /// ping interval and hoping the mesh got there.
+    async fn wait_until(
+        state: &watch::Receiver<MeshState>,
+        what: &str,
+        cond: impl Fn(&MeshState) -> bool,
+    ) {
+        let deadline = tokio::time::Instant::now() + SETTLE_TIMEOUT;
+        loop {
+            {
+                let current = state.borrow();
+                if cond(&current) {
+                    return;
+                }
+                if tokio::time::Instant::now() >= deadline {
+                    panic!(
+                        "timed out waiting for {what}; active={:?} need_sync={:?}",
+                        current.active().keys_vec(),
+                        current.need_sync().keys_vec(),
+                    );
+                }
+            }
+            tokio::time::sleep(PING_INTERVAL).await;
+        }
+    }
 
     async fn expect_status(
         watcher: &mut connection::ConnectionWatcher,
@@ -173,15 +265,43 @@ mod tests {
         expected: NodeStatus,
     ) {
         for _ in 0..20 {
-            if let Ok((p, status, _info)) =
-                tokio::time::timeout(Duration::from_millis(500), watcher.next()).await
-            {
-                if p == participant && status == expected {
-                    return;
+            match tokio::time::timeout(Duration::from_millis(500), watcher.next()).await {
+                Ok(Some(connection::MeshUpdate::Status(p, status, _info)))
+                    if p == participant && status == expected =>
+                {
+                    return
                 }
+                Ok(None) => panic!("connection watcher ended while waiting for {participant:?}"),
+                _ => continue,
             }
         }
         panic!("timed out waiting for {participant:?} to become {expected:?}");
+    }
+
+    /// Collect statuses from the watcher until every peer in `expect` has
+    /// reported `status`, so the test asserts the set it cares about rather than
+    /// a fixed number of arbitrary updates.
+    async fn expect_all(
+        watcher: &mut connection::ConnectionWatcher,
+        mut expect: HashSet<Participant>,
+        status: NodeStatus,
+    ) {
+        let deadline = tokio::time::Instant::now() + SETTLE_TIMEOUT;
+        while !expect.is_empty() {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out waiting for {status:?} from {expect:?}"
+            );
+            match tokio::time::timeout(remaining, watcher.next()).await {
+                Ok(Some(connection::MeshUpdate::Status(p, got, _))) if got == status => {
+                    expect.remove(&p);
+                }
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("connection watcher ended waiting for {status:?}"),
+                Err(_) => panic!("timed out waiting for {status:?} from {expect:?}"),
+            }
+        }
     }
 
     #[test(tokio::test)]
@@ -195,39 +315,49 @@ mod tests {
         let mut watcher = pool.watch();
         pool.connect_nodes(&participants, &mut HashSet::new()).await;
 
-        // We do not sync with ourselves, so only expect 1..num_nodes
-        tokio::time::sleep(PING_INTERVAL * 3).await;
-        let mut syncing = HashSet::new();
-        for i in 1..num_nodes {
-            match tokio::time::timeout(Duration::from_millis(100), watcher.next()).await {
-                Ok((participant, status, _info)) => {
-                    tracing::info!(?participant, ?status, "got connection update for syncing");
-                    if matches!(status, NodeStatus::Syncing) {
-                        syncing.insert(participant);
-                    }
-                }
-                Err(_) => {
-                    panic!("timed out waiting for syncing nodes idx={i}");
-                }
-            }
-        }
-        for i in 1..num_nodes {
-            pool.report_node_synced(servers[i].id()).await;
-        }
+        // We never connect to ourselves, so servers[0] is not expected here.
+        let peers: HashSet<Participant> = (1..num_nodes).map(|i| servers[i].id()).collect();
 
-        // Same with active. We only expect 1..num_nodes for new statuses
-        tokio::time::sleep(PING_INTERVAL * 3).await;
-        for i in 1..num_nodes {
-            match tokio::time::timeout(Duration::from_millis(100), watcher.next()).await {
-                Ok((participant, status, _info)) => {
-                    tracing::info!(?participant, ?status, "got connection update for active");
-                    if matches!(status, NodeStatus::Active) {
-                        syncing.insert(participant);
-                    }
+        expect_all(&mut watcher, peers.clone(), NodeStatus::Syncing).await;
+        for &peer in &peers {
+            pool.report_node_synced(peer);
+        }
+        expect_all(&mut watcher, peers, NodeStatus::Active).await;
+    }
+
+    /// A peer leaving the connection set must reach the watcher as a drop even
+    /// though it never reports a status again.
+    #[test(tokio::test)]
+    async fn test_pool_reports_dropped_connections() {
+        let num_nodes = 2;
+        let servers = MockServers::run(num_nodes).await;
+        let my_id = servers[0].account_id().clone();
+
+        let mut pool = Pool::new(&servers.client(), &my_id, PING_INTERVAL);
+        let mut watcher = pool.watch();
+        pool.connect_nodes(&servers.participants(), &mut HashSet::new())
+            .await;
+
+        let peer = servers[1].id();
+        expect_status(&mut watcher, peer, NodeStatus::Syncing).await;
+
+        pool.disconnect_all();
+
+        let deadline = tokio::time::Instant::now() + SETTLE_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out waiting for drop of {peer:?}"
+            );
+            match tokio::time::timeout(remaining, watcher.next()).await {
+                Ok(Some(connection::MeshUpdate::Dropped(p))) => {
+                    assert_eq!(p, peer);
+                    return;
                 }
-                Err(_) => {
-                    panic!("timed out waiting for active nodes idx={i}");
-                }
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("connection watcher ended before reporting the drop"),
+                Err(_) => panic!("timed out waiting for drop of {peer:?}"),
             }
         }
     }
@@ -261,61 +391,63 @@ mod tests {
             sync_rx,
         );
 
-        let mut mesh_state = mesh.watch();
+        let mesh_state = mesh.watch();
         let mesh_task = tokio::spawn(mesh.run(contract_watcher));
 
         // check that the mesh state is updated.
         {
-            tokio::time::sleep(PING_INTERVAL * 3).await;
-            let state = mesh_state.borrow();
-            assert!(state.active().contains_key(&me));
-            drop(state);
+            wait_until(&mesh_state, "self to be active", |state| {
+                state.active().contains_key(&me)
+            })
+            .await;
 
             for idx in 0..num_nodes {
                 sync_tx.send(servers[idx].id()).await.unwrap();
             }
-            tokio::time::sleep(PING_INTERVAL * 3).await;
+            wait_until(&mesh_state, "all nodes to be active", |state| {
+                state.active().len() == num_nodes && state.need_sync().is_empty()
+            })
+            .await;
 
             let state = mesh_state.borrow();
-            assert_eq!(state.active().len(), num_nodes);
             assert_eq!(state.active(), &expected_participants);
-            assert!(state.need_sync().is_empty());
             for idx in 0..num_nodes {
                 assert!(state.active().contains_key(&servers[idx].id()));
             }
-            assert!(state.active().contains_key(&me));
         }
 
         // check that the mesh state is updated when a participant goes offline
         {
             servers[1].make_offline().await;
-            tokio::time::sleep(PING_INTERVAL * 3).await;
+            wait_until(&mesh_state, "offline node to leave active", |state| {
+                !state.active().contains_key(&servers[1].id())
+            })
+            .await;
 
             let state = mesh_state.borrow();
             assert_eq!(state.active().len(), num_nodes - 1);
             assert!(state.active().contains_key(&me));
             assert!(state.active().contains_key(&servers[0].id()));
-            assert!(!state.active().contains_key(&servers[1].id()));
             assert!(state.active().contains_key(&servers[2].id()));
         }
 
         // check that the mesh state is updated when a participant goes back online.
         {
             servers[1].make_online().await;
-            tokio::time::sleep(PING_INTERVAL * 3).await;
-
             // Node is now syncing: should be in need_sync but not in active yet.
-            let state = mesh_state.borrow_and_update().clone();
-            assert_eq!(state.active().len(), num_nodes - 1);
-            assert!(!state.active().contains_key(&servers[1].id()));
-            assert!(state.need_sync().contains_key(&servers[1].id()));
+            wait_until(&mesh_state, "returning node to need sync", |state| {
+                state.need_sync().contains_key(&servers[1].id())
+            })
+            .await;
+            assert!(!mesh_state.borrow().active().contains_key(&servers[1].id()));
 
             sync_tx.send(servers[1].id()).await.unwrap();
-            tokio::time::sleep(PING_INTERVAL).await;
+            wait_until(&mesh_state, "synced node to become active", |state| {
+                state.active().len() == num_nodes && state.need_sync().is_empty()
+            })
+            .await;
 
-            let state = mesh_state.borrow_and_update().clone();
-            assert_eq!(state.active().len(), num_nodes);
-            assert!(state.need_sync().is_empty());
+            let state = mesh_state.borrow();
             for idx in 0..num_nodes {
                 assert!(state.active().contains_key(&servers[idx].id()));
             }
@@ -368,16 +500,20 @@ mod tests {
 
             // Wait for the mesh to process the contract update and connect the new participant
             let expected_participants = servers.participants();
-            tokio::time::sleep(PING_INTERVAL * 3).await;
+            wait_until(&mesh_state, "new participant to be tracked", |state| {
+                state.active().len() + state.need_sync().len() == num_nodes
+            })
+            .await;
             for i in 0..num_nodes {
                 sync_tx.send(servers[i].id()).await.unwrap();
             }
 
-            tokio::time::sleep(PING_INTERVAL * 3).await;
+            wait_until(&mesh_state, "new participant to become active", |state| {
+                state.active().len() == num_nodes && state.need_sync().is_empty()
+            })
+            .await;
             let state = mesh_state.borrow();
 
-            assert!(state.active().len() == num_nodes);
-            assert!(state.need_sync().is_empty());
             for i in 0..num_nodes {
                 assert!(
                     state.active().contains_key(&servers[i].id()),
@@ -402,11 +538,12 @@ mod tests {
 
             // Wait for the mesh to process the contract update and remove the participant
             let expected_participants = servers.participants();
-            tokio::time::sleep(PING_INTERVAL * 3).await;
+            wait_until(&mesh_state, "removed participant to be dropped", |state| {
+                state.active().len() == num_nodes && state.need_sync().is_empty()
+            })
+            .await;
             let state = mesh_state.borrow();
 
-            assert!(state.need_sync().is_empty());
-            assert!(state.active().len() == num_nodes);
             for i in 0..num_nodes {
                 assert!(
                     state.active().contains_key(&servers[i].id()),
@@ -433,7 +570,7 @@ mod tests {
         let remote_id = servers[1].id();
 
         expect_status(&mut watcher, remote_id, NodeStatus::Syncing).await;
-        pool.report_node_synced(remote_id).await;
+        pool.report_node_synced(remote_id);
         expect_status(&mut watcher, remote_id, NodeStatus::Active).await;
 
         servers[1].set_protocol_version(None).await;
@@ -441,7 +578,7 @@ mod tests {
 
         servers[1].make_online().await;
         expect_status(&mut watcher, remote_id, NodeStatus::Syncing).await;
-        pool.report_node_synced(remote_id).await;
+        pool.report_node_synced(remote_id);
         expect_status(&mut watcher, remote_id, NodeStatus::Active).await;
 
         servers[1].set_protocol_version(Some(0)).await;

--- a/chain-signatures/node/src/mesh/state.rs
+++ b/chain-signatures/node/src/mesh/state.rs
@@ -45,6 +45,17 @@ impl MeshState {
         self.need_sync.remove(&participant);
     }
 
+    /// Drop every participant failing `keep`.
+    ///
+    /// Membership changes are driven by the contract, but removals otherwise
+    /// only reach this state as per-connection drop events. This is the
+    /// reconciling path: it lets the caller assert the whole set against the
+    /// contract instead of trusting that one event per departed peer arrived.
+    pub fn retain(&mut self, keep: impl Fn(&Participant) -> bool) {
+        self.active.participants.retain(|p, _| keep(p));
+        self.need_sync.participants.retain(|p, _| keep(p));
+    }
+
     pub fn clear(&mut self) {
         self.active.clear();
         self.need_sync.clear();
@@ -54,6 +65,81 @@ impl MeshState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn participant(id: u32) -> (Participant, ParticipantInfo) {
+        (Participant::from(id), ParticipantInfo::new(id))
+    }
+
+    /// `retain` is the reconciling path against the contract, so it has to clear
+    /// both sets. A participant left behind in `need_sync` would keep drawing
+    /// sync broadcasts after the contract dropped it.
+    #[test]
+    fn retain_drops_participants_from_both_sets() {
+        let (active, active_info) = participant(1);
+        let (syncing, syncing_info) = participant(2);
+        let (kept, kept_info) = participant(3);
+        let mut state = MeshState::default();
+
+        state.update(active, NodeStatus::Active, active_info);
+        state.update(syncing, NodeStatus::Syncing, syncing_info);
+        state.update(kept, NodeStatus::Active, kept_info);
+
+        state.retain(|p| *p == kept);
+
+        assert!(state.active().contains_key(&kept));
+        assert!(!state.active().contains_key(&active));
+        assert!(!state.need_sync().contains_key(&syncing));
+        assert_eq!(state.active().len(), 1);
+        assert!(state.need_sync().is_empty());
+    }
+
+    /// A participant re-added under a different index must not linger under the
+    /// old one: that is what leaves a departed peer selectable for signing.
+    #[test]
+    fn remove_then_readd_under_new_index_leaves_no_stale_entry() {
+        let (old_index, old_info) = participant(4);
+        let (new_index, new_info) = participant(5);
+        let mut state = MeshState::default();
+
+        state.update(old_index, NodeStatus::Active, old_info);
+        state.remove(old_index);
+        state.update(new_index, NodeStatus::Active, new_info);
+
+        assert!(!state.active().contains_key(&old_index));
+        assert!(state.active().contains_key(&new_index));
+        assert_eq!(state.active().len(), 1);
+    }
+
+    #[test]
+    fn clear_empties_both_sets() {
+        let (active, active_info) = participant(6);
+        let (syncing, syncing_info) = participant(7);
+        let mut state = MeshState::default();
+
+        state.update(active, NodeStatus::Active, active_info);
+        state.update(syncing, NodeStatus::Syncing, syncing_info);
+        state.clear();
+
+        assert!(state.active().is_empty());
+        assert!(state.need_sync().is_empty());
+    }
+
+    /// Both offline reasons must evict from `need_sync` too, or a peer that goes
+    /// down mid-sync keeps being broadcast to forever.
+    #[test]
+    fn offline_and_inactive_clear_pending_sync() {
+        for status in [NodeStatus::Offline, NodeStatus::Inactive] {
+            let (p, info) = participant(8);
+            let mut state = MeshState::default();
+
+            state.update(p, NodeStatus::Syncing, info.clone());
+            assert!(state.need_sync().contains_key(&p));
+
+            state.update(p, status, info);
+            assert!(!state.need_sync().contains_key(&p), "{status:?}");
+            assert!(!state.active().contains_key(&p), "{status:?}");
+        }
+    }
 
     #[test]
     fn syncing_moves_participant_out_of_active_until_reactivated() {

--- a/chain-signatures/node/src/mesh/state.rs
+++ b/chain-signatures/node/src/mesh/state.rs
@@ -4,6 +4,13 @@ use crate::mesh::connection::NodeStatus;
 use crate::protocol::contract::primitives::Participants;
 use crate::protocol::ParticipantInfo;
 
+/// This node's view of which participants are usable right now.
+///
+/// A participant is in at most one of the two sets. See the [module
+/// docs](crate::mesh) for the states, the transitions between them, and which
+/// component drives each one.
+///
+/// Only [`active()`](Self::active) may be used to select peers for a protocol.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct MeshState {
     /// Participants that are active in the network; synced and responsive to pings.

--- a/chain-signatures/node/src/metrics/mesh.rs
+++ b/chain-signatures/node/src/metrics/mesh.rs
@@ -1,0 +1,54 @@
+//! Metrics for the mesh's view of peer liveness.
+//!
+//! Every wait in the signing path is gated on the size of the active set, and
+//! those waits are unbounded, so "why is this node not signing" is almost always
+//! "how big was the active set, and why". Without these, that question can only
+//! be answered from logs.
+
+use std::sync::LazyLock;
+
+use prometheus::{CounterVec, IntGaugeVec};
+
+use super::{
+    try_create_counter_vec_with_node_account_id, try_create_int_gauge_vec_with_node_account_id,
+};
+
+/// Size of each mesh participant set. Label `state` is `active` or `need_sync`.
+pub(crate) static MESH_PARTICIPANTS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    try_create_int_gauge_vec_with_node_account_id(
+        "multichain_mesh_participants",
+        "number of participants in each mesh set as seen by this node",
+        &["state"],
+    )
+    .unwrap()
+});
+
+/// Peer status transitions observed by this node, labelled by the new status.
+pub(crate) static MESH_STATUS_TRANSITIONS: LazyLock<CounterVec> = LazyLock::new(|| {
+    try_create_counter_vec_with_node_account_id(
+        "multichain_mesh_status_transitions_total",
+        "peer connection status transitions observed by this node",
+        &["status"],
+    )
+    .unwrap()
+});
+
+/// Why a peer was marked offline.
+///
+/// Both reasons collapse to [`NodeStatus::Offline`] because neither is usable in
+/// a protocol, but they call for opposite responses: `version_mismatch` across a
+/// rollout is expected and self-resolving, `unreachable` is not. The status alone
+/// cannot tell an operator which one they are looking at.
+///
+/// [`NodeStatus::Offline`]: crate::mesh::connection::NodeStatus::Offline
+pub(crate) static MESH_PEER_OFFLINE: LazyLock<CounterVec> = LazyLock::new(|| {
+    try_create_counter_vec_with_node_account_id(
+        "multichain_mesh_peer_offline_total",
+        "times a peer was marked offline, by reason",
+        &["reason"],
+    )
+    .unwrap()
+});
+
+pub(crate) const OFFLINE_UNREACHABLE: &str = "unreachable";
+pub(crate) const OFFLINE_VERSION_MISMATCH: &str = "version_mismatch";

--- a/chain-signatures/node/src/metrics/mod.rs
+++ b/chain-signatures/node/src/metrics/mod.rs
@@ -8,6 +8,7 @@ use prometheus::{HistogramOpts, HistogramVec, Opts, Result};
 
 pub mod hardware;
 pub mod indexers;
+pub mod mesh;
 pub mod messaging;
 pub mod nodes;
 pub mod protocols;

--- a/chain-signatures/node/src/node_client.rs
+++ b/chain-signatures/node/src/node_client.rs
@@ -1,6 +1,5 @@
 use crate::backlog::Checkpoint;
 use crate::protocol::message::cbor_to_bytes;
-use crate::protocol::sync::SyncUpdate;
 use crate::protocol::Chain;
 use crate::web::{CheckpointResponse, StateView, StatusResponse};
 
@@ -232,11 +231,15 @@ impl NodeClient {
         Ok(resp.json().await?)
     }
 
+    /// Exchange sealed sync envelopes. Both directions carry a [`SignedMessage`],
+    /// so neither side has to trust a sender claim made in the payload.
+    ///
+    /// [`SignedMessage`]: crate::protocol::message::SignedMessage
     pub async fn sync(
         &self,
         base: impl IntoUrl,
-        update: &SyncUpdate,
-    ) -> Result<SyncUpdate, RequestError> {
+        update: &Ciphered,
+    ) -> Result<Ciphered, RequestError> {
         let mut url = base.into_url()?;
         url.set_path("sync");
         self.post_cbor_response(

--- a/chain-signatures/node/src/protocol/sync/mod.rs
+++ b/chain-signatures/node/src/protocol/sync/mod.rs
@@ -6,12 +6,14 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::{JoinHandle, JoinSet};
 
+use crate::config::NetworkConfig;
 use crate::mesh::MeshState;
 use crate::node_client::NodeClient;
 use crate::rpc::ContractStateWatcher;
 use crate::storage::{PresignatureStorage, StorageError, TripleStorage};
 
-use super::contract::primitives::ParticipantInfo;
+use super::contract::primitives::{ParticipantInfo, ParticipantMap};
+use super::message::SignedMessage;
 use super::presignature::PresignatureId;
 use super::triple::TripleId;
 
@@ -66,6 +68,11 @@ impl SyncUpdate {
 }
 
 pub struct SyncRequest {
+    /// Sender proven by the envelope signature. This, and never the payload's
+    /// `from`, is what may reach storage: `remove_outdated` deletes every
+    /// artifact we hold for the owner it is given, so an unverified owner is a
+    /// remote delete primitive.
+    pub from: Participant,
     pub update: SyncUpdate,
     pub response_tx: oneshot::Sender<Result<SyncUpdate, StorageError>>,
 }
@@ -80,7 +87,7 @@ impl SyncRequest {
         let start = Instant::now();
 
         let outdated_triples = match triples
-            .remove_outdated(self.update.from, &self.update.triples)
+            .remove_outdated(self.from, &self.update.triples)
             .await
         {
             Ok(result) => result,
@@ -90,7 +97,7 @@ impl SyncRequest {
             }
         };
         let outdated_presignatures = match presignatures
-            .remove_outdated(self.update.from, &self.update.presignatures)
+            .remove_outdated(self.from, &self.update.presignatures)
             .await
         {
             Ok(result) => result,
@@ -131,6 +138,7 @@ pub struct SyncTask {
     contract: ContractStateWatcher,
     requests: SyncRequestReceiver,
     synced_peer_tx: mpsc::Sender<Participant>,
+    network: NetworkConfig,
 }
 
 // TODO: add a watch channel for mesh active participants.
@@ -142,6 +150,7 @@ impl SyncTask {
         mesh_state: watch::Receiver<MeshState>,
         contract: ContractStateWatcher,
         synced_peer_tx: mpsc::Sender<Participant>,
+        network: NetworkConfig,
     ) -> (SyncChannel, Self) {
         let (requests, channel) = SyncChannel::new();
         let task = Self {
@@ -152,6 +161,7 @@ impl SyncTask {
             contract,
             requests,
             synced_peer_tx,
+            network,
         };
         (channel, task)
     }
@@ -200,6 +210,8 @@ impl SyncTask {
                         update,
                         receivers.into_iter(),
                         me,
+                        self.network.clone(),
+                        self.contract.participant_map().await,
                     ));
                     broadcast = Some((start, task));
                 }
@@ -346,27 +358,65 @@ impl SyncTask {
 /// Broadcast an update to all participants specified by `receivers`.
 /// Returns results for all peers that complete within BROADCAST_TIMEOUT.
 /// Peers that don't respond are not included in results and will be retried later.
+///
+/// Each update is sealed to the recipient's `cipher_pk` and signed with our
+/// `sign_sk`, and each response is verified to be signed by the peer we actually
+/// contacted. A response drives `remove_holder_and_prune` locally, so accepting
+/// one from an unverified sender would let any host prune our artifacts.
 async fn broadcast_sync(
     client: NodeClient,
     update: SyncUpdate,
     receivers: impl Iterator<Item = (Participant, ParticipantInfo)>,
     me: Participant,
+    network: NetworkConfig,
+    participants: ParticipantMap,
 ) -> Vec<(Participant, SyncPeerResponse)> {
     let mut tasks = JoinSet::new();
     let update = Arc::new(update);
+    let participants = Arc::new(participants);
 
     for (p, info) in receivers {
         let client = client.clone();
         let update = update.clone();
+        let network = network.clone();
+        let participants = participants.clone();
         let url = info.url;
         tasks.spawn(async move {
-            let sync_result = if p != me {
-                match client.sync(&url, &update).await {
-                    Ok(response) => SyncPeerResponse::Success(response),
-                    Err(err) => SyncPeerResponse::Failed(err.to_string()),
+            if p == me {
+                return (p, SyncPeerResponse::SelfPeer);
+            }
+
+            let sealed =
+                match SignedMessage::encrypt(&*update, me, &network.sign_sk, &info.cipher_pk) {
+                    Ok(sealed) => sealed,
+                    Err(err) => {
+                        return (
+                            p,
+                            SyncPeerResponse::Failed(format!("encrypt failed: {err}")),
+                        )
+                    }
+                };
+
+            let sync_result = match client.sync(&url, &sealed).await {
+                Ok(sealed) => {
+                    match SignedMessage::decrypt_with::<SyncUpdate, _>(
+                        &sealed,
+                        &network.cipher_sk,
+                        &participants,
+                        |_| Ok(()),
+                    ) {
+                        // A peer must not be able to answer for another peer:
+                        // the pruning below is applied against `p`.
+                        Ok((signer, _)) if signer != p => SyncPeerResponse::Failed(format!(
+                            "response signed by {signer:?}, expected {p:?}"
+                        )),
+                        Ok((_, response)) => SyncPeerResponse::Success(response),
+                        Err(err) => {
+                            SyncPeerResponse::Failed(format!("response verify failed: {err}"))
+                        }
+                    }
                 }
-            } else {
-                SyncPeerResponse::SelfPeer
+                Err(err) => SyncPeerResponse::Failed(err.to_string()),
             };
             (p, sync_result)
         });
@@ -424,10 +474,17 @@ impl SyncChannel {
         (requests, channel)
     }
 
-    pub async fn request_update(&self, update: SyncUpdate) -> Result<SyncUpdate, SyncError> {
+    /// `from` must be the sender authenticated by the transport envelope, not a
+    /// value taken from the payload.
+    pub async fn request_update(
+        &self,
+        from: Participant,
+        update: SyncUpdate,
+    ) -> Result<SyncUpdate, SyncError> {
         let (response_tx, response_rx) = oneshot::channel();
         let request = SyncRequest {
-            update: update.clone(),
+            from,
+            update,
             response_tx,
         };
 
@@ -450,5 +507,94 @@ impl SyncChannel {
             tracing::debug!(?err, "sync processing failed in storage layer");
             SyncError::ResponseFailed
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::contract::primitives::Participants;
+    use crate::protocol::ParticipantInfo;
+
+    fn keyed_participant(id: u32, seed: &str) -> (ParticipantInfo, near_crypto::SecretKey) {
+        let sign_sk = near_crypto::SecretKey::from_seed(near_crypto::KeyType::ED25519, seed);
+        let (_, cipher_pk) = mpc_keys::hpke::generate();
+        let mut info = ParticipantInfo::new(id);
+        info.sign_pk = sign_sk.public_key();
+        info.cipher_pk = cipher_pk;
+        (info, sign_sk)
+    }
+
+    /// The `/sync` handler feeds `remove_outdated`, which deletes every artifact
+    /// we hold for the owner it is handed. That owner must come from the
+    /// envelope signature, never from the payload, or any caller could name a
+    /// victim. Lock in that the two are distinguishable: a forged payload `from`
+    /// does not change who the envelope proves sent it.
+    #[test]
+    fn payload_from_cannot_impersonate_another_participant() {
+        let attacker = Participant::from(1u32);
+        let victim = Participant::from(2u32);
+
+        let (attacker_info, attacker_sk) = keyed_participant(1, "sync-attacker");
+        let (victim_info, _victim_sk) = keyed_participant(2, "sync-victim");
+        let (recipient_cipher_sk, recipient_cipher_pk) = mpc_keys::hpke::generate();
+
+        let mut participants = Participants::default();
+        participants.insert(&attacker, attacker_info);
+        participants.insert(&victim, victim_info);
+        let participants = ParticipantMap::One(participants);
+
+        // The attacker signs with its own key but claims to be the victim in
+        // the payload, which is what would reach storage if it were trusted.
+        let forged = SyncUpdate {
+            from: victim,
+            triples: Vec::new(),
+            presignatures: Vec::new(),
+        };
+        let sealed =
+            SignedMessage::encrypt(&forged, attacker, &attacker_sk, &recipient_cipher_pk).unwrap();
+
+        let (signer, update) = SignedMessage::decrypt_with::<SyncUpdate, _>(
+            &sealed,
+            &recipient_cipher_sk,
+            &participants,
+            |_| Ok(()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            signer, attacker,
+            "the authenticated sender must be the signer"
+        );
+        assert_eq!(
+            update.from, victim,
+            "the payload still carries the forged claim, so it must never be used as the owner"
+        );
+        assert_ne!(signer, update.from);
+    }
+
+    /// A participant absent from the contract set cannot be authenticated at all,
+    /// so an outside caller never reaches storage.
+    #[test]
+    fn unknown_sender_is_rejected() {
+        let outsider = Participant::from(9u32);
+        let (_outsider_info, outsider_sk) = keyed_participant(9, "sync-outsider");
+        let (recipient_cipher_sk, recipient_cipher_pk) = mpc_keys::hpke::generate();
+
+        let update = SyncUpdate {
+            from: outsider,
+            triples: Vec::new(),
+            presignatures: Vec::new(),
+        };
+        let sealed =
+            SignedMessage::encrypt(&update, outsider, &outsider_sk, &recipient_cipher_pk).unwrap();
+
+        let result = SignedMessage::decrypt_with::<SyncUpdate, _>(
+            &sealed,
+            &recipient_cipher_sk,
+            &ParticipantMap::One(Participants::default()),
+            |_| Ok(()),
+        );
+        assert!(result.is_err(), "unknown participant must not authenticate");
     }
 }

--- a/chain-signatures/node/src/web/error.rs
+++ b/chain-signatures/node/src/web/error.rs
@@ -26,6 +26,11 @@ pub enum Error {
     Sync(#[from] SyncError),
     #[error("invalid parameters: {0}")]
     InvalidParameters(String),
+    /// Sender could not be authenticated against the contract participant set.
+    /// Deliberately carries no detail: the caller is unauthenticated, so the
+    /// reason is only logged server-side.
+    #[error("unauthorized")]
+    Unauthorized,
 }
 
 impl Error {
@@ -38,6 +43,7 @@ impl Error {
             Error::Rpc(_) => StatusCode::BAD_REQUEST,
             Error::InvalidParameters(_) => StatusCode::BAD_REQUEST,
             Error::Sync(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Error::Unauthorized => StatusCode::UNAUTHORIZED,
         }
     }
 }

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -8,13 +8,26 @@ pub mod debug;
 
 use self::error::Error;
 use crate::backlog::{Backlog, Checkpoint};
+use crate::config::NetworkConfig;
 use crate::metrics::messaging::WEB_ENDPOINT_LATENCY;
+use crate::protocol::message::SignedMessage;
 use crate::protocol::state::{NodeStateWatcher, NodeStatus, ResharingStatus};
 use crate::protocol::sync::{SyncChannel, SyncUpdate};
 use crate::protocol::{Chain, MessageChannel};
+use crate::rpc::ContractStateWatcher;
 use crate::storage::{PresignatureStorage, TripleStorage};
 use crate::web::cbor::Cbor;
 use crate::web::error::Result;
+
+/// Upper bound on a `/sync` body.
+///
+/// A sync update carries one id per artifact the sender owns. With the contract
+/// defaults (`max_triples` = 1024 * 32 * 128, `max_presignatures` half that,
+/// ids being CBOR-encoded `u64`s) a single owner holding the entire network-wide
+/// pool lands in the tens of megabytes, so this is a real ceiling rather than a
+/// tight bound. It is only a backstop against oversized bodies: authenticity is
+/// enforced by the signed envelope in [`sync`], not by this limit.
+const MAX_SYNC_BODY_BYTES: usize = 20 * 1024 * 1024;
 
 use anyhow::Context;
 use axum::body::Body;
@@ -45,6 +58,8 @@ struct AxumState {
     #[allow(dead_code)] // used by debug-page
     my_account_id: AccountId,
     backlog: Backlog,
+    contract: ContractStateWatcher,
+    network: NetworkConfig,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -57,6 +72,8 @@ pub async fn run(
     sync_channel: SyncChannel,
     my_account_id: AccountId,
     backlog: Backlog,
+    contract: ContractStateWatcher,
+    network: NetworkConfig,
 ) {
     tracing::info!("starting web server");
     let axum_state = AxumState {
@@ -67,12 +84,16 @@ pub async fn run(
         sync_channel,
         my_account_id,
         backlog,
+        contract,
+        network,
     };
 
-    // Sync can be a large payload, so we set a higher limit for payload.
+    // A sync update carries one id per artifact we own, so the payload scales
+    // with the artifact cap rather than being bounded by a fixed guess. The
+    // limit is the last line before decryption, so keep it tight.
     let sync = Router::new()
         .route("/sync", post(sync))
-        .layer(DefaultBodyLimit::max(20 * 1024 * 1024));
+        .layer(DefaultBodyLimit::max(MAX_SYNC_BODY_BYTES));
 
     let mut router = Router::new()
         // healthcheck endpoint
@@ -304,17 +325,57 @@ async fn bench_metrics() -> Json<BenchMetrics> {
     })
 }
 
+/// Peer state sync.
+///
+/// The request is a [`SignedMessage`]: sealed to our `cipher_pk` and signed by
+/// the sender, so the sender is authenticated against the contract's participant
+/// set before any storage work happens. This is load-bearing, not defence in
+/// depth. The handler feeds `remove_outdated`, which deletes every artifact we
+/// hold for the owner it is given; trusting a `from` taken from the payload
+/// would make this endpoint a remote "delete all presignatures owned by P"
+/// primitive for any unauthenticated caller.
+///
+/// The response is sealed and signed the same way, so the peer can likewise
+/// verify it is acting on our answer and not an interposed one.
+///
+/// [`SignedMessage`]: crate::protocol::message::SignedMessage
 #[tracing::instrument(level = "debug", skip_all)]
 async fn sync(
     Extension(state): Extension<Arc<AxumState>>,
-    WithRejection(Cbor(update), _): WithRejection<Cbor<SyncUpdate>, Error>,
-) -> Result<Cbor<SyncUpdate>> {
+    WithRejection(Cbor(sealed), _): WithRejection<Cbor<Ciphered>, Error>,
+) -> Result<Cbor<Ciphered>> {
     let start = Instant::now();
-    let response = state.sync_channel.request_update(update).await?;
+
+    let participants = state.contract.participant_map().await;
+    let (from, update) = SignedMessage::decrypt_with::<SyncUpdate, _>(
+        &sealed,
+        &state.network.cipher_sk,
+        &participants,
+        |_| Ok(()),
+    )
+    .map_err(|err| {
+        tracing::warn!(?err, "rejecting unverified sync request");
+        Error::Unauthorized
+    })?;
+
+    let response = state.sync_channel.request_update(from, update).await?;
+
+    // `SyncRequest::process` stamps the response with our own participant id.
+    let me = response.from;
+    let peer = participants.get(&from).ok_or_else(|| {
+        tracing::warn!(?from, "no participant info to seal sync response to");
+        Error::Unauthorized
+    })?;
+    let sealed = SignedMessage::encrypt(&response, me, &state.network.sign_sk, &peer.cipher_pk)
+        .map_err(|err| {
+            tracing::warn!(?err, ?from, "failed to seal sync response");
+            Error::Unauthorized
+        })?;
+
     WEB_ENDPOINT_LATENCY
         .with_label_values(&["sync"])
         .observe(start.elapsed().as_millis() as f64);
-    Ok(Cbor(response))
+    Ok(Cbor(sealed))
 }
 
 type ChainAndDigest = (Chain, Option<[u8; 32]>);

--- a/doc/MESH_ACTIVE_REVIEW.md
+++ b/doc/MESH_ACTIVE_REVIEW.md
@@ -235,7 +235,9 @@ Shipped:
 - **S10, S11** — mesh set-size gauges, a status-transition counter, and an offline
   counter split by `unreachable` vs `version_mismatch`.
 - **S12** — `report_node_synced` no longer `async`; `Pool::connect` takes
-  `&ProtocolState`.
+  `&ProtocolState`; the state machine is documented in the `mesh` module docs
+  (states, transitions, which component drives each, and the liveness dependency
+  on the sync task draining `need_sync()`).
 - **S13** — sleeps replaced with condition waits, `test_pool_update` now asserts
   the set it was silently ignoring, plus new coverage for drops, `retain`,
   `clear`, re-add under a new index, and the offline/inactive sync-eviction path.

--- a/doc/MESH_ACTIVE_REVIEW.md
+++ b/doc/MESH_ACTIVE_REVIEW.md
@@ -1,0 +1,217 @@
+# Mesh "active" subsystem review
+
+Scope: `chain-signatures/node/src/mesh/` (`mod.rs`, `connection.rs`, `state.rs`),
+the `/sync` and `/status` endpoints that feed it (`web/mod.rs`, `node_client.rs`),
+`protocol/sync/mod.rs`, and the consumers of `MeshState::active()`
+(`protocol/request/organize.rs`, `protocol/triple.rs`, `protocol/presignature.rs`,
+`backlog/consensus.rs`, `stream/recovery.rs`, `indexer_hydration/mod.rs`).
+
+## How it works today
+
+Each node runs a `connection::Pool` holding one `NodeConnection` task per peer
+listed in the contract. That task polls the peer's `/status` every
+`MPC_MESH_PING_INTERVAL` (default 1s) and derives a `NodeStatus`:
+
+- `/status` unreachable, or `protocol_version` mismatch -> `Offline`
+- peer reports anything other than `Running` -> `Inactive`
+- peer reports `Running`, and we were previously not `Active` -> `Syncing`
+- `Syncing` -> `Active` only when `Pool::report_node_synced` is called, which
+  happens after `SyncTask` completed a `/sync` round-trip with that peer
+
+Status changes flow through a broadcast channel into `ConnectionWatcher`, which a
+task inside `Mesh::run` folds into a `watch::Sender<MeshState>`. `MeshState` holds
+two `Participants` maps, `active` and `need_sync`. Everything downstream reads
+`active()` to decide who can be used in a protocol, and `need_sync()` drives the
+next `/sync` broadcast.
+
+## Findings
+
+Ordered by severity. IDs are referenced by the implementation plan below.
+
+### S1 (critical) — `/sync` is unauthenticated and can remotely delete protocol artifacts
+
+`POST /sync` is served with no authentication
+([web/mod.rs:74](chain-signatures/node/src/web/mod.rs:74)). The body deserializes
+straight into a `SyncUpdate`, whose `from: Participant` field is an unverified
+attacker-controlled claim, and is passed to
+`TripleStorage::remove_outdated(update.from, &update.triples)`
+([protocol/sync/mod.rs:82](chain-signatures/node/src/protocol/sync/mod.rs:82)).
+
+`remove_outdated` treats the supplied id list as the owner's authoritative set and
+deletes everything we hold for that owner which is *not* in the list
+([storage/protocol_storage.rs:400](chain-signatures/node/src/storage/protocol_storage.rs:400)).
+So:
+
+```
+POST /sync  {from: P, triples: [], presignatures: []}
+```
+
+deletes every triple and presignature we hold that is owned by `P`. Iterating `P`
+over the participant set wipes the node's entire artifact store; replaying it in a
+loop keeps it wiped. Presignature and triple generation is the expensive part of
+the protocol, so this is a cheap, remote, unauthenticated, indefinitely repeatable
+denial of service against signing — and it can be aimed at every node in the
+network simultaneously.
+
+The endpoint is reachable from the internet: `infra/partner-mainnet/main.tf`
+fronts port 3000 with an `EXTERNAL` global HTTPS load balancer on a public IP,
+the URL map has no path restrictions, and there is no Cloud Armor policy in the
+repo. The GCE firewall rule only constrains the direct instance path, not the LB.
+
+The fix already exists in the codebase and is used by `/msg`:
+`SignedMessage::encrypt` / `decrypt_with`
+([protocol/message/crypto.rs](chain-signatures/node/src/protocol/message/crypto.rs))
+HPKE-seals a payload to the recipient's `cipher_pk` and signs it with the sender's
+`sign_sk`, and `decrypt_with` returns the *authenticated* sender after checking the
+signature against the contract's `ParticipantMap`. `/sync` should use the same
+envelope, and the authenticated sender — not the `from` field inside the payload —
+must be what reaches storage.
+
+### S2 (high) — unauthenticated 20 MB body and unbounded work per request
+
+`/sync` sets `DefaultBodyLimit::max(20 * 1024 * 1024)`
+([web/mod.rs:75](chain-signatures/node/src/web/mod.rs:75)). Anyone can post 20 MB
+of CBOR ids and make the node run a Redis Lua script over all of them, with no
+rate limit and no concurrency bound. Fixed as a side effect of S1 (the envelope
+must decrypt and verify before any work happens), but the limit should also be
+sized to the real maximum (participants x per-owner artifact cap) rather than a
+round 20 MB.
+
+### S3 (high) — lost connection updates are silently swallowed
+
+`ConnectionWatcher::next` matches `Ok(update) = self.conn_update.recv()`
+([mesh/connection.rs:361](chain-signatures/node/src/mesh/connection.rs:361)). A
+`broadcast::error::RecvError::Lagged` does not match the pattern, so the branch is
+skipped and the missed updates are gone with no log. A dropped
+`ConnectionUpdate::New(p, rx)` means `p`'s status watcher is never registered, so
+`p` can never become active on this node — a silent, permanent capacity loss that
+persists until the next contract change happens to re-create the connection. The
+channel holds 256 entries; a contract update touching a large participant set
+while the consumer is busy is enough to lag it.
+
+### S4 (high) — `ConnectionWatcher::next` panics when the pool goes away
+
+In the same `select!`, if the broadcast channel is closed (all senders dropped,
+i.e. `Pool` dropped) the first branch is permanently disabled, and if `watchers` is
+empty `StreamMap::next()` returns `None`, disabling the second. `tokio::select!`
+with all branches disabled and no `else` panics. The updater task in `Mesh::run`
+([mesh/mod.rs:74](chain-signatures/node/src/mesh/mod.rs:74)) is a detached
+`tokio::spawn` with no join handle and no supervision, so the panic is invisible:
+`MeshState` freezes at its last value forever while the node keeps reporting
+healthy on `/status` and `/`. A frozen-but-populated `MeshState` is worse than an
+empty one, because downstream `wait_threshold_active` calls succeed against stale
+data and protocols are started with peers that may be long gone.
+
+### S5 (medium) — `MeshState` is never reconciled against the contract
+
+`MeshState` is only ever mutated incrementally, one participant at a time. The
+only removal driven by contract state is `previous_me`
+([mesh/mod.rs:102](chain-signatures/node/src/mesh/mod.rs:102)). Removal of any
+other participant depends entirely on a `ConnectionUpdate::Drop` arriving — which
+S3 shows is not guaranteed. There is no periodic or event-driven pass that asserts
+"`active` is a subset of the current contract participants". A participant removed
+from the contract can therefore stay in `active()` and be selected as a
+presignature holder or a sign-round participant.
+
+### S6 (medium) — we exempt ourselves from the liveness checks we apply to peers
+
+On a `Running` contract, `Mesh::run` marks *this* node `Active` unconditionally
+([mesh/mod.rs:96](chain-signatures/node/src/mesh/mod.rs:96)). `ProtocolState::Running`
+describes the network, not this node: locally we may still be in `Joining`,
+`Generating`, or `WaitingForConsensus`, exactly the states for which we would
+classify a *peer* as `Inactive`. We also skip the `Syncing` handshake we require of
+every peer. The result is that `active().len()` is inflated by one during our own
+startup, so `wait_threshold_active` and
+`OrganizingPhase::wait_for_active_participants` can clear the threshold using a
+node that cannot actually participate. Self status should be derived from
+`NodeStateWatcher`, the same source `/status` serves to peers.
+
+### S7 (medium) — byzantine peers can drive artifact pruning
+
+`process_sync_responses` takes a peer's `not_found` list at face value and calls
+`remove_holder_and_prune(peer, threshold, ...)`, which deletes the artifact
+outright once the holder set drops below `threshold`
+([storage/protocol_storage.rs:1021](chain-signatures/node/src/storage/protocol_storage.rs:1021)).
+The Lua script defends against a peer touching artifacts we do not own, but not
+against a participant that simply lies about everything being missing. One
+byzantine (or badly desynced) participant can therefore force pruning across the
+network. This is a design property rather than a bug, but it is unmonitored: there
+is no metric or alert on prune volume, so it would present as unexplained
+presignature starvation. This is the same failure shape as the devnet holder-set
+shrinkage already seen in production.
+
+### S8 (medium) — `Drop` updates fabricate a placeholder `ParticipantInfo`
+
+To satisfy the `(Participant, NodeStatus, ParticipantInfo)` return type,
+`ConnectionWatcher::next` invents `ParticipantInfo::new(u32::MAX)` for drops
+([mesh/connection.rs:370](chain-signatures/node/src/mesh/connection.rs:370)). It is
+harmless only because `MeshState::update` happens to ignore `info` on the
+`Offline` arm. Any future change that inserts on `Offline` silently writes a
+participant with a bogus id and an empty URL into the mesh state. The type should
+make the drop case unrepresentable rather than relying on a downstream coincidence.
+
+### S9 (medium) — head-of-line blocking in the sync broadcast
+
+`SyncTask` holds a single global broadcast slot and skips all work while one is in
+flight ([protocol/sync/mod.rs:180](chain-signatures/node/src/protocol/sync/mod.rs:180)).
+The receiver set is snapshotted when the broadcast starts, so a peer entering
+`need_sync` one tick later waits for the whole current broadcast — up to
+`BROADCAST_TIMEOUT` (120s) — before its sync is even attempted. With per-request
+client timeouts this is usually short, but the worst case is a peer sitting in
+`need_sync`, and therefore out of `active()`, for two minutes for no reason of its
+own.
+
+### S10 (low) — the mesh emits no metrics at all
+
+There is no gauge for active count, `need_sync` count, or per-peer status; no
+counter for status transitions; no histogram for time spent in `Syncing` or below
+threshold. `wait_threshold_active` and `wait_for_active_participants` can both
+block forever and each logs exactly one line when they start waiting (already
+recorded as a known gap). Every incident in this subsystem currently has to be
+diagnosed from logs.
+
+### S11 (low) — version mismatch is indistinguishable from unreachable
+
+A protocol version mismatch and a dead peer both collapse to `Offline`
+([mesh/connection.rs:120](chain-signatures/node/src/mesh/connection.rs:120)). During
+a rolling upgrade, version skew is expected and self-resolving; a network partition
+is not. Operators cannot tell them apart from the mesh state.
+
+### S12 (low) — small maintenance items
+
+- `Pool::report_node_synced` is an `async fn` with no `await`
+  ([mesh/connection.rs:314](chain-signatures/node/src/mesh/connection.rs:314)).
+- `Pool::connect` takes `ProtocolState` by value only to clone participants out of
+  it ([mesh/connection.rs:211](chain-signatures/node/src/mesh/connection.rs:211)).
+- The mesh state machine is not documented anywhere; the `NodeStatus` variant docs
+  are good but do not describe the transitions or who drives them.
+
+### S13 (low) — mesh tests are sleep-based, and one asserts nothing
+
+- Every mesh test paces itself with `tokio::time::sleep(PING_INTERVAL * 3)` and
+  will get flaky on a loaded machine. `expect_status` already shows the right
+  pattern (poll until a condition holds, with a timeout); the rest should use it.
+- `test_pool_update`'s second loop inserts into the `syncing` set and never reads
+  it back ([mesh/mod.rs:219](chain-signatures/node/src/mesh/mod.rs:219)). The test
+  passes whether or not any node reaches `Active`.
+- `MeshState` has a single unit test. `remove`, `clear`, and re-adding a
+  participant under a different `Participant` index are untested.
+
+## Implementation plan
+
+Ordered so that each step is independently reviewable and shippable.
+
+1. **S1 + S2** — authenticate `/sync` with the existing `SignedMessage` envelope.
+   Storage must key off the verified sender, not the payload's `from`.
+2. **S3 + S4** — make `ConnectionWatcher` lag-aware and panic-free; supervise the
+   mesh updater task.
+3. **S5 + S6** — reconcile `MeshState` against the contract participant set on
+   every contract update, and derive self status from `NodeStateWatcher`.
+4. **S8 + S12** — tighten the update type so drops carry no fabricated info; drop
+   the spurious `async`; take `&ProtocolState`; document the state machine.
+5. **S10 + S11** — add mesh metrics, splitting version mismatch from unreachable.
+6. **S13** — replace sleeps with condition waits, fix the vacuous assertions, and
+   cover the untested `MeshState` transitions.
+7. **S7 + S9** — design work, not covered by the steps above: bound how much a
+   single peer's sync response can prune per round, and replace the global
+   broadcast slot with per-peer sync tasks.

--- a/doc/MESH_ACTIVE_REVIEW.md
+++ b/doc/MESH_ACTIVE_REVIEW.md
@@ -197,21 +197,68 @@ is not. Operators cannot tell them apart from the mesh state.
 - `MeshState` has a single unit test. `remove`, `clear`, and re-adding a
   participant under a different `Participant` index are untested.
 
-## Implementation plan
+## What was done
 
-Ordered so that each step is independently reviewable and shippable.
+Two things changed after a second pass over the plan, both worth recording
+because they are the parts that could have caused an outage.
 
-1. **S1 + S2** — authenticate `/sync` with the existing `SignedMessage` envelope.
-   Storage must key off the verified sender, not the payload's `from`.
-2. **S3 + S4** — make `ConnectionWatcher` lag-aware and panic-free; supervise the
-   mesh updater task.
-3. **S5 + S6** — reconcile `MeshState` against the contract participant set on
-   every contract update, and derive self status from `NodeStateWatcher`.
-4. **S8 + S12** — tighten the update type so drops carry no fabricated info; drop
-   the spurious `async`; take `&ProtocolState`; document the state machine.
-5. **S10 + S11** — add mesh metrics, splitting version mismatch from unreachable.
-6. **S13** — replace sleeps with condition waits, fix the vacuous assertions, and
-   cover the untested `MeshState` transitions.
-7. **S7 + S9** — design work, not covered by the steps above: bound how much a
-   single peer's sync response can prune per round, and replace the global
-   broadcast slot with per-peer sync tasks.
+**A `/sync` wire change needs a `PROTOCOL_VERSION` bump, and that is not
+optional.** The first plan treated the envelope as a self-contained fix. It is
+not: a new node sending a sealed envelope to an old node would fail to decode on
+every round, the peer would never leave `need_sync`, and it would sit outside
+`active()` indefinitely with nothing but a decode warning. Because the mesh
+already marks version-mismatched peers `Offline`, bumping the version makes a
+mixed-version deployment cleanly partitioned instead of subtly half-broken. That
+is an existing, understood behaviour rather than a new one.
+
+**S3 and S4 have one root cause, and patching them separately would have been
+the wrong fix.** The plan proposed making the watcher lag-aware and adding
+supervision. The real problem is that a *set* was being described by a stream of
+add/remove events, so any lost event caused permanent divergence. Replacing the
+broadcast channel with a `watch` of the connection set removes lag as a failure
+mode by construction, makes drops fall out of a set difference (so S8's
+fabricated `ParticipantInfo` disappears with it), and leaves the loop with a
+clean termination condition rather than a panic.
+
+Shipped:
+
+- **S1, S2** — `/sync` carries a `SignedMessage` in both directions; storage keys
+  off the verified signer, and a response is rejected unless signed by the peer
+  we contacted. `PROTOCOL_VERSION` bumped to 2. The body limit is kept at 20 MB
+  and documented: derived from the artifact caps, it is a real ceiling, and the
+  security property comes from the envelope, not the limit.
+- **S3, S4, S8** — connection set published over a `watch` channel; `MeshUpdate`
+  makes drops unrepresentable as fake status updates; the updater's death is
+  surfaced and stops the mesh instead of freezing it.
+- **S5** — `MeshState::retain` reconciles against the contract participant set on
+  every contract update.
+- **S10, S11** — mesh set-size gauges, a status-transition counter, and an offline
+  counter split by `unreachable` vs `version_mismatch`.
+- **S12** — `report_node_synced` no longer `async`; `Pool::connect` takes
+  `&ProtocolState`.
+- **S13** — sleeps replaced with condition waits, `test_pool_update` now asserts
+  the set it was silently ignoring, plus new coverage for drops, `retain`,
+  `clear`, re-add under a new index, and the offline/inactive sync-eviction path.
+
+Deferred, with reasons:
+
+- **S6** (self exempt from liveness checks) — the fix is to drive self status from
+  `NodeStateWatcher`. Confirmed non-circular: `wait_threshold_active` only gates
+  indexer hydration and backlog recovery, and `cryptography.rs` reads
+  `mesh_state.active()` for logging only, so gating self on local `Running` cannot
+  deadlock the state machine. Left out of this pass because it changes when a node
+  considers itself usable during startup, which deserves its own change and its
+  own soak.
+- **S7** (byzantine peers drive pruning) and **S9** (broadcast head-of-line
+  blocking) — design work. S7 wants a bound on how much one peer's response may
+  prune per round plus an alert on prune volume; S9 wants per-peer sync tasks
+  instead of one global broadcast slot.
+
+## Verification
+
+`cargo test -p mpc-node --lib` passes (185 tests), clippy is clean on
+`--all-targets`. The `integration-tests` crate could not be compiled while making
+these changes: `near-workspaces` fails its build script on `x86_64-apple-darwin`,
+which is a pre-existing platform limitation unrelated to this work. Its call
+sites were updated and checked against the type definitions by hand, so they need
+a CI run on a supported platform before this is trusted.

--- a/integration-tests/benches/store.rs
+++ b/integration-tests/benches/store.rs
@@ -129,6 +129,13 @@ fn env() -> (Runtime, SyncEnv) {
             mesh.watch(),
             contract_watcher,
             synced_peer_tx,
+            mpc_node::config::NetworkConfig {
+                sign_sk: near_crypto::SecretKey::from_seed(
+                    near_crypto::KeyType::ED25519,
+                    "bench-sync",
+                ),
+                cipher_sk: mpc_keys::hpke::SecretKey::from_bytes(&[0u8; 32]),
+            },
         );
 
         SyncEnv {

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -543,6 +543,7 @@ impl MpcFixtureNodeBuilder {
         let (rpc_tx, rpc_rx) = mpsc::channel(MAX_CONCURRENT_RPC_REQUESTS);
         let rpc_channel = RpcChannel { tx: rpc_tx };
         let (mesh_tx, mesh_rx) = watch::channel(context.init_mesh.clone());
+        let network = self.config.local.network.clone();
         let (config_tx, config_rx) = watch::channel(self.config);
 
         let channels = protocol::test_setup::TestProtocolChannels {
@@ -618,12 +619,15 @@ impl MpcFixtureNodeBuilder {
             triple_storage.clone(),
             presignature_storage.clone(),
             mesh_rx.clone(),
-            context.contract_state,
+            context.contract_state.clone(),
             mpc_node::protocol::sync::SyncTask::synced_nodes_channel().0,
+            network.clone(),
         );
         tokio::spawn(sync_task.run());
 
         let mut node = MpcFixtureNode {
+            contract: context.contract_state,
+            network,
             me: self.me,
             account_id: self.participant_info.account_id.clone(),
             state: node_state,

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -50,6 +50,10 @@ pub struct MpcFixtureNode {
 
     pub sync_channel: mpc_node::protocol::sync::SyncChannel,
     pub web_handle: Option<tokio::task::JoinHandle<()>>,
+
+    /// Needed by the web interface to authenticate `/sync` peers.
+    pub contract: mpc_node::rpc::ContractStateWatcher,
+    pub network: mpc_node::config::NetworkConfig,
 }
 
 /// Logs for reading outputs after a test run for assertions and debugging.
@@ -308,8 +312,9 @@ impl MpcFixtureNode {
             triples,
             presignatures,
         };
+        // Stands in for the sender the web layer authenticates from the envelope.
         self.sync_channel
-            .request_update(update)
+            .request_update(from, update)
             .await
             .expect("sync_channel request_update failed")
     }
@@ -386,6 +391,8 @@ impl MpcFixtureNode {
             SyncChannel::new().1,
             account_id,
             self.backlog.clone(),
+            self.contract.clone(),
+            self.network.clone(),
         );
         self.web_handle = Some(tokio::spawn(task));
         Some(web_port)


### PR DESCRIPTION
Closes the one item from the mesh review that I listed as shipped but never actually did: S12's third bullet, the mesh state machine documentation. Stacked on #1124 because it documents the state machine as that PR leaves it.

Docs only, no behaviour change.

## Why this was the item worth going back for

The `NodeStatus` variant docs were already good at saying what each state *means*. What was missing was everything needed to reason about the subsystem: which component performs each transition, and which transitions nobody performs. I had to reconstruct that from the code to do the review, and the next person would have had to do it again.

Two facts in particular are invisible until you trace the ping loop by hand:

- **No ping can move a peer to `Active`.** A peer reporting `Running` is written as `Syncing`, deliberately, because reachable is not the same as holding our view of the artifacts we own. `Active` is reachable only through `report_node_synced`. Read casually, `NodeConnection::run` looks like it sets `Active`, because it computes `NodeStatus::Active` and then overwrites it three lines later.
- **`Syncing` is not a state a peer leaves on its own.** It is a work queue the sync task drains. If the sync task stalls, peers stay there, `active()` decays below threshold, and signing stops while every peer still looks reachable from `/status`. That coupling is a real operational failure mode and it was written down nowhere.

## What's here

Module docs on `mesh` carrying the states, the status-to-set mapping, the transition rules, who drives each one, and the self-entry exception. Short pointers on `MeshState` and `NodeStatus` so the types lead back to it.

I first drew the transitions as a state diagram and threw it away. The graph is nearly complete (every state reaches `Offline` and `Inactive` on the next ping), so boxes and arrows mostly encoded "almost everything goes almost everywhere". A current-state by ping-outcome table says the same thing in four rows and makes the one non-ping edge stand out by sitting outside it.

The self-entry is documented as-is, with a pointer to S6: a node writes its own status straight from the contract without pinging itself, so its own entry in `active()` says what the contract expects of it rather than what it can actually do. Documenting it is not endorsing it, and S6 remains open.

Also updates the S12 line in `doc/MESH_ACTIVE_REVIEW.md`, which listed the two code items and silently dropped this third one.

## Verification

`cargo doc -p mpc-node --no-deps` is clean for `mesh` and every intra-doc link resolves. Two warnings remain in the crate (`unclosed HTML tag` for `Vec<removed>` / `Vec<updated>` at `storage/protocol_storage.rs:987`); both pre-date this branch, came in with #671, and are in an unrelated subsystem, so I left them.

`cargo fmt --check` clean.

**`mesh::tests::test_mesh_update` is flaky on the base branch and fails under load.** Not caused by this PR (comments cannot change test behaviour) and it passes in isolation, but I am not going to claim a green run I did not get. It is a defect in #1124's own test rewrite: the test sends sync reports right after waiting for "self to be active", but self is marked active by the contract arm rather than by a ping, so that condition is satisfied before the peers' first ping completes. `report_node_synced` only promotes a peer already in `Syncing`, so a report landing while the peer is still `Offline` is dropped and never re-sent, and the peer sits in `need_sync` until the 10s timeout. Fix belongs in #1124, where the test lives.
