### PR TITLE
feat(storage): add retry with exponential backoff for Redis connection

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,6 @@
+[profile.default]
+slow-timeout = { period = "30s", terminate-after = 4 }
+
 [test-groups]
 cluster = { max-threads = "num-cpus" }
 fixture = { max-threads = "num-cpus" }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,5 @@
 [profile.default]
-slow-timeout = { period = "30s", terminate-after = 4 }
+slow-timeout = { period = "60s", terminate-after = 4 }
 
 [test-groups]
 cluster = { max-threads = "num-cpus" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8951,6 +8951,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-extra",
+ "backon",
  "borsh 1.8.0",
  "cait-sith",
  "chrono",

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 async-trait.workspace = true
 axum = "0.7.9"
 axum-extra = "0.9.6"
+backon.workspace = true
 chrono = "0.4.24"
 dashmap = "6.1"
 google-datastore1 = "=5.0.4"

--- a/chain-signatures/node/src/storage/protocol_storage.rs
+++ b/chain-signatures/node/src/storage/protocol_storage.rs
@@ -1,14 +1,23 @@
+use backon::{ExponentialBuilder, Retryable};
 use cait_sith::protocol::Participant;
 use deadpool_redis::{Connection, Pool};
 use near_sdk::AccountId;
 use redis::{AsyncCommands, FromRedisValue, ToRedisArgs};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
-use std::{fmt, time::Instant};
+use std::{
+    fmt,
+    time::{Duration, Instant},
+};
 use tokio::sync::RwLock;
 use tracing;
 
 use super::{owner_key, STORAGE_VERSION};
+
+// Redis connection backoff configuration
+const REDIS_CONNECT_MIN_DELAY_MS: u64 = 100;
+const REDIS_CONNECT_MAX_DELAY_SECS: u64 = 2;
+const REDIS_CONNECT_MAX_TIMES: usize = 3;
 
 #[derive(Debug, thiserror::Error)]
 pub enum StorageError {
@@ -306,13 +315,23 @@ impl<A: ProtocolArtifact> ProtocolStorage<A> {
         }
     }
 
+    /// Returns a backoff builder for retrying Redis connections.
+    fn connect_backoff() -> ExponentialBuilder {
+        ExponentialBuilder::default()
+            .with_min_delay(Duration::from_millis(REDIS_CONNECT_MIN_DELAY_MS))
+            .with_max_delay(Duration::from_secs(REDIS_CONNECT_MAX_DELAY_SECS))
+            .with_max_times(REDIS_CONNECT_MAX_TIMES)
+    }
+
     async fn connect(&self) -> Option<Connection> {
-        self.redis_pool
-            .get()
-            .await
-            .inspect_err(|err| {
-                tracing::warn!(?err, "failed to connect to redis");
+        let mut attempt = 0;
+        let op = || self.redis_pool.get();
+        op.retry(&Self::connect_backoff())
+            .notify(move |err: &deadpool_redis::PoolError, sleep: Duration| {
+                attempt += 1;
+                tracing::warn!(attempt, ?err, retry_in = ?sleep, "failed to connect to redis");
             })
+            .await
             .ok()
     }
 

--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -11,6 +11,7 @@ use crate::NodeConfig;
 use anchor_client::anchor_lang::{InstructionData, ToAccountMetas};
 use anyhow::{anyhow, Context};
 use async_process::{Child, Command};
+use backon::{ExponentialBuilder, Retryable};
 use bollard::container::LogsOptions;
 use bollard::errors::Error as DockerError;
 use bollard::network::CreateNetworkOptions;
@@ -59,6 +60,11 @@ use tokio::io::AsyncWriteExt;
 use tokio::runtime::Builder;
 use tokio::time::sleep;
 use tracing;
+
+// Backoff configuration for Redis host-port readiness checks
+const REDIS_PING_MIN_DELAY_MS: u64 = 200;
+const REDIS_PING_MAX_DELAY_SECS: u64 = 2;
+const REDIS_PING_MAX_TIMES: usize = 15;
 
 pub type Container = ContainerAsync<GenericImage>;
 
@@ -463,6 +469,8 @@ impl Redis {
             .unwrap();
         let internal_address = format!("redis://127.0.0.1:{host_port}");
 
+        Self::wait_for_host_port_readiness(&internal_address).await;
+
         tracing::info!(
             external_address,
             internal_address,
@@ -473,6 +481,42 @@ impl Redis {
             container,
             internal_address,
             external_address,
+        }
+    }
+
+    /// Wait for the Redis container to be reachable via the host port.
+    async fn wait_for_host_port_readiness(internal_address: &str) {
+        let cfg = deadpool_redis::Config::from_url(
+            url::Url::parse(internal_address).expect("valid redis url"),
+        );
+        let pool = cfg
+            .create_pool(Some(deadpool_redis::Runtime::Tokio1))
+            .expect("valid redis pool config");
+
+        let ping = || async {
+            let mut conn = pool.get().await.map_err(anyhow::Error::from)?;
+            deadpool_redis::redis::cmd("PING")
+                .query_async::<()>(&mut conn)
+                .await
+                .map_err(anyhow::Error::from)
+        };
+
+        let strategy = ExponentialBuilder::default()
+            .with_min_delay(Duration::from_millis(REDIS_PING_MIN_DELAY_MS))
+            .with_max_delay(Duration::from_secs(REDIS_PING_MAX_DELAY_SECS))
+            .with_max_times(REDIS_PING_MAX_TIMES);
+        if ping
+            .retry(&strategy)
+            .notify(|err, sleep| {
+                tracing::warn!(?err, retry_in = ?sleep, "redis not reachable via host port yet");
+            })
+            .await
+            .is_err()
+        {
+            tracing::error!(
+                internal_address,
+                "redis never became reachable via host port"
+            );
         }
     }
 


### PR DESCRIPTION
Integration tests frequently fails on both CI and locally due to stale Redis connection (`connect()` is a single attempt), this PR introduces retry mechanism to mitigate this (shouldn't harm in production too).

- Add retry with backoff using `backon` for Redis connection in `protocol_storage.rs`
- Make Redis readiness check for integration tests (`containers.rs`) more reliable
- Add `slow-timeout = { period = "60s", terminate-after = 4 }` for nextest config, so stuck tests fail instead of blocking workflow