### PR TITLE
fix(tests): prevent cross-process port collisions

### DIFF
--- a/integration-tests/src/local.rs
+++ b/integration-tests/src/local.rs
@@ -200,7 +200,7 @@ impl Node {
         };
 
         let mpc_node_id = format!("multichain/{}", config.account.id());
-        let process = execute::spawn_node_with_binary(
+        let mut process = execute::spawn_node_with_binary(
             config.binary_path.clone(),
             ctx.release,
             &mpc_node_id,
@@ -208,7 +208,7 @@ impl Node {
         )?;
         let address = format!("http://127.0.0.1:{web_port}");
         tracing::info!("node is starting at {address}");
-        utils::ping_until_ok(&address, 120).await?;
+        utils::ping_until_ok(&mut process, &address, 120).await?;
         tracing::info!(node_account_id = %config.account.id(), ?address, "node started");
 
         Ok(Self {

--- a/integration-tests/src/utils.rs
+++ b/integration-tests/src/utils.rs
@@ -250,7 +250,7 @@ fn process_port_slice() -> std::ops::RangeInclusive<u16> {
         .ok()
         .and_then(|id| id.parse::<u32>().ok())
         .unwrap_or(0);
-    
+
     let unique_id = (pid ^ execution_id) % NUM_SLICES;
     let start = BASE + (unique_id as u16) * SLICE_LEN;
     start..=start + SLICE_LEN - 1

--- a/integration-tests/src/utils.rs
+++ b/integration-tests/src/utils.rs
@@ -237,8 +237,38 @@ fn reserve_port_block(start: u16, len: usize) -> bool {
     true
 }
 
-/// Request an unused port from the OS, guaranteed unique within this process.
+/// Returns the range of ports allocated to this process's slice of the port range.
+/// The slice is determined by the process ID modulo the number of slices.
+/// This ensures that each process gets a unique subset of the port range, preventing conflicts between parallel test processes.
+fn process_port_slice() -> std::ops::RangeInclusive<u16> {
+    const SLICE_LEN: u16 = 160;
+    const NUM_SLICES: u32 = 200;
+    const BASE: u16 = 30_000;
+
+    let slice = std::process::id() % NUM_SLICES;
+    let start = BASE + (slice as u16) * SLICE_LEN;
+    start..=start + SLICE_LEN - 1
+}
+
+/// Request an unused port, guaranteed unique within this process and
+/// allocated from this process's slice of the port range.
 pub async fn pick_unused_port() -> anyhow::Result<u16> {
+    let slice = process_port_slice();
+    let (lo, hi) = (*slice.start(), *slice.end());
+    let span = (hi - lo) as u32;
+    let offset = rand::thread_rng().gen_range(0..=span);
+
+    for i in 0..=span {
+        // reserve_port_block checks both the in-process dedup set and that the
+        // port is actually bindable right now.
+        let port = lo + ((offset + i) % (span + 1)) as u16;
+        if reserve_port_block(port, 1) {
+            return Ok(port);
+        }
+    }
+
+    // Slice exhausted: fall back to an OS-assigned ephemeral port with the
+    // original drop-and-dedup behavior.
     // Port 0 means the OS gives us an unused port.
     // Important to use localhost as using 0.0.0.0 leads to users getting brief firewall popups to
     // allow inbound connections on macOS.

--- a/integration-tests/src/utils.rs
+++ b/integration-tests/src/utils.rs
@@ -6,8 +6,11 @@ use near_workspaces::{
     Account, AccountId, Worker,
 };
 use rand::Rng;
-use std::collections::HashSet;
 use std::sync::{Mutex, Once};
+use std::{
+    collections::HashSet,
+    time::{Duration, Instant},
+};
 use tracing_subscriber::EnvFilter;
 
 /// Tracks ports already handed out by `pick_unused_port` within this process
@@ -332,17 +335,40 @@ pub async fn pick_preferred_or_unused_port(preferred: u16) -> u16 {
     pick_preferred_or_unused_port_block(preferred, 1).await
 }
 
-pub async fn ping_until_ok(addr: &str, timeout: u64) -> anyhow::Result<()> {
-    tokio::time::timeout(std::time::Duration::from_secs(timeout), async {
-        loop {
-            match get(addr).await {
-                Ok(status) if status == StatusCode::OK => break,
-                _ => tokio::time::sleep(std::time::Duration::from_millis(500)).await,
+/// Wait until the node's web server answers `GET /` with 200.
+pub async fn ping_until_ok(
+    process: &mut async_process::Child,
+    addr: &str,
+    timeout: u64,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(timeout);
+    loop {
+        match process.try_status() {
+            Ok(Some(status)) => {
+                anyhow::bail!(
+                    "node process exited with {status} while waiting for its web server on {addr}"
+                );
+            }
+            Ok(None) => {}
+            Err(err) => {
+                anyhow::bail!("failed to check node process status while pinging {addr}: {err}");
             }
         }
-    })
-    .await?;
-    Ok(())
+
+        if let Ok(status) = get(addr).await {
+            if status == StatusCode::OK {
+                return Ok(());
+            }
+        }
+
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "node web server on {addr} did not respond within {timeout}s \
+                 (process still running; likely failed to bind its web port)"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
 }
 
 // Account with short name for testing

--- a/integration-tests/src/utils.rs
+++ b/integration-tests/src/utils.rs
@@ -244,8 +244,8 @@ fn reserve_port_block(start: u16, len: usize) -> bool {
 /// This ensures that each process gets a unique subset of the port range, preventing conflicts between parallel test processes.
 fn process_port_slice() -> std::ops::RangeInclusive<u16> {
     const SLICE_LEN: u16 = 160;
-    const NUM_SLICES: u32 = 200;
-    const BASE: u16 = 30_000;
+    const NUM_SLICES: u32 = 100;
+    const BASE: u16 = 16_000;
 
     // Use the process ID and the NEXTEST_RUN_ID environment variable to determine a unique slice for this process.
     let pid = std::process::id() as u32;

--- a/integration-tests/src/utils.rs
+++ b/integration-tests/src/utils.rs
@@ -238,15 +238,21 @@ fn reserve_port_block(start: u16, len: usize) -> bool {
 }
 
 /// Returns the range of ports allocated to this process's slice of the port range.
-/// The slice is determined by the process ID modulo the number of slices.
 /// This ensures that each process gets a unique subset of the port range, preventing conflicts between parallel test processes.
 fn process_port_slice() -> std::ops::RangeInclusive<u16> {
     const SLICE_LEN: u16 = 160;
     const NUM_SLICES: u32 = 200;
     const BASE: u16 = 30_000;
 
-    let slice = std::process::id() % NUM_SLICES;
-    let start = BASE + (slice as u16) * SLICE_LEN;
+    // Use the process ID and the NEXTEST_RUN_ID environment variable to determine a unique slice for this process.
+    let pid = std::process::id() as u32;
+    let execution_id = std::env::var("NEXTEST_RUN_ID")
+        .ok()
+        .and_then(|id| id.parse::<u32>().ok())
+        .unwrap_or(0);
+    
+    let unique_id = (pid ^ execution_id) % NUM_SLICES;
+    let start = BASE + (unique_id as u16) * SLICE_LEN;
     start..=start + SLICE_LEN - 1
 }
 


### PR DESCRIPTION
Occasionally different integration tests hang due to port collision (`failed to bind web server … AddrInUse` in logs). This happens because nextest runs tests in parallel as separate processes and few tests can be handed the same port. This PR implements port allocation from a per-process disjoint slice of the port range, which is used in `pick_unused_port` helper. Harness only change.