### PR TITLE
fix: wait on latest ethereum final block instead of latest optimistic for anchor

### DIFF
--- a/chain-signatures/chain-ethereum/src/client.rs
+++ b/chain-signatures/chain-ethereum/src/client.rs
@@ -447,13 +447,6 @@ impl EthereumClient {
         )
     }
 
-    pub async fn get_latest_block_number(&self) -> anyhow::Result<Option<u64>> {
-        Ok(self
-            .get_block(BlockId::Number(BlockNumberOrTag::Latest))
-            .await?
-            .map(|block| block.header.number))
-    }
-
     pub fn clamp_oldest_supported(
         &self,
         requested_start: u64,

--- a/chain-signatures/chain-ethereum/src/finalized_head.rs
+++ b/chain-signatures/chain-ethereum/src/finalized_head.rs
@@ -5,10 +5,11 @@ use crate::EthConfig;
 use alloy::eips::BlockNumberOrTag;
 use alloy::rpc::types::BlockId;
 use mpc_primitives::{Chain, ChainConfig as _};
-use mpc_utils::task::{AbortOnDrop, CancellationTokenExt};
+use mpc_utils::task::CancellationTokenExt;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::watch;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 /// Tracks finalized-head advancement for stall detection, emitting the
@@ -75,17 +76,79 @@ impl FinalizedHeadStall {
 /// from a spawned task.
 #[derive(Clone)]
 pub struct FinalizedHeadTracker {
-    head: watch::Sender<u64>,
+    head: watch::Sender<Option<u64>>,
     optimistic: bool,
     refresh_interval: Duration,
     max_failures: u32,
     stall_rewarn_secs: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WatcherExit {
+    Cancelled,
+    UnexpectedExit,
+    Panicked,
+    JoinCancelled,
+}
+
+/// Owns the watcher task. Waiting through this guard observes task exit as
+/// well as head updates; retaining the watch sender alone cannot do that.
+/// A resolved task is terminal: waits return an error and production callers
+/// immediately stop the indexer, so this handle is never polled again.
+pub struct FinalizedHeadWatcher {
+    tracker: FinalizedHeadTracker,
+    task: JoinHandle<Result<(), WatcherExit>>,
+}
+
+impl Drop for FinalizedHeadWatcher {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+impl FinalizedHeadWatcher {
+    fn map_join(result: Result<Result<(), WatcherExit>, tokio::task::JoinError>) -> WatcherExit {
+        match result {
+            Ok(Ok(())) => WatcherExit::UnexpectedExit,
+            Ok(Err(exit)) => exit,
+            Err(err) if err.is_cancelled() => WatcherExit::JoinCancelled,
+            Err(_) => WatcherExit::Panicked,
+        }
+    }
+
+    pub async fn wait_initialized(&mut self) -> Result<u64, WatcherExit> {
+        let mut head_rx = self.tracker.head.subscribe();
+        loop {
+            if let Some(head) = *head_rx.borrow_and_update() {
+                return Ok(head);
+            }
+            tokio::select! {
+                changed = head_rx.changed() => if changed.is_err() { return Err(WatcherExit::UnexpectedExit); },
+                result = &mut self.task => return Err(Self::map_join(result)),
+            }
+        }
+    }
+
+    pub async fn wait_for(&mut self, block_number: u64) -> Result<u64, WatcherExit> {
+        let mut head_rx = self.tracker.head.subscribe();
+        loop {
+            if let Some(head) = *head_rx.borrow_and_update() {
+                if head >= block_number {
+                    return Ok(head);
+                }
+            }
+            tokio::select! {
+                changed = head_rx.changed() => if changed.is_err() { return Err(WatcherExit::UnexpectedExit); },
+                result = &mut self.task => return Err(Self::map_join(result)),
+            }
+        }
+    }
+}
+
 impl FinalizedHeadTracker {
     pub fn new(eth: &EthConfig) -> Self {
         Self {
-            head: watch::channel(0).0,
+            head: watch::channel(None).0,
             optimistic: eth.optimistic_requests,
             refresh_interval: Duration::from_millis(eth.refresh_finalized_interval),
             max_failures: eth.indexer.max_finalized_failures,
@@ -98,7 +161,7 @@ impl FinalizedHeadTracker {
     fn new_for_test() -> Self {
         let indexer = IndexerConfig::default();
         Self {
-            head: watch::channel(0).0,
+            head: watch::channel(None).0,
             optimistic: false, // existing unit tests assume finalized mode
             refresh_interval: Duration::from_millis(100),
             max_failures: indexer.max_finalized_failures,
@@ -107,45 +170,56 @@ impl FinalizedHeadTracker {
     }
 
     /// Cached finalized block number.
-    pub fn current(&self) -> u64 {
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn current(&self) -> Option<u64> {
         *self.head.borrow()
     }
 
     /// Force the cached head to `n` (used by tests to bypass the watcher).
     #[cfg(test)]
     pub fn set_head(&self, n: u64) {
-        self.head.send_replace(n);
+        self.head.send_replace(Some(n));
     }
 
-    /// Blocks until the cached head covers `block_number`. In production the
-    /// head tracks the finalized block; in optimistic mode it tracks the latest
-    /// tip (the watcher polls `Latest`).
-    pub async fn wait_for(&self, block_number: u64) -> anyhow::Result<()> {
-        if *self.head.borrow() >= block_number {
-            return Ok(());
-        }
-
-        // Slow path: wait for the watcher to publish an advance.
+    #[cfg(test)]
+    async fn wait_initialized(&self) -> anyhow::Result<u64> {
         let mut rx = self.head.subscribe();
         loop {
-            if *rx.borrow_and_update() >= block_number {
-                return Ok(());
+            if let Some(head) = *rx.borrow_and_update() {
+                return Ok(head);
             }
-            if rx.changed().await.is_err() {
-                anyhow::bail!(
-                    "finalized-head watcher terminated before block {block_number} finalized"
-                );
-            }
+            rx.changed()
+                .await
+                .map_err(|_| anyhow::anyhow!("head channel closed"))?;
         }
     }
 
-    /// Spawn the background watcher that maintains the cached head. Returns a guard whose drop aborts the task.
+    #[cfg(test)]
+    async fn wait_for(&self, block_number: u64) -> anyhow::Result<()> {
+        if self.current().is_some_and(|head| head >= block_number) {
+            return Ok(());
+        }
+        let mut rx = self.head.subscribe();
+        loop {
+            if rx
+                .borrow_and_update()
+                .is_some_and(|head| head >= block_number)
+            {
+                return Ok(());
+            }
+            rx.changed()
+                .await
+                .map_err(|_| anyhow::anyhow!("head channel closed"))?;
+        }
+    }
+
+    /// Spawn the background watcher that maintains the cached head.
     pub fn spawn_watcher(
         &self,
         client: Arc<EthereumClient>,
         cancel: CancellationToken,
-    ) -> AbortOnDrop {
-        AbortOnDrop(tokio::spawn(Self::watch_head(
+    ) -> FinalizedHeadWatcher {
+        let task = tokio::spawn(Self::watch_head(
             client,
             self.head.clone(),
             self.refresh_interval,
@@ -153,7 +227,24 @@ impl FinalizedHeadTracker {
             self.stall_rewarn_secs,
             self.optimistic,
             cancel,
-        )))
+        ));
+        FinalizedHeadWatcher {
+            tracker: self.clone(),
+            task,
+        }
+    }
+
+    #[cfg(test)]
+    fn spawn_panicking_watcher(&self) -> FinalizedHeadWatcher {
+        fn panic_result() -> Result<(), WatcherExit> {
+            panic!("test watcher panic");
+        }
+
+        let task = tokio::spawn(async { panic_result() });
+        FinalizedHeadWatcher {
+            tracker: self.clone(),
+            task,
+        }
     }
 
     // TODO: Currently if this dies silently we have to wait 35 min for the stream supervisor to restart it. Implement faster failure detection and restart.
@@ -165,13 +256,13 @@ impl FinalizedHeadTracker {
     /// watchdog remains the escape hatch.
     async fn watch_head(
         client: Arc<EthereumClient>,
-        head: watch::Sender<u64>,
+        head: watch::Sender<Option<u64>>,
         refresh_interval: Duration,
         max_failures: u32,
         stall_rewarn_secs: u64,
         optimistic: bool,
         cancel: CancellationToken,
-    ) {
+    ) -> Result<(), WatcherExit> {
         let mut stall = FinalizedHeadStall::new(
             Chain::Ethereum.expected_finality_time_secs(),
             stall_rewarn_secs,
@@ -192,8 +283,8 @@ impl FinalizedHeadTracker {
                     let new_final = block.header.number;
                     stall.observe(new_final);
                     head.send_if_modified(|cur| {
-                        if new_final > *cur {
-                            *cur = new_final;
+                        if cur.is_none_or(|current| new_final > current) {
+                            *cur = Some(new_final);
                             true
                         } else {
                             false
@@ -217,7 +308,7 @@ impl FinalizedHeadTracker {
             }
 
             if cancel.cancelled_within(refresh_interval).await {
-                return;
+                return Err(WatcherExit::Cancelled);
             }
         }
     }
@@ -225,7 +316,7 @@ impl FinalizedHeadTracker {
 
 #[cfg(test)]
 mod tests {
-    use super::FinalizedHeadTracker;
+    use super::{FinalizedHeadTracker, WatcherExit};
     use crate::test_utils;
     use mockito::{Matcher, Server};
     use serde_json::json;
@@ -266,6 +357,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn wait_initialized_never_returns_cached_zero() {
+        let tracker = FinalizedHeadTracker::new_for_test();
+        let publisher = tracker.clone();
+        let task = tokio::spawn(async move { tracker.wait_initialized().await.unwrap() });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!task.is_finished());
+        publisher.set_head(42);
+        assert_eq!(task.await.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn sequential_waits_reuse_one_watcher_task() {
+        let tracker = FinalizedHeadTracker::new_for_test();
+        let client = Arc::new(test_utils::create_test_ethereum_client("http://127.0.0.1:1").await);
+        let cancel = CancellationToken::new();
+        let mut watcher = tracker.spawn_watcher(client, cancel.clone());
+
+        tracker.set_head(10);
+        let head = watcher.wait_initialized().await.unwrap();
+        assert_eq!(head, 10);
+        let head = watcher.wait_for(5).await.unwrap();
+        assert_eq!(head, 10);
+        tracker.set_head(20);
+        let head = watcher.wait_for(15).await.unwrap();
+        assert_eq!(head, 20);
+
+        cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn watcher_panic_before_initialization_is_an_error() {
+        let tracker = FinalizedHeadTracker::new_for_test();
+        let mut watcher = tracker.spawn_panicking_watcher();
+        assert!(matches!(
+            watcher.wait_initialized().await,
+            Err(WatcherExit::Panicked)
+        ));
+    }
+
+    #[tokio::test]
+    async fn watcher_cancellation_during_wait_is_an_error() {
+        let tracker = FinalizedHeadTracker::new_for_test();
+        let client = Arc::new(test_utils::create_test_ethereum_client("http://127.0.0.1:1").await);
+        let cancel = CancellationToken::new();
+        let mut watcher = tracker.spawn_watcher(client, cancel.clone());
+        cancel.cancel();
+        assert!(matches!(
+            watcher.wait_for(100).await,
+            Err(WatcherExit::Cancelled)
+        ));
+    }
+
+    #[tokio::test]
     async fn spawn_watcher_advances_head_and_unblocks_waiter() {
         let mut server = Server::new_async().await;
 
@@ -286,9 +431,16 @@ mod tests {
         let tracker = FinalizedHeadTracker::new_for_test();
 
         let cancel = CancellationToken::new();
-        let _watcher = tracker.spawn_watcher(client, cancel.clone());
+        let mut watcher = tracker.spawn_watcher(client, cancel.clone());
 
-        tracker
+        assert_eq!(
+            watcher
+                .wait_initialized()
+                .await
+                .expect("watcher should publish its first finalized sample"),
+            100
+        );
+        watcher
             .wait_for(50)
             .await
             .expect("watcher should advance the head past 50 and unblock the wait");

--- a/chain-signatures/chain-ethereum/src/finalized_head.rs
+++ b/chain-signatures/chain-ethereum/src/finalized_head.rs
@@ -116,19 +116,6 @@ impl FinalizedHeadWatcher {
         }
     }
 
-    pub async fn wait_initialized(&mut self) -> Result<u64, WatcherExit> {
-        let mut head_rx = self.tracker.head.subscribe();
-        loop {
-            if let Some(head) = *head_rx.borrow_and_update() {
-                return Ok(head);
-            }
-            tokio::select! {
-                changed = head_rx.changed() => if changed.is_err() { return Err(WatcherExit::UnexpectedExit); },
-                result = &mut self.task => return Err(Self::map_join(result)),
-            }
-        }
-    }
-
     pub async fn wait_for(&mut self, block_number: u64) -> Result<u64, WatcherExit> {
         let mut head_rx = self.tracker.head.subscribe();
         loop {
@@ -182,19 +169,6 @@ impl FinalizedHeadTracker {
     }
 
     #[cfg(test)]
-    async fn wait_initialized(&self) -> anyhow::Result<u64> {
-        let mut rx = self.head.subscribe();
-        loop {
-            if let Some(head) = *rx.borrow_and_update() {
-                return Ok(head);
-            }
-            rx.changed()
-                .await
-                .map_err(|_| anyhow::anyhow!("head channel closed"))?;
-        }
-    }
-
-    #[cfg(test)]
     async fn wait_for(&self, block_number: u64) -> anyhow::Result<()> {
         if self.current().is_some_and(|head| head >= block_number) {
             return Ok(());
@@ -228,19 +202,6 @@ impl FinalizedHeadTracker {
             self.optimistic,
             cancel,
         ));
-        FinalizedHeadWatcher {
-            tracker: self.clone(),
-            task,
-        }
-    }
-
-    #[cfg(test)]
-    fn spawn_panicking_watcher(&self) -> FinalizedHeadWatcher {
-        fn panic_result() -> Result<(), WatcherExit> {
-            panic!("test watcher panic");
-        }
-
-        let task = tokio::spawn(async { panic_result() });
         FinalizedHeadWatcher {
             tracker: self.clone(),
             task,
@@ -357,47 +318,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn wait_initialized_never_returns_cached_zero() {
-        let tracker = FinalizedHeadTracker::new_for_test();
-        let publisher = tracker.clone();
-        let task = tokio::spawn(async move { tracker.wait_initialized().await.unwrap() });
-
-        tokio::time::sleep(Duration::from_millis(20)).await;
-        assert!(!task.is_finished());
-        publisher.set_head(42);
-        assert_eq!(task.await.unwrap(), 42);
-    }
-
-    #[tokio::test]
-    async fn sequential_waits_reuse_one_watcher_task() {
-        let tracker = FinalizedHeadTracker::new_for_test();
-        let client = Arc::new(test_utils::create_test_ethereum_client("http://127.0.0.1:1").await);
-        let cancel = CancellationToken::new();
-        let mut watcher = tracker.spawn_watcher(client, cancel.clone());
-
-        tracker.set_head(10);
-        let head = watcher.wait_initialized().await.unwrap();
-        assert_eq!(head, 10);
-        let head = watcher.wait_for(5).await.unwrap();
-        assert_eq!(head, 10);
-        tracker.set_head(20);
-        let head = watcher.wait_for(15).await.unwrap();
-        assert_eq!(head, 20);
-
-        cancel.cancel();
-    }
-
-    #[tokio::test]
-    async fn watcher_panic_before_initialization_is_an_error() {
-        let tracker = FinalizedHeadTracker::new_for_test();
-        let mut watcher = tracker.spawn_panicking_watcher();
-        assert!(matches!(
-            watcher.wait_initialized().await,
-            Err(WatcherExit::Panicked)
-        ));
-    }
-
-    #[tokio::test]
     async fn watcher_cancellation_during_wait_is_an_error() {
         let tracker = FinalizedHeadTracker::new_for_test();
         let client = Arc::new(test_utils::create_test_ethereum_client("http://127.0.0.1:1").await);
@@ -433,13 +353,6 @@ mod tests {
         let cancel = CancellationToken::new();
         let mut watcher = tracker.spawn_watcher(client, cancel.clone());
 
-        assert_eq!(
-            watcher
-                .wait_initialized()
-                .await
-                .expect("watcher should publish its first finalized sample"),
-            100
-        );
         watcher
             .wait_for(50)
             .await

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -2,7 +2,7 @@ use crate::abi::ChainSignatures;
 use crate::client::{block_may_contain_logs, CatchupItem, CatchupIter, EthereumClient};
 use crate::event_parsing::{emit_respond_events, parse_filtered_logs};
 use crate::execution_watcher::{ExecutionWatcher, WatcherGateState};
-use crate::finalized_head::FinalizedHeadTracker;
+use crate::finalized_head::{FinalizedHeadTracker, FinalizedHeadWatcher};
 use crate::EthConfig;
 use alloy::primitives::Address;
 use alloy::rpc::types::{Block, Log};
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use futures_util::{stream, Stream};
 use mpc_chain_integration_core::{ChainIndexer, ChainTelemetry, StateManager};
 use mpc_primitives::{Chain, ChainEvent, IndexedSignRequest};
-use mpc_utils::task::{retry_until_ok, retry_until_some, AbortOnDrop};
+use mpc_utils::task::retry_until_ok;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tokio::time::Duration;
@@ -102,7 +102,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
 
     /// Spawn the background head watcher (`Finalized` in production, `Latest` in
     /// optimistic dev mode). Returns a guard whose drop aborts the task.
-    pub fn spawn_finalized_head_watcher(&self, cancel: CancellationToken) -> AbortOnDrop {
+    pub fn spawn_finalized_head_watcher(&self, cancel: CancellationToken) -> FinalizedHeadWatcher {
         self.finalized_head
             .spawn_watcher(self.client.clone(), cancel)
     }
@@ -315,32 +315,39 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         }
     }
 
-    /// The catchup-live anchor: the startup tip + 1 (exclusive catchup end and
-    /// first live block), retrying until the tip is available.
+    /// The catchup-live anchor: the first initialized processable head + 1.
     /// Returns `None` on cancellation.
-    async fn sample_anchor(&self, cancel: &CancellationToken) -> Option<u64> {
-        retry_until_some(
-            cancel,
-            Self::RETRY_DELAY,
-            "ethereum latest block",
-            || async { self.client.get_latest_block_number().await },
-        )
-        .await
-        .map(|tip| tip.saturating_add(1))
+    async fn sample_anchor(
+        &self,
+        watcher: &mut FinalizedHeadWatcher,
+        cancel: &CancellationToken,
+    ) -> anyhow::Result<Option<u64>> {
+        tokio::select! {
+            _ = cancel.cancelled() => Ok(None),
+            head = watcher.wait_initialized() => match head {
+                Ok(head) => Ok(Some(head.saturating_add(1))),
+                Err(_err) if cancel.is_cancelled() => Ok(None),
+                Err(err) => Err(anyhow::anyhow!("head watcher exited: {err:?}")),
+            },
+        }
     }
 
     /// Wait until `next` is processable (the head covers it), returning the
     /// ready upper bound. Returns `None` on cancellation.
     async fn wait_processable_bound(
         &self,
+        watcher: &mut FinalizedHeadWatcher,
         next: u64,
         cancel: &CancellationToken,
     ) -> anyhow::Result<Option<u64>> {
         tokio::select! {
             _ = cancel.cancelled() => Ok(None),
-            res = self.finalized_head.wait_for(next) => {
-                res?;
-                Ok(Some(self.finalized_head.current()))
+            res = watcher.wait_for(next) => {
+                match res {
+                    Ok(head) => Ok(Some(head)),
+                    Err(_err) if cancel.is_cancelled() => Ok(None),
+                    Err(err) => Err(anyhow::anyhow!("head watcher exited: {err:?}")),
+                }
             }
         }
     }
@@ -391,12 +398,12 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
         tracing::info!("ethereum indexer started");
 
         // Spawn the finalized head watcher.
-        let _finalized_watcher = self
+        let mut finalized_watcher = self
             .finalized_head
             .spawn_watcher(self.client.clone(), cancel.clone());
 
         // Anchor = tip-at-startup + 1: the catchup-live boundary.
-        let Some(anchor) = self.sample_anchor(&cancel).await else {
+        let Some(anchor) = self.sample_anchor(&mut finalized_watcher, &cancel).await? else {
             tracing::debug!("ethereum indexer cancelled before the startup tip was sampled");
             return Ok(());
         };
@@ -428,7 +435,10 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
         // Catchup: process all blocks up to the anchor, then emit a CatchupCompleted event.
         while next < anchor {
             // Wait for the next block to be processable
-            let Some(upper) = self.wait_processable_bound(next, &cancel).await? else {
+            let Some(upper) = self
+                .wait_processable_bound(&mut finalized_watcher, next, &cancel)
+                .await?
+            else {
                 return Ok(()); // cancelled while waiting
             };
             // Clamp the upper bound to the anchor so we don't process beyond it.
@@ -452,7 +462,10 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
 
         // Live tail: process each block as it becomes processable, waiting for the finalized head to reach it.
         loop {
-            let Some(upper) = self.wait_processable_bound(next, &cancel).await? else {
+            let Some(upper) = self
+                .wait_processable_bound(&mut finalized_watcher, next, &cancel)
+                .await?
+            else {
                 return Ok(()); // cancelled while waiting
             };
             self.process_range(&events_tx, next, upper + 1, &cancel)
@@ -889,6 +902,21 @@ mod tests {
                 .create_async()
                 .await;
 
+            server
+                .mock("POST", "/")
+                .match_body(Matcher::PartialJson(json!({
+                    "method": "eth_getBlockByNumber",
+                    "params": ["finalized", false]
+                })))
+                .with_status(200)
+                .with_header("content-type", "application/json")
+                .with_body_from_request({
+                    let latest = latest.clone();
+                    move |req| block_reply(req, latest.load(Ordering::Relaxed))
+                })
+                .create_async()
+                .await;
+
             // Catchup batches (JSON-RPC array body): derive ids and block
             // numbers from the request.
             server
@@ -1020,8 +1048,11 @@ mod tests {
             head.set_head(100);
         });
 
+        let mut watcher = indexer
+            .finalized_head
+            .spawn_watcher(indexer.client.clone(), cancel.clone());
         let upper = indexer
-            .wait_processable_bound(50, &cancel)
+            .wait_processable_bound(&mut watcher, 50, &cancel)
             .await
             .expect("wait_processable_bound resolves once the head covers next");
         assert_eq!(upper, Some(100));

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -316,18 +316,19 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         }
     }
 
-    /// The catchup-live anchor: the first processable finalized head + 1.
+    /// The catchup-live anchor: the first processable head + 1.
     /// Returns `None` on cancellation.
     async fn sample_anchor(&self, cancel: &CancellationToken) -> Option<u64> {
+        let tag = if self.eth.optimistic_requests {
+            BlockNumberOrTag::Latest
+        } else {
+            BlockNumberOrTag::Finalized
+        };
         retry_until_some(
             cancel,
             Self::RETRY_DELAY,
-            "ethereum finalized head sampling",
-            || async {
-                self.client
-                    .get_block(BlockId::Number(BlockNumberOrTag::Finalized))
-                    .await
-            },
+            "ethereum startup head sampling",
+            || async { self.client.get_block(BlockId::Number(tag)).await },
         )
         .await
         .map(|block| block.header.number.saturating_add(1))
@@ -517,6 +518,32 @@ mod tests {
             Some(43)
         );
         finalized_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn sample_anchor_fetches_latest_head_in_optimistic_mode() {
+        let mut server = Server::new_async().await;
+        let latest_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockByNumber",
+                "params": ["latest", false]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(test_utils::block_response(2, 42).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+        let mut builder = test_utils::TestIndexerBuilder::new(server.url());
+        builder.eth.optimistic_requests = true;
+        let indexer = builder.build().await;
+
+        assert_eq!(
+            indexer.sample_anchor(&CancellationToken::new()).await,
+            Some(43)
+        );
+        latest_mock.assert_async().await;
     }
 
     #[tokio::test]

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -899,36 +899,21 @@ mod tests {
     }
 
     /// Fixture for running the indexer in a test with a mock JSON-RPC server.
-    /// Holds the mock server, latest block, and other state for running the indexer in tests.
+    /// Holds the mock server, finalized block, and other state for running the indexer in tests.
     struct RunFixture {
         _server: mockito::ServerGuard,
-        latest: Arc<AtomicU64>,
+        finalized: Arc<AtomicU64>,
         cancel: CancellationToken,
         run_handle: tokio::task::JoinHandle<anyhow::Result<()>>,
         events_rx: mpsc::Receiver<ChainEvent>,
     }
 
     impl RunFixture {
-        async fn spawn(processed: u64, latest: u64) -> Self {
+        async fn spawn(processed: u64, finalized: u64) -> Self {
             let mut server = Server::new_async().await;
-            let latest = Arc::new(AtomicU64::new(latest));
+            let finalized = Arc::new(AtomicU64::new(finalized));
 
-            // Anchor sampling + live head polling.
-            server
-                .mock("POST", "/")
-                .match_body(Matcher::PartialJson(json!({
-                    "method": "eth_getBlockByNumber",
-                    "params": ["latest", false]
-                })))
-                .with_status(200)
-                .with_header("content-type", "application/json")
-                .with_body_from_request({
-                    let latest = latest.clone();
-                    move |req| block_reply(req, latest.load(Ordering::Relaxed))
-                })
-                .create_async()
-                .await;
-
+            // Anchor sampling + finalized head polling.
             server
                 .mock("POST", "/")
                 .match_body(Matcher::PartialJson(json!({
@@ -938,8 +923,8 @@ mod tests {
                 .with_status(200)
                 .with_header("content-type", "application/json")
                 .with_body_from_request({
-                    let latest = latest.clone();
-                    move |req| block_reply(req, latest.load(Ordering::Relaxed))
+                    let finalized = finalized.clone();
+                    move |req| block_reply(req, finalized.load(Ordering::Relaxed))
                 })
                 .create_async()
                 .await;
@@ -988,7 +973,7 @@ mod tests {
 
             Self {
                 _server: server,
-                latest,
+                finalized,
                 cancel,
                 run_handle,
                 events_rx,
@@ -1037,7 +1022,7 @@ mod tests {
         let mut f = RunFixture::spawn(9, 9).await;
         assert!(matches!(f.next_event().await, ChainEvent::CatchupCompleted));
 
-        f.latest.store(10, Ordering::Relaxed);
+        f.finalized.store(10, Ordering::Relaxed);
         let event = f.next_event().await;
         assert!(
             matches!(event, ChainEvent::Block(10)),
@@ -1064,8 +1049,7 @@ mod tests {
     async fn wait_processable_bound_waits_for_finalized_head() {
         // Non-optimistic mode: wait_processable_bound blocks on the cached finalized
         // head, so no RPC is needed.
-        let mut builder = test_utils::TestIndexerBuilder::new("http://127.0.0.1:1");
-        builder.eth.optimistic_requests = false;
+        let builder = test_utils::TestIndexerBuilder::new("http://127.0.0.1:1");
         let indexer = builder.build().await;
         let cancel = CancellationToken::new();
 
@@ -1090,13 +1074,13 @@ mod tests {
         let mut f = RunFixture::spawn(9, 9).await;
         assert!(matches!(f.next_event().await, ChainEvent::CatchupCompleted));
 
-        f.latest.store(10, Ordering::Relaxed);
+        f.finalized.store(10, Ordering::Relaxed);
         assert!(matches!(f.next_event().await, ChainEvent::Block(10)));
 
         f.cancel_and_join().await;
 
         // After cancellation, advancing the tip must not produce any more blocks.
-        f.latest.store(11, Ordering::Relaxed);
+        f.finalized.store(11, Ordering::Relaxed);
         tokio::time::sleep(Duration::from_millis(1200)).await;
         assert!(
             f.events_rx.try_recv().is_err(),

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -4,15 +4,16 @@ use crate::event_parsing::{emit_respond_events, parse_filtered_logs};
 use crate::execution_watcher::{ExecutionWatcher, WatcherGateState};
 use crate::finalized_head::{FinalizedHeadTracker, FinalizedHeadWatcher};
 use crate::EthConfig;
+use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::Address;
-use alloy::rpc::types::{Block, Log};
+use alloy::rpc::types::{Block, BlockId, Log};
 use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use async_trait::async_trait;
 use futures_util::{stream, Stream};
 use mpc_chain_integration_core::{ChainIndexer, ChainTelemetry, StateManager};
 use mpc_primitives::{Chain, ChainEvent, IndexedSignRequest};
-use mpc_utils::task::retry_until_ok;
+use mpc_utils::task::{retry_until_ok, retry_until_some};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tokio::time::Duration;
@@ -315,21 +316,21 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         }
     }
 
-    /// The catchup-live anchor: the first initialized processable head + 1.
+    /// The catchup-live anchor: the first processable finalized head + 1.
     /// Returns `None` on cancellation.
-    async fn sample_anchor(
-        &self,
-        watcher: &mut FinalizedHeadWatcher,
-        cancel: &CancellationToken,
-    ) -> anyhow::Result<Option<u64>> {
-        tokio::select! {
-            _ = cancel.cancelled() => Ok(None),
-            head = watcher.wait_initialized() => match head {
-                Ok(head) => Ok(Some(head.saturating_add(1))),
-                Err(_err) if cancel.is_cancelled() => Ok(None),
-                Err(err) => Err(anyhow::anyhow!("head watcher exited: {err:?}")),
+    async fn sample_anchor(&self, cancel: &CancellationToken) -> Option<u64> {
+        retry_until_some(
+            cancel,
+            Self::RETRY_DELAY,
+            "ethereum finalized head sampling",
+            || async {
+                self.client
+                    .get_block(BlockId::Number(BlockNumberOrTag::Finalized))
+                    .await
             },
-        }
+        )
+        .await
+        .map(|block| block.header.number.saturating_add(1))
     }
 
     /// Wait until `next` is processable (the head covers it), returning the
@@ -403,7 +404,7 @@ impl<S: StateManager, T: ChainTelemetry> ChainIndexer for EthereumIndexer<S, T> 
             .spawn_watcher(self.client.clone(), cancel.clone());
 
         // Anchor = tip-at-startup + 1: the catchup-live boundary.
-        let Some(anchor) = self.sample_anchor(&mut finalized_watcher, &cancel).await? else {
+        let Some(anchor) = self.sample_anchor(&cancel).await else {
             tracing::debug!("ethereum indexer cancelled before the startup tip was sampled");
             return Ok(());
         };
@@ -491,6 +492,32 @@ mod tests {
     use tokio::sync::mpsc;
     use tokio::time::Duration;
     use tokio_util::sync::CancellationToken;
+
+    #[tokio::test]
+    async fn sample_anchor_fetches_finalized_head_directly() {
+        let mut server = Server::new_async().await;
+        let finalized_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "eth_getBlockByNumber",
+                "params": ["finalized", false]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(test_utils::block_response(1, 42).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+        let indexer = test_utils::TestIndexerBuilder::new(server.url())
+            .build()
+            .await;
+
+        assert_eq!(
+            indexer.sample_anchor(&CancellationToken::new()).await,
+            Some(43)
+        );
+        finalized_mock.assert_async().await;
+    }
 
     #[tokio::test]
     async fn missing_catchup_block_is_refetched() {

--- a/chain-signatures/chain-ethereum/src/test_utils.rs
+++ b/chain-signatures/chain-ethereum/src/test_utils.rs
@@ -77,7 +77,7 @@ impl TestIndexerBuilder {
                 network: "sepolia".to_string(),
                 helios_data_path: "/tmp/helios-test".to_string(),
                 refresh_finalized_interval: DEFAULT_REFRESH_FINALIZED_INTERVAL,
-                optimistic_requests: true,
+                optimistic_requests: false,
                 light_client: false,
                 rpc: Default::default(),
                 gas: Default::default(),
@@ -115,6 +115,18 @@ impl TestIndexerBuilder {
             client,
             Address::ZERO,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TestIndexerBuilder;
+
+    #[test]
+    fn builder_defaults_to_finalized_requests() {
+        let builder = TestIndexerBuilder::new("http://127.0.0.1:1");
+
+        assert!(!builder.eth.optimistic_requests);
     }
 }
 


### PR DESCRIPTION
Fixes #1132.

This fixes the ethereum catch-up, so it anchors at the first initialized finalized head instead of the latest unfinalized tip.

The indexer previously:
1. Sampled the anchor with latest tip at startup.
2. Used latest + 1 as the catch-up boundary.
3. Waited for the finalized head before processing each block.

Because Ethereum finality trails the tip by roughly two epochs, catch-up could wait 6–13 minutes for its startup boundary to become processable. If the indexer restarted during that period (i.e. from new consensus checkpoint), it sampled a newer tip and moved the boundary forward again.

This could prevent CatchupCompleted from being emitted and keep restored requests from entering the signing pipeline for some nodes.

So this PR just makes it so we get the anchor from the latest finalized instead of the latest optimistic