### PR TITLE
refactor(EthClient): enhance batch processing and flush logic 

### DIFF
--- a/chain-signatures/chain-ethereum/src/publisher.rs
+++ b/chain-signatures/chain-ethereum/src/publisher.rs
@@ -49,43 +49,56 @@ impl From<&Signature> for ChainSignatures::Signature {
 /// This client is separate from the client used by the indexer (separation of concerns: read vs write).
 #[derive(Clone)]
 pub struct EthClient {
-    /// The contract instance for interacting with the ChainSignatures contract
-    contract: ChainSignatures::ChainSignaturesInstance<EthContractFillProvider>,
     /// Channel used to send actions to the background batching task
     batch_tx: mpsc::Sender<PublishAction>,
+}
+
+/// Publishing machinery for the background batching task.
+///
+/// Kept separate from `EthClient` so the spawned task owns no channel sender —
+/// otherwise the channel could never close and the batching loop could never
+/// shut down. Once every `EthClient` clone is dropped, the channel closes and
+/// the loop flushes any leftover batch and exits.
+#[derive(Clone)]
+struct BatchPublisher {
+    /// The contract instance for interacting with the ChainSignatures contract
+    contract: ChainSignatures::ChainSignaturesInstance<EthContractFillProvider>,
     /// Telemetry interface for recording metrics related to publishing signatures
     telemetry: Arc<dyn PublisherTelemetry>,
     /// Gas configuration for estimating and clamping gas limits
     gas: GasConfig,
     /// Publisher configuration for controlling batching and retry behavior
-    publisher: PublisherConfig,
+    config: PublisherConfig,
 }
 
 impl EthClient {
     pub fn new(eth: &EthConfig, telemetry: Arc<dyn PublisherTelemetry>) -> Self {
+        let (batch_tx, batch_rx) = mpsc::channel(eth.publisher.channel_capacity);
+
+        // Spawn the background batching loop; it owns no sender, so it can shut
+        // down once every EthClient is dropped.
+        let batcher = BatchPublisher::new(eth, telemetry);
+        tokio::spawn(async move {
+            batcher.run_batch_respond(batch_rx).await;
+        });
+
+        Self { batch_tx }
+    }
+}
+
+impl BatchPublisher {
+    fn new(eth: &EthConfig, telemetry: Arc<dyn PublisherTelemetry>) -> Self {
         let wallet = EthereumWallet::from(eth.account_sk.clone());
         let provider = ProviderBuilder::new()
             .wallet(wallet)
             .connect_http(eth.execution_rpc_http_url.clone());
 
-        let contract = ChainSignatures::new(eth.contract_address, provider);
-
-        let (batch_tx, batch_rx) = mpsc::channel(eth.publisher.channel_capacity);
-        let client = Self {
-            contract,
-            batch_tx,
+        Self {
+            contract: ChainSignatures::new(eth.contract_address, provider),
             telemetry,
             gas: eth.gas.clone(),
-            publisher: eth.publisher.clone(),
-        };
-
-        // Spawn the background batching loop
-        let client_clone = client.clone();
-        tokio::spawn(async move {
-            client_clone.run_batch_respond(batch_rx).await;
-        });
-
-        client
+            config: eth.publisher.clone(),
+        }
     }
 
     /// Run the background batching loop that collects publish actions and sends them in batches to the Ethereum contract.
@@ -93,8 +106,7 @@ impl EthClient {
     /// A batch is flushed once it reaches `max_batch_size`, or `batch_flush_interval` after its
     /// first action was queued.
     async fn run_batch_respond(self, mut actions_rx: mpsc::Receiver<PublishAction>) {
-        let mut actions_batch: Vec<PublishAction> =
-            Vec::with_capacity(self.publisher.max_batch_size);
+        let mut actions_batch: Vec<PublishAction> = Vec::with_capacity(self.config.max_batch_size);
         // Starts with a sleep of Duration::MAX, which will be reset when the first action is received.
         let flush_timer = tokio::time::sleep(Duration::MAX);
         tokio::pin!(flush_timer);
@@ -105,7 +117,7 @@ impl EthClient {
 
             // Determine the capacity for receiving new actions based on the current batch size and max batch size.
             let capacity = self
-                .publisher
+                .config
                 .max_batch_size
                 .saturating_sub(actions_batch.len())
                 .max(1);
@@ -123,7 +135,7 @@ impl EthClient {
                     if is_empty {
                         flush_timer
                             .as_mut()
-                            .reset(tokio::time::Instant::now() + self.publisher.batch_flush_interval);
+                            .reset(tokio::time::Instant::now() + self.config.batch_flush_interval);
                     }
                 }
                 // Flush the batch if the flush timer has elapsed and the batch is not empty.
@@ -133,7 +145,7 @@ impl EthClient {
             }
 
             // Flush the batch if it has reached the maximum batch size.
-            if actions_batch.len() >= self.publisher.max_batch_size {
+            if actions_batch.len() >= self.config.max_batch_size {
                 self.execute_batch_publish(&mut actions_batch).await;
             }
         }
@@ -152,7 +164,7 @@ impl EthClient {
 
         let res = retry_rpc!(
             Duration::MAX, // Prevent from timing out
-            self.publisher.batch_publish_retry,
+            self.config.batch_publish_retry,
             |attempt, err, sleep| {
                 tracing::warn!(
                     "batch publish failed (attempt {attempt}): {err}, retrying in {sleep:?}"
@@ -180,8 +192,8 @@ impl EthClient {
         sign_ids: &[SignId],
     ) -> anyhow::Result<TransactionReceipt> {
         retry_rpc!(
-            self.publisher.receipt_timeout,
-            self.publisher.receipt_retry,
+            self.config.receipt_timeout,
+            self.config.receipt_retry,
             // Log the error and retry attempt
             |attempt, err, sleep| {
                 tracing::error!(
@@ -219,8 +231,8 @@ impl EthClient {
         sign_ids: &[SignId],
     ) -> anyhow::Result<B256> {
         retry_rpc!(
-            self.publisher.send_timeout,
-            self.publisher.send_retry,
+            self.config.send_timeout,
+            self.config.send_retry,
             |attempt, err, sleep| {
                 tracing::warn!(
                     ?sign_ids,
@@ -304,7 +316,7 @@ impl EthClient {
         }
     }
 
-    pub async fn batch_publish_signatures(
+    async fn batch_publish_signatures(
         &self,
         actions: &[PublishAction],
         signatures: &HashMap<SignId, Signature>,
@@ -591,11 +603,11 @@ mod tests {
             .create_async()
             .await;
 
-        let client = EthClient::new(
+        let publisher = BatchPublisher::new(
             &mock_config(&server.url()),
             Arc::new(NoopPublisherTelemetry),
         );
-        let receipt = client
+        let receipt = publisher
             .wait_for_transaction_receipt(tx_hash, &[SignId::new([2u8; 32])])
             .await
             .unwrap();
@@ -630,13 +642,13 @@ mod tests {
             .expect_at_least(2)
             .create_async().await;
 
-        let client = EthClient::new(
+        let publisher = BatchPublisher::new(
             &mock_config(&server.url()),
             Arc::new(NoopPublisherTelemetry),
         );
 
         // Attempt to send
-        let result = client
+        let result = publisher
             .send_responses(vec![], 21000, &[SignId::new([3u8; 32])])
             .await;
 
@@ -694,13 +706,13 @@ mod tests {
             .create_async()
             .await;
 
-        let client = EthClient::new(
+        let publisher = BatchPublisher::new(
             &mock_config(&server.url()),
             Arc::new(NoopPublisherTelemetry),
         );
 
         // Execute the full publish pipeline
-        let result = client
+        let result = publisher
             .execute_publish(vec![], 21000, &[SignId::new([4u8; 32])])
             .await;
 
@@ -753,12 +765,12 @@ mod tests {
             .create_async()
             .await;
 
-        let client = EthClient::new(
+        let publisher = BatchPublisher::new(
             &mock_config(&server.url()),
             Arc::new(NoopPublisherTelemetry),
         );
 
-        let result = client
+        let result = publisher
             .execute_publish(vec![], 21000, &[SignId::new([5u8; 32])])
             .await;
 
@@ -784,13 +796,13 @@ mod tests {
             .create_async()
             .await;
 
-        let client = EthClient::new(
+        let publisher = BatchPublisher::new(
             &mock_config(&server.url()),
             Arc::new(NoopPublisherTelemetry),
         );
 
         // 500_000 * 12 / 10 == 600_000
-        let gas = client.estimate_batch_gas(&[], 1).await;
+        let gas = publisher.estimate_batch_gas(&[], 1).await;
         assert_eq!(gas, 600_000);
     }
 
@@ -810,12 +822,12 @@ mod tests {
             .create_async()
             .await;
 
-        let client = EthClient::new(
+        let publisher = BatchPublisher::new(
             &mock_config(&server.url()),
             Arc::new(NoopPublisherTelemetry),
         );
 
-        let gas = client.estimate_batch_gas(&[], 1).await;
+        let gas = publisher.estimate_batch_gas(&[], 1).await;
         assert_eq!(gas, GasConfig::default().base_gas_limit);
     }
 
@@ -840,13 +852,13 @@ mod tests {
             .create_async()
             .await;
 
-        let client = EthClient::new(
+        let publisher = BatchPublisher::new(
             &mock_config(&server.url()),
             Arc::new(NoopPublisherTelemetry),
         );
 
         // 3 requests -> static heuristic = max(40_000, 20_000 * 3) = 60_000.
-        let gas = client.estimate_batch_gas(&[], 3).await;
+        let gas = publisher.estimate_batch_gas(&[], 3).await;
         assert_eq!(gas, 60_000);
     }
 
@@ -857,16 +869,16 @@ mod tests {
         mock_alloy_background_rpcs(&mut server).await;
         let send_mock = mock_publish_pipeline(&mut server, tx_hash, 2).await;
 
-        let mut client = EthClient::new(
+        let mut batcher = BatchPublisher::new(
             &mock_config(&server.url()),
             Arc::new(NoopPublisherTelemetry),
         );
-        client.publisher.max_batch_size = 10;
+        batcher.config.max_batch_size = 10;
         // Disable the interval so only batch-fullness triggers a flush.
-        client.publisher.batch_flush_interval = Duration::from_secs(3600);
+        batcher.config.batch_flush_interval = Duration::from_secs(3600);
 
         let (tx, rx) = mpsc::channel(64);
-        tokio::spawn(client.run_batch_respond(rx));
+        tokio::spawn(batcher.run_batch_respond(rx));
 
         // 20 actions: two full batches must be published without waiting on the interval.
         for i in 0u8..20 {
@@ -883,15 +895,15 @@ mod tests {
         mock_alloy_background_rpcs(&mut server).await;
         let send_mock = mock_publish_pipeline(&mut server, tx_hash, 1).await;
 
-        let mut client = EthClient::new(
+        let mut batcher = BatchPublisher::new(
             &mock_config(&server.url()),
             Arc::new(NoopPublisherTelemetry),
         );
-        client.publisher.max_batch_size = 10;
-        client.publisher.batch_flush_interval = Duration::from_millis(200);
+        batcher.config.max_batch_size = 10;
+        batcher.config.batch_flush_interval = Duration::from_millis(200);
 
         let (tx, rx) = mpsc::channel(64);
-        tokio::spawn(client.run_batch_respond(rx));
+        tokio::spawn(batcher.run_batch_respond(rx));
 
         // Fewer actions than a full batch: must still flush once the interval elapses.
         for i in 0u8..3 {
@@ -908,18 +920,20 @@ mod tests {
         mock_alloy_background_rpcs(&mut server).await;
         let send_mock = mock_publish_pipeline(&mut server, tx_hash, 1).await;
 
-        let mut client = EthClient::new(
+        let mut batcher = BatchPublisher::new(
             &mock_config(&server.url()),
             Arc::new(NoopPublisherTelemetry),
         );
-        client.publisher.max_batch_size = 10;
+        batcher.config.max_batch_size = 10;
         // Interval longer than the test: only the channel close may trigger the flush.
-        client.publisher.batch_flush_interval = Duration::from_secs(3600);
+        batcher.config.batch_flush_interval = Duration::from_secs(3600);
 
         let (tx, rx) = mpsc::channel(64);
-        tokio::spawn(client.run_batch_respond(rx));
+        tokio::spawn(batcher.run_batch_respond(rx));
 
         tx.send(mock_publish_action(1)).await.unwrap();
+        // Drop the only sender: the channel closes, so the loop must flush the
+        // leftover batch and exit.
         drop(tx);
 
         wait_for_hits(&send_mock, Duration::from_secs(5)).await;

--- a/chain-signatures/chain-ethereum/src/publisher.rs
+++ b/chain-signatures/chain-ethereum/src/publisher.rs
@@ -17,7 +17,7 @@ use mpc_chain_integration_core::{
 use mpc_primitives::{SignId, Signature};
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::sync::mpsc;
 
 type EthContractFillProvider = FillProvider<
@@ -89,31 +89,61 @@ impl EthClient {
     }
 
     /// Run the background batching loop that collects publish actions and sends them in batches to the Ethereum contract.
+    ///
+    /// A batch is flushed once it reaches `max_batch_size`, or `batch_flush_interval` after its
+    /// first action was queued.
     async fn run_batch_respond(self, mut actions_rx: mpsc::Receiver<PublishAction>) {
-        let mut start = Instant::now();
-        let mut actions_batch: Vec<PublishAction> = vec![];
-        let mut interval = tokio::time::interval(Duration::from_millis(100));
+        let mut actions_batch: Vec<PublishAction> =
+            Vec::with_capacity(self.publisher.max_batch_size);
+        let flush_timer = tokio::time::sleep(Duration::MAX);
+        tokio::pin!(flush_timer);
+
         loop {
-            interval.tick().await;
-            if (start.elapsed() > self.publisher.batch_flush_interval
-                || actions_batch.len() >= self.publisher.max_batch_size)
-                && !actions_batch.is_empty()
-            {
-                tracing::info!(
-                    num_requests = actions_batch.len(),
-                    "publishing batch of ethereum signatures",
-                );
-                self.execute_batch_publish(&mut actions_batch).await;
-                start = Instant::now();
+            // Check if the batch is empty before receiving new actions.
+            let is_empty = actions_batch.is_empty();
+
+            // Determine the capacity for receiving new actions based on the current batch size and max batch size.
+            let capacity = self
+                .publisher
+                .max_batch_size
+                .saturating_sub(actions_batch.len())
+                .max(1);
+
+            tokio::select! {
+                // Receive new actions from the channel and add them to the batch.
+                received = actions_rx.recv_many(&mut actions_batch, capacity) => {
+                    if received == 0 {
+                        // All senders dropped: flush what's left and shut down.
+                        if !actions_batch.is_empty() {
+                            self.execute_batch_publish(&mut actions_batch).await;
+                        }
+                        return;
+                    }
+                    if is_empty {
+                        flush_timer
+                            .as_mut()
+                            .reset(tokio::time::Instant::now() + self.publisher.batch_flush_interval);
+                    }
+                }
+                // Flush the batch if the flush timer has elapsed and the batch is not empty.
+                _ = &mut flush_timer, if !actions_batch.is_empty() => {
+                    self.execute_batch_publish(&mut actions_batch).await;
+                }
             }
-            if let Ok(action) = actions_rx.try_recv() {
-                actions_batch.push(action);
+
+            // Flush the batch if it has reached the maximum batch size.
+            if actions_batch.len() >= self.publisher.max_batch_size {
+                self.execute_batch_publish(&mut actions_batch).await;
             }
         }
     }
 
     /// Execute a batch publish of signatures to the Ethereum contract, with retry logic.
     async fn execute_batch_publish(&self, actions: &mut Vec<PublishAction>) {
+        tracing::info!(
+            num_requests = actions.len(),
+            "publishing batch of ethereum signatures",
+        );
         let signatures: HashMap<SignId, Signature> = actions
             .iter()
             .map(|action| (action.request.id, action.signature))
@@ -321,9 +351,78 @@ mod tests {
     use super::*;
     use alloy::primitives::{Address, B256, U256};
     use k256::{AffinePoint, Scalar};
-    use mockito::{Matcher, Server};
+    use mockito::{Matcher, Mock, Server};
+    use mpc_chain_integration_core::utils::test::make_publish_action;
     use mpc_chain_integration_core::NoopPublisherTelemetry;
+    use mpc_primitives::{Chain, SignKind};
     use serde_json::json;
+
+    fn mock_publish_action(id: u8) -> PublishAction {
+        make_publish_action(Chain::Ethereum, SignKind::Sign, SignId::new([id; 32]))
+    }
+
+    /// Poll until `mock` has been hit the expected number of times, or panic.
+    async fn wait_for_hits(mock: &Mock, timeout: Duration) {
+        let deadline = tokio::time::Instant::now() + timeout;
+        while !mock.matched_async().await {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for expected mock hits"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    /// Mocks the full happy-path publish pipeline: nonce fetch, tx send and a success receipt.
+    /// Returns the send mock for hit-count assertions.
+    async fn mock_publish_pipeline(
+        server: &mut Server,
+        tx_hash: B256,
+        expected_sends: usize,
+    ) -> Mock {
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_getTransactionCount"}),
+            ))
+            .with_status(200)
+            .with_body(json!({"jsonrpc": "2.0", "id": 1, "result": "0x1"}).to_string())
+            .expect_at_least(expected_sends)
+            .create_async()
+            .await;
+
+        let send_mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_sendRawTransaction"}),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({"jsonrpc": "2.0", "id": 1, "result": format!("{tx_hash:#x}")}).to_string(),
+            )
+            .expect(expected_sends)
+            .create_async()
+            .await;
+
+        server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(
+                json!({"method": "eth_getTransactionReceipt"}),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0", "id": 1,
+                    "result": mock_receipt_json(tx_hash, "0x1")
+                })
+                .to_string(),
+            )
+            .expect(expected_sends)
+            .create_async()
+            .await;
+
+        send_mock
+    }
 
     fn create_test_signature() -> mpc_primitives::Signature {
         mpc_primitives::Signature::new(AffinePoint::GENERATOR, Scalar::from(42u64), 1)
@@ -748,5 +847,80 @@ mod tests {
         // 3 requests -> static heuristic = max(40_000, 20_000 * 3) = 60_000.
         let gas = client.estimate_batch_gas(&[], 3).await;
         assert_eq!(gas, 60_000);
+    }
+
+    #[tokio::test]
+    async fn test_run_batch_respond_flushes_full_batches_immediately() {
+        let mut server = Server::new_async().await;
+        let tx_hash = B256::repeat_byte(0x21);
+        mock_alloy_background_rpcs(&mut server).await;
+        let send_mock = mock_publish_pipeline(&mut server, tx_hash, 2).await;
+
+        let mut client = EthClient::new(
+            &mock_config(&server.url()),
+            Arc::new(NoopPublisherTelemetry),
+        );
+        client.publisher.max_batch_size = 10;
+        // Disable the interval so only batch-fullness triggers a flush.
+        client.publisher.batch_flush_interval = Duration::from_secs(3600);
+
+        let (tx, rx) = mpsc::channel(64);
+        tokio::spawn(client.run_batch_respond(rx));
+
+        // 20 actions: two full batches must be published without waiting on the interval.
+        for i in 0u8..20 {
+            tx.send(mock_publish_action(i)).await.unwrap();
+        }
+
+        wait_for_hits(&send_mock, Duration::from_millis(1500)).await;
+    }
+
+    #[tokio::test]
+    async fn test_run_batch_respond_flushes_partial_batch_after_interval() {
+        let mut server = Server::new_async().await;
+        let tx_hash = B256::repeat_byte(0x22);
+        mock_alloy_background_rpcs(&mut server).await;
+        let send_mock = mock_publish_pipeline(&mut server, tx_hash, 1).await;
+
+        let mut client = EthClient::new(
+            &mock_config(&server.url()),
+            Arc::new(NoopPublisherTelemetry),
+        );
+        client.publisher.max_batch_size = 10;
+        client.publisher.batch_flush_interval = Duration::from_millis(200);
+
+        let (tx, rx) = mpsc::channel(64);
+        tokio::spawn(client.run_batch_respond(rx));
+
+        // Fewer actions than a full batch: must still flush once the interval elapses.
+        for i in 0u8..3 {
+            tx.send(mock_publish_action(i)).await.unwrap();
+        }
+
+        wait_for_hits(&send_mock, Duration::from_secs(5)).await;
+    }
+
+    #[tokio::test]
+    async fn test_run_batch_respond_flushes_on_channel_close() {
+        let mut server = Server::new_async().await;
+        let tx_hash = B256::repeat_byte(0x23);
+        mock_alloy_background_rpcs(&mut server).await;
+        let send_mock = mock_publish_pipeline(&mut server, tx_hash, 1).await;
+
+        let mut client = EthClient::new(
+            &mock_config(&server.url()),
+            Arc::new(NoopPublisherTelemetry),
+        );
+        client.publisher.max_batch_size = 10;
+        // Interval longer than the test: only the channel close may trigger the flush.
+        client.publisher.batch_flush_interval = Duration::from_secs(3600);
+
+        let (tx, rx) = mpsc::channel(64);
+        tokio::spawn(client.run_batch_respond(rx));
+
+        tx.send(mock_publish_action(1)).await.unwrap();
+        drop(tx);
+
+        wait_for_hits(&send_mock, Duration::from_secs(5)).await;
     }
 }

--- a/chain-signatures/chain-ethereum/src/publisher.rs
+++ b/chain-signatures/chain-ethereum/src/publisher.rs
@@ -95,6 +95,7 @@ impl EthClient {
     async fn run_batch_respond(self, mut actions_rx: mpsc::Receiver<PublishAction>) {
         let mut actions_batch: Vec<PublishAction> =
             Vec::with_capacity(self.publisher.max_batch_size);
+        // Starts with a sleep of Duration::MAX, which will be reset when the first action is received.
         let flush_timer = tokio::time::sleep(Duration::MAX);
         tokio::pin!(flush_timer);
 


### PR DESCRIPTION
This PR addresses some of the issues in `run_batch_respond` (publishing flow): 

- Idle idle polling every 100 ms
- Task leak on shutdown
- Structural cap of one action per tick (~10/sec) (not critical at the moment, but would become an issue if load increases)

Main changes:

- Extract `BatchPublisher` from `EthClient` (now a thin wrapper). `BatchPublisher` holds all publishing machinery. `EthClient` builds and spawns `BatchPublisher` on initialization. This helps with batch flushing on shutdown (spawned task owns no sender)
- Replace 100ms polling with a `tokio::select!` event loop
- Use `actions_rx.recv_many(...)`, which parks on the channel while idle
- Introduce flush deadline - partial batch flushes exactly `batch_flush_interval` after first action
- Added unit tests:
  - `test_run_batch_respond_flushes_full_batches_immediately` - verify full batch is flushed immediately
  - `test_run_batch_respond_flushes_partial_batch_after_interval` - verify partial batch is flushed after `batch_flush_interval`
  - `test_run_batch_respond_flushes_on_channel_close` - verify leftover batch is flushed on channel close
