### PR TITLE
refactor(solana): adopt `retry_rpc_gated` with shared `SharedBackoff`

### DIFF
--- a/chain-signatures/chain-solana/src/client.rs
+++ b/chain-signatures/chain-solana/src/client.rs
@@ -46,6 +46,7 @@ const SOL_RPC_MIN_DELAY: Duration = Duration::from_millis(500);
 const SOL_RPC_MAX_DELAY: Duration = Duration::from_secs(10);
 const SOL_RPC_MAX_RETRIES: usize = 5;
 
+/// Default retry strategy
 fn default_retry_strategy() -> RetryConfig {
     RetryConfig {
         min_delay: SOL_RPC_MIN_DELAY,

--- a/chain-signatures/chain-solana/src/client.rs
+++ b/chain-signatures/chain-solana/src/client.rs
@@ -1,7 +1,7 @@
 use futures_util::StreamExt;
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use mpc_chain_integration_core::{
-    utils::retry::{retry_rpc, RetryConfig},
+    utils::retry::{retry_rpc_gated, RetryConfig, SharedBackoff},
     ChainPublisher, PublishAction, PublisherTelemetry,
 };
 use mpc_primitives::SignKind;
@@ -46,7 +46,6 @@ const SOL_RPC_MIN_DELAY: Duration = Duration::from_millis(500);
 const SOL_RPC_MAX_DELAY: Duration = Duration::from_secs(10);
 const SOL_RPC_MAX_RETRIES: usize = 5;
 
-/// Default retry strategy
 fn default_retry_strategy() -> RetryConfig {
     RetryConfig {
         min_delay: SOL_RPC_MIN_DELAY,
@@ -94,6 +93,8 @@ pub struct SolanaClient {
     rpc_retry: RetryConfig,
     /// Retry strategy for RPC calls that are part of catchup (e.g. get_block, fetch_blocks, fetch_signatures_from_latest)
     catchup_retry: RetryConfig,
+    /// Shared 429 cooldown across all RPC call sites
+    shared_backoff: SharedBackoff,
     pub rpc_client: Arc<RpcClient>,
     pub rpc_http_url: String,
     pub rpc_ws_url: String,
@@ -122,6 +123,7 @@ impl SolanaClient {
             client: Arc::new(client),
             rpc_retry: default_retry_strategy(),
             catchup_retry: catchup_retry_strategy(),
+            shared_backoff: SharedBackoff::new(),
             rpc_client,
             rpc_http_url: sol.rpc_http_url.clone(),
             rpc_ws_url: sol.rpc_ws_url.clone(),
@@ -151,6 +153,7 @@ impl SolanaClient {
             client: Arc::new(client),
             rpc_retry: default_retry_strategy(),
             catchup_retry: catchup_retry_strategy(),
+            shared_backoff: SharedBackoff::new(),
             rpc_client,
             rpc_http_url,
             rpc_ws_url,
@@ -187,12 +190,18 @@ impl SolanaClient {
     }
 
     pub async fn get_slot(&self) -> anyhow::Result<u64> {
-        retry_rpc!(SOL_RPC_TIMEOUT, self.rpc_retry, "get_slot", {
-            self.rpc_client
-                .get_slot()
-                .await
-                .map_err(|e| anyhow::anyhow!(e))
-        })
+        retry_rpc_gated!(
+            SOL_RPC_TIMEOUT,
+            self.rpc_retry,
+            self.shared_backoff,
+            "get_slot",
+            {
+                self.rpc_client
+                    .get_slot()
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+        )
     }
 
     pub async fn get_tx(
@@ -200,9 +209,10 @@ impl SolanaClient {
         signature: &Signature,
     ) -> anyhow::Result<EncodedConfirmedTransactionWithStatusMeta> {
         let max_attempts = self.rpc_retry.max_times;
-        retry_rpc!(
+        retry_rpc_gated!(
             SOL_RPC_TIMEOUT,
             self.rpc_retry,
+            self.shared_backoff,
             |attempt, err, sleep| {
                 tracing::warn!(
                     operation = %signature,
@@ -232,9 +242,10 @@ impl SolanaClient {
     // TODO: Do not retry indefinitely on deterministic block errors like SlotWasSkipped or BlockNotAvailable
     pub async fn get_block(&self, slot: u64) -> anyhow::Result<UiConfirmedBlock> {
         let max_attempts = self.catchup_retry.max_times;
-        retry_rpc!(
+        retry_rpc_gated!(
             SOL_RPC_TIMEOUT,
             self.catchup_retry,
+            self.shared_backoff,
             // Notify on retry with structured logging
             |attempt, err, delay| {
                 tracing::warn!(
@@ -262,9 +273,10 @@ impl SolanaClient {
         }
 
         let max_attempts = self.catchup_retry.max_times;
-        let res = retry_rpc!(
+        let res = retry_rpc_gated!(
             SOL_BATCH_TIMEOUT,
             self.catchup_retry,
+            self.shared_backoff,
             // Notify on retry with structured logging
             |attempt, err, delay| {
                 tracing::warn!(
@@ -331,9 +343,10 @@ impl SolanaClient {
         address: &Pubkey,
         before: Option<Signature>,
     ) -> anyhow::Result<Vec<RpcConfirmedTransactionStatusWithSignature>> {
-        retry_rpc!(
+        retry_rpc_gated!(
             SOL_RPC_TIMEOUT,
             self.catchup_retry,
+            self.shared_backoff,
             // Notify on retry with structured logging
             |attempts, err, delay| {
                 tracing::warn!(


### PR DESCRIPTION
Replace `retry_rpc` with `retry_rpc_gated` with `SharedBackoff`, so we can handle rate-limits gracefully - a prerequisite for live polling transition