### PR TITLE
feat: reduce cloning of IndexedSignRequest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ mockito = "1.7.0"
 rand = "0.8.5"
 reqwest = { version = "0.11.16", features = ["blocking", "json"] }
 semver = "1.0.23"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_bytes = "0.11.15"
 serde_json = "1"
 sha3 = "0.10.8"

--- a/chain-signatures/chain-canton/src/events.rs
+++ b/chain-signatures/chain-canton/src/events.rs
@@ -9,6 +9,7 @@ use crate::signing::{parse_canton_signature, CantonSignBidirectionalRequestedEve
 use mpc_primitives::{Chain, ChainEvent, RespondBidirectionalEvent, SignatureRespondedEvent};
 use mpc_utils::time::current_unix_timestamp;
 use std::collections::HashSet;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 
 /// Process a single Canton event from a WebSocket transaction update.
@@ -55,7 +56,7 @@ pub async fn process_canton_event(
                     Ok(request) => {
                         if events_tx
                             .send(ChainEvent::SignRequest {
-                                request,
+                                request: Arc::new(request),
                                 block_timestamp: None,
                             })
                             .await

--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -222,7 +222,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         for request in indexed_requests {
             events_tx
                 .send(ChainEvent::SignRequest {
-                    request,
+                    request: Arc::new(request),
                     block_timestamp: Some(block_timestamp),
                 })
                 .await

--- a/chain-signatures/chain-integration-core/src/publish.rs
+++ b/chain-signatures/chain-integration-core/src/publish.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Instant;
 
 use cait_sith::protocol::Participant;
@@ -20,7 +21,7 @@ pub struct PublishAction {
     /// The public key associated with the signature.
     pub public_key: PublicKey,
     /// The indexed sign request that this signature corresponds to.
-    pub request: IndexedSignRequest,
+    pub request: Arc<IndexedSignRequest>,
     /// The actual signature to be published.
     pub signature: Signature,
     /// The participants involved in the signing process.
@@ -32,10 +33,11 @@ pub struct PublishAction {
 impl PublishAction {
     pub fn new(
         public_key: PublicKey,
-        request: IndexedSignRequest,
+        request: impl Into<Arc<IndexedSignRequest>>,
         output: FullSignature<Secp256k1>,
         participants: Vec<Participant>,
     ) -> Option<Self> {
+        let request: Arc<IndexedSignRequest> = request.into();
         let expected_public_key = mpc_crypto::derive_key(public_key, request.args.epsilon);
         let signature = mpc_crypto::reconstruct_signature(
             &expected_public_key,

--- a/chain-signatures/chain-integration-core/src/publish.rs
+++ b/chain-signatures/chain-integration-core/src/publish.rs
@@ -33,11 +33,10 @@ pub struct PublishAction {
 impl PublishAction {
     pub fn new(
         public_key: PublicKey,
-        request: impl Into<Arc<IndexedSignRequest>>,
+        request: Arc<IndexedSignRequest>,
         output: FullSignature<Secp256k1>,
         participants: Vec<Participant>,
     ) -> Option<Self> {
-        let request: Arc<IndexedSignRequest> = request.into();
         let expected_public_key = mpc_crypto::derive_key(public_key, request.args.epsilon);
         let signature = mpc_crypto::reconstruct_signature(
             &expected_public_key,
@@ -79,7 +78,7 @@ mod tests {
             SignId::new([0u8; 32]),
         );
 
-        assert!(PublishAction::new(pk, request, output, vec![]).is_some());
+        assert!(PublishAction::new(pk, Arc::new(request), output, vec![]).is_some());
     }
 
     #[test]
@@ -99,6 +98,6 @@ mod tests {
             SignId::new([0u8; 32]),
         );
 
-        assert!(PublishAction::new(pk, request, output, vec![]).is_none());
+        assert!(PublishAction::new(pk, Arc::new(request), output, vec![]).is_none());
     }
 }

--- a/chain-signatures/chain-integration-core/src/utils/test.rs
+++ b/chain-signatures/chain-integration-core/src/utils/test.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context as _;
@@ -89,7 +90,7 @@ pub fn make_publish_action_for(
     let pk: AffinePoint = sk.public_key().into();
     let output = make_signature(&sk, epsilon, payload);
     let request = make_indexed(chain, epsilon, payload, kind, sign_id);
-    PublishAction::new(pk, request, output, vec![])
+    PublishAction::new(pk, Arc::new(request), output, vec![])
         .expect("valid signature should produce a publish action")
 }
 

--- a/chain-signatures/chain-midnight/src/indexer.rs
+++ b/chain-signatures/chain-midnight/src/indexer.rs
@@ -13,6 +13,7 @@ use midnight_base_crypto::fab::AlignedValue;
 use midnight_onchain_state::state::StateValue;
 
 use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Context as _;
@@ -566,7 +567,7 @@ impl<S: StateManager, T: ChainTelemetry> MidnightIndexer<S, T> {
         for request in requests {
             events_tx
                 .send(ChainEvent::SignRequest {
-                    request,
+                    request: Arc::new(request),
                     block_timestamp: None,
                 })
                 .await

--- a/chain-signatures/chain-near/src/indexer.rs
+++ b/chain-signatures/chain-near/src/indexer.rs
@@ -4,6 +4,7 @@ use mpc_primitives::{Chain, IndexedSignRequest, SignArgs, SignCommand, SignId};
 use mpc_utils::time::current_unix_timestamp;
 use near_account_id::AccountId;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -187,7 +188,11 @@ async fn poll_pending_requests<S: StateManager>(ctx: &mut Context<S>) -> anyhow:
             sign_id = ?request.id,
             "sending new sign request to processing queue"
         );
-        if let Err(err) = ctx.sign_tx.send(SignCommand::Request(request)).await {
+        if let Err(err) = ctx
+            .sign_tx
+            .send(SignCommand::Request(Arc::new(request)))
+            .await
+        {
             tracing::error!(?err, "failed to send the sign request into sign queue");
         }
     }

--- a/chain-signatures/chain-solana/src/indexer.rs
+++ b/chain-signatures/chain-solana/src/indexer.rs
@@ -1083,7 +1083,7 @@ async fn emit_events(
                     );
                     events_tx
                         .send(ChainEvent::SignRequest {
-                            request,
+                            request: Arc::new(request),
                             block_timestamp: None,
                         })
                         .await?;

--- a/chain-signatures/node/src/backlog/consensus.rs
+++ b/chain-signatures/node/src/backlog/consensus.rs
@@ -202,6 +202,7 @@ mod tests {
 
     use mpc_primitives::{CheckpointDigest, IndexedSignRequest, PendingTx, SignArgs, SignId};
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     struct AlignFixture {
         chain: Chain,
@@ -369,7 +370,7 @@ mod tests {
                         chain,
                         0,
                     );
-                    fixture.backlog.insert(tx).await;
+                    fixture.backlog.insert(Arc::new(tx)).await;
                 }
 
                 for &height in &case.local_checkpoints {

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -281,11 +281,7 @@ impl Backlog {
     }
 
     /// Insert a new Sign request into the backlog for the specified chain.
-    pub async fn insert(
-        &self,
-        request: impl Into<Arc<IndexedSignRequest>>,
-    ) -> Option<BacklogEntry> {
-        let request: Arc<IndexedSignRequest> = request.into();
+    pub async fn insert(&self, request: Arc<IndexedSignRequest>) -> Option<BacklogEntry> {
         let chain = request.chain;
         let id = request.id;
         let entry = BacklogEntry::new(request);
@@ -459,7 +455,7 @@ impl Backlog {
         &self,
         chain: Chain,
         id: &SignId,
-        request: impl Into<Arc<IndexedSignRequest>>,
+        request: Arc<IndexedSignRequest>,
     ) -> Result<(), BacklogError> {
         let mut pending = self.pending(&chain).write().await;
 
@@ -848,24 +844,18 @@ pub struct BacklogEntry {
 }
 
 impl BacklogEntry {
-    pub fn new(request: impl Into<Arc<IndexedSignRequest>>) -> Self {
+    pub fn new(request: Arc<IndexedSignRequest>) -> Self {
         Self {
-            request: request.into(),
+            request,
             status: SignStatus::PendingGeneration,
         }
     }
 
-    pub fn with_status(request: impl Into<Arc<IndexedSignRequest>>, status: SignStatus) -> Self {
-        Self {
-            request: request.into(),
-            status,
-        }
+    pub fn with_status(request: Arc<IndexedSignRequest>, status: SignStatus) -> Self {
+        Self { request, status }
     }
 
-    pub fn pending_execution(
-        request: impl Into<Arc<IndexedSignRequest>>,
-        tx: BidirectionalTx,
-    ) -> Self {
+    pub fn pending_execution(request: Arc<IndexedSignRequest>, tx: BidirectionalTx) -> Self {
         Self::with_status(request, SignStatus::PendingExecution { tx })
     }
 
@@ -898,8 +888,8 @@ impl BacklogEntry {
 
     /// Test-only; see the note on [`Backlog::set_request`].
     #[cfg(any(test, feature = "test-feature"))]
-    pub fn set_request(&mut self, request: impl Into<Arc<IndexedSignRequest>>) {
-        self.request = request.into();
+    pub fn set_request(&mut self, request: Arc<IndexedSignRequest>) {
+        self.request = request;
     }
 
     /// Rewrite this entry into the final-response request produced by a confirmed
@@ -1094,8 +1084,14 @@ mod tests {
         args: SignArgs,
         kind: SignKind,
         unix_timestamp_indexed: u64,
-    ) -> IndexedSignRequest {
-        IndexedSignRequest::new(sign_id, args, chain, unix_timestamp_indexed, kind)
+    ) -> Arc<IndexedSignRequest> {
+        Arc::new(IndexedSignRequest::new(
+            sign_id,
+            args,
+            chain,
+            unix_timestamp_indexed,
+            kind,
+        ))
     }
 
     fn create_bidirectional_request(
@@ -1103,14 +1099,14 @@ mod tests {
         chain: Chain,
         dest: &str,
         unix_timestamp_indexed: u64,
-    ) -> IndexedSignRequest {
-        IndexedSignRequest::sign_bidirectional(
+    ) -> Arc<IndexedSignRequest> {
+        Arc::new(IndexedSignRequest::sign_bidirectional(
             sign_id,
             create_test_args(sign_id.request_id[0]),
             chain,
             unix_timestamp_indexed,
             create_test_event(dest),
-        )
+        ))
     }
 
     fn create_execution_entry(
@@ -1130,13 +1126,13 @@ mod tests {
         unix_timestamp_indexed: u64,
     ) -> BacklogEntry {
         let sign_id = SignId::new(tx.request_id);
-        let request = IndexedSignRequest::new(
+        let request = Arc::new(IndexedSignRequest::new(
             sign_id,
             create_test_args(tx.request_id[0]),
             chain,
             unix_timestamp_indexed,
             SignKind::SignBidirectional(create_test_event(dest)),
-        );
+        ));
 
         match status {
             SignStatus::PendingExecution { .. } => BacklogEntry::pending_execution(request, tx),
@@ -1171,7 +1167,7 @@ mod tests {
                     },
                 );
                 backlog
-                    .set_request(chain, &sign_id, completion_request)
+                    .set_request(chain, &sign_id, Arc::new(completion_request))
                     .await
                     .unwrap();
                 backlog
@@ -1206,7 +1202,7 @@ mod tests {
                     },
                 );
                 backlog
-                    .set_request(chain, &sign_id, completion_request)
+                    .set_request(chain, &sign_id, Arc::new(completion_request))
                     .await
                     .unwrap();
                 backlog.set_status(chain, &sign_id, status).await;
@@ -1581,7 +1577,7 @@ mod tests {
         );
 
         let mut pending_generation = PendingRequests::new();
-        pending_generation.insert(sign_id, BacklogEntry::new(request.clone()));
+        pending_generation.insert(sign_id, BacklogEntry::new(Arc::clone(&request)));
         pending_generation.set_processed_block(100);
 
         let mut pending_publish = PendingRequests::new();
@@ -1633,8 +1629,10 @@ mod tests {
                 chain_ctx: None,
             },
         );
-        let mut final_response =
-            BacklogEntry::with_status(response_request, SignStatus::PendingGenerationBidirectional);
+        let mut final_response = BacklogEntry::with_status(
+            Arc::new(response_request),
+            SignStatus::PendingGenerationBidirectional,
+        );
         let final_consensus_tag = final_response.status().consensus_tag();
         final_response
             .mark_publishing(test_publish_state(true))
@@ -2027,7 +2025,7 @@ mod tests {
                 },
             );
             recovered
-                .set_request(Chain::Solana, &sign_id, completion_request)
+                .set_request(Chain::Solana, &sign_id, Arc::new(completion_request))
                 .await
                 .expect("failed to store completion request");
             recovered
@@ -2069,7 +2067,7 @@ mod tests {
             },
         );
 
-        backlog.insert(completion_request).await;
+        backlog.insert(Arc::new(completion_request)).await;
         backlog
             .set_status(
                 Chain::Solana,
@@ -2131,7 +2129,7 @@ mod tests {
             },
         );
 
-        backlog.insert(completion_request).await;
+        backlog.insert(Arc::new(completion_request)).await;
         backlog
             .set_status(
                 Chain::Solana,
@@ -2516,7 +2514,7 @@ mod tests {
         );
 
         // Insert first time
-        backlog.insert(request.clone()).await;
+        backlog.insert(Arc::clone(&request)).await;
         assert_eq!(backlog.len(), 1);
 
         // Insert exactly the same ID again (overwrites)

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -475,7 +475,7 @@ impl Backlog {
         &self,
         chain: Chain,
         id: &SignId,
-        request: impl Into<Arc<IndexedSignRequest>>,
+        request: Arc<IndexedSignRequest>,
     ) -> Result<BacklogEntry, BacklogError> {
         let mut pending = self.pending(&chain).write().await;
 
@@ -483,7 +483,7 @@ impl Backlog {
             .requests
             .get_mut(id)
             .ok_or(BacklogError::NotFound { chain, id: *id })?;
-        entry.transition_to_bidirectional_response(request.into())?;
+        entry.transition_to_bidirectional_response(request)?;
         Ok(entry.clone())
     }
 
@@ -912,9 +912,8 @@ impl BacklogEntry {
     /// identifiers diverge, which is the only way to reach this rejection.
     fn transition_to_bidirectional_response(
         &mut self,
-        request: impl Into<Arc<IndexedSignRequest>>,
+        request: Arc<IndexedSignRequest>,
     ) -> Result<(), BacklogError> {
-        let request = request.into();
         if self.request.id != request.id
             || !matches!(&request.kind, SignKind::RespondBidirectional(_))
         {
@@ -1669,7 +1668,7 @@ mod tests {
         );
 
         entry
-            .transition_to_bidirectional_response(response_request)
+            .transition_to_bidirectional_response(Arc::new(response_request))
             .unwrap();
 
         assert!(matches!(
@@ -1702,7 +1701,7 @@ mod tests {
         );
 
         let err = entry
-            .transition_to_bidirectional_response(response_request)
+            .transition_to_bidirectional_response(Arc::new(response_request))
             .unwrap_err();
 
         assert!(matches!(

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -281,7 +281,11 @@ impl Backlog {
     }
 
     /// Insert a new Sign request into the backlog for the specified chain.
-    pub async fn insert(&self, request: IndexedSignRequest) -> Option<BacklogEntry> {
+    pub async fn insert(
+        &self,
+        request: impl Into<Arc<IndexedSignRequest>>,
+    ) -> Option<BacklogEntry> {
+        let request: Arc<IndexedSignRequest> = request.into();
         let chain = request.chain;
         let id = request.id;
         let entry = BacklogEntry::new(request);
@@ -347,14 +351,14 @@ impl Backlog {
 
     /// Returns backlog requests for a chain that are still eligible to be
     /// enqueued for processing after catchup completes.
-    pub async fn take_requeueable_requests(&self, chain: Chain) -> Vec<IndexedSignRequest> {
+    pub async fn take_requeueable_requests(&self, chain: Chain) -> Vec<Arc<IndexedSignRequest>> {
         let pending = self.pending(&chain).write().await;
 
         let mut requeueable: Vec<_> = pending
             .requests
             .values()
             .filter(|entry| entry.status().is_pending_generation())
-            .map(|entry| entry.request.clone())
+            .map(|entry| Arc::clone(&entry.request))
             .collect();
 
         requeueable.sort_by(|left, right| {
@@ -371,7 +375,7 @@ impl Backlog {
     pub async fn publishable_requests(
         &self,
         chain: Chain,
-    ) -> Vec<(IndexedSignRequest, PublishState)> {
+    ) -> Vec<(Arc<IndexedSignRequest>, PublishState)> {
         let pending = self.pending(&chain).write().await;
 
         let mut publishable: Vec<_> = pending
@@ -380,7 +384,7 @@ impl Backlog {
             .filter_map(|entry| match entry.status() {
                 SignStatus::PendingPublish { publish }
                 | SignStatus::PendingPublishBidirectional { publish } => {
-                    Some((entry.request.clone(), publish))
+                    Some((Arc::clone(&entry.request), publish))
                 }
                 _ => None,
             })
@@ -455,7 +459,7 @@ impl Backlog {
         &self,
         chain: Chain,
         id: &SignId,
-        request: IndexedSignRequest,
+        request: impl Into<Arc<IndexedSignRequest>>,
     ) -> Result<(), BacklogError> {
         let mut pending = self.pending(&chain).write().await;
 
@@ -471,7 +475,7 @@ impl Backlog {
         &self,
         chain: Chain,
         id: &SignId,
-        request: IndexedSignRequest,
+        request: impl Into<Arc<IndexedSignRequest>>,
     ) -> Result<BacklogEntry, BacklogError> {
         let mut pending = self.pending(&chain).write().await;
 
@@ -479,7 +483,7 @@ impl Backlog {
             .requests
             .get_mut(id)
             .ok_or(BacklogError::NotFound { chain, id: *id })?;
-        entry.transition_to_bidirectional_response(request)?;
+        entry.transition_to_bidirectional_response(request.into())?;
         Ok(entry.clone())
     }
 
@@ -839,23 +843,29 @@ pub enum BacklogError {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BacklogEntry {
-    pub request: IndexedSignRequest,
+    pub request: Arc<IndexedSignRequest>,
     pub status: SignStatus,
 }
 
 impl BacklogEntry {
-    pub fn new(request: IndexedSignRequest) -> Self {
+    pub fn new(request: impl Into<Arc<IndexedSignRequest>>) -> Self {
         Self {
-            request,
+            request: request.into(),
             status: SignStatus::PendingGeneration,
         }
     }
 
-    pub fn with_status(request: IndexedSignRequest, status: SignStatus) -> Self {
-        Self { request, status }
+    pub fn with_status(request: impl Into<Arc<IndexedSignRequest>>, status: SignStatus) -> Self {
+        Self {
+            request: request.into(),
+            status,
+        }
     }
 
-    pub fn pending_execution(request: IndexedSignRequest, tx: BidirectionalTx) -> Self {
+    pub fn pending_execution(
+        request: impl Into<Arc<IndexedSignRequest>>,
+        tx: BidirectionalTx,
+    ) -> Self {
         Self::with_status(request, SignStatus::PendingExecution { tx })
     }
 
@@ -888,8 +898,8 @@ impl BacklogEntry {
 
     /// Test-only; see the note on [`Backlog::set_request`].
     #[cfg(any(test, feature = "test-feature"))]
-    pub fn set_request(&mut self, request: IndexedSignRequest) {
-        self.request = request;
+    pub fn set_request(&mut self, request: impl Into<Arc<IndexedSignRequest>>) {
+        self.request = request.into();
     }
 
     /// Rewrite this entry into the final-response request produced by a confirmed
@@ -902,8 +912,9 @@ impl BacklogEntry {
     /// identifiers diverge, which is the only way to reach this rejection.
     fn transition_to_bidirectional_response(
         &mut self,
-        request: IndexedSignRequest,
+        request: impl Into<Arc<IndexedSignRequest>>,
     ) -> Result<(), BacklogError> {
+        let request = request.into();
         if self.request.id != request.id
             || !matches!(&request.kind, SignKind::RespondBidirectional(_))
         {
@@ -1109,12 +1120,22 @@ mod tests {
         status: SignStatus,
         dest: &str,
     ) -> BacklogEntry {
+        create_execution_entry_with_timestamp(tx, chain, status, dest, 0)
+    }
+
+    fn create_execution_entry_with_timestamp(
+        tx: BidirectionalTx,
+        chain: Chain,
+        status: SignStatus,
+        dest: &str,
+        unix_timestamp_indexed: u64,
+    ) -> BacklogEntry {
         let sign_id = SignId::new(tx.request_id);
         let request = IndexedSignRequest::new(
             sign_id,
             create_test_args(tx.request_id[0]),
             chain,
-            0,
+            unix_timestamp_indexed,
             SignKind::SignBidirectional(create_test_event(dest)),
         );
 
@@ -1737,26 +1758,20 @@ mod tests {
     async fn test_checkpoint_digest_ignores_timestamp() {
         let tx = create_test_tx(8);
 
-        let entry1 = {
-            let mut e = create_execution_entry(
-                tx.clone(),
-                Chain::Ethereum,
-                SignStatus::PendingGeneration,
-                "ethereum",
-            );
-            e.request.unix_timestamp_indexed = 1000;
-            e
-        };
-        let entry2 = {
-            let mut e = create_execution_entry(
-                tx.clone(),
-                Chain::Ethereum,
-                SignStatus::PendingGeneration,
-                "ethereum",
-            );
-            e.request.unix_timestamp_indexed = 9999;
-            e
-        };
+        let entry1 = create_execution_entry_with_timestamp(
+            tx.clone(),
+            Chain::Ethereum,
+            SignStatus::PendingGeneration,
+            "ethereum",
+            1000,
+        );
+        let entry2 = create_execution_entry_with_timestamp(
+            tx.clone(),
+            Chain::Ethereum,
+            SignStatus::PendingGeneration,
+            "ethereum",
+            9999,
+        );
 
         let mut pending1 = PendingRequests::new();
         pending1.insert(SignId::new(tx.request_id), entry1);

--- a/chain-signatures/node/src/indexer_hydration/mod.rs
+++ b/chain-signatures/node/src/indexer_hydration/mod.rs
@@ -30,6 +30,7 @@ use sp_runtime::traits::BlakeTwo256;
 use sp_state_machine::read_proof_check;
 use sp_trie::StorageProof;
 use std::convert::TryInto;
+use std::sync::Arc;
 use std::time::Duration;
 use subxt::backend::{legacy::LegacyRpcMethods, rpc::RpcClient};
 use subxt::config::HashFor;
@@ -557,7 +558,7 @@ pub async fn run<T: ChainTelemetry>(
                     };
 
                     if let Err(e) =
-                        crate::stream::ops::process_sign_request(sign_request, &ctx).await
+                        crate::stream::ops::process_sign_request(Arc::new(sign_request), &ctx).await
                     {
                         tracing::error!("failed to process sign event: {e}");
                     }
@@ -608,7 +609,7 @@ pub async fn run<T: ChainTelemetry>(
                     };
 
                     if let Err(e) =
-                        crate::stream::ops::process_sign_request(sign_request, &ctx).await
+                        crate::stream::ops::process_sign_request(Arc::new(sign_request), &ctx).await
                     {
                         tracing::error!("failed to process sign event: {e}");
                     }

--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -160,10 +160,9 @@ impl SignatureSpawner {
     fn add_request(
         &mut self,
         governance: &GovernanceInfo,
-        request: impl Into<Arc<IndexedSignRequest>>,
+        request: Arc<IndexedSignRequest>,
         cfg: ProtocolConfig,
     ) {
-        let request: Arc<IndexedSignRequest> = request.into();
         let sign_id = request.id;
         // Ensure we don't retain the dead tag from a prior incarnation of this
         // sign ID (e.g. after regression recovery re-queues a completed request).
@@ -612,7 +611,7 @@ mod tests {
             path: "test".to_string(),
             key_version: 1,
         };
-        let request = IndexedSignRequest::sign(sign_id, args, Chain::Solana, 0);
+        let request = Arc::new(IndexedSignRequest::sign(sign_id, args, Chain::Solana, 0));
 
         let probe_id = SignId::new([43u8; 32]);
         let probe_request = IndexedSignRequest::sign(
@@ -643,7 +642,7 @@ mod tests {
         });
 
         // Step 1: Spawn → mailbox created, request retained, not dead
-        spawner.add_request(&governance, request.clone(), cfg.clone());
+        spawner.add_request(&governance, Arc::clone(&request), cfg.clone());
         assert!(spawner.test_tasks_contains(sign_id));
         assert!(spawner.test_posit_mailboxes_contains(&sign_id));
         assert!(spawner.test_requests_contains(&sign_id));

--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -117,7 +117,7 @@ const MAX_DEAD_IDS: usize = 4096;
 /// task incarnation and read by the deadline watcher; `round` carries the
 /// posit round across respawns.
 struct SignEntry {
-    request: IndexedSignRequest,
+    request: Arc<IndexedSignRequest>,
     is_proposer: Arc<AtomicBool>,
     round: Arc<AtomicUsize>,
 }
@@ -160,9 +160,10 @@ impl SignatureSpawner {
     fn add_request(
         &mut self,
         governance: &GovernanceInfo,
-        request: IndexedSignRequest,
+        request: impl Into<Arc<IndexedSignRequest>>,
         cfg: ProtocolConfig,
     ) {
+        let request: Arc<IndexedSignRequest> = request.into();
         let sign_id = request.id;
         // Ensure we don't retain the dead tag from a prior incarnation of this
         // sign ID (e.g. after regression recovery re-queues a completed request).
@@ -171,7 +172,7 @@ impl SignatureSpawner {
         self.requests.insert(
             sign_id,
             SignEntry {
-                request: request.clone(),
+                request: Arc::clone(&request),
                 is_proposer: Arc::clone(&is_proposer),
                 round: Arc::new(AtomicUsize::new(0)),
             },
@@ -217,7 +218,7 @@ impl SignatureSpawner {
     fn spawn_task(
         &mut self,
         governance: &GovernanceInfo,
-        request: IndexedSignRequest,
+        request: Arc<IndexedSignRequest>,
         cfg: ProtocolConfig,
     ) {
         let sign_id = request.id;
@@ -260,10 +261,10 @@ impl SignatureSpawner {
     /// have aborted previous incarnations. Not a retirement: mailboxes,
     /// watchers, and dedup state survive.
     fn spawn_tasks(&mut self, governance: &GovernanceInfo, cfg: &ProtocolConfig) {
-        let requests: Vec<IndexedSignRequest> = self
+        let requests: Vec<Arc<IndexedSignRequest>> = self
             .requests
             .values()
-            .map(|entry| entry.request.clone())
+            .map(|entry| Arc::clone(&entry.request))
             .collect();
         tracing::info!(
             count = requests.len(),
@@ -631,7 +632,7 @@ mod tests {
         spawner.requests.insert(
             probe_id,
             SignEntry {
-                request: probe_request,
+                request: Arc::new(probe_request),
                 is_proposer: Arc::new(AtomicBool::new(false)),
                 round: Arc::new(AtomicUsize::new(0)),
             },

--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -530,7 +530,7 @@ mod tests {
             SignKind::Sign,
         );
         let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
-        let state = SignState::new(request, mesh_rx, Arc::clone(&ctx.round));
+        let state = SignState::new(Arc::new(request), mesh_rx, Arc::clone(&ctx.round));
 
         TestSetup {
             ctx,

--- a/chain-signatures/node/src/protocol/request/state.rs
+++ b/chain-signatures/node/src/protocol/request/state.rs
@@ -5,7 +5,7 @@ use super::*;
 
 pub struct SignState {
     round: usize,
-    pub request: IndexedSignRequest,
+    pub request: Arc<IndexedSignRequest>,
     pub mesh_state: watch::Receiver<MeshState>,
     /// Budget for the current organizing+posit attempt.
     pub budget: TimeoutBudget,
@@ -31,7 +31,7 @@ pub struct SignState {
 
 impl SignState {
     pub fn new(
-        request: IndexedSignRequest,
+        request: Arc<IndexedSignRequest>,
         mesh_state: watch::Receiver<MeshState>,
         carried_round: Arc<AtomicUsize>,
     ) -> Self {
@@ -153,7 +153,7 @@ mod tests {
         let carried = Arc::new(AtomicUsize::new(0));
         let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
 
-        let mut state = SignState::new(request(), mesh_rx.clone(), Arc::clone(&carried));
+        let mut state = SignState::new(Arc::new(request()), mesh_rx.clone(), Arc::clone(&carried));
         state.reorganize("test");
         state.highest_seen_round = 9;
         state.reorganize("test");
@@ -161,7 +161,7 @@ mod tests {
 
         // The task is aborted and a new incarnation takes over.
         drop(state);
-        let respawned = SignState::new(request(), mesh_rx, carried);
+        let respawned = SignState::new(Arc::new(request()), mesh_rx, carried);
         assert_eq!(respawned.round(), 9);
     }
 }

--- a/chain-signatures/node/src/protocol/request/task.rs
+++ b/chain-signatures/node/src/protocol/request/task.rs
@@ -86,7 +86,7 @@ impl GeneratingPhase {
         let generator = match SignGenerator::new(
             &gen_ctx,
             self.proposer,
-            state.request().clone(),
+            Arc::clone(&state.request),
             presignature_pending,
             self.accepted_participants.clone(),
         )
@@ -175,7 +175,7 @@ impl SignTask {
     /// Drive the signature generation state machine to completion
     pub async fn run(
         mut self,
-        request: IndexedSignRequest,
+        request: Arc<IndexedSignRequest>,
         mesh_state: watch::Receiver<MeshState>,
         mailbox: Arc<PositMailbox>,
     ) -> Result<(), SignError> {

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -17,6 +17,7 @@ use k256::Secp256k1;
 use mpc_contract::config::ProtocolConfig;
 use mpc_crypto::derive_key;
 use mpc_primitives::IndexedSignRequest;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 
@@ -49,7 +50,7 @@ pub(crate) struct SignGenerator {
     participants: Vec<Participant>,
     /// Node that proposed this round (determines who publishes).
     proposer: Participant,
-    request: IndexedSignRequest,
+    request: Arc<IndexedSignRequest>,
     /// Start time, for the generation timeout and latency metrics.
     created: Instant,
     timeout: Duration,
@@ -66,7 +67,7 @@ impl SignGenerator {
     pub(crate) async fn new(
         ctx: &GenerateCtx,
         proposer: Participant,
-        request: IndexedSignRequest,
+        request: Arc<IndexedSignRequest>,
         presignature: PendingPresignature,
         participants: Vec<Participant>,
     ) -> Result<Self, InitializationError> {
@@ -305,7 +306,7 @@ impl SignGenerator {
                         crate::metrics::protocols::SIGNATURE_GENERATOR_MINE_SUCCESS.inc();
                         ctx.rpc.publish(
                             ctx.governance.public_key,
-                            self.request.clone(),
+                            Arc::clone(&self.request),
                             output,
                             self.participants.clone(),
                         );

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -102,11 +102,10 @@ impl RpcChannel {
     pub fn publish(
         &self,
         public_key: mpc_crypto::PublicKey,
-        request: impl Into<Arc<IndexedSignRequest>>,
+        request: Arc<IndexedSignRequest>,
         output: FullSignature<Secp256k1>,
         participants: Vec<Participant>,
     ) {
-        let request: Arc<IndexedSignRequest> = request.into();
         let sign_id = request.id;
         let Some(action) = PublishAction::new(public_key, request, output, participants) else {
             tracing::error!(
@@ -126,11 +125,10 @@ impl RpcChannel {
     pub fn publish_signature(
         &self,
         public_key: mpc_crypto::PublicKey,
-        request: impl Into<Arc<IndexedSignRequest>>,
+        request: Arc<IndexedSignRequest>,
         signature: Signature,
         participants: Vec<Participant>,
     ) {
-        let request: Arc<IndexedSignRequest> = request.into();
         let rpc = self.clone();
         tokio::spawn(async move {
             if let Err(err) = rpc

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -102,10 +102,11 @@ impl RpcChannel {
     pub fn publish(
         &self,
         public_key: mpc_crypto::PublicKey,
-        request: IndexedSignRequest,
+        request: impl Into<Arc<IndexedSignRequest>>,
         output: FullSignature<Secp256k1>,
         participants: Vec<Participant>,
     ) {
+        let request: Arc<IndexedSignRequest> = request.into();
         let sign_id = request.id;
         let Some(action) = PublishAction::new(public_key, request, output, participants) else {
             tracing::error!(
@@ -125,10 +126,11 @@ impl RpcChannel {
     pub fn publish_signature(
         &self,
         public_key: mpc_crypto::PublicKey,
-        request: IndexedSignRequest,
+        request: impl Into<Arc<IndexedSignRequest>>,
         signature: Signature,
         participants: Vec<Participant>,
     ) {
+        let request: Arc<IndexedSignRequest> = request.into();
         let rpc = self.clone();
         tokio::spawn(async move {
             if let Err(err) = rpc

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::Context;
 
 use crate::respond_bidirectional::CompletedTx;
@@ -33,8 +35,13 @@ pub(crate) async fn process_sign_request(
         }
     }
 
+    let sign_request = Arc::new(sign_request);
     // `Backlog::insert` returns `None` if the request is new, or `Some(_)` if it was already present.
-    let is_new = ctx.backlog.insert(sign_request.clone()).await.is_none();
+    let is_new = ctx
+        .backlog
+        .insert(Arc::clone(&sign_request))
+        .await
+        .is_none();
 
     ctx.try_enqueue(SignCommand::Request(sign_request)).await?;
 
@@ -296,8 +303,8 @@ pub async fn process_execution_confirmed(
         .backlog
         .get(pending_tx.source_chain, &unwatched_sign_id)
         .await
-        .and_then(|entry| match entry.request.kind {
-            SignKind::SignBidirectional(event) => event.chain_ctx,
+        .and_then(|entry| match &entry.request.kind {
+            SignKind::SignBidirectional(event) => event.chain_ctx.clone(),
             _ => None,
         });
 
@@ -313,12 +320,13 @@ pub async fn process_execution_confirmed(
         }
     };
 
+    let sign_request = Arc::new(sign_request);
     let updated_tx = ctx
         .backlog
         .transition_to_bidirectional_response(
             pending_tx.source_chain,
             &unwatched_sign_id,
-            sign_request.clone(),
+            Arc::clone(&sign_request),
         )
         .await
         .with_context(|| {

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -14,7 +14,7 @@ use mpc_primitives::{
 };
 
 pub(crate) async fn process_sign_request(
-    sign_request: IndexedSignRequest,
+    sign_request: Arc<IndexedSignRequest>,
     ctx: &StreamContext,
 ) -> anyhow::Result<bool> {
     if matches!(sign_request.kind, SignKind::RespondBidirectional(_)) {
@@ -35,7 +35,6 @@ pub(crate) async fn process_sign_request(
         }
     }
 
-    let sign_request = Arc::new(sign_request);
     // `Backlog::insert` returns `None` if the request is new, or `Some(_)` if it was already present.
     let is_new = ctx
         .backlog

--- a/chain-signatures/node/src/stream/ops_tests.rs
+++ b/chain-signatures/node/src/stream/ops_tests.rs
@@ -183,7 +183,7 @@ async fn process_execution_confirmed_success_creates_respond_request() {
         .unwrap();
     match msg {
         SignCommand::Request(req) => {
-            if let mpc_primitives::SignKind::RespondBidirectional(res) = req.kind {
+            if let mpc_primitives::SignKind::RespondBidirectional(res) = &req.kind {
                 assert_eq!(res.tx_id, tx.id);
             } else {
                 panic!("Expected RespondBidirectional request");
@@ -999,7 +999,7 @@ async fn process_execution_confirmed_failed_creates_error_respond_request() {
         .unwrap();
     match msg {
         SignCommand::Request(req) => {
-            if let mpc_primitives::SignKind::RespondBidirectional(res) = req.kind {
+            if let mpc_primitives::SignKind::RespondBidirectional(res) = &req.kind {
                 assert_eq!(res.tx_id, tx.id);
                 // Expect the serialized output to begin with MAGIC_ERROR_PREFIX
                 assert!(res.output.starts_with(&[0xde, 0xad, 0xbe, 0xef]));
@@ -1156,7 +1156,7 @@ async fn process_execution_confirmed_carries_canton_chain_ctx_to_final_request()
         SignCommand::Request(req) => {
             assert_eq!(req.id, sign_id);
             assert_eq!(req.chain, tx.source_chain);
-            match req.kind {
+            match &req.kind {
                 SignKind::RespondBidirectional(res) => {
                     assert_eq!(res.tx_id, tx.id);
                     assert_eq!(res.output, vec![1]);

--- a/chain-signatures/node/src/stream/ops_tests.rs
+++ b/chain-signatures/node/src/stream/ops_tests.rs
@@ -22,6 +22,7 @@ use mpc_primitives::{
 };
 use mpc_utils::time::current_unix_timestamp;
 use near_primitives::types::AccountId;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, watch};
 use tokio::time::timeout;
@@ -442,7 +443,7 @@ async fn process_respond_event_rejects_invalid_bidirectional_target_chain() {
     let unsigned_rlp = rlp_s.out().to_vec();
 
     backlog
-        .insert(IndexedSignRequest::sign_bidirectional(
+        .insert(Arc::new(IndexedSignRequest::sign_bidirectional(
             sign_id,
             args.clone(),
             Chain::Ethereum,
@@ -462,7 +463,7 @@ async fn process_respond_event_rejects_invalid_bidirectional_target_chain() {
                 output_deserialization_schema: vec![],
                 respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
             },
-        ))
+        )))
         .await;
 
     let root_sk = k256::SecretKey::random(&mut rand::thread_rng());
@@ -557,7 +558,7 @@ async fn process_sign_request_rejects_empty_bidirectional_serialized_transaction
 
     let (sign_tx, _sign_rx) = mpsc::channel(4);
     let ctx = make_test_stream_context_with_generator_pk(backlog.clone(), sign_tx, true);
-    let err = process_sign_request(request, &ctx)
+    let err = process_sign_request((*request).clone(), &ctx)
         .await
         .expect_err("empty serialized_transaction should be rejected at ingestion");
     assert!(err.to_string().contains("empty serialized_transaction"));
@@ -585,7 +586,7 @@ async fn process_sign_request_duplicate_is_idempotent() {
     let ctx = make_test_stream_context_with_generator_pk(backlog.clone(), sign_tx, false);
 
     // First emission inserts a new entry.
-    let was_new = process_sign_request(request.clone(), &ctx)
+    let was_new = process_sign_request((*request).clone(), &ctx)
         .await
         .expect("first sign request should be accepted");
     assert!(was_new, "first insert must report a new entry");
@@ -593,7 +594,7 @@ async fn process_sign_request_duplicate_is_idempotent() {
 
     // Replay: the indexer re-emitted the same SignId
     // backlog.insert is keyed on SignId, so the replay is absorbed, not duplicated.
-    let is_new = process_sign_request(request.clone(), &ctx)
+    let is_new = process_sign_request((*request).clone(), &ctx)
         .await
         .expect("replayed sign request should be accepted");
     assert!(!is_new, "replayed insert must report an existing entry");
@@ -681,7 +682,7 @@ async fn process_respond_bidirectional_event_duplicate_is_idempotent() {
     let args = test_sign_args(13);
 
     backlog
-        .insert(IndexedSignRequest::respond_bidirectional(
+        .insert(Arc::new(IndexedSignRequest::respond_bidirectional(
             sign_id,
             args.clone(),
             Chain::Solana,
@@ -691,7 +692,7 @@ async fn process_respond_bidirectional_event_duplicate_is_idempotent() {
                 output: vec![1, 2, 3],
                 chain_ctx: None,
             },
-        ))
+        )))
         .await;
 
     let root_sk = k256::SecretKey::random(&mut rand::thread_rng());
@@ -736,7 +737,7 @@ async fn process_respond_bidirectional_event_rejects_invalid_signature() {
     let args = test_sign_args(16);
 
     backlog
-        .insert(IndexedSignRequest::respond_bidirectional(
+        .insert(Arc::new(IndexedSignRequest::respond_bidirectional(
             sign_id,
             args.clone(),
             Chain::Solana,
@@ -746,7 +747,7 @@ async fn process_respond_bidirectional_event_rejects_invalid_signature() {
                 output: vec![1, 2, 3],
                 chain_ctx: None,
             },
-        ))
+        )))
         .await;
 
     let root_sk = k256::SecretKey::random(&mut rand::thread_rng());
@@ -851,7 +852,7 @@ async fn process_respond_event_advances_bidirectional_from_pending_publish() {
     let unsigned_rlp = rlp_s.out().to_vec();
 
     backlog
-        .insert(IndexedSignRequest::sign_bidirectional(
+        .insert(Arc::new(IndexedSignRequest::sign_bidirectional(
             sign_id,
             args.clone(),
             Chain::Ethereum,
@@ -871,7 +872,7 @@ async fn process_respond_event_advances_bidirectional_from_pending_publish() {
                 output_deserialization_schema: tx.output_deserialization_schema.clone(),
                 respond_serialization_schema: tx.respond_serialization_schema.clone(),
             },
-        ))
+        )))
         .await;
 
     backlog

--- a/chain-signatures/node/src/stream/ops_tests.rs
+++ b/chain-signatures/node/src/stream/ops_tests.rs
@@ -519,7 +519,7 @@ async fn process_sign_request_rejects_respond_bidirectional_kind() {
 
     let (sign_tx, _sign_rx) = mpsc::channel(4);
     let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
-    let err = process_sign_request(request, &ctx)
+    let err = process_sign_request(Arc::new(request), &ctx)
         .await
         .expect_err("RespondBidirectional should be rejected from the sign queue path");
     assert!(err.to_string().contains("Unexpected sign request kind"));
@@ -558,7 +558,7 @@ async fn process_sign_request_rejects_empty_bidirectional_serialized_transaction
 
     let (sign_tx, _sign_rx) = mpsc::channel(4);
     let ctx = make_test_stream_context_with_generator_pk(backlog.clone(), sign_tx, true);
-    let err = process_sign_request((*request).clone(), &ctx)
+    let err = process_sign_request(request, &ctx)
         .await
         .expect_err("empty serialized_transaction should be rejected at ingestion");
     assert!(err.to_string().contains("empty serialized_transaction"));
@@ -586,7 +586,7 @@ async fn process_sign_request_duplicate_is_idempotent() {
     let ctx = make_test_stream_context_with_generator_pk(backlog.clone(), sign_tx, false);
 
     // First emission inserts a new entry.
-    let was_new = process_sign_request((*request).clone(), &ctx)
+    let was_new = process_sign_request(Arc::clone(&request), &ctx)
         .await
         .expect("first sign request should be accepted");
     assert!(was_new, "first insert must report a new entry");
@@ -594,7 +594,7 @@ async fn process_sign_request_duplicate_is_idempotent() {
 
     // Replay: the indexer re-emitted the same SignId
     // backlog.insert is keyed on SignId, so the replay is absorbed, not duplicated.
-    let is_new = process_sign_request((*request).clone(), &ctx)
+    let is_new = process_sign_request(request, &ctx)
         .await
         .expect("replayed sign request should be accepted");
     assert!(!is_new, "replayed insert must report an existing entry");

--- a/chain-signatures/node/src/stream/stream_tests.rs
+++ b/chain-signatures/node/src/stream/stream_tests.rs
@@ -401,7 +401,7 @@ async fn test_execution_confirmation_advances_to_respond_bidirectional() {
                 req.id, sign_id,
                 "follow-up request should reuse the sign id"
             );
-            match req.kind {
+            match &req.kind {
                 SignKind::RespondBidirectional(rb) => {
                     assert_eq!(rb.tx_id, tx_id, "tx_id should match the watched tx");
                     assert_eq!(

--- a/chain-signatures/node/src/stream/stream_tests.rs
+++ b/chain-signatures/node/src/stream/stream_tests.rs
@@ -17,6 +17,7 @@ use mpc_primitives::{
 };
 use mpc_utils::time::current_unix_timestamp;
 use near_primitives::types::AccountId;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, watch};
 use tokio::time::timeout;
@@ -148,10 +149,10 @@ async fn test_stream_handles_sign_and_respond() {
 }
 
 /// Build a `SignKind::SignBidirectional` request from Solana to Ethereum.
-/// Returns `(IndexedSignRequest, SignArgs, SecretKey)`
+/// Returns `(Arc<IndexedSignRequest>, SignArgs, SecretKey)`
 fn build_solana_to_ethereum_bidirectional_request(
     seed: u8,
-) -> (IndexedSignRequest, SignArgs, k256::SecretKey) {
+) -> (Arc<IndexedSignRequest>, SignArgs, k256::SecretKey) {
     use mpc_primitives::SignBidirectionalEvent as SBE;
 
     let sign_id = SignId::new([seed; 32]);
@@ -195,7 +196,7 @@ fn build_solana_to_ethereum_bidirectional_request(
     );
 
     let root_sk = k256::SecretKey::random(&mut rand::thread_rng());
-    (request, args, root_sk)
+    (Arc::new(request), args, root_sk)
 }
 
 /// Receiving a `ChainEvent::SignRequest` with a bidirectional event should
@@ -209,7 +210,7 @@ async fn test_bidirectional_sign_request_enqueues_command() {
     let indexer = SolanaTestIndexer::new(vec![
         Some(ChainEvent::CatchupCompleted),
         Some(ChainEvent::SignRequest {
-            request: request.clone(),
+            request: (*request).clone(),
             block_timestamp: None,
         }),
         None,
@@ -433,12 +434,12 @@ async fn test_stream_suppresses_pre_catchup_ethereum_completion() {
     let args = test_sign_args(9);
 
     seeded_backlog
-        .insert(IndexedSignRequest::sign(
+        .insert(Arc::new(IndexedSignRequest::sign(
             sign_id,
             args.clone(),
             Chain::Ethereum,
             current_unix_timestamp(),
-        ))
+        )))
         .await;
     seeded_backlog
         .set_processed_block(Chain::Ethereum, 100)
@@ -479,12 +480,12 @@ async fn test_stream_requeues_replaced_ethereum_recovery_entry_after_catchup() {
     let replayed_timestamp = recovered_timestamp.saturating_add(1);
 
     seeded_backlog
-        .insert(IndexedSignRequest::sign(
+        .insert(Arc::new(IndexedSignRequest::sign(
             sign_id,
             args.clone(),
             Chain::Ethereum,
             recovered_timestamp,
-        ))
+        )))
         .await;
     seeded_backlog
         .set_processed_block(Chain::Ethereum, 100)
@@ -541,12 +542,12 @@ async fn test_stream_resumes_pending_publish_after_catchup() {
     let signature = Signature::new(AffinePoint::GENERATOR, Scalar::ONE, 0);
 
     backlog
-        .insert(IndexedSignRequest::sign(
+        .insert(Arc::new(IndexedSignRequest::sign(
             sign_id,
             test_sign_args(9),
             Chain::Solana,
             current_unix_timestamp(),
-        ))
+        )))
         .await;
     backlog
         .set_status(
@@ -627,12 +628,12 @@ async fn test_stream_does_not_resume_non_proposer_pending_publish_after_catchup(
     let signature = Signature::new(AffinePoint::GENERATOR, Scalar::ONE, 0);
 
     backlog
-        .insert(IndexedSignRequest::sign(
+        .insert(Arc::new(IndexedSignRequest::sign(
             sign_id,
             test_sign_args(10),
             Chain::Solana,
             current_unix_timestamp(),
-        ))
+        )))
         .await;
     backlog
         .set_status(

--- a/chain-signatures/node/src/stream/stream_tests.rs
+++ b/chain-signatures/node/src/stream/stream_tests.rs
@@ -92,7 +92,7 @@ async fn test_stream_handles_sign_and_respond() {
     let indexer = SolanaTestIndexer::new(vec![
         Some(ChainEvent::CatchupCompleted),
         Some(ChainEvent::SignRequest {
-            request: request.clone(),
+            request: Arc::new(request),
             block_timestamp: None,
         }),
         Some(ChainEvent::Respond(sig_responded)),
@@ -210,7 +210,7 @@ async fn test_bidirectional_sign_request_enqueues_command() {
     let indexer = SolanaTestIndexer::new(vec![
         Some(ChainEvent::CatchupCompleted),
         Some(ChainEvent::SignRequest {
-            request: (*request).clone(),
+            request: Arc::clone(&request),
             block_timestamp: None,
         }),
         None,
@@ -496,7 +496,7 @@ async fn test_stream_requeues_replaced_ethereum_recovery_entry_after_catchup() {
         IndexedSignRequest::sign(sign_id, args.clone(), Chain::Ethereum, replayed_timestamp);
     let indexer = EthereumTestIndexer::new(vec![
         Some(ChainEvent::SignRequest {
-            request: replacement,
+            request: Arc::new(replacement),
             block_timestamp: None,
         }),
         Some(ChainEvent::CatchupCompleted),

--- a/chain-signatures/node/src/stream/test_utils.rs
+++ b/chain-signatures/node/src/stream/test_utils.rs
@@ -19,6 +19,7 @@ use mpc_primitives::{
 };
 use mpc_utils::time::current_unix_timestamp;
 use near_primitives::types::AccountId;
+use std::sync::Arc;
 use tokio::sync::{mpsc, watch};
 
 pub fn test_indexed_request(
@@ -27,8 +28,14 @@ pub fn test_indexed_request(
     args: SignArgs,
     unix_timestamp_indexed: u64,
     kind: SignKind,
-) -> IndexedSignRequest {
-    IndexedSignRequest::new(sign_id, args, chain, unix_timestamp_indexed, kind)
+) -> Arc<IndexedSignRequest> {
+    Arc::new(IndexedSignRequest::new(
+        sign_id,
+        args,
+        chain,
+        unix_timestamp_indexed,
+        kind,
+    ))
 }
 
 pub fn test_bidirectional_tx(id: u8, source_chain: Chain, target_chain: Chain) -> BidirectionalTx {
@@ -67,13 +74,13 @@ pub fn test_sign_args(id: u8) -> SignArgs {
 pub fn test_canton_sign_bidirectional_request(
     sign_id: SignId,
     sign_event_contract_id: &str,
-) -> IndexedSignRequest {
+) -> Arc<IndexedSignRequest> {
     let ctx = CantonChainCtx {
         sign_event_contract_id: sign_event_contract_id.to_string(),
     };
     let chain_ctx =
         Some(borsh::to_vec(&ctx).expect("CantonChainCtx Borsh serialization is infallible"));
-    IndexedSignRequest::sign_bidirectional(
+    Arc::new(IndexedSignRequest::sign_bidirectional(
         sign_id,
         test_sign_args(sign_id.request_id[0]),
         Chain::Canton,
@@ -93,7 +100,7 @@ pub fn test_canton_sign_bidirectional_request(
             chain: Chain::Canton,
             chain_ctx,
         },
-    )
+    ))
 }
 
 pub fn respond_event(sign_id: SignId, signature: Signature) -> RespondBidirectionalEvent {

--- a/chain-signatures/primitives/src/events.rs
+++ b/chain-signatures/primitives/src/events.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     bidirectional::RespondBidirectionalEvent, BidirectionalTxId, Chain, IndexedSignRequest, SignId,
     Signature,
@@ -9,7 +11,7 @@ use crate::{
 pub enum ChainEvent {
     SignRequest {
         /// The sign request that was observed on the chain.
-        request: IndexedSignRequest,
+        request: Arc<IndexedSignRequest>,
         /// Optional block timestamp of the request, if available. This is used for metrics reporting.
         block_timestamp: Option<u64>,
     },

--- a/chain-signatures/primitives/src/requests.rs
+++ b/chain-signatures/primitives/src/requests.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{Chain, RespondBidirectionalTx, SignArgs, SignBidirectionalEvent, SignId};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -12,7 +14,7 @@ pub enum SignKind {
 #[derive(Debug, Clone, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum SignCommand {
-    Request(IndexedSignRequest),
+    Request(Arc<IndexedSignRequest>),
     Completion(SignId),
     AbortChain(Chain),
 }

--- a/integration-tests/src/mpc_fixture/mock_chain.rs
+++ b/integration-tests/src/mpc_fixture/mock_chain.rs
@@ -45,7 +45,7 @@ impl MockChain {
         let events: Vec<ChainEvent> = requests
             .iter()
             .map(|r| ChainEvent::SignRequest {
-                request: r.clone(),
+                request: Arc::new(r.clone()),
                 block_timestamp: None,
             })
             .collect();

--- a/integration-tests/src/mpc_fixture/mock_stream.rs
+++ b/integration-tests/src/mpc_fixture/mock_stream.rs
@@ -138,7 +138,7 @@ impl InnerMockStream {
             }
 
             block.push(ChainEvent::SignRequest {
-                request: request.clone(),
+                request: Arc::new(request.clone()),
                 block_timestamp: None,
             });
         }

--- a/integration-tests/tests/cases/canton_stream.rs
+++ b/integration-tests/tests/cases/canton_stream.rs
@@ -38,7 +38,7 @@ async fn run_canton_indexer(
 async fn wait_for_sign_request(
     indexer: &mut ChainIndexerStream,
     timeout_secs: u64,
-) -> Result<IndexedSignRequest> {
+) -> Result<Arc<IndexedSignRequest>> {
     timeout(Duration::from_secs(timeout_secs), async {
         loop {
             match indexer.next_event().await {
@@ -253,7 +253,7 @@ async fn test_canton_stream_checkpoint_persistence() -> Result<()> {
             match event {
                 ChainEvent::SignRequest { request, .. } => {
                     saw_sign_request = true;
-                    backlog.insert(Arc::new(request)).await;
+                    backlog.insert(request).await;
                 }
                 ChainEvent::Block(height) => {
                     if let Some(persisted_checkpoint) = backlog
@@ -306,7 +306,7 @@ async fn test_canton_stream_checkpoint_persistence() -> Result<()> {
         match timeout(Duration::from_secs(5), indexer2.next_event()).await {
             Ok(Some(ChainEvent::SignRequest { request, .. })) => {
                 sign_request_ids.push(request.id.request_id);
-                backlog.insert(Arc::new(request)).await;
+                backlog.insert(request).await;
                 if saw_new_checkpoint {
                     break;
                 }

--- a/integration-tests/tests/cases/canton_stream.rs
+++ b/integration-tests/tests/cases/canton_stream.rs
@@ -16,6 +16,7 @@ use mpc_primitives::{ChainEvent, ScalarExt, SignKind, Signature, LATEST_MPC_KEY_
 use serde_json::json;
 use serial_test::serial;
 use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::Duration;
 use test_log::test;
 use tokio::time::timeout;
@@ -252,7 +253,7 @@ async fn test_canton_stream_checkpoint_persistence() -> Result<()> {
             match event {
                 ChainEvent::SignRequest { request, .. } => {
                     saw_sign_request = true;
-                    backlog.insert(request).await;
+                    backlog.insert(Arc::new(request)).await;
                 }
                 ChainEvent::Block(height) => {
                     if let Some(persisted_checkpoint) = backlog
@@ -305,7 +306,7 @@ async fn test_canton_stream_checkpoint_persistence() -> Result<()> {
         match timeout(Duration::from_secs(5), indexer2.next_event()).await {
             Ok(Some(ChainEvent::SignRequest { request, .. })) => {
                 sign_request_ids.push(request.id.request_id);
-                backlog.insert(request).await;
+                backlog.insert(Arc::new(request)).await;
                 if saw_new_checkpoint {
                     break;
                 }

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -983,7 +983,7 @@ async fn test_ethereum_stream_checkpointing() -> Result<()> {
                     if matches!(request.kind, SignKind::RespondBidirectional(_)) {
                         continue;
                     }
-                    backlog.insert(Arc::new(request.clone())).await;
+                    backlog.insert(request).await;
                 }
                 ChainEvent::Block(height) => {
                     tracing::info!(height, "observed block event");
@@ -1028,7 +1028,7 @@ async fn test_ethereum_stream_checkpointing() -> Result<()> {
                 if matches!(request.kind, SignKind::RespondBidirectional(_)) {
                     continue;
                 }
-                backlog.insert(Arc::new(request.clone())).await;
+                backlog.insert(request).await;
 
                 if saw_new_checkpoint {
                     break;

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -31,6 +31,7 @@ use mpc_primitives::{
 };
 use mpc_utils::time::current_unix_timestamp;
 use near_primitives::types::AccountId;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, watch};
 use tokio::time::timeout;
@@ -475,20 +476,20 @@ async fn test_ethereum_stream_linear_catchup_from_checkpoint() -> Result<()> {
     let resolved_sign_id = SignId::new([0x11; 32]);
     let requeued_sign_id = SignId::new([0x22; 32]);
     seeded_backlog
-        .insert(mpc_node::protocol::IndexedSignRequest::sign(
+        .insert(Arc::new(mpc_node::protocol::IndexedSignRequest::sign(
             resolved_sign_id,
             test_sign_args(0x11),
             Chain::Ethereum,
             current_unix_timestamp(),
-        ))
+        )))
         .await;
     seeded_backlog
-        .insert(mpc_node::protocol::IndexedSignRequest::sign(
+        .insert(Arc::new(mpc_node::protocol::IndexedSignRequest::sign(
             requeued_sign_id,
             test_sign_args(0x22),
             Chain::Ethereum,
             current_unix_timestamp(),
-        ))
+        )))
         .await;
     seeded_backlog
         .set_processed_block(Chain::Ethereum, checkpoint_height)
@@ -502,12 +503,14 @@ async fn test_ethereum_stream_linear_catchup_from_checkpoint() -> Result<()> {
 
     let execution_sign_id = SignId::new([0x33; 32]);
     backlog
-        .insert(mpc_node::protocol::IndexedSignRequest::sign_bidirectional(
-            execution_sign_id,
-            test_sign_args(0x33),
-            Chain::Solana,
-            current_unix_timestamp(),
-            test_bidirectional_event(),
+        .insert(Arc::new(
+            mpc_node::protocol::IndexedSignRequest::sign_bidirectional(
+                execution_sign_id,
+                test_sign_args(0x33),
+                Chain::Solana,
+                current_unix_timestamp(),
+                test_bidirectional_event(),
+            ),
         ))
         .await;
 
@@ -759,12 +762,12 @@ async fn test_ethereum_stream_backfills_late_execution_watcher_after_catchup() -
 
     let dummy_sign_id = SignId::new([0x66; 32]);
     backlog
-        .insert(IndexedSignRequest::sign(
+        .insert(Arc::new(IndexedSignRequest::sign(
             dummy_sign_id,
             test_sign_args(0x66),
             Chain::Ethereum,
             current_unix_timestamp(),
-        ))
+        )))
         .await;
 
     let indexer =
@@ -855,13 +858,13 @@ async fn test_ethereum_stream_backfills_late_execution_watcher_after_catchup() -
         nonce: 0,
     };
     backlog
-        .insert(IndexedSignRequest::sign_bidirectional(
+        .insert(Arc::new(IndexedSignRequest::sign_bidirectional(
             sign_id,
             test_sign_args(0x88),
             Chain::Solana,
             current_unix_timestamp(),
             test_bidirectional_event(),
-        ))
+        )))
         .await;
     backlog
         .set_status(
@@ -980,7 +983,7 @@ async fn test_ethereum_stream_checkpointing() -> Result<()> {
                     if matches!(request.kind, SignKind::RespondBidirectional(_)) {
                         continue;
                     }
-                    backlog.insert(request.clone()).await;
+                    backlog.insert(Arc::new(request.clone())).await;
                 }
                 ChainEvent::Block(height) => {
                     tracing::info!(height, "observed block event");
@@ -1025,7 +1028,7 @@ async fn test_ethereum_stream_checkpointing() -> Result<()> {
                 if matches!(request.kind, SignKind::RespondBidirectional(_)) {
                     continue;
                 }
-                backlog.insert(request.clone()).await;
+                backlog.insert(Arc::new(request.clone())).await;
 
                 if saw_new_checkpoint {
                     break;

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -890,7 +890,7 @@ async fn test_ethereum_stream_backfills_late_execution_watcher_after_catchup() -
         SignCommand::Request(req) => {
             assert_eq!(req.id, sign_id);
             assert_eq!(req.chain, Chain::Solana);
-            match req.kind {
+            match &req.kind {
                 SignKind::RespondBidirectional(res) => {
                     assert_eq!(res.tx_id, tx_id);
                     assert!(

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -287,12 +287,12 @@ async fn test_sign_request_during_resharing() {
 }
 
 fn sign_request(seed: u8) -> SignCommand {
-    SignCommand::Request(IndexedSignRequest::sign(
+    SignCommand::Request(Arc::new(IndexedSignRequest::sign(
         SignId::new([seed; 32]),
         super::helpers::test_sign_arg(seed),
         Chain::NEAR,
         0,
-    ))
+    )))
 }
 
 /// Drive the network through a threshold-change resharing via the real

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -22,6 +22,7 @@ use mpc_primitives::{
 };
 use near_primitives::types::AccountId;
 use solana_sdk::signer::Signer;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
 use tokio::time::timeout;
@@ -409,7 +410,7 @@ async fn test_solana_stream_republishes_pending_publish_after_checkpoint_recover
     let checkpoint_slot = solana.rpc_client.get_slot().await?;
 
     seeded_backlog
-        .insert(IndexedSignRequest::sign(
+        .insert(Arc::new(IndexedSignRequest::sign(
             sign_id,
             SignArgs {
                 entropy: [9u8; 32],
@@ -420,7 +421,7 @@ async fn test_solana_stream_republishes_pending_publish_after_checkpoint_recover
             },
             Chain::Solana,
             0,
-        ))
+        )))
         .await;
     seeded_backlog
         .set_status(

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -58,7 +58,9 @@ async fn run_solana_indexer_with_backlog(
 }
 
 /// Helper to wait for a specific event type, skipping block events
-async fn wait_for_sign_request(indexer: &mut ChainIndexerStream) -> Result<IndexedSignRequest> {
+async fn wait_for_sign_request(
+    indexer: &mut ChainIndexerStream,
+) -> Result<Arc<IndexedSignRequest>> {
     loop {
         match timeout(Duration::from_secs(6), indexer.next_event()).await {
             Ok(Some(ChainEvent::SignRequest { request, .. })) => return Ok(request),


### PR DESCRIPTION
This is an easy win and first step for https://github.com/sig-net/mpc/issues/1145 but doesn't fix it completely. This just makes it so we don't clone the `IndexedSignRequest` around too much by wrapping it in an `Arc`.

---

Memory savings:

| Request Type | Previous (4–5 Owned Copies) | Current (`Arc<IndexedSignRequest>`) | **Net Memory Saved** |
| :--- | :--- | :--- | :--- |
| **100k Sign Requests** | `100,000 × 5 × 475 B` = **`~237 MB`** | `100,000 × (475 B + 4 × 8 B)` = **`~50 MB`** | **`~187 MB` (~79% reduction)** |
| **100k Bidirectional Requests** *(e.g. ~1 KB tx payload)* | `100,000 × 5 × 1.5 KB` = **`~750 MB`** | `100,000 × 1.5 KB` = **`~150 MB`** | **`~600 MB` (~80% reduction)** |