### PR TITLE
fix(node): bound /msg ingress against OOM

### DIFF
--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -23,7 +23,11 @@ pub use inbox::MessageInbox;
 pub use outbox::{MessageOutbox, SendMessage};
 pub use sub::Subscriber;
 
-pub const MAX_MESSAGE_INCOMING: usize = 1024 * 1024;
+/// Depth of the inbox queue of undecrypted, unauthenticated `Ciphered` from
+/// `/msg` — a memory ceiling (~depth x body limit) that fills only under a
+/// flood the microsecond-scale consumer can't drain. Past it `send_inbox`
+/// backpressures and the sender retries. Tune via the `channel="incoming"` gauge.
+pub const MAX_MESSAGE_INCOMING: usize = 16 * 1024;
 pub const MAX_MESSAGE_OUTGOING: usize = 1024 * 1024;
 pub const MAX_OUTBOX_PAYLOAD_LIMIT: usize = 256 * 1024;
 pub const MAX_SUBSCRIBE_REQUESTS: usize = 16 * 1024;

--- a/chain-signatures/node/src/protocol/message/mod.rs
+++ b/chain-signatures/node/src/protocol/message/mod.rs
@@ -23,10 +23,6 @@ pub use inbox::MessageInbox;
 pub use outbox::{MessageOutbox, SendMessage};
 pub use sub::Subscriber;
 
-/// Depth of the inbox queue of undecrypted, unauthenticated `Ciphered` from
-/// `/msg` — a memory ceiling (~depth x body limit) that fills only under a
-/// flood the microsecond-scale consumer can't drain. Past it `send_inbox`
-/// backpressures and the sender retries. Tune via the `channel="incoming"` gauge.
 pub const MAX_MESSAGE_INCOMING: usize = 16 * 1024;
 pub const MAX_MESSAGE_OUTGOING: usize = 1024 * 1024;
 pub const MAX_OUTBOX_PAYLOAD_LIMIT: usize = 256 * 1024;

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -74,6 +74,12 @@ pub async fn run(
         .route("/sync", post(sync))
         .layer(DefaultBodyLimit::max(20 * 1024 * 1024));
 
+    // A legit `/msg` body is one <=256 KB encrypted partition. Set the limit
+    // explicitly so the bound isn't axum's invisible 2 MiB default.
+    let msg = Router::new()
+        .route("/msg", post(msg))
+        .layer(DefaultBodyLimit::max(2 * 1024 * 1024));
+
     let mut router = Router::new()
         // healthcheck endpoint
         .route(
@@ -83,12 +89,12 @@ pub async fn run(
                 StatusCode::OK
             }),
         )
-        .route("/msg", post(msg))
         .route("/state", get(state))
         .route("/status", get(status))
         .route("/metrics", get(metrics))
         .route("/checkpoint", get(checkpoint))
         .route("/debug", get(debug::page))
+        .merge(msg)
         .merge(sync);
 
     if cfg!(feature = "bench") {
@@ -139,11 +145,12 @@ async fn msg(
     WithRejection(Cbor(encrypted), _): WithRejection<Cbor<Vec<Ciphered>>, Error>,
 ) {
     let start = Instant::now();
+    // Forward each message inline instead of spawning a task per element.
+    // Spawning let one request create unboundedly many parked tasks (one per
+    // `Ciphered`, each holding its bytes) whenever the inbox channel was full.
+    // Awaiting instead lets a full inbox slow the connection.
     for encrypted in encrypted.into_iter() {
-        let msg_channel = state.msg_channel.clone();
-        tokio::spawn(async move {
-            msg_channel.send_inbox(encrypted).await;
-        });
+        state.msg_channel.send_inbox(encrypted).await;
     }
     WEB_ENDPOINT_LATENCY
         .with_label_values(&["msg"])


### PR DESCRIPTION
## What

`/msg` reacts to peer input on a path with no HTTP-layer auth — the message signature is verified only later, inside the inbox actor (after HPKE decrypt) — so unauthenticated junk reaches the ingress machinery regardless. Two OOM issues there:

1. The handler spawned one `tokio::spawn` per `Ciphered` in the body, each awaiting the bounded inbox channel. Once the channel filled, a single request amplified into one parked task per element, unbounded across concurrent requests. Now each message is forwarded inline, so the channel's backpressure reaches the connection instead of spawning around it.
2. With the spawn gone, the inbox channel *is* the ingress buffer, and it was `MAX_MESSAGE_INCOMING = 1M` deep — worst-case memory ≈ depth × body size, i.e. hundreds of GB of unverified `Ciphered`. Lowered to 16384. The consumer decrypts in microseconds, so a few thousand slots is ample for legitimate bursts; past the cap `send_inbox` backpressures and the idempotent sender retries.

The `/msg` body limit is also made explicit at 2 MiB (it was relying on axum's implicit 2 MiB default; the visible `DefaultBodyLimit` in this file covered only `/sync`). A legitimate body is a single ≤256 KB encrypted partition.

## Open question

Is **16384** the right inbox depth? It's a liveness/memory trade: lower bounds worst-case memory harder but backpressures legitimate bursts sooner. Watch `multichain_channel_capacity_size{channel="incoming"}` to tune. (The same reasoning could justify tightening the 2 MiB body limit toward the ~256 KB legit size — left generous for now.)

## Testing

`cargo test -p mpc-node --lib protocol::message` — 15 passed. `cargo check -p mpc-node` clean.

## Not addressed

Every `Ciphered` triggers an HPKE open before the signature check, so a junk-filled body is still a CPU amplifier — a separate DoS class needing a pre-decrypt gate (per-peer rate limit / transport auth), not backpressure.
