### PR TITLE
fix(integration): align test tiers, rename jobs, update `fixture` profile, etc.

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,17 +3,18 @@ cluster = { max-threads = "num-cpus" }
 fixture = { max-threads = "num-cpus" }
 
 [[profile.default.overrides]]
-filter = 'test(cases::mpc) | test(cases::state_sync) | test(cases::mpc_with_stream)'
+filter = 'test(cases::mpc) | test(cases::state_sync) | test(cases::mpc_with_stream) | test(cases::checkpoint)'
 test-group = 'fixture'
 
 [[profile.default.overrides]]
-filter = 'not (test(cases::mpc) | test(cases::state_sync) | test(cases::mpc_with_stream))'
+filter = 'not (test(cases::mpc) | test(cases::state_sync) | test(cases::mpc_with_stream) | test(cases::checkpoint))'
 test-group = 'cluster'
 
 # Usage: cargo nextest run -p integration-tests --profile fixture
 [profile.fixture]
-default-filter = 'test(cases::mpc) | test(cases::state_sync) | test(cases::mpc_with_stream)'
+default-filter = 'test(cases::mpc) | test(cases::state_sync) | test(cases::mpc_with_stream) | test(cases::checkpoint)'
+retries = 2
 
 # Usage: cargo nextest run -p integration-tests --profile cluster
 [profile.cluster]
-default-filter = 'not (test(cases::mpc) | test(cases::state_sync) | test(cases::mpc_with_stream))'
+default-filter = 'not (test(cases::mpc) | test(cases::state_sync) | test(cases::mpc_with_stream) | test(cases::checkpoint))'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,3 +18,4 @@ retries = 2
 # Usage: cargo nextest run -p integration-tests --profile cluster
 [profile.cluster]
 default-filter = 'not (test(cases::mpc) | test(cases::state_sync) | test(cases::mpc_with_stream) | test(cases::checkpoint))'
+retries = 1

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,9 +13,7 @@ test-group = 'cluster'
 # Usage: cargo nextest run -p integration-tests --profile fixture
 [profile.fixture]
 default-filter = 'test(cases::mpc) | test(cases::state_sync) | test(cases::mpc_with_stream) | test(cases::checkpoint)'
-retries = 2
 
 # Usage: cargo nextest run -p integration-tests --profile cluster
 [profile.cluster]
 default-filter = 'not (test(cases::mpc) | test(cases::state_sync) | test(cases::mpc_with_stream) | test(cases::checkpoint))'
-retries = 1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,9 +13,10 @@ on:
 env:
   RUSTFLAGS: -D warnings
 jobs:
-  # Light-weight component tests using the MPC fixture, these can run in parallel.
-  component-test:
-    name: Component Test
+  # Fixture tests: in-process MPC protocol tests, no Docker or external infra needed.
+  # Runs the `fixture` nextest profile (see .config/nextest.toml).
+  fixture-test:
+    name: Fixture Test
     runs-on: warp-ubuntu-latest-x64-4x
 
     steps:
@@ -61,7 +62,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: component-test
+          shared-key: fixture-test
           cache-targets: true
           cache-on-failure: false
           # Prevent every PR from uploading multi-GB caches
@@ -78,13 +79,11 @@ jobs:
 
       - name: Build integration test artifacts
         run: ./setup.sh
-        env:
-          MPC_ENABLE_HELIOS: 1
 
       # Build the tests before actually running them to see how long the tests take to run by itself
       # instead of including the build time in the test time report on Github.
       - name: Build Chain-Signatures Integration Tests
-        run: cargo build -p integration-tests --tests --features helios
+        run: cargo build -p integration-tests --tests
 
       - name: Test
         run: cargo nextest run -p integration-tests --profile fixture
@@ -94,7 +93,7 @@ jobs:
 
   # Integration tests that need Docker (near-sandbox, anvil, solana validator) and
   # additional Solana/Anchor setup. Runs with num-cpus threads (see .config/nextest.toml).
-  sequential-integration-test:
+  cluster-test:
     name: Integration Test
     strategy:
       matrix:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -87,13 +87,13 @@ jobs:
         run: cargo build -p integration-tests --tests --features helios
 
       - name: Test
-        run: cargo nextest run -p integration-tests --features helios --profile fixture
+        run: cargo nextest run -p integration-tests --profile fixture
         env:
           RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1
 
-  # Integration tests that share the mpc_it_network Docker network and thus must run sequentially.
-  # This also requires additional Solana/Anchor setup.
+  # Integration tests that need Docker (near-sandbox, anvil, solana validator) and
+  # additional Solana/Anchor setup. Runs with num-cpus threads (see .config/nextest.toml).
   sequential-integration-test:
     name: Integration Test
     strategy:


### PR DESCRIPTION
This PR includes few enhancements for integration tests:

- **Reclassify `cases::checkpoint` into the fixture tier**. These tests do not need any of the cluster infra. Previously were in cluster tier due to filtering (not `mpc`, `state_sync` or `mpc_with_stream`). 
- **Drop `--features helios` from fixture job.** Redundant for fixture tests
- **Rename `sequential-integration-test` to `cluster-test`.** Stale name, it's not sequential for a while
- **Rename `component-test` to `fixture-test`.** Name was misleading, aligned with `nextest` profile