### PR TITLE
fix(audit): ignore RUSTSEC-2026-0258

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -27,4 +27,8 @@ ignore = [
 	# wasmtime stores can mix up type indices between engines; only reachable via near-sdk's `unit-testing`
 	# dev-only dependency (near-vm-runner 0.37.2 pins wasmtime ^45, which has no patched release; blocked upstream).
 	"RUSTSEC-2026-0222",
+	# h2 unbounded empty DATA frames (RUSTSEC-2026-0258); DoS via CPU exhaustion on HTTP/2 stream parsing (not a secret/data leakage vulnerability).
+	# Server-side traffic uses hyper 1.x / h2 0.4 which is upgraded to >=0.4.16. h2 0.3.x is used solely by outgoing client connections
+	# to GCP Secret Manager endpoints (via unmaintained google-apis-rs / hyper 0.14) with no upstream 0.3 patch available.
+	"RUSTSEC-2026-0258",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3822,7 +3822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.119",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5472,9 +5472,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -5491,9 +5491,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -6145,14 +6145,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6169,7 +6169,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -11634,7 +11634,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
@@ -11675,7 +11675,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.14",
+ "h2 0.4.16",
  "hickory-resolver",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -17868,7 +17868,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.7",
  "rand 0.8.5",
  "static_assertions",


### PR DESCRIPTION
Bump h2 to 0.4.16 so we don't have this issue on our endpoints. But we still ignore it since our google dependencies have this issue. We need to fix the google dependency separately but as long as google does not DDoS us, it's not too important