### PR TITLE
feat: contract reset checkpoint now resets local checkpoint

### DIFF
--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -16,7 +16,7 @@ use mpc_crypto::{
     derive_epsilon_near, derive_key, kdf::check_ec_signature, near_public_key_to_affine_point,
     ScalarExt as _,
 };
-use mpc_primitives::ConsensusCheckpointDigest;
+use mpc_primitives::{CheckpointDirective, ConsensusCheckpointDigest};
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::env::panic_str;
 use near_sdk::json_types::U128;
@@ -85,7 +85,7 @@ pub struct MpcContract {
     pending_requests: IterableMap<SignId, PendingRequest>,
     proposed_updates: ProposedUpdates,
     config: Config,
-    latest_checkpoints: IterableMap<Chain, ConsensusCheckpointDigest>,
+    latest_checkpoints: IterableMap<Chain, CheckpointDirective>,
     checkpoint_votes: CheckpointVotes,
 }
 
@@ -131,7 +131,7 @@ impl MpcContract {
             pending_requests: IterableMap::new(StorageKey::PendingRequests),
             proposed_updates: ProposedUpdates::default(),
             config: config.unwrap_or_default(),
-            latest_checkpoints: IterableMap::new(StorageKey::LatestCheckpointDigests),
+            latest_checkpoints: IterableMap::new(StorageKey::CheckpointDirectives),
             checkpoint_votes: CheckpointVotes::new(),
         }
     }
@@ -809,10 +809,10 @@ impl VersionedMpcContract {
             return Err(InitError::ThresholdTooHigh.into());
         }
 
-        let mut latest_checkpoints = IterableMap::new(StorageKey::LatestCheckpointDigests);
+        let mut latest_checkpoints = IterableMap::new(StorageKey::CheckpointDirectives);
         if let Some(checkpoints) = checkpoints {
             for (chain, checkpoint) in checkpoints {
-                latest_checkpoints.insert(chain, checkpoint);
+                latest_checkpoints.insert(chain, CheckpointDirective::Consensus(checkpoint));
             }
         }
 
@@ -871,7 +871,7 @@ impl VersionedMpcContract {
         }
     }
 
-    pub fn latest_checkpoint(&self, chain: Chain) -> Option<&ConsensusCheckpointDigest> {
+    pub fn latest_checkpoint(&self, chain: Chain) -> Option<&CheckpointDirective> {
         self.latest_checkpoints().get(&chain)
     }
 
@@ -921,6 +921,11 @@ impl VersionedMpcContract {
     ///
     /// The submitted checkpoint is handled as follows:
     ///
+    /// - If the chain was reset (a [`CheckpointDirective::Restart`] marker is
+    ///   stored), the request is rejected with
+    ///   [`CheckpointError::CheckpointBehind`] when its height is below the
+    ///   restart height. Otherwise voting proceeds as if no checkpoint
+    ///   existed.
     /// - If the contract already has a checkpoint at a greater height, the
     ///   request is rejected with [`CheckpointError::CheckpointBehind`]. No
     ///   vote is recorded or removed.
@@ -960,16 +965,25 @@ impl VersionedMpcContract {
         };
 
         if let Some(existing) = self.latest_checkpoint(checkpoint.chain) {
-            if existing.height > checkpoint.height {
-                // checkpoint is behind, reject.
-                return Err(CheckpointError::CheckpointBehind.into());
-            }
-            if existing.height == checkpoint.height {
-                if existing.digest == checkpoint.digest {
-                    // checkpoint is already settled, no-op.
-                    return Ok(true);
+            match existing {
+                CheckpointDirective::Consensus(existing) => {
+                    if existing.height > checkpoint.height {
+                        // checkpoint is behind, reject.
+                        return Err(CheckpointError::CheckpointBehind.into());
+                    }
+                    if existing.height == checkpoint.height {
+                        if existing.digest == checkpoint.digest {
+                            // checkpoint is already settled, no-op.
+                            return Ok(true);
+                        }
+                        return Err(CheckpointError::ConflictingCheckpoint.into());
+                    }
                 }
-                return Err(CheckpointError::ConflictingCheckpoint.into());
+                CheckpointDirective::Restart(reset_height) => {
+                    if checkpoint.height < *reset_height {
+                        return Err(CheckpointError::CheckpointBehind.into());
+                    }
+                }
             }
         }
 
@@ -1230,13 +1244,13 @@ impl VersionedMpcContract {
         Ok(voter)
     }
 
-    fn latest_checkpoints(&self) -> &IterableMap<Chain, ConsensusCheckpointDigest> {
+    fn latest_checkpoints(&self) -> &IterableMap<Chain, CheckpointDirective> {
         match self {
             Self::V0(mpc_contract) => &mpc_contract.latest_checkpoints,
         }
     }
 
-    fn latest_checkpoints_mut(&mut self) -> &mut IterableMap<Chain, ConsensusCheckpointDigest> {
+    fn latest_checkpoints_mut(&mut self) -> &mut IterableMap<Chain, CheckpointDirective> {
         match self {
             Self::V0(mpc_contract) => &mut mpc_contract.latest_checkpoints,
         }
@@ -1245,7 +1259,9 @@ impl VersionedMpcContract {
     fn insert_checkpoint(&mut self, chain: Chain, checkpoint: ConsensusCheckpointDigest) {
         match self {
             Self::V0(mpc_contract) => {
-                mpc_contract.latest_checkpoints.insert(chain, checkpoint);
+                mpc_contract
+                    .latest_checkpoints
+                    .insert(chain, CheckpointDirective::Consensus(checkpoint));
             }
         }
     }
@@ -1256,11 +1272,20 @@ impl VersionedMpcContract {
         }
     }
 
+    /// Reset checkpoints for the given chains and mark each with a restart
+    /// height.
+    ///
+    /// Removes any settled checkpoint for each `(chain, height)` pair, stores
+    /// a [`CheckpointDirective::Restart`] marker so indexers restart from
+    /// `height`, and drops all recorded checkpoint votes for the chain.
+    /// Callable only by the contract account itself.
     #[private]
-    pub fn reset_checkpoint(&mut self, chains: Vec<Chain>) {
-        let chains: HashSet<Chain> = chains.into_iter().collect();
-        for chain in &chains {
-            self.latest_checkpoints_mut().remove(chain);
+    pub fn reset_checkpoints(&mut self, resets: Vec<(Chain, u64)>) {
+        let mut chains = HashSet::new();
+        for (chain, height) in resets {
+            chains.insert(chain);
+            self.latest_checkpoints_mut()
+                .insert(chain, CheckpointDirective::Restart(height));
         }
         self.checkpoint_votes_mut()
             .votes
@@ -1274,6 +1299,9 @@ mod tests {
     use near_sdk::borsh::BorshSerialize;
     use near_sdk::test_utils::VMContextBuilder;
     use near_sdk::testing_env;
+    use std::str::FromStr;
+
+    use primitives::ParticipantInfo;
 
     #[derive(BorshSerialize)]
     struct OldMpcContract {
@@ -1295,11 +1323,11 @@ mod tests {
     }
 
     // Mirrors near-sdk's `IterableMap::with_hasher` layout for the map half:
-    // `LatestCheckpointDigests` is split into a vector of iterable keys under
+    // `CheckpointDirectives` is split into a vector of iterable keys under
     // `<prefix>v` and a lookup map under `<prefix>m`.
     fn latest_checkpoints_map_prefix() -> Vec<u8> {
         let mut prefix = Vec::new();
-        StorageKey::LatestCheckpointDigests
+        StorageKey::CheckpointDirectives
             .serialize(&mut prefix)
             .unwrap();
         [prefix.as_slice(), b"m"].concat()
@@ -1318,7 +1346,7 @@ mod tests {
         let storage_key = env::sha256_array(&key_bytes);
 
         let value = IterableMapValueAndIndexForTest {
-            value: checkpoint,
+            value: CheckpointDirective::Consensus(checkpoint),
             key_index: 0,
         };
         let value_bytes = borsh::to_vec(&value).unwrap();
@@ -1397,7 +1425,7 @@ mod tests {
             pending_requests: IterableMap::new(StorageKey::PendingRequests),
             proposed_updates: ProposedUpdates::default(),
             config: Config::default(),
-            latest_checkpoints: IterableMap::new(StorageKey::LatestCheckpointDigests),
+            latest_checkpoints: IterableMap::new(StorageKey::CheckpointDirectives),
             checkpoint_votes: CheckpointVotes::new(),
         });
 
@@ -1426,12 +1454,15 @@ mod tests {
         let stored = checkpoints
             .get(&Chain::Solana)
             .expect("read(Checkpoints) should not rely on IterableMap::iter()");
+        let CheckpointDirective::Consensus(stored) = stored else {
+            panic!("expected consensus checkpoint");
+        };
         assert_eq!(stored.height, checkpoint.height);
         assert_eq!(stored.digest, checkpoint.digest);
     }
 
     #[test]
-    fn reset_checkpoint_clears_votes_for_selected_chains() {
+    fn reset_checkpoints_writes_restart_markers_and_clears_votes() {
         let mut contract = VersionedMpcContract::V0(MpcContract::init(0, BTreeMap::new(), None));
         let solana_checkpoint = ConsensusCheckpointDigest::new(Chain::Solana, 10, [1u8; 32]);
         let ethereum_checkpoint = ConsensusCheckpointDigest::new(Chain::Ethereum, 20, [2u8; 32]);
@@ -1446,10 +1477,108 @@ mod tests {
             .entry(ethereum_checkpoint)
             .insert("voter.near".parse().unwrap());
 
-        contract.reset_checkpoint(vec![Chain::Solana]);
+        contract.reset_checkpoints(vec![(Chain::Solana, 5)]);
 
-        assert_eq!(contract.latest_checkpoint(Chain::Solana), None);
+        assert_eq!(
+            contract.latest_checkpoint(Chain::Solana),
+            Some(&CheckpointDirective::Restart(5))
+        );
         assert!(contract.checkpoint_votes(Chain::Solana).is_empty());
         assert_eq!(contract.checkpoint_votes(Chain::Ethereum).len(), 1);
+    }
+
+    // Builds a Running-state contract with `alice.near` as the sole
+    // participant so that `vote_checkpoint` passes the voter check.
+    fn running_contract(threshold: usize) -> VersionedMpcContract {
+        let context = VMContextBuilder::new()
+            .current_account_id("contract.near".parse().unwrap())
+            .signer_account_id("alice.near".parse().unwrap())
+            .build();
+        testing_env!(context);
+
+        let alice: AccountId = "alice.near".parse().unwrap();
+        let mut participants = Participants::new();
+        participants.insert(
+            alice.clone(),
+            ParticipantInfo {
+                account_id: alice,
+                url: "https://alice.example".to_owned(),
+                cipher_pk: [7; 32],
+                sign_pk: PublicKey::from_str(
+                    "ed25519:J75xXmF7WUPS3xCm3hy2tgwLCKdYM1iJd4BWF8sWVnae",
+                )
+                .unwrap(),
+            },
+        );
+
+        VersionedMpcContract::V0(MpcContract {
+            protocol_state: ProtocolContractState::Running(RunningContractState {
+                epoch: 0,
+                participants,
+                threshold,
+                public_key: PublicKey::from_str(
+                    "ed25519:J75xXmF7WUPS3xCm3hy2tgwLCKdYM1iJd4BWF8sWVnae",
+                )
+                .unwrap(),
+                candidates: Candidates::new(),
+                join_votes: Votes::new(),
+                leave_votes: Votes::new(),
+                threshold_votes: ThresholdVotes::new(),
+            }),
+            pending_requests: IterableMap::new(StorageKey::PendingRequests),
+            proposed_updates: ProposedUpdates::default(),
+            config: Config::default(),
+            latest_checkpoints: IterableMap::new(StorageKey::CheckpointDirectives),
+            checkpoint_votes: CheckpointVotes::new(),
+        })
+    }
+
+    #[test]
+    fn vote_checkpoint_rejects_heights_below_restart_marker() {
+        let mut contract = running_contract(1);
+        contract.reset_checkpoints(vec![(Chain::Solana, 100)]);
+
+        let behind = ConsensusCheckpointDigest::new(Chain::Solana, 99, [1u8; 32]);
+        assert!(contract.vote_checkpoint(behind).is_err());
+        assert!(contract.checkpoint_votes(Chain::Solana).is_empty());
+
+        // At or above the restart height voting proceeds normally.
+        let at_height = ConsensusCheckpointDigest::new(Chain::Solana, 100, [2u8; 32]);
+        assert!(contract.vote_checkpoint(at_height).is_ok());
+        let above = ConsensusCheckpointDigest::new(Chain::Solana, 101, [3u8; 32]);
+        assert!(contract.vote_checkpoint(above).is_ok());
+
+        // A settled consensus checkpoint replaces the restart marker.
+        let CheckpointDirective::Consensus(settled) =
+            contract.latest_checkpoint(Chain::Solana).unwrap()
+        else {
+            panic!("expected consensus checkpoint after settling");
+        };
+        assert_eq!(settled.height, 101);
+    }
+
+    #[test]
+    fn vote_checkpoint_conflicts_at_restart_height_after_settling() {
+        let mut contract = running_contract(1);
+        contract.reset_checkpoints(vec![(Chain::Solana, 100)]);
+
+        // Two competing digests at the restart height: the first to reach the
+        // threshold settles, the second is conflicting — the marker does not
+        // weaken settled-checkpoint semantics.
+        let first = ConsensusCheckpointDigest::new(Chain::Solana, 100, [1u8; 32]);
+        assert!(matches!(contract.vote_checkpoint(first), Ok(true)));
+
+        let conflicting = ConsensusCheckpointDigest::new(Chain::Solana, 100, [2u8; 32]);
+        let conflict_err = contract.vote_checkpoint(conflicting).unwrap_err();
+        assert!(conflict_err
+            .to_string()
+            .contains(&CheckpointError::ConflictingCheckpoint.to_string()));
+
+        // And below the now-settled height is simply behind again.
+        let behind = ConsensusCheckpointDigest::new(Chain::Solana, 99, [3u8; 32]);
+        let behind_err = contract.vote_checkpoint(behind).unwrap_err();
+        assert!(behind_err
+            .to_string()
+            .contains(&CheckpointError::CheckpointBehind.to_string()));
     }
 }

--- a/chain-signatures/contract/src/migration.rs
+++ b/chain-signatures/contract/src/migration.rs
@@ -11,7 +11,7 @@ use crate::update::ProposedUpdates;
 use crate::{MpcContract, VersionedMpcContract};
 
 use borsh::BorshDeserialize;
-use mpc_primitives::{Chain, ConsensusCheckpointDigest, SignId};
+use mpc_primitives::{Chain, CheckpointDirective, ConsensusCheckpointDigest, SignId};
 use near_sdk::store::IterableMap;
 use near_sdk::{AccountId, PublicKey};
 use std::collections::BTreeMap;
@@ -85,51 +85,17 @@ fn upgrade_protocol_state(old: OldProtocolContractState) -> ProtocolContractStat
     }
 }
 
-#[derive(BorshDeserialize)]
-struct DevnetRunningContractState {
-    pub epoch: u64,
-    pub participants: Participants,
-    pub threshold: usize,
-    pub public_key: PublicKey,
-    pub candidates: LegacyCandidates,
-    pub join_votes: Votes,
-    pub leave_votes: Votes,
-    pub threshold_votes: ThresholdVotes,
-}
-
-#[derive(BorshDeserialize)]
-enum DevnetProtocolContractState {
-    NotInitialized,
-    Initializing(LegacyInitializingContractState),
-    Running(DevnetRunningContractState),
-    Resharing(ResharingContractState),
-}
-
-fn upgrade_devnet_protocol_state(old: DevnetProtocolContractState) -> ProtocolContractState {
-    match old {
-        DevnetProtocolContractState::NotInitialized => ProtocolContractState::NotInitialized,
-        DevnetProtocolContractState::Initializing(state) => {
-            ProtocolContractState::Initializing(migrate_initializing(state))
-        }
-        DevnetProtocolContractState::Running(state) => {
-            ProtocolContractState::Running(RunningContractState {
-                epoch: state.epoch,
-                participants: state.participants,
-                threshold: state.threshold,
-                public_key: state.public_key,
-                candidates: migrate_candidates(state.candidates),
-                join_votes: state.join_votes,
-                leave_votes: state.leave_votes,
-                threshold_votes: state.threshold_votes,
-            })
-        }
-        DevnetProtocolContractState::Resharing(state) => ProtocolContractState::Resharing(state),
-    }
-}
-
+/// The contract state shape currently deployed on devnet: identical to
+/// [`MpcContract`] except that `latest_checkpoints` stores bare
+/// [`ConsensusCheckpointDigest`] values.
+///
+/// Its blob layout is byte-identical to the current shape (store collections
+/// serialize only their prefixes and never their entries or value types), so
+/// it is never selected by borsh rejection — `migrate` routes to it via
+/// [`detect_checkpoint_layout`].
 #[derive(BorshDeserialize)]
 pub(crate) struct PreviousDevnet {
-    protocol_state: DevnetProtocolContractState,
+    protocol_state: ProtocolContractState,
     pending_requests: IterableMap<SignId, PendingRequest>,
     proposed_updates: ProposedUpdates,
     config: Config,
@@ -140,11 +106,11 @@ pub(crate) struct PreviousDevnet {
 impl PreviousDevnet {
     fn upgrade(self) -> MpcContract {
         MpcContract {
-            protocol_state: upgrade_devnet_protocol_state(self.protocol_state),
+            protocol_state: self.protocol_state,
             pending_requests: self.pending_requests,
             proposed_updates: self.proposed_updates,
             config: self.config,
-            latest_checkpoints: self.latest_checkpoints,
+            latest_checkpoints: wrap_digest_checkpoints(self.latest_checkpoints),
             checkpoint_votes: self.checkpoint_votes,
         }
     }
@@ -171,7 +137,7 @@ impl PreviousTestnet {
             pending_requests,
             proposed_updates,
             config,
-            latest_checkpoints: IterableMap::new(StorageKey::LatestCheckpointDigests),
+            latest_checkpoints: IterableMap::new(StorageKey::CheckpointDirectives),
             checkpoint_votes: CheckpointVotes::new(),
         }
     }
@@ -198,15 +164,104 @@ impl PreviousMainnet {
             pending_requests,
             proposed_updates,
             config,
-            latest_checkpoints: IterableMap::new(StorageKey::LatestCheckpointDigests),
+            latest_checkpoints: IterableMap::new(StorageKey::CheckpointDirectives),
             checkpoint_votes: CheckpointVotes::new(),
         }
     }
 }
 
+fn wrap_digest_checkpoints(
+    mut old: IterableMap<Chain, ConsensusCheckpointDigest>,
+) -> IterableMap<Chain, CheckpointDirective> {
+    // Snapshot the legacy entries before writing anything: `migrated` uses a
+    // different storage prefix, but reading through the old map after any
+    // new-format write would be unsafe if they shared one.
+    let mut entries = Vec::new();
+    for (chain, checkpoint) in old.iter() {
+        entries.push((*chain, *checkpoint));
+    }
+
+    let mut migrated = IterableMap::new(StorageKey::CheckpointDirectives);
+    for (chain, checkpoint) in &entries {
+        migrated.insert(*chain, CheckpointDirective::Consensus(*checkpoint));
+    }
+
+    // Reclaim the trie keys holding legacy-encoded values.
+    for (chain, _) in &entries {
+        old.remove(chain);
+    }
+    migrated
+}
+
 #[derive(BorshDeserialize)]
 enum VersionedPreviousDevnet {
     V0(PreviousDevnet),
+}
+
+/// A blob interpreted as either already-migrated current state or as
+/// pre-marker devnet state awaiting upgrade.
+enum DevnetState {
+    Current(VersionedMpcContract),
+    Legacy(VersionedPreviousDevnet),
+}
+
+impl VersionedPreviousDevnet {
+    /// The serialized tail of an empty `IterableMap`: everything after the
+    /// element count, i.e. exactly the keys-vector and lookup-map storage
+    /// prefixes. Maps with different fingerprints can never alias each
+    /// other's trie keys.
+    fn checkpoint_prefix_fingerprint<V>(prefix: StorageKey) -> Vec<u8>
+    where
+        V: borsh::BorshSerialize,
+    {
+        let empty = IterableMap::<Chain, V>::new(prefix);
+        let bytes = borsh::to_vec(&empty).expect("empty map serialization cannot fail");
+        bytes[std::mem::size_of::<u32>()..].to_vec()
+    }
+
+    /// Interprets a blob whose layout matches both this devnet shape and the
+    /// current contract shape. The two are byte-identical — store collections
+    /// serialize only their prefixes and never their entries or value types,
+    /// so borsh alone accepts either reading — but they store checkpoints
+    /// under different prefixes (`CheckpointDirectiveDigests` vs
+    /// `CheckpointDirectives`). The prefix fingerprint distinguishes them
+    /// without touching (and potentially mis-decoding) any entry.
+    ///
+    /// Returns `Ok(None)` when the bytes describe an older generation; those
+    /// fall through to their own probes in [`migrate`].
+    fn interpret(state_bytes: &[u8]) -> Result<Option<DevnetState>, Error> {
+        let Ok(current) = VersionedMpcContract::try_from_slice(state_bytes) else {
+            return Ok(None);
+        };
+
+        let actual = match &current {
+            VersionedMpcContract::V0(contract) => borsh::to_vec(&contract.latest_checkpoints)
+                .expect("map metadata serialization cannot fail")[std::mem::size_of::<u32>()..]
+                .to_vec(),
+        };
+        if actual
+            == Self::checkpoint_prefix_fingerprint::<CheckpointDirective>(
+                StorageKey::CheckpointDirectives,
+            )
+        {
+            return Ok(Some(DevnetState::Current(current)));
+        }
+        if actual
+            == Self::checkpoint_prefix_fingerprint::<ConsensusCheckpointDigest>(
+                StorageKey::CheckpointDirectiveDigests,
+            )
+        {
+            // Layout equality with the current shape was already proven
+            // above, so this parse cannot fail.
+            let legacy = Self::try_from_slice(state_bytes).map_err(|_| {
+                InvalidState::ContractStateIsMissing
+                    .message("digest-checkpoint state failed to re-parse")
+            })?;
+            return Ok(Some(DevnetState::Legacy(legacy)));
+        }
+        Err(InvalidState::ContractStateIsMissing
+            .message("unrecognized latest_checkpoints storage prefix"))
+    }
 }
 
 #[derive(BorshDeserialize)]
@@ -215,14 +270,17 @@ enum VersionedPreviousTestnet {
 }
 
 pub(crate) fn migrate(state_bytes: &[u8]) -> Result<VersionedMpcContract, Error> {
-    if let Ok(current) = VersionedMpcContract::try_from_slice(state_bytes) {
-        return Ok(current);
-    }
-
-    if let Ok(VersionedPreviousDevnet::V0(previous)) =
-        VersionedPreviousDevnet::try_from_slice(state_bytes)
-    {
-        return Ok(VersionedMpcContract::V0(previous.upgrade()));
+    // The deployed devnet shape and the current shape share one blob layout,
+    // so a single probe covers both; `interpret` decides between returning
+    // the state unchanged and running the digest-to-enum upgrade. Older
+    // generations differ in bytes and fall through to their own probes.
+    if let Some(state) = VersionedPreviousDevnet::interpret(state_bytes)? {
+        return Ok(match state {
+            DevnetState::Current(versioned) => versioned,
+            DevnetState::Legacy(VersionedPreviousDevnet::V0(previous)) => {
+                VersionedMpcContract::V0(previous.upgrade())
+            }
+        });
     }
 
     if let Ok(VersionedPreviousTestnet::V0(previous)) =
@@ -241,90 +299,86 @@ pub(crate) fn migrate(state_bytes: &[u8]) -> Result<VersionedMpcContract, Error>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use near_sdk::borsh::BorshSerialize;
     use near_sdk::test_utils::VMContextBuilder;
     use near_sdk::testing_env;
-    use std::str::FromStr;
 
-    #[test]
-    fn migrating_devnet_initializing_state_preserves_candidates_and_pk_votes() {
-        testing_env!(VMContextBuilder::new().build());
+    // Mirrors the pre-upgrade contract shape: identical to `MpcContract` but
+    // with bare digests in `latest_checkpoints`.
+    #[derive(BorshSerialize)]
+    struct DigestCheckpointsContract {
+        protocol_state: ProtocolContractState,
+        pending_requests: IterableMap<SignId, PendingRequest>,
+        proposed_updates: ProposedUpdates,
+        config: Config,
+        latest_checkpoints: IterableMap<Chain, ConsensusCheckpointDigest>,
+        checkpoint_votes: CheckpointVotes,
+    }
 
-        let candidate_id: AccountId = "candidate.near".parse().unwrap();
-        let candidate = CandidateInfo {
-            account_id: candidate_id.clone(),
-            url: "https://candidate.example".to_owned(),
-            cipher_pk: [7; 32],
-            sign_pk: PublicKey::from_str("ed25519:J75xXmF7WUPS3xCm3hy2tgwLCKdYM1iJd4BWF8sWVnae")
-                .unwrap(),
-        };
-        let mut pk_votes = PkVotes::new();
-        pk_votes
-            .entry(candidate.sign_pk.clone())
-            .insert(candidate_id.clone());
-
-        let migrated = upgrade_devnet_protocol_state(DevnetProtocolContractState::Initializing(
-            LegacyInitializingContractState {
-                candidates: LegacyCandidates {
-                    candidates: [(candidate_id.clone(), candidate.clone())].into(),
-                },
-                threshold: 2,
-                pk_votes,
-            },
-        ));
-
-        let ProtocolContractState::Initializing(initializing) = migrated else {
-            panic!("expected initializing state");
-        };
-        assert_eq!(initializing.candidates.get(&candidate_id), Some(&candidate));
-        assert!(initializing
-            .pk_votes
-            .votes
-            .get(&candidate.sign_pk)
-            .is_some_and(|votes| votes.contains(&candidate_id)));
+    #[derive(BorshSerialize)]
+    enum VersionedDigestCheckpointsContract {
+        V0(DigestCheckpointsContract),
     }
 
     #[test]
-    fn migrating_devnet_running_state_preserves_candidates_and_join_votes() {
-        testing_env!(VMContextBuilder::new().build());
+    fn migrating_digest_checkpoint_state_wraps_into_consensus() {
+        testing_env!(VMContextBuilder::new()
+            .current_account_id("contract.near".parse().unwrap())
+            .build());
 
-        let candidate_id: AccountId = "candidate.near".parse().unwrap();
-        let voter_id: AccountId = "voter.near".parse().unwrap();
-        let candidate = CandidateInfo {
-            account_id: candidate_id.clone(),
-            url: "https://candidate.example".to_owned(),
-            cipher_pk: [7; 32],
-            sign_pk: PublicKey::from_str("ed25519:J75xXmF7WUPS3xCm3hy2tgwLCKdYM1iJd4BWF8sWVnae")
-                .unwrap(),
-        };
-        let candidates = LegacyCandidates {
-            candidates: [(candidate_id.clone(), candidate.clone())].into(),
-        };
-        let mut join_votes = Votes::new();
-        join_votes
-            .entry(candidate_id.clone())
-            .insert(voter_id.clone());
+        let checkpoint = ConsensusCheckpointDigest::new(Chain::Solana, 120, [7u8; 32]);
+        let mut latest_checkpoints = IterableMap::new(StorageKey::CheckpointDirectiveDigests);
+        latest_checkpoints.insert(Chain::Solana, checkpoint);
 
-        let migrated = upgrade_devnet_protocol_state(DevnetProtocolContractState::Running(
-            DevnetRunningContractState {
-                epoch: 3,
-                participants: Participants::new(),
-                threshold: 2,
-                public_key: candidate.sign_pk.clone(),
-                candidates,
-                join_votes,
-                leave_votes: Votes::new(),
-                threshold_votes: ThresholdVotes::new(),
+        let old_bytes = borsh::to_vec(&VersionedDigestCheckpointsContract::V0(
+            DigestCheckpointsContract {
+                protocol_state: ProtocolContractState::NotInitialized,
+                pending_requests: IterableMap::new(StorageKey::PendingRequests),
+                proposed_updates: ProposedUpdates::default(),
+                config: Config::default(),
+                latest_checkpoints,
+                checkpoint_votes: CheckpointVotes::new(),
             },
-        ));
+        ))
+        .unwrap();
 
-        let ProtocolContractState::Running(running) = migrated else {
-            panic!("expected running state");
-        };
-        assert_eq!(running.candidates.get(&candidate_id), Some(&candidate));
-        assert!(running
-            .join_votes
-            .votes
-            .get(&candidate_id)
-            .is_some_and(|votes| votes.contains(&voter_id)));
+        let migrated = migrate(&old_bytes).expect("digest-checkpoint state should migrate");
+
+        let VersionedMpcContract::V0(contract) = migrated;
+        assert_eq!(
+            contract.latest_checkpoints.get(&Chain::Solana),
+            Some(&CheckpointDirective::Consensus(checkpoint))
+        );
+    }
+
+    #[test]
+    fn migrating_current_state_preserves_restart_markers() {
+        testing_env!(VMContextBuilder::new()
+            .current_account_id("contract.near".parse().unwrap())
+            .build());
+
+        // Current-shape state carrying a restart marker. Store collections
+        // serialize only prefixes into the blob, so this is byte-identical to
+        // the legacy devnet shape: only the storage-prefix fingerprint tells
+        // them apart.
+        let mut current = VersionedMpcContract::V0(MpcContract::init(0, BTreeMap::new(), None));
+        current.reset_checkpoints(vec![(Chain::Solana, 42)]);
+        let bytes = borsh::to_vec(&current).unwrap();
+
+        // Store collections buffer writes in memory until flush; dropping
+        // mirrors the on-chain flow where the previous transaction committed
+        // state to the trie before `migrate` ever runs.
+        drop(current);
+
+        // Re-running migrate on already-migrated state must be a no-op, not a
+        // wipe of the marker.
+        let migrated = migrate(&bytes).expect("current state should migrate");
+
+        let VersionedMpcContract::V0(contract) = migrated;
+        assert_eq!(
+            contract.latest_checkpoints.get(&Chain::Solana),
+            Some(&CheckpointDirective::Restart(42)),
+            "re-migration must preserve restart markers"
+        );
     }
 }

--- a/chain-signatures/contract/src/primitives.rs
+++ b/chain-signatures/contract/src/primitives.rs
@@ -1,4 +1,4 @@
-pub use mpc_primitives::ConsensusCheckpointDigest;
+pub use mpc_primitives::{CheckpointDirective, ConsensusCheckpointDigest};
 pub use signet_primitives::{Chain, SignRequest};
 
 use crate::config::Config;
@@ -20,8 +20,8 @@ pub mod hpke {
 pub enum StorageKey {
     PendingRequests,
     ProposedUpdatesEntries,
-    LatestCheckpoints,
-    LatestCheckpointDigests,
+    CheckpointDirectives,
+    CheckpointDirectiveDigests,
     Candidates,
 }
 
@@ -51,7 +51,7 @@ pub enum Read {
 pub enum View {
     State(ProtocolContractStateView),
     Config(Config),
-    Checkpoints(HashMap<Chain, ConsensusCheckpointDigest>),
+    Checkpoints(HashMap<Chain, CheckpointDirective>),
 }
 
 /// The index into calling the YieldResume feature of NEAR. This will allow to resume

--- a/chain-signatures/contract/tests/sign.rs
+++ b/chain-signatures/contract/tests/sign.rs
@@ -3,7 +3,7 @@ use common::{candidates, create_response, init, init_env, sign_and_validate};
 
 use mpc_contract::errors;
 use mpc_contract::primitives::{CandidateInfo, Read, SignRequest, View};
-use mpc_primitives::ConsensusCheckpointDigest;
+use mpc_primitives::{CheckpointDirective, ConsensusCheckpointDigest};
 use near_workspaces::types::{AccountId, NearToken};
 use signet_primitives::{Chain, Signature, LATEST_MPC_KEY_VERSION};
 
@@ -388,21 +388,24 @@ async fn test_checkpoint_voting() -> anyhow::Result<()> {
         .args_json(serde_json::json!({ "reads": [Read::Checkpoints] }))
         .await?
         .json()?;
-    let checkpoints: HashMap<Chain, ConsensusCheckpointDigest> = views
+    let checkpoints: HashMap<Chain, CheckpointDirective> = views
         .into_iter()
         .find_map(|view| match view {
             View::Checkpoints(checkpoints) => Some(checkpoints),
             _ => None,
         })
         .expect("read should return a Checkpoints view");
-    assert_eq!(checkpoints.get(&Chain::Solana), Some(&checkpoint));
+    assert_eq!(
+        checkpoints.get(&Chain::Solana),
+        Some(&CheckpointDirective::Consensus(checkpoint))
+    );
 
-    let latest: Option<ConsensusCheckpointDigest> = contract
+    let latest: Option<CheckpointDirective> = contract
         .view("latest_checkpoint")
         .args_json(serde_json::json!({ "chain": Chain::Solana }))
         .await?
         .json()?;
-    assert_eq!(latest, Some(checkpoint));
+    assert_eq!(latest, Some(CheckpointDirective::Consensus(checkpoint)));
 
     let competing_a = ConsensusCheckpointDigest::new(Chain::Solana, 240, [1u8; 32]);
     let competing_b = ConsensusCheckpointDigest::new(Chain::Solana, 240, [2u8; 32]);
@@ -465,6 +468,75 @@ async fn test_checkpoint_voting() -> anyhow::Result<()> {
         .transact()
         .await?;
     assert!(unauthorized.is_failure());
+
+    // Reset the chain's checkpoints via a call signed by the contract account
+    // itself (satisfying #[private]), then verify the restart marker governs
+    // subsequent voting.
+    let reset = contract
+        .call("reset_checkpoints")
+        .args_json(serde_json::json!({ "resets": [[Chain::Solana, 100]] }))
+        .max_gas()
+        .transact()
+        .await?;
+    assert!(reset.is_success(), "reset_checkpoints failed: {reset:#?}");
+
+    let latest: Option<CheckpointDirective> = contract
+        .view("latest_checkpoint")
+        .args_json(serde_json::json!({ "chain": Chain::Solana }))
+        .await?
+        .json()?;
+    assert_eq!(latest, Some(CheckpointDirective::Restart(100)));
+
+    let votes_after_reset = contract
+        .view("checkpoint_votes")
+        .args_json(serde_json::json!({ "chain": Chain::Solana }))
+        .await?
+        .json::<Vec<(ConsensusCheckpointDigest, usize)>>()?;
+    assert!(votes_after_reset.is_empty());
+
+    let below_restart = ConsensusCheckpointDigest::new(Chain::Solana, 99, [9u8; 32]);
+    let rejected = accounts[0]
+        .call(contract.id(), "vote_checkpoint")
+        .args_json(serde_json::json!({ "checkpoint": below_restart }))
+        .max_gas()
+        .transact()
+        .await?;
+    assert!(rejected.is_failure());
+    assert!(rejected
+        .into_result()
+        .expect_err("below-restart vote should be rejected")
+        .to_string()
+        .contains(&errors::CheckpointError::CheckpointBehind.to_string()));
+
+    let post_reset = ConsensusCheckpointDigest::new(Chain::Solana, 100, [4u8; 32]);
+    let first_post_reset_vote = accounts[0]
+        .call(contract.id(), "vote_checkpoint")
+        .args_json(serde_json::json!({ "checkpoint": post_reset }))
+        .max_gas()
+        .transact()
+        .await?;
+    assert!(first_post_reset_vote.is_success());
+    assert!(!first_post_reset_vote.json::<bool>()?);
+
+    let second_post_reset_vote = accounts[1]
+        .call(contract.id(), "vote_checkpoint")
+        .args_json(serde_json::json!({ "checkpoint": post_reset }))
+        .max_gas()
+        .transact()
+        .await?;
+    assert!(second_post_reset_vote.is_success());
+    assert!(second_post_reset_vote.json::<bool>()?);
+
+    let latest: Option<CheckpointDirective> = contract
+        .view("latest_checkpoint")
+        .args_json(serde_json::json!({ "chain": Chain::Solana }))
+        .await?
+        .json()?;
+    assert_eq!(
+        latest,
+        Some(CheckpointDirective::Consensus(post_reset)),
+        "settled consensus checkpoint should replace the restart marker"
+    );
 
     Ok(())
 }

--- a/chain-signatures/node/src/backlog/checkpoints.rs
+++ b/chain-signatures/node/src/backlog/checkpoints.rs
@@ -307,6 +307,15 @@ impl Checkpoints {
         Ok(())
     }
 
+    /// Returns the confirmed checkpoint, ignoring any newer pending ones.
+    ///
+    /// Unlike [`Self::latest`], this only reflects what the contract itself
+    /// has settled (promoted on consensus), so it is the right signal for
+    /// deciding whether pre-reset state is still present.
+    pub(super) async fn durable_latest(&self, chain: Chain) -> Option<Checkpoint> {
+        self.storage.load_latest(chain).await.ok().flatten()
+    }
+
     /// Returns the newest pending checkpoint or the latest confirmed checkpoint.
     pub(super) async fn latest(&self, chain: Chain) -> Option<Checkpoint> {
         if let Some(checkpoint) = self

--- a/chain-signatures/node/src/backlog/checkpoints.rs
+++ b/chain-signatures/node/src/backlog/checkpoints.rs
@@ -295,6 +295,18 @@ impl Checkpoints {
         Ok(())
     }
 
+    /// Removes all local checkpoint state for `chain` (durable latest, durable
+    /// pending, and the in-memory pending mirror).
+    ///
+    /// Used when the contract's checkpoints are reset; indexers re-anchor at
+    /// the reset height afterwards.
+    pub(super) async fn clear(&self, chain: Chain) -> anyhow::Result<()> {
+        self.storage.clear(chain).await?;
+        self.pending(chain).write().await.clear();
+        self.observe(chain, 0);
+        Ok(())
+    }
+
     /// Returns the newest pending checkpoint or the latest confirmed checkpoint.
     pub(super) async fn latest(&self, chain: Chain) -> Option<Checkpoint> {
         if let Some(checkpoint) = self
@@ -583,6 +595,22 @@ mod tests {
                 .unwrap(),
             Some(consensus)
         );
+    }
+
+    #[tokio::test]
+    async fn clear_wipes_local_and_durable_checkpoint_state() {
+        let storage = CheckpointStorage::in_memory();
+        let confirmed = checkpoint(1);
+        let pending = checkpoint(2);
+        let checkpoints = Checkpoints::new(storage.clone());
+        storage.persist(&confirmed).await.unwrap();
+        checkpoints.persist_pending(&pending).await.unwrap();
+
+        checkpoints.clear(confirmed.chain).await.unwrap();
+
+        assert_eq!(checkpoints.count(confirmed.chain).await, 0);
+        assert_eq!(checkpoints.latest(confirmed.chain).await, None);
+        assert_eq!(storage.load_latest(confirmed.chain).await.unwrap(), None);
     }
 
     #[tokio::test]

--- a/chain-signatures/node/src/backlog/checkpoints.rs
+++ b/chain-signatures/node/src/backlog/checkpoints.rs
@@ -312,7 +312,7 @@ impl Checkpoints {
     /// Unlike [`Self::latest`], this only reflects what the contract itself
     /// has settled (promoted on consensus), so it is the right signal for
     /// deciding whether pre-reset state is still present.
-    pub(super) async fn durable_latest(&self, chain: Chain) -> Option<Checkpoint> {
+    pub(super) async fn latest_consensus(&self, chain: Chain) -> Option<Checkpoint> {
         self.storage.load_latest(chain).await.ok().flatten()
     }
 

--- a/chain-signatures/node/src/backlog/consensus.rs
+++ b/chain-signatures/node/src/backlog/consensus.rs
@@ -2,7 +2,7 @@ use crate::backlog::Backlog;
 use crate::mesh::MeshState;
 use crate::node_client::NodeClient;
 use crate::protocol::contract::primitives::ParticipantInfo;
-use crate::types::CheckpointWatcher;
+use crate::types::{CheckpointDirective, CheckpointWatcher};
 
 use crate::backlog::Checkpoint;
 use cait_sith::protocol::Participant;
@@ -22,12 +22,27 @@ pub async fn align_backlog_with_consensus(
     node_client: &NodeClient,
     my_account_id: &AccountId,
 ) -> Option<u64> {
-    let checkpoint_digest = checkpoints_rx.borrow_and_update().as_ref()?.clone();
+    let directive = checkpoints_rx.borrow_and_update().as_ref().cloned()?;
 
-    match backlog
-        .confirm_consensus(chain, checkpoint_digest.digest)
-        .await
-    {
+    let target_digest = match directive {
+        CheckpointDirective::Consensus(digest) => digest.digest,
+        CheckpointDirective::Restart(height) => {
+            tracing::warn!(
+                ?chain,
+                height,
+                "consensus checkpoints were reset; clearing local checkpoint state"
+            );
+            return match backlog.apply_reset(chain, height).await {
+                Ok(()) => None,
+                Err(err) => {
+                    tracing::error!(?err, %chain, "failed to apply contract checkpoint reset");
+                    Some(height)
+                }
+            };
+        }
+    };
+
+    match backlog.confirm_consensus(chain, target_digest).await {
         Ok(found) => {
             if found {
                 return None;
@@ -45,14 +60,14 @@ pub async fn align_backlog_with_consensus(
 
     tracing::warn!(
         ?chain,
-        ?checkpoint_digest.digest,
+        ?target_digest,
         "Consensus checkpoint mismatch/divergence detected: triggering regression"
     );
     let fetched_checkpoint = find_consensus_checkpoint(
         mesh_state,
         node_client,
         chain,
-        checkpoint_digest.digest,
+        target_digest,
         checkpoints_rx,
         my_account_id,
     )
@@ -147,13 +162,16 @@ pub(crate) async fn find_consensus_checkpoint(
                 if changed.is_err() {
                     return None;
                 }
-                let checkpoint_digest = consensus_rx.borrow_and_update();
-                match &*checkpoint_digest {
+                match consensus_rx.borrow_and_update().as_ref() {
                     None => {
                         tracing::info!(?chain, "consensus digest is empty, aborting...");
                         return None;
                     }
-                    Some(cp) => {
+                    Some(CheckpointDirective::Restart(_)) => {
+                        tracing::info!(?chain, "consensus checkpoints were reset during wait, aborting...");
+                        return None;
+                    }
+                    Some(CheckpointDirective::Consensus(cp)) => {
                         if cp.digest != target_digest {
                             tracing::info!(?chain, "consensus digest changed during wait, aborting...");
                             return None;
@@ -200,15 +218,16 @@ mod tests {
     use crate::node_client::Options as NodeClientOptions;
 
     use crate::backlog::BacklogEntry;
-    use mpc_primitives::{CheckpointDigest, IndexedSignRequest, SignArgs, SignId};
+    use crate::types::CheckpointDirective;
+    use mpc_primitives::{ConsensusCheckpointDigest, IndexedSignRequest, SignArgs, SignId};
     use std::collections::HashMap;
     use std::sync::Arc;
 
     struct AlignFixture {
         chain: Chain,
         backlog: Backlog,
-        checkpoints_tx: watch::Sender<Option<CheckpointDigest>>,
-        checkpoints_rx: watch::Receiver<Option<CheckpointDigest>>,
+        checkpoints_tx: watch::Sender<Option<CheckpointDirective>>,
+        checkpoints_rx: watch::Receiver<Option<CheckpointDirective>>,
         mesh_tx: watch::Sender<MeshState>,
         mesh_rx: watch::Receiver<MeshState>,
         node_client: NodeClient,
@@ -216,10 +235,10 @@ mod tests {
     }
 
     impl AlignFixture {
-        fn new(digest: Option<CheckpointDigest>) -> Self {
+        fn new(directive: Option<CheckpointDirective>) -> Self {
             let chain = Chain::Ethereum;
             let backlog = Backlog::new();
-            let (checkpoints_tx, checkpoints_rx) = watch::channel(digest);
+            let (checkpoints_tx, checkpoints_rx) = watch::channel(directive);
             let (mesh_tx, mesh_rx) = watch::channel(MeshState::default());
             let node_client = NodeClient::new(&NodeClientOptions::default());
             let my_account_id: AccountId = "test.near".parse().unwrap();
@@ -453,9 +472,12 @@ mod tests {
                 remote_digest = Some(peer_digest);
             }
 
-            let msg = remote_digest.map(|digest| CheckpointDigest {
-                height: case.remote_height,
-                digest,
+            let msg = remote_digest.map(|digest| {
+                CheckpointDirective::Consensus(ConsensusCheckpointDigest::new(
+                    Chain::Ethereum,
+                    case.remote_height,
+                    digest,
+                ))
             });
 
             fixture.checkpoints_tx.send(msg).unwrap();
@@ -591,10 +613,9 @@ mod tests {
     #[tokio::test]
     async fn test_align_mismatch_abort_on_consensus_change() {
         let chain = Chain::Ethereum;
-        let fixture = AlignFixture::new(Some(CheckpointDigest {
-            height: 100,
-            digest: [0xabu8; 32],
-        }));
+        let fixture = AlignFixture::new(Some(CheckpointDirective::Consensus(
+            ConsensusCheckpointDigest::new(Chain::Ethereum, 100, [0xabu8; 32]),
+        )));
 
         // Create a local checkpoint at 100
         fixture
@@ -628,5 +649,58 @@ mod tests {
 
         let result = handle.await.unwrap();
         assert!(result.is_none(), "aborted align should return None");
+    }
+
+    #[tokio::test]
+    async fn test_align_applies_contract_reset() {
+        let chain = Chain::Ethereum;
+        // Local state has a pre-reset checkpoint at height 100.
+        let mut fixture = AlignFixture::new(None);
+        fixture
+            .backlog
+            .set_processed_block(chain, 100)
+            .await
+            .unwrap();
+        let stale = fixture.backlog.checkpoint(chain).await.unwrap();
+        assert!(
+            fixture
+                .backlog
+                .confirm_consensus(chain, stale.digest())
+                .await
+                .unwrap(),
+            "local checkpoint should confirm"
+        );
+
+        // The contract was reset: indexers must restart from height 42.
+        fixture
+            .checkpoints_tx
+            .send(Some(CheckpointDirective::Restart(42)))
+            .unwrap();
+
+        let result = fixture.run().await;
+
+        assert_eq!(result, None, "applied reset is aligned, not a regression");
+        assert_eq!(
+            fixture
+                .backlog
+                .checkpoint_storage()
+                .load_latest(chain)
+                .await
+                .unwrap(),
+            None,
+            "durable latest checkpoint should be cleared"
+        );
+        assert_eq!(
+            fixture.backlog.latest_checkpoint(chain).await,
+            None,
+            "local checkpoint should be cleared"
+        );
+
+        use mpc_chain_integration_core::StateManager as _;
+        assert_eq!(
+            fixture.backlog.get_processed_block(chain).await,
+            Some(42),
+            "processed block should be re-anchored at the restart height"
+        );
     }
 }

--- a/chain-signatures/node/src/backlog/consensus.rs
+++ b/chain-signatures/node/src/backlog/consensus.rs
@@ -13,7 +13,25 @@ use rand::thread_rng;
 use std::time::Duration;
 use tokio::sync::watch;
 
-/// Returns None if we are aligned, Some(<new_height>) if we have regressed.
+/// Outcome of aligning the backlog with the contract's checkpoint directive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Alignment {
+    /// Local state already matches the directive (or nothing could be done
+    /// this pass; the next directive change or restart retries).
+    Aligned,
+    /// Local state diverged from the settled consensus digest and was
+    /// regressed to the checkpoint fetched from peers at the given height.
+    Regressed(u64),
+    /// The contract reset its checkpoints; local state was wiped and the
+    /// processed-block cursor parked below the given inclusive restart
+    /// height.
+    ResetApplied(u64),
+    /// The contract reset its checkpoints but wiping local state failed; the
+    /// caller should retry via another recovery pass.
+    ResetFailed(u64),
+}
+
+/// Aligns the local backlog with the contract's checkpoint directive.
 pub async fn align_backlog_with_consensus(
     chain: Chain,
     backlog: &Backlog,
@@ -21,8 +39,10 @@ pub async fn align_backlog_with_consensus(
     mesh_state: &mut watch::Receiver<MeshState>,
     node_client: &NodeClient,
     my_account_id: &AccountId,
-) -> Option<u64> {
-    let directive = checkpoints_rx.borrow_and_update().as_ref().cloned()?;
+) -> Alignment {
+    let Some(directive) = checkpoints_rx.borrow_and_update().as_ref().cloned() else {
+        return Alignment::Aligned;
+    };
 
     let target_digest = match directive {
         CheckpointDirective::Consensus(digest) => digest.digest,
@@ -33,10 +53,10 @@ pub async fn align_backlog_with_consensus(
                 "consensus checkpoints were reset; clearing local checkpoint state"
             );
             return match backlog.apply_reset(chain, height).await {
-                Ok(()) => None,
+                Ok(()) => Alignment::ResetApplied(height),
                 Err(err) => {
                     tracing::error!(?err, %chain, "failed to apply contract checkpoint reset");
-                    Some(height)
+                    Alignment::ResetFailed(height)
                 }
             };
         }
@@ -45,7 +65,7 @@ pub async fn align_backlog_with_consensus(
     match backlog.confirm_consensus(chain, target_digest).await {
         Ok(found) => {
             if found {
-                return None;
+                return Alignment::Aligned;
             }
         }
         Err(err) => {
@@ -54,7 +74,7 @@ pub async fn align_backlog_with_consensus(
                 %err,
                 "transient storage error confirming consensus checkpoint; retrying later"
             );
-            return None;
+            return Alignment::Aligned;
         }
     }
 
@@ -63,7 +83,7 @@ pub async fn align_backlog_with_consensus(
         ?target_digest,
         "Consensus checkpoint mismatch/divergence detected: triggering regression"
     );
-    let fetched_checkpoint = find_consensus_checkpoint(
+    let Some(fetched_checkpoint) = find_consensus_checkpoint(
         mesh_state,
         node_client,
         chain,
@@ -71,16 +91,19 @@ pub async fn align_backlog_with_consensus(
         checkpoints_rx,
         my_account_id,
     )
-    .await?;
+    .await
+    else {
+        return Alignment::Aligned;
+    };
 
     let height = fetched_checkpoint.block_height;
 
     if let Err(err) = backlog.regress(fetched_checkpoint).await {
         tracing::error!(?err, %chain, "failed to regress backlog to checkpoint");
-        return None;
+        return Alignment::Aligned;
     }
 
-    Some(height)
+    Alignment::Regressed(height)
 }
 
 async fn fetch_peer_checkpoint(
@@ -218,6 +241,7 @@ mod tests {
     use crate::node_client::Options as NodeClientOptions;
 
     use crate::backlog::BacklogEntry;
+    use crate::storage::CheckpointStorage;
     use crate::types::CheckpointDirective;
     use mpc_primitives::{ConsensusCheckpointDigest, IndexedSignRequest, SignArgs, SignId};
     use std::collections::HashMap;
@@ -254,7 +278,7 @@ mod tests {
             }
         }
 
-        async fn run(&mut self) -> Option<u64> {
+        async fn run(&mut self) -> Alignment {
             align_backlog_with_consensus(
                 self.chain,
                 &self.backlog,
@@ -281,7 +305,7 @@ mod tests {
         peer_checkpoint_height: u64,
         peer_checkpoint_has_pending_tx: bool,
         // Expected results
-        expected_result: Option<u64>,
+        expected_result: Alignment,
         expected_persisted_height: Option<u64>,
     }
 
@@ -298,7 +322,7 @@ mod tests {
                 peer_has_checkpoint: true,
                 peer_checkpoint_height: 100,
                 peer_checkpoint_has_pending_tx: false,
-                expected_result: Some(100),
+                expected_result: Alignment::Regressed(100),
                 expected_persisted_height: Some(100),
             },
             TestCase {
@@ -311,7 +335,7 @@ mod tests {
                 peer_has_checkpoint: false,
                 peer_checkpoint_height: 0,
                 peer_checkpoint_has_pending_tx: false,
-                expected_result: None,
+                expected_result: Alignment::Aligned,
                 expected_persisted_height: None,
             },
             TestCase {
@@ -324,7 +348,7 @@ mod tests {
                 peer_has_checkpoint: false,
                 peer_checkpoint_height: 0,
                 peer_checkpoint_has_pending_tx: false,
-                expected_result: None,
+                expected_result: Alignment::Aligned,
                 expected_persisted_height: None,
             },
             TestCase {
@@ -337,7 +361,7 @@ mod tests {
                 peer_has_checkpoint: false,
                 peer_checkpoint_height: 0,
                 peer_checkpoint_has_pending_tx: false,
-                expected_result: None,
+                expected_result: Alignment::Aligned,
                 expected_persisted_height: Some(100),
             },
             TestCase {
@@ -350,7 +374,7 @@ mod tests {
                 peer_has_checkpoint: false,
                 peer_checkpoint_height: 0,
                 peer_checkpoint_has_pending_tx: false,
-                expected_result: None,
+                expected_result: Alignment::Aligned,
                 expected_persisted_height: Some(100),
             },
             TestCase {
@@ -363,7 +387,7 @@ mod tests {
                 peer_has_checkpoint: true,
                 peer_checkpoint_height: 100,
                 peer_checkpoint_has_pending_tx: false,
-                expected_result: Some(100),
+                expected_result: Alignment::Regressed(100),
                 expected_persisted_height: Some(100),
             },
         ];
@@ -648,7 +672,32 @@ mod tests {
         fixture.checkpoints_tx.send(None).unwrap();
 
         let result = handle.await.unwrap();
-        assert!(result.is_none(), "aborted align should return None");
+        assert_eq!(
+            result,
+            Alignment::Aligned,
+            "aborted align should report aligned (nothing done this pass)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_align_reports_reset_failure_when_storage_unavailable() {
+        let chain = Chain::Ethereum;
+        let mut fixture = AlignFixture::new(None);
+        // Swap in a storage that fails every operation.
+        fixture.backlog = Backlog::persisted(CheckpointStorage::failing());
+
+        fixture
+            .checkpoints_tx
+            .send(Some(CheckpointDirective::Restart(42)))
+            .unwrap();
+
+        let result = fixture.run().await;
+
+        assert_eq!(
+            result,
+            Alignment::ResetFailed(42),
+            "a failed reset must be reported so the supervisor retries"
+        );
     }
 
     #[tokio::test]
@@ -679,7 +728,11 @@ mod tests {
 
         let result = fixture.run().await;
 
-        assert_eq!(result, None, "applied reset is aligned, not a regression");
+        assert_eq!(
+            result,
+            Alignment::ResetApplied(42),
+            "applied reset should be reported so the supervisor suppresses it"
+        );
         assert_eq!(
             fixture
                 .backlog

--- a/chain-signatures/node/src/backlog/consensus.rs
+++ b/chain-signatures/node/src/backlog/consensus.rs
@@ -681,7 +681,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_align_reports_reset_failure_when_storage_unavailable() {
-        let chain = Chain::Ethereum;
         let mut fixture = AlignFixture::new(None);
         // Swap in a storage that fails every operation.
         fixture.backlog = Backlog::persisted(CheckpointStorage::failing());

--- a/chain-signatures/node/src/backlog/consensus.rs
+++ b/chain-signatures/node/src/backlog/consensus.rs
@@ -697,10 +697,12 @@ mod tests {
         );
 
         use mpc_chain_integration_core::StateManager as _;
+        // The cursor is exclusive while the restart height is inclusive, so
+        // it is parked one below and indexers resume at 42 itself.
         assert_eq!(
             fixture.backlog.get_processed_block(chain).await,
-            Some(42),
-            "processed block should be re-anchored at the restart height"
+            Some(41),
+            "cursor should be parked just below the inclusive restart height"
         );
     }
 }

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -634,7 +634,7 @@ impl Backlog {
     /// a reset window (directive is `Restart`) this stays `None` from the wipe
     /// until the network settles a fresh checkpoint.
     pub async fn confirmed_checkpoint(&self, chain: Chain) -> Option<Checkpoint> {
-        self.checkpoints.durable_latest(chain).await
+        self.checkpoints.latest_consensus(chain).await
     }
 
     /// Check if the chain backlog has an available checkpoint slot.

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -605,6 +605,18 @@ impl Backlog {
         Ok(())
     }
 
+    /// Apply a contract-side checkpoint reset: wipe local checkpoint state and
+    /// re-anchor the processed-block height so indexers resume at `height + 1`.
+    ///
+    /// The height is anchored without triggering interval-checkpoint creation;
+    /// a fresh checkpoint forms naturally once indexing resumes.
+    pub async fn apply_reset(&self, chain: Chain, height: u64) -> anyhow::Result<()> {
+        self.checkpoints.clear(chain).await?;
+        self.set_processed_block_interval(chain, height, 0).await;
+        tracing::info!(?chain, height, "applied contract checkpoint reset");
+        Ok(())
+    }
+
     /// Get the latest checkpoint for a specific chain.
     pub async fn latest_checkpoint(&self, chain: Chain) -> Option<Checkpoint> {
         self.checkpoints.latest(chain).await

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -628,6 +628,15 @@ impl Backlog {
         self.checkpoints.latest(chain).await
     }
 
+    /// Get the confirmed checkpoint for a chain, ignoring newer pending ones.
+    ///
+    /// Only contract-settled checkpoints are promoted to confirmed, so during
+    /// a reset window (directive is `Restart`) this stays `None` from the wipe
+    /// until the network settles a fresh checkpoint.
+    pub async fn confirmed_checkpoint(&self, chain: Chain) -> Option<Checkpoint> {
+        self.checkpoints.durable_latest(chain).await
+    }
+
     /// Check if the chain backlog has an available checkpoint slot.
     pub async fn has_checkpoint_slot(&self, chain: Chain) -> bool {
         self.checkpoints.has_slot(chain).await

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -605,14 +605,20 @@ impl Backlog {
         Ok(())
     }
 
-    /// Apply a contract-side checkpoint reset: wipe local checkpoint state and
-    /// re-anchor the processed-block height so indexers resume at `height + 1`.
+    /// Apply a contract-side checkpoint reset: wipe local checkpoint state
+    /// and re-anchor indexing at `height`.
     ///
-    /// The height is anchored without triggering interval-checkpoint creation;
-    /// a fresh checkpoint forms naturally once indexing resumes.
+    /// The restart height is inclusive — block `height` itself is
+    /// (re-)processed — while the processed-block cursor is exclusive
+    /// (indexers resume one past it), so the cursor is parked at
+    /// `height - 1`. Leaving it unset instead would make indexers ignore the
+    /// height and fall back to their own anchoring. The write uses a zero
+    /// checkpoint interval so no checkpoint is created for the parked cursor;
+    /// a fresh one forms naturally once indexing resumes.
     pub async fn apply_reset(&self, chain: Chain, height: u64) -> anyhow::Result<()> {
         self.checkpoints.clear(chain).await?;
-        self.set_processed_block_interval(chain, height, 0).await;
+        self.set_processed_block_interval(chain, height.saturating_sub(1), 0)
+            .await;
         tracing::info!(?chain, height, "applied contract checkpoint reset");
         Ok(())
     }

--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -28,6 +28,7 @@ pub use args::{
     solana::SolArgs,
 };
 
+use crate::types::CheckpointDirective;
 use cait_sith::protocol::Participant;
 use clap::Parser;
 use deadpool_redis::Runtime;
@@ -41,7 +42,7 @@ use mpc_chain_midnight::{MidnightConfig, MidnightIndexer, MidnightPublisher};
 use mpc_chain_near::NearClient;
 use mpc_chain_solana::{SolConfig, SolanaClient, SolanaIndexer};
 use mpc_keys::hpke;
-use mpc_primitives::{Chain, CheckpointDigest, SignCommand};
+use mpc_primitives::{Chain, SignCommand};
 use near_account_id::AccountId;
 use near_crypto::{InMemorySigner, PublicKey, SecretKey};
 use sha3::Digest;
@@ -464,8 +465,8 @@ fn calculate_digest(
 
 #[allow(clippy::type_complexity)]
 fn checkpoint_watchers() -> (
-    EnumMap<Chain, watch::Sender<Option<CheckpointDigest>>>,
-    EnumMap<Chain, watch::Receiver<Option<CheckpointDigest>>>,
+    EnumMap<Chain, watch::Sender<Option<CheckpointDirective>>>,
+    EnumMap<Chain, watch::Receiver<Option<CheckpointDirective>>>,
 ) {
     let channels = EnumMap::from_fn(|_| watch::channel(None));
     let checkpoints_tx = EnumMap::from_fn(|chain| channels[chain].0.clone());
@@ -716,8 +717,8 @@ struct ProtocolHandles {
     node: Node,
     node_watcher: NodeStateWatcher,
     config_tx: watch::Sender<Config>,
-    checkpoints_tx: EnumMap<Chain, watch::Sender<Option<CheckpointDigest>>>,
-    checkpoints_rx: EnumMap<Chain, watch::Receiver<Option<CheckpointDigest>>>,
+    checkpoints_tx: EnumMap<Chain, watch::Sender<Option<CheckpointDirective>>>,
+    checkpoints_rx: EnumMap<Chain, watch::Receiver<Option<CheckpointDirective>>>,
 }
 
 impl ProtocolHandles {
@@ -797,7 +798,7 @@ async fn spawn_indexers(
     contract_watcher: ContractStateWatcher,
     mesh_state: watch::Receiver<MeshState>,
     node_client: NodeClient,
-    checkpoints_rx: EnumMap<Chain, watch::Receiver<Option<CheckpointDigest>>>,
+    checkpoints_rx: EnumMap<Chain, watch::Receiver<Option<CheckpointDirective>>>,
 ) {
     let ChainConfigs {
         eth,

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -23,7 +23,9 @@ use mpc_chain_integration_core::{
     ChainPublisher, PublishAction,
 };
 pub use mpc_contract::primitives::{Read, View};
-use mpc_primitives::{CheckpointDigest, ConsensusCheckpointDigest, SignId, Signature};
+use mpc_primitives::{ConsensusCheckpointDigest, SignId, Signature};
+
+use crate::types::CheckpointDirective;
 
 use near_account_id::AccountId;
 use std::collections::HashMap;
@@ -425,7 +427,7 @@ impl RpcExecutor {
         mut self,
         contract: watch::Sender<Option<ProtocolState>>,
         config: watch::Sender<Config>,
-        checkpoints: EnumMap<Chain, watch::Sender<Option<CheckpointDigest>>>,
+        checkpoints: EnumMap<Chain, watch::Sender<Option<crate::types::CheckpointDirective>>>,
     ) {
         // Spin up update task for updating contract state, config and checkpoints
         let near = self.near.clone();
@@ -543,7 +545,7 @@ async fn update_contract_data(
     near: NearGovernanceClient,
     contract: watch::Sender<Option<ProtocolState>>,
     config: watch::Sender<Config>,
-    checkpoints: EnumMap<Chain, watch::Sender<Option<CheckpointDigest>>>,
+    checkpoints: EnumMap<Chain, watch::Sender<Option<CheckpointDirective>>>,
 ) {
     let reads = vec![Read::State, Read::Config, Read::Checkpoints];
     let views = match near.read(reads).await {
@@ -589,18 +591,14 @@ async fn update_contract_data(
             }
         }
     }
-
     if let Some(signed_checkpoints) = checkpoints_view {
         for (chain, tx) in &checkpoints {
-            let new_digest = signed_checkpoints.get(&chain).map(|sc| CheckpointDigest {
-                height: sc.height,
-                digest: sc.digest,
-            });
+            let new_directive = signed_checkpoints.get(&chain).copied();
             tx.send_if_modified(|old| {
-                if *old == new_digest {
+                if *old == new_directive {
                     return false;
                 }
-                *old = new_digest;
+                *old = new_directive;
                 true
             });
         }

--- a/chain-signatures/node/src/storage/checkpoint_storage.rs
+++ b/chain-signatures/node/src/storage/checkpoint_storage.rs
@@ -361,6 +361,32 @@ impl CheckpointStorage {
             CheckpointStorage::Failing => anyhow::bail!("failing storage"),
         }
     }
+
+    /// Remove all durable checkpoint state (latest and pending) for `chain`.
+    ///
+    /// Used when the contract's checkpoints are reset: local state must not
+    /// outlive the chain-wide consensus it was derived from.
+    pub async fn clear(&self, chain: Chain) -> anyhow::Result<()> {
+        match self {
+            CheckpointStorage::Redis(pool, _) => {
+                let mut conn = pool.get().await.context("failed to get redis connection")?;
+                redis::pipe()
+                    .del(self.checkpoint_key(chain))
+                    .del(self.pending_checkpoint_key(chain))
+                    .del(self.pending_digest_key(chain))
+                    .query_async::<()>(&mut conn)
+                    .await
+                    .context("failed to clear checkpoint state from redis")?;
+            }
+            CheckpointStorage::InMemory { latest, pending } => {
+                latest.write().await.remove(&chain);
+                pending.write().await.remove(&chain);
+            }
+            #[cfg(test)]
+            CheckpointStorage::Failing => anyhow::bail!("failing storage"),
+        }
+        Ok(())
+    }
 }
 
 fn encode_checkpoint(checkpoint: &Checkpoint) -> anyhow::Result<Vec<u8>> {
@@ -466,6 +492,30 @@ mod tests {
                 .await?
         );
         assert_eq!(storage.load_pending(Chain::Solana).await?, vec![checkpoint]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn clear_removes_all_checkpoint_state_for_chain() -> anyhow::Result<()> {
+        let storage = CheckpointStorage::in_memory();
+        let chain = Chain::Solana;
+        let checkpoint = |block_height| Checkpoint {
+            chain,
+            block_height,
+            pending_requests: vec![],
+            cumulative_digest: Checkpoint::empty_cumulative_digest(),
+        };
+
+        storage.persist(&checkpoint(10)).await?;
+        storage.persist_pending(&checkpoint(20)).await?;
+
+        storage.clear(chain).await?;
+
+        assert_eq!(storage.load_latest(chain).await?, None);
+        assert!(storage.load_pending(chain).await?.is_empty());
+
+        // Other chains are untouched.
+        assert!(storage.load_latest(Chain::Ethereum).await?.is_none());
         Ok(())
     }
 

--- a/chain-signatures/node/src/stream/recovery.rs
+++ b/chain-signatures/node/src/stream/recovery.rs
@@ -12,6 +12,10 @@ use tokio::sync::watch;
 /// then aligns the backlog with the consensus checkpoint feed. Mesh availability
 /// is handled inside `align_backlog_with_consensus` when it needs to fetch a
 /// checkpoint from peers.
+///
+/// Returns `Some(height)` when a contract checkpoint reset was applied at
+/// `height`, so the supervisor can suppress re-triggering on the unchanged
+/// directive. `None` covers every other outcome.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn recover_backlog(
     chain: Chain,
@@ -21,7 +25,7 @@ pub(crate) async fn recover_backlog(
     mesh_state: &mut watch::Receiver<MeshState>,
     node_client: &NodeClient,
     my_account_id: &AccountId,
-) {
+) -> Option<u64> {
     tracing::info!(%chain, load_local, "starting checkpoint recovery or regression");
 
     // Hydrate the local checkpoint before aligning: the web server (spawned
@@ -48,9 +52,7 @@ pub(crate) async fn recover_backlog(
         }
     }
 
-    // Returns None when no alignment is needed (the normal case); Some(height) when
-    // the backlog was regressed.
-    if consensus::align_backlog_with_consensus(
+    match consensus::align_backlog_with_consensus(
         chain,
         backlog,
         checkpoints_rx,
@@ -59,8 +61,23 @@ pub(crate) async fn recover_backlog(
         my_account_id,
     )
     .await
-    .is_some()
     {
-        tracing::warn!(%chain, "backlog regressed via consensus checkpoint");
+        consensus::Alignment::Aligned => None,
+        consensus::Alignment::Regressed(height) => {
+            tracing::warn!(%chain, height, "backlog regressed via consensus checkpoint");
+            None
+        }
+        consensus::Alignment::ResetApplied(height) => {
+            tracing::warn!(%chain, height, "contract checkpoint reset applied");
+            Some(height)
+        }
+        consensus::Alignment::ResetFailed(height) => {
+            tracing::error!(
+                %chain,
+                height,
+                "failed to apply contract checkpoint reset; will retry"
+            );
+            None
+        }
     }
 }

--- a/chain-signatures/node/src/stream/recovery.rs
+++ b/chain-signatures/node/src/stream/recovery.rs
@@ -12,10 +12,6 @@ use tokio::sync::watch;
 /// then aligns the backlog with the consensus checkpoint feed. Mesh availability
 /// is handled inside `align_backlog_with_consensus` when it needs to fetch a
 /// checkpoint from peers.
-///
-/// Returns `Some(height)` when a contract checkpoint reset was applied at
-/// `height`, so the supervisor can suppress re-triggering on the unchanged
-/// directive. `None` covers every other outcome.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn recover_backlog(
     chain: Chain,
@@ -25,7 +21,7 @@ pub(crate) async fn recover_backlog(
     mesh_state: &mut watch::Receiver<MeshState>,
     node_client: &NodeClient,
     my_account_id: &AccountId,
-) -> Option<u64> {
+) {
     tracing::info!(%chain, load_local, "starting checkpoint recovery or regression");
 
     // Hydrate the local checkpoint before aligning: the web server (spawned
@@ -62,14 +58,12 @@ pub(crate) async fn recover_backlog(
     )
     .await
     {
-        consensus::Alignment::Aligned => None,
+        consensus::Alignment::Aligned => {}
         consensus::Alignment::Regressed(height) => {
             tracing::warn!(%chain, height, "backlog regressed via consensus checkpoint");
-            None
         }
         consensus::Alignment::ResetApplied(height) => {
             tracing::warn!(%chain, height, "contract checkpoint reset applied");
-            Some(height)
         }
         consensus::Alignment::ResetFailed(height) => {
             tracing::error!(
@@ -77,7 +71,6 @@ pub(crate) async fn recover_backlog(
                 height,
                 "failed to apply contract checkpoint reset; will retry"
             );
-            None
         }
     }
 }

--- a/chain-signatures/node/src/stream/supervisor.rs
+++ b/chain-signatures/node/src/stream/supervisor.rs
@@ -5,7 +5,7 @@ use super::recovery::recover_backlog;
 use super::{handle_chain_event, StreamContext};
 
 use crate::backlog::Backlog;
-use crate::types::CheckpointWatcher;
+use crate::types::{CheckpointDirective, CheckpointWatcher};
 use mpc_chain_integration_core::utils::stream::chain_event_channel;
 use mpc_chain_integration_core::{ChainIndexer, ChainTelemetry};
 use mpc_primitives::{Chain, ChainConfig as _, ChainEvent, SignCommand};
@@ -30,7 +30,10 @@ pub(crate) fn live_block_timeout(chain: Chain) -> Duration {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RegressionOutcome {
-    /// Consensus digest mismatches local backlog — transition to Recovery.
+    /// Consensus digest mismatches local backlog, or the contract reset its
+    /// checkpoints — either way, transition to Recovery. A reset follows the
+    /// exact same path: abort in-flight work and rerun recovery, which wipes
+    /// local state and re-anchors indexing at the restart height.
     Recovery,
     /// Local backlog is aligned with consensus, continue current state.
     Aligned,
@@ -38,66 +41,90 @@ pub(crate) enum RegressionOutcome {
     Shutdown,
 }
 
-/// Waits for a consensus checkpoint digest change, then checks for regression.
+/// Waits for a consensus checkpoint directive change, then checks for regression.
+///
+/// An unchanged `Restart(height)` directive stops re-triggering once recovery
+/// has applied it: `applied_restart` records the height whose reset recovery
+/// reported as applied (see `recover_backlog`). The tracker is cleared
+/// whenever a non-reset directive is observed, so a later reset to the same
+/// height still triggers.
 pub(crate) async fn wait_detected_regression(
     checkpoints_rx: &mut CheckpointWatcher,
     backlog: &Backlog,
     chain: Chain,
+    applied_restart: &mut Option<u64>,
 ) -> RegressionOutcome {
-    if detect_regression(chain, backlog, checkpoints_rx).await {
-        return RegressionOutcome::Recovery;
+    let outcome = detect_regression(checkpoints_rx, backlog, chain, applied_restart).await;
+    if !matches!(outcome, RegressionOutcome::Aligned) {
+        return outcome;
     }
     if checkpoints_rx.changed().await.is_err() {
         return RegressionOutcome::Shutdown;
     }
-    if detect_regression(chain, backlog, checkpoints_rx).await {
-        return RegressionOutcome::Recovery;
-    }
-    RegressionOutcome::Aligned
+    detect_regression(checkpoints_rx, backlog, chain, applied_restart).await
 }
 
-/// Returns `true` if a regression is detected. When the consensus digest matches
-/// a local checkpoint (latest or historical), the checkpoint is confirmed via
-/// `confirm_consensus`. A transient storage error is treated as aligned so it is
-/// retried on the next checkpoint change. Returns `false` when the backlog is
-/// aligned (no regression).
+/// Classifies the current directive against local state without waiting for
+/// changes.
+///
+/// - No directive: aligned. Chains without one fall back to their own
+///   anchoring, leaving nothing to check.
+/// - `Restart(height)`: regression unless recovery has already applied this
+///   height's reset. Not yet applied keeps reporting so a failed application
+///   is retried via another restart cycle.
+/// - `Consensus(digest)`: a digest matching a local checkpoint (latest or a
+///   retained pending one) confirms and is aligned. A transient storage error
+///   is treated as aligned so it is retried on the next directive change;
+///   anything else is a regression.
 async fn detect_regression(
-    chain: Chain,
-    backlog: &Backlog,
     checkpoints_rx: &mut CheckpointWatcher,
-) -> bool {
-    let Some(checkpoint_digest) = checkpoints_rx.borrow_and_update().as_ref().cloned() else {
-        return false;
-    };
-
-    if backlog.latest_checkpoint(chain).await.is_none() {
-        tracing::info!(?chain, "no local checkpoint; skipping regression check");
-        return false;
-    }
-
-    // A consensus digest can match either the latest checkpoint or a retained
-    // pending checkpoint while this node is ahead of consensus.
-    match backlog
-        .confirm_consensus(chain, checkpoint_digest.digest)
-        .await
-    {
-        Ok(found) => {
-            if found {
-                return false;
+    backlog: &Backlog,
+    chain: Chain,
+    applied_restart: &mut Option<u64>,
+) -> RegressionOutcome {
+    let directive = *checkpoints_rx.borrow_and_update();
+    match directive.as_ref() {
+        None => RegressionOutcome::Aligned,
+        Some(CheckpointDirective::Restart(height)) => {
+            if *applied_restart == Some(*height) {
+                RegressionOutcome::Aligned
+            } else {
+                RegressionOutcome::Recovery
             }
         }
-        Err(err) => {
-            tracing::warn!(
-                ?chain,
-                %err,
-                "transient storage error confirming checkpoint; retrying on next change"
-            );
-            return false;
+        Some(CheckpointDirective::Consensus(digest)) => {
+            *applied_restart = None;
+
+            if backlog.latest_checkpoint(chain).await.is_none() {
+                tracing::info!(?chain, "no local checkpoint; skipping regression check");
+                return RegressionOutcome::Aligned;
+            }
+
+            // A consensus digest can match either the latest checkpoint or a
+            // retained pending checkpoint while this node is ahead of
+            // consensus.
+            match backlog.confirm_consensus(chain, digest.digest).await {
+                Ok(true) => RegressionOutcome::Aligned,
+                Ok(false) => {
+                    tracing::warn!(
+                        ?chain,
+                        height = digest.height,
+                        ?digest.digest,
+                        "consensus checkpoint mismatch/divergence detected"
+                    );
+                    RegressionOutcome::Recovery
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        ?chain,
+                        %err,
+                        "transient storage error confirming checkpoint; retrying on next change"
+                    );
+                    RegressionOutcome::Aligned
+                }
+            }
         }
     }
-
-    // No match → regression detected.
-    true
 }
 
 /// Delay before respawning a `run()` that returned an error.
@@ -135,8 +162,13 @@ async fn run_supervised_with_watchdog<I: ChainIndexer, T: ChainTelemetry>(
     }
 
     let mut load_local = true;
+    // The restart height whose reset recovery reported as applied; prevents an
+    // unchanged `Restart` directive from looping the supervisor. Cleared when
+    // a non-reset directive is observed, so a later reset to the same height
+    // still triggers.
+    let mut applied_restart: Option<u64> = None;
     loop {
-        recover_backlog(
+        if let Some(height) = recover_backlog(
             chain,
             load_local,
             &ctx.backlog,
@@ -145,7 +177,10 @@ async fn run_supervised_with_watchdog<I: ChainIndexer, T: ChainTelemetry>(
             &ctx.node_client,
             &my_account_id,
         )
-        .await;
+        .await
+        {
+            applied_restart = Some(height);
+        }
         load_local = false;
 
         let (events_tx, mut events_rx) = chain_event_channel();
@@ -189,7 +224,12 @@ async fn run_supervised_with_watchdog<I: ChainIndexer, T: ChainTelemetry>(
                         tracing::error!(?err, %chain, "failed to process chain event");
                     }
                 }
-                result = wait_detected_regression(&mut ctx.checkpoints_rx, &ctx.backlog, chain) => {
+                result = wait_detected_regression(
+                    &mut ctx.checkpoints_rx,
+                    &ctx.backlog,
+                    chain,
+                    &mut applied_restart,
+                ) => {
                     match result {
                         RegressionOutcome::Recovery => {
                             ctx.rpc.abort_checkpoints(chain).await;
@@ -241,10 +281,11 @@ mod tests {
     use crate::mesh::MeshState;
     use crate::rpc::RpcAction;
     use crate::stream::test_utils::make_test_stream_context;
+    use crate::types::CheckpointDirective;
 
     use k256::ProjectivePoint;
     use mpc_chain_integration_core::{NoopChainTelemetry, StateManager};
-    use mpc_primitives::{Chain, CheckpointDigest, SignCommand};
+    use mpc_primitives::{Chain, ConsensusCheckpointDigest, SignCommand};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::sync::{mpsc, watch, Notify};
 
@@ -254,7 +295,7 @@ mod tests {
         sign_tx: mpsc::Sender<SignCommand>,
     ) -> (
         StreamContext,
-        watch::Sender<Option<CheckpointDigest>>,
+        watch::Sender<Option<CheckpointDirective>>,
         watch::Sender<MeshState>,
         mpsc::Receiver<RpcAction>,
     ) {
@@ -268,28 +309,39 @@ mod tests {
         )
     }
 
+    fn make_directive(
+        directive: CheckpointDirective,
+    ) -> (
+        watch::Sender<Option<CheckpointDirective>>,
+        watch::Receiver<Option<CheckpointDirective>>,
+    ) {
+        watch::channel(Some(directive))
+    }
+
     fn make_digest(
         height: u64,
         digest: [u8; 32],
     ) -> (
-        watch::Sender<Option<CheckpointDigest>>,
-        watch::Receiver<Option<CheckpointDigest>>,
+        watch::Sender<Option<CheckpointDirective>>,
+        watch::Receiver<Option<CheckpointDirective>>,
     ) {
-        watch::channel(Some(CheckpointDigest { height, digest }))
+        make_directive(CheckpointDirective::Consensus(
+            ConsensusCheckpointDigest::new(Chain::Ethereum, height, digest),
+        ))
     }
 
     #[tokio::test]
-    async fn test_empty_digest_returns_false() {
+    async fn test_no_directive_is_aligned() {
         let backlog = Backlog::new();
         let chain = Chain::Ethereum;
         let (_tx, mut rx) = watch::channel(None);
 
-        let result = detect_regression(chain, &backlog, &mut rx).await;
-        assert!(!result, "empty digest should not trigger regression");
+        let result = detect_regression(&mut rx, &backlog, chain, &mut None).await;
+        assert_eq!(result, RegressionOutcome::Aligned);
     }
 
     #[tokio::test]
-    async fn test_matching_consensus_confirms_and_returns_false() {
+    async fn test_matching_consensus_confirms_and_is_aligned() {
         let backlog = Backlog::new();
         let chain = Chain::Ethereum;
 
@@ -299,8 +351,8 @@ mod tests {
 
         let (_tx, mut rx) = make_digest(100, digest);
 
-        let result = detect_regression(chain, &backlog, &mut rx).await;
-        assert!(!result, "matching digest should not trigger regression");
+        let result = detect_regression(&mut rx, &backlog, chain, &mut None).await;
+        assert_eq!(result, RegressionOutcome::Aligned);
 
         let persisted = backlog
             .checkpoint_storage()
@@ -327,8 +379,8 @@ mod tests {
         let digest1 = cp1.digest();
         let (_tx, mut rx) = make_digest(100, digest1);
 
-        let result = detect_regression(chain, &backlog, &mut rx).await;
-        assert!(!result, "ahead with match should not trigger regression");
+        let result = detect_regression(&mut rx, &backlog, chain, &mut None).await;
+        assert_eq!(result, RegressionOutcome::Aligned);
 
         let persisted = backlog
             .checkpoint_storage()
@@ -340,7 +392,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_mismatch_triggers_regression() {
+    async fn test_mismatch_triggers_regression_outcome() {
         let backlog = Backlog::new();
         let chain = Chain::Ethereum;
 
@@ -350,20 +402,20 @@ mod tests {
         let different_digest = [0xabu8; 32];
         let (_tx, mut rx) = make_digest(200, different_digest);
 
-        let result = detect_regression(chain, &backlog, &mut rx).await;
-        assert!(result, "mismatched digest should trigger regression");
+        let result = detect_regression(&mut rx, &backlog, chain, &mut None).await;
+        assert_eq!(result, RegressionOutcome::Recovery);
     }
 
     #[tokio::test]
-    async fn test_no_local_returns_false() {
+    async fn test_no_local_is_aligned() {
         let backlog = Backlog::new();
         let chain = Chain::Ethereum;
 
         let digest = [0x42u8; 32];
         let (_tx, mut rx) = make_digest(100, digest);
 
-        let result = detect_regression(chain, &backlog, &mut rx).await;
-        assert!(!result, "no local checkpoint should not trigger regression");
+        let result = detect_regression(&mut rx, &backlog, chain, &mut None).await;
+        assert_eq!(result, RegressionOutcome::Aligned);
     }
 
     #[tokio::test]
@@ -377,9 +429,10 @@ mod tests {
         let (mut _tx, mut rx) = make_digest(200, [0xabu8; 32]);
         let _ = rx.borrow_and_update();
 
+        let mut applied_restart = None;
         let result = tokio::time::timeout(
             Duration::from_millis(500),
-            wait_detected_regression(&mut rx, &backlog, chain),
+            wait_detected_regression(&mut rx, &backlog, chain, &mut applied_restart),
         )
         .await
         .expect("should not hang — upfront check catches mismatch");
@@ -387,6 +440,77 @@ mod tests {
             result,
             RegressionOutcome::Recovery,
             "should detect regression even when receiver state was consumed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reset_directive_reports_until_applied() {
+        let backlog = Backlog::new();
+        let chain = Chain::Ethereum;
+        let (_tx, mut rx) = make_directive(CheckpointDirective::Restart(42));
+        let mut applied_restart: Option<u64> = None;
+
+        // A restart is plain Recovery: identical handling to a regression. It
+        // keeps being reported until recovery reports the reset as applied,
+        // so a transient apply failure is retried instead of swallowed.
+        for _ in 0..2 {
+            let outcome = detect_regression(&mut rx, &backlog, chain, &mut applied_restart).await;
+            assert_eq!(outcome, RegressionOutcome::Recovery);
+            let _ = rx.borrow_and_update();
+        }
+        assert_eq!(applied_restart, None);
+
+        // Once recovery reports the reset applied (recorded by the supervisor
+        // loop), the unchanged directive classifies as aligned so the
+        // supervisor does not hot-restart.
+        applied_restart = Some(42);
+        let outcome = detect_regression(&mut rx, &backlog, chain, &mut applied_restart).await;
+        assert_eq!(outcome, RegressionOutcome::Aligned);
+
+        // A different restart height triggers again.
+        _tx.send(Some(CheckpointDirective::Restart(43))).unwrap();
+        let outcome = detect_regression(&mut rx, &backlog, chain, &mut applied_restart).await;
+        assert_eq!(outcome, RegressionOutcome::Recovery);
+
+        // Observing a non-reset directive clears the tracker so a later
+        // reset to a previously seen height still triggers.
+        _tx.send(Some(CheckpointDirective::Consensus(
+            ConsensusCheckpointDigest::new(Chain::Ethereum, 50, [0x11u8; 32]),
+        )))
+        .unwrap();
+        let outcome = detect_regression(&mut rx, &backlog, chain, &mut applied_restart).await;
+        assert_eq!(outcome, RegressionOutcome::Aligned);
+        assert_eq!(applied_restart, None);
+
+        _tx.send(Some(CheckpointDirective::Restart(42))).unwrap();
+        let outcome = detect_regression(&mut rx, &backlog, chain, &mut applied_restart).await;
+        assert_eq!(outcome, RegressionOutcome::Recovery);
+    }
+
+    #[tokio::test]
+    async fn test_wait_treats_reset_transition_as_regression() {
+        let backlog = Backlog::new();
+        let chain = Chain::Ethereum;
+
+        let digest = [0x42u8; 32];
+        let (tx, mut rx) = make_digest(100, digest);
+
+        let handle = tokio::spawn(async move {
+            let mut applied_restart = None;
+            wait_detected_regression(&mut rx, &backlog, chain, &mut applied_restart).await
+        });
+
+        tx.send(Some(CheckpointDirective::Restart(7))).unwrap();
+
+        let result = tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("timeout")
+            .expect("task should not panic");
+
+        assert_eq!(
+            result,
+            RegressionOutcome::Recovery,
+            "a live transition into a restart directive must be treated as a regression"
         );
     }
 
@@ -401,13 +525,14 @@ mod tests {
 
         let (tx, mut rx) = make_digest(100, matching_digest);
 
-        let handle =
-            tokio::spawn(async move { wait_detected_regression(&mut rx, &backlog, chain).await });
+        let handle = tokio::spawn(async move {
+            let mut applied_restart = None;
+            wait_detected_regression(&mut rx, &backlog, chain, &mut applied_restart).await
+        });
 
-        tx.send(Some(CheckpointDigest {
-            height: 200,
-            digest: [0xabu8; 32],
-        }))
+        tx.send(Some(CheckpointDirective::Consensus(
+            ConsensusCheckpointDigest::new(Chain::Ethereum, 200, [0xabu8; 32]),
+        )))
         .unwrap();
 
         let result = tokio::time::timeout(Duration::from_secs(1), handle)
@@ -541,10 +666,9 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
         cp_tx
-            .send(Some(CheckpointDigest {
-                height: 200,
-                digest: [0xab; 32],
-            }))
+            .send(Some(CheckpointDirective::Consensus(
+                ConsensusCheckpointDigest::new(Chain::Ethereum, 200, [0xab; 32]),
+            )))
             .unwrap();
         assert!(matches!(
             tokio::time::timeout(Duration::from_secs(1), rpc_rx.recv())
@@ -566,6 +690,88 @@ mod tests {
             .await
             .expect("supervisor should shut down after second run() exits")
             .expect("supervisor task should not panic");
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    /// A live transition into a `Restart` directive must abort in-flight
+    /// checkpoint work, wipe local checkpoint state, re-anchor the processed
+    /// block at the restart height during recovery, and settle into the
+    /// restarted run instead of looping on the unchanged directive.
+    #[tokio::test]
+    async fn reset_directive_restarts_anchors_and_settles() {
+        let chain = Chain::Ethereum;
+        let backlog = Backlog::new();
+        // Pre-reset state: local checkpoint at height 100.
+        backlog.set_processed_block(chain, 100).await.unwrap();
+        backlog.checkpoint(chain).await.unwrap();
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let first_cancel = Arc::new(Notify::new());
+        let indexer = StalledRunIndexer {
+            attempts: attempts.clone(),
+            first_cancel: first_cancel.clone(),
+        };
+        let (sign_tx, mut sign_rx) = mpsc::channel(8);
+        let (ctx, cp_tx, _mesh_tx, mut rpc_rx) = test_ctx(backlog.clone(), sign_tx);
+
+        let task = tokio::spawn(run_supervised_with_watchdog(
+            indexer,
+            ctx,
+            NoopChainTelemetry,
+            Duration::from_secs(60),
+        ));
+
+        while attempts.load(Ordering::SeqCst) == 0 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        cp_tx.send(Some(CheckpointDirective::Restart(42))).unwrap();
+
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(1), rpc_rx.recv())
+                .await
+                .expect("reset should abort RPC work immediately"),
+            Some(RpcAction::AbortCheckpoints(Chain::Ethereum))
+        ));
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(1), sign_rx.recv())
+                .await
+                .expect("reset should abort sign tasks immediately"),
+            Some(SignCommand::AbortChain(Chain::Ethereum))
+        ));
+        first_cancel.notified().await;
+
+        tokio::time::timeout(Duration::from_secs(10), task)
+            .await
+            .expect("supervisor should shut down after restarted run() exits")
+            .expect("supervisor task should not panic");
+
+        use mpc_chain_integration_core::StateManager as _;
+        // Exclusive cursor parked one below the inclusive restart height:
+        // block 42 itself will be re-processed.
+        assert_eq!(
+            backlog.get_processed_block(chain).await,
+            Some(41),
+            "recovery must park the cursor below the restart height"
+        );
+        assert_eq!(
+            backlog.latest_checkpoint(chain).await,
+            None,
+            "local checkpoint state must be wiped by the reset"
+        );
+        assert_eq!(
+            backlog
+                .checkpoint_storage()
+                .load_latest(chain)
+                .await
+                .unwrap(),
+            None,
+            "durable checkpoint state must be wiped by the reset"
+        );
+
+        // Exactly two runs: the stalled original and the post-reset rerun. A
+        // third attempt would mean the unchanged Restart directive is
+        // re-triggering restarts instead of being suppressed after
+        // confirmation.
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
     }
 

--- a/chain-signatures/node/src/stream/supervisor.rs
+++ b/chain-signatures/node/src/stream/supervisor.rs
@@ -42,87 +42,75 @@ pub(crate) enum RegressionOutcome {
 }
 
 /// Waits for a consensus checkpoint directive change, then checks for regression.
-///
-/// An unchanged `Restart(height)` directive stops re-triggering once recovery
-/// has applied it: `applied_restart` records the height whose reset recovery
-/// reported as applied (see `recover_backlog`). The tracker is cleared
-/// whenever a non-reset directive is observed, so a later reset to the same
-/// height still triggers.
 pub(crate) async fn wait_detected_regression(
     checkpoints_rx: &mut CheckpointWatcher,
     backlog: &Backlog,
     chain: Chain,
-    applied_restart: &mut Option<u64>,
 ) -> RegressionOutcome {
-    let outcome = detect_regression(checkpoints_rx, backlog, chain, applied_restart).await;
+    let outcome = detect_regression(checkpoints_rx, backlog, chain).await;
     if !matches!(outcome, RegressionOutcome::Aligned) {
         return outcome;
     }
     if checkpoints_rx.changed().await.is_err() {
         return RegressionOutcome::Shutdown;
     }
-    detect_regression(checkpoints_rx, backlog, chain, applied_restart).await
+    detect_regression(checkpoints_rx, backlog, chain).await
 }
 
 /// Classifies the current directive against local state without waiting for
 /// changes.
-///
-/// - No directive: aligned. Chains without one fall back to their own
-///   anchoring, leaving nothing to check.
-/// - `Restart(height)`: regression unless recovery has already applied this
-///   height's reset. Not yet applied keeps reporting so a failed application
-///   is retried via another restart cycle.
-/// - `Consensus(digest)`: a digest matching a local checkpoint (latest or a
-///   retained pending one) confirms and is aligned. A transient storage error
-///   is treated as aligned so it is retried on the next directive change;
-///   anything else is a regression.
 async fn detect_regression(
     checkpoints_rx: &mut CheckpointWatcher,
     backlog: &Backlog,
     chain: Chain,
-    applied_restart: &mut Option<u64>,
 ) -> RegressionOutcome {
-    let directive = *checkpoints_rx.borrow_and_update();
-    match directive.as_ref() {
-        None => RegressionOutcome::Aligned,
-        Some(CheckpointDirective::Restart(height)) => {
-            if *applied_restart == Some(*height) {
-                RegressionOutcome::Aligned
-            } else {
-                RegressionOutcome::Recovery
-            }
-        }
-        Some(CheckpointDirective::Consensus(digest)) => {
-            *applied_restart = None;
+    let Some(directive) = *checkpoints_rx.borrow_and_update() else {
+        // Chains without a directive fall back to their own anchoring.
+        return RegressionOutcome::Aligned;
+    };
 
-            if backlog.latest_checkpoint(chain).await.is_none() {
-                tracing::info!(?chain, "no local checkpoint; skipping regression check");
+    let digest = match directive {
+        CheckpointDirective::Consensus(digest) => digest,
+        CheckpointDirective::Restart(_) => {
+            // We have previously applied a restart if we don't have a checkpoint.
+            let Some(stale) = backlog.confirmed_checkpoint(chain).await else {
                 return RegressionOutcome::Aligned;
-            }
+            };
 
-            // A consensus digest can match either the latest checkpoint or a
-            // retained pending checkpoint while this node is ahead of
-            // consensus.
-            match backlog.confirm_consensus(chain, digest.digest).await {
-                Ok(true) => RegressionOutcome::Aligned,
-                Ok(false) => {
-                    tracing::warn!(
-                        ?chain,
-                        height = digest.height,
-                        ?digest.digest,
-                        "consensus checkpoint mismatch/divergence detected"
-                    );
-                    RegressionOutcome::Recovery
-                }
-                Err(err) => {
-                    tracing::warn!(
-                        ?chain,
-                        %err,
-                        "transient storage error confirming checkpoint; retrying on next change"
-                    );
-                    RegressionOutcome::Aligned
-                }
-            }
+            tracing::info!(
+                ?chain,
+                stale_height = stale.block_height,
+                "confirmed checkpoint predates the contract reset"
+            );
+            return RegressionOutcome::Recovery;
+        }
+    };
+
+    if backlog.latest_checkpoint(chain).await.is_none() {
+        tracing::info!(?chain, "no local checkpoint; skipping regression check");
+        return RegressionOutcome::Aligned;
+    }
+
+    // The digest can match either the latest checkpoint or a retained pending
+    // one while this node is ahead of consensus.
+    match backlog.confirm_consensus(chain, digest.digest).await {
+        Ok(true) => RegressionOutcome::Aligned,
+        Ok(false) => {
+            tracing::warn!(
+                ?chain,
+                height = digest.height,
+                ?digest.digest,
+                "consensus checkpoint mismatch/divergence detected"
+            );
+            RegressionOutcome::Recovery
+        }
+        Err(err) => {
+            tracing::warn!(
+                ?chain,
+                %err,
+                "transient storage error confirming checkpoint; retrying on next change"
+            );
+            RegressionOutcome::Aligned
         }
     }
 }
@@ -162,13 +150,8 @@ async fn run_supervised_with_watchdog<I: ChainIndexer, T: ChainTelemetry>(
     }
 
     let mut load_local = true;
-    // The restart height whose reset recovery reported as applied; prevents an
-    // unchanged `Restart` directive from looping the supervisor. Cleared when
-    // a non-reset directive is observed, so a later reset to the same height
-    // still triggers.
-    let mut applied_restart: Option<u64> = None;
     loop {
-        if let Some(height) = recover_backlog(
+        recover_backlog(
             chain,
             load_local,
             &ctx.backlog,
@@ -177,10 +160,7 @@ async fn run_supervised_with_watchdog<I: ChainIndexer, T: ChainTelemetry>(
             &ctx.node_client,
             &my_account_id,
         )
-        .await
-        {
-            applied_restart = Some(height);
-        }
+        .await;
         load_local = false;
 
         let (events_tx, mut events_rx) = chain_event_channel();
@@ -224,12 +204,7 @@ async fn run_supervised_with_watchdog<I: ChainIndexer, T: ChainTelemetry>(
                         tracing::error!(?err, %chain, "failed to process chain event");
                     }
                 }
-                result = wait_detected_regression(
-                    &mut ctx.checkpoints_rx,
-                    &ctx.backlog,
-                    chain,
-                    &mut applied_restart,
-                ) => {
+                result = wait_detected_regression(&mut ctx.checkpoints_rx, &ctx.backlog, chain) => {
                     match result {
                         RegressionOutcome::Recovery => {
                             ctx.rpc.abort_checkpoints(chain).await;
@@ -336,7 +311,7 @@ mod tests {
         let chain = Chain::Ethereum;
         let (_tx, mut rx) = watch::channel(None);
 
-        let result = detect_regression(&mut rx, &backlog, chain, &mut None).await;
+        let result = detect_regression(&mut rx, &backlog, chain).await;
         assert_eq!(result, RegressionOutcome::Aligned);
     }
 
@@ -351,7 +326,7 @@ mod tests {
 
         let (_tx, mut rx) = make_digest(100, digest);
 
-        let result = detect_regression(&mut rx, &backlog, chain, &mut None).await;
+        let result = detect_regression(&mut rx, &backlog, chain).await;
         assert_eq!(result, RegressionOutcome::Aligned);
 
         let persisted = backlog
@@ -379,7 +354,7 @@ mod tests {
         let digest1 = cp1.digest();
         let (_tx, mut rx) = make_digest(100, digest1);
 
-        let result = detect_regression(&mut rx, &backlog, chain, &mut None).await;
+        let result = detect_regression(&mut rx, &backlog, chain).await;
         assert_eq!(result, RegressionOutcome::Aligned);
 
         let persisted = backlog
@@ -402,7 +377,7 @@ mod tests {
         let different_digest = [0xabu8; 32];
         let (_tx, mut rx) = make_digest(200, different_digest);
 
-        let result = detect_regression(&mut rx, &backlog, chain, &mut None).await;
+        let result = detect_regression(&mut rx, &backlog, chain).await;
         assert_eq!(result, RegressionOutcome::Recovery);
     }
 
@@ -414,7 +389,7 @@ mod tests {
         let digest = [0x42u8; 32];
         let (_tx, mut rx) = make_digest(100, digest);
 
-        let result = detect_regression(&mut rx, &backlog, chain, &mut None).await;
+        let result = detect_regression(&mut rx, &backlog, chain).await;
         assert_eq!(result, RegressionOutcome::Aligned);
     }
 
@@ -429,10 +404,9 @@ mod tests {
         let (mut _tx, mut rx) = make_digest(200, [0xabu8; 32]);
         let _ = rx.borrow_and_update();
 
-        let mut applied_restart = None;
         let result = tokio::time::timeout(
             Duration::from_millis(500),
-            wait_detected_regression(&mut rx, &backlog, chain, &mut applied_restart),
+            wait_detected_regression(&mut rx, &backlog, chain),
         )
         .await
         .expect("should not hang — upfront check catches mismatch");
@@ -444,47 +418,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_reset_directive_reports_until_applied() {
-        let backlog = Backlog::new();
+    async fn test_reset_is_regression_while_confirmed_checkpoint_exists() {
         let chain = Chain::Ethereum;
-        let (_tx, mut rx) = make_directive(CheckpointDirective::Restart(42));
-        let mut applied_restart: Option<u64> = None;
 
-        // A restart is plain Recovery: identical handling to a regression. It
-        // keeps being reported until recovery reports the reset as applied,
-        // so a transient apply failure is retried instead of swallowed.
+        // Pre-reset state: a confirmed checkpoint exists — regression, however
+        // often it is observed, with no bookkeeping beyond local state itself.
+        let backlog = Backlog::new();
+        backlog.set_processed_block(chain, 100).await.unwrap();
+        let cp = backlog.checkpoint(chain).await.unwrap();
+        assert!(
+            backlog.confirm_consensus(chain, cp.digest()).await.unwrap(),
+            "test setup should leave a confirmed checkpoint"
+        );
+
+        let (_tx, mut rx) = make_directive(CheckpointDirective::Restart(42));
         for _ in 0..2 {
-            let outcome = detect_regression(&mut rx, &backlog, chain, &mut applied_restart).await;
-            assert_eq!(outcome, RegressionOutcome::Recovery);
+            let outcome = detect_regression(&mut rx, &backlog, chain).await;
+            assert_eq!(
+                outcome,
+                RegressionOutcome::Recovery,
+                "stale confirmed checkpoint must keep reporting as regression"
+            );
             let _ = rx.borrow_and_update();
         }
-        assert_eq!(applied_restart, None);
 
-        // Once recovery reports the reset applied (recorded by the supervisor
-        // loop), the unchanged directive classifies as aligned so the
-        // supervisor does not hot-restart.
-        applied_restart = Some(42);
-        let outcome = detect_regression(&mut rx, &backlog, chain, &mut applied_restart).await;
+        // Applying the reset wipes the confirmed checkpoint: the unchanged
+        // directive now classifies as aligned, so no hot-restart loop. New
+        // pending checkpoints do not resurrect it — only contract settlement
+        // does, which flips the directive to Consensus in the same update.
+        backlog.apply_reset(chain, 42).await.unwrap();
+        let outcome = detect_regression(&mut rx, &backlog, chain).await;
         assert_eq!(outcome, RegressionOutcome::Aligned);
-
-        // A different restart height triggers again.
-        _tx.send(Some(CheckpointDirective::Restart(43))).unwrap();
-        let outcome = detect_regression(&mut rx, &backlog, chain, &mut applied_restart).await;
-        assert_eq!(outcome, RegressionOutcome::Recovery);
-
-        // Observing a non-reset directive clears the tracker so a later
-        // reset to a previously seen height still triggers.
-        _tx.send(Some(CheckpointDirective::Consensus(
-            ConsensusCheckpointDigest::new(Chain::Ethereum, 50, [0x11u8; 32]),
-        )))
-        .unwrap();
-        let outcome = detect_regression(&mut rx, &backlog, chain, &mut applied_restart).await;
-        assert_eq!(outcome, RegressionOutcome::Aligned);
-        assert_eq!(applied_restart, None);
-
-        _tx.send(Some(CheckpointDirective::Restart(42))).unwrap();
-        let outcome = detect_regression(&mut rx, &backlog, chain, &mut applied_restart).await;
-        assert_eq!(outcome, RegressionOutcome::Recovery);
     }
 
     #[tokio::test]
@@ -492,13 +456,16 @@ mod tests {
         let backlog = Backlog::new();
         let chain = Chain::Ethereum;
 
+        // Pre-reset state: a confirmed checkpoint exists.
+        backlog.set_processed_block(chain, 100).await.unwrap();
+        let cp = backlog.checkpoint(chain).await.unwrap();
+        assert!(backlog.confirm_consensus(chain, cp.digest()).await.unwrap());
+
         let digest = [0x42u8; 32];
         let (tx, mut rx) = make_digest(100, digest);
 
-        let handle = tokio::spawn(async move {
-            let mut applied_restart = None;
-            wait_detected_regression(&mut rx, &backlog, chain, &mut applied_restart).await
-        });
+        let handle =
+            tokio::spawn(async move { wait_detected_regression(&mut rx, &backlog, chain).await });
 
         tx.send(Some(CheckpointDirective::Restart(7))).unwrap();
 
@@ -525,10 +492,8 @@ mod tests {
 
         let (tx, mut rx) = make_digest(100, matching_digest);
 
-        let handle = tokio::spawn(async move {
-            let mut applied_restart = None;
-            wait_detected_regression(&mut rx, &backlog, chain, &mut applied_restart).await
-        });
+        let handle =
+            tokio::spawn(async move { wait_detected_regression(&mut rx, &backlog, chain).await });
 
         tx.send(Some(CheckpointDirective::Consensus(
             ConsensusCheckpointDigest::new(Chain::Ethereum, 200, [0xabu8; 32]),
@@ -701,9 +666,10 @@ mod tests {
     async fn reset_directive_restarts_anchors_and_settles() {
         let chain = Chain::Ethereum;
         let backlog = Backlog::new();
-        // Pre-reset state: local checkpoint at height 100.
+        // Pre-reset state: confirmed local checkpoint at height 100.
         backlog.set_processed_block(chain, 100).await.unwrap();
-        backlog.checkpoint(chain).await.unwrap();
+        let cp = backlog.checkpoint(chain).await.unwrap();
+        assert!(backlog.confirm_consensus(chain, cp.digest()).await.unwrap());
 
         let attempts = Arc::new(AtomicUsize::new(0));
         let first_cancel = Arc::new(Notify::new());

--- a/chain-signatures/node/src/stream/test_utils.rs
+++ b/chain-signatures/node/src/stream/test_utils.rs
@@ -14,9 +14,9 @@ use mockito::Server;
 use mpc_chain_canton::CantonChainCtx;
 use mpc_chain_integration_core::{ChainIndexer, NoopChainTelemetry};
 use mpc_primitives::{
-    BidirectionalTx, BidirectionalTxId, Chain, CheckpointDigest, IndexedSignRequest,
-    RespondBidirectionalEvent, SignArgs, SignBidirectionalEvent, SignCommand, SignId, SignKind,
-    Signature, SignatureRespondedEvent,
+    BidirectionalTx, BidirectionalTxId, Chain, IndexedSignRequest, RespondBidirectionalEvent,
+    SignArgs, SignBidirectionalEvent, SignCommand, SignId, SignKind, Signature,
+    SignatureRespondedEvent,
 };
 use mpc_utils::time::current_unix_timestamp;
 use near_primitives::types::AccountId;
@@ -140,7 +140,7 @@ pub fn make_test_stream_context(
     threshold: usize,
 ) -> (
     StreamContext,
-    watch::Sender<Option<CheckpointDigest>>,
+    watch::Sender<Option<crate::types::CheckpointDirective>>,
     watch::Sender<MeshState>,
     mpsc::Receiver<RpcAction>,
 ) {

--- a/chain-signatures/node/src/types.rs
+++ b/chain-signatures/node/src/types.rs
@@ -2,7 +2,6 @@ use cait_sith::protocol::{Action, InitializationError, MessageData, Participant,
 use cait_sith::{protocol::Protocol, KeygenOutput};
 use cait_sith::{FullSignature, PresignOutput};
 use k256::{elliptic_curve::CurveArithmetic, Secp256k1};
-use mpc_primitives::CheckpointDigest;
 use tokio::sync::watch;
 
 use crate::protocol::contract::ResharingContractState;
@@ -22,7 +21,9 @@ pub type SignatureProtocol = Box<dyn Protocol<Output = FullSignature<Secp256k1>>
 
 pub type Epoch = u64;
 
-pub type CheckpointWatcher = watch::Receiver<Option<CheckpointDigest>>;
+pub use mpc_primitives::CheckpointDirective;
+
+pub type CheckpointWatcher = watch::Receiver<Option<CheckpointDirective>>;
 
 pub struct KeygenProtocol {
     me: Participant,
@@ -99,5 +100,27 @@ impl ReshareProtocol {
 
     pub fn message(&mut self, from: Participant, data: MessageData) {
         self.protocol.message(from, data);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mpc_primitives::{Chain, ConsensusCheckpointDigest};
+
+    #[test]
+    fn only_consensus_directives_expose_a_digest() {
+        assert!(CheckpointDirective::Restart(42)
+            .consensus_digest()
+            .is_none());
+
+        let digest = ConsensusCheckpointDigest::new(Chain::Ethereum, 100, [7u8; 32]);
+        assert_eq!(
+            CheckpointDirective::Consensus(digest)
+                .consensus_digest()
+                .unwrap()
+                .height,
+            100
+        );
     }
 }

--- a/chain-signatures/primitives/src/backlog.rs
+++ b/chain-signatures/primitives/src/backlog.rs
@@ -74,8 +74,52 @@ impl ConsensusCheckpointDigest {
     }
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CheckpointDigest {
     pub height: u64,
     pub digest: [u8; 32],
+}
+
+/// The contract's checkpoint directive for a chain.
+///
+/// Absence (no entry) means the contract holds no directive: chains fall back
+/// to their own anchoring behavior. A [`CheckpointDirective::Restart`] marker
+/// is written by a checkpoint reset and instructs indexers to restart from
+/// the given height.
+#[derive(
+    BorshDeserialize,
+    BorshSerialize,
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+)]
+pub enum CheckpointDirective {
+    /// Checkpoints were reset; indexers should restart from this height.
+    Restart(u64),
+    /// The latest consensus-settled checkpoint digest.
+    Consensus(ConsensusCheckpointDigest),
+}
+
+impl CheckpointDirective {
+    /// The settled checkpoint digest, if this is a consensus directive.
+    pub fn consensus_digest(&self) -> Option<&ConsensusCheckpointDigest> {
+        match self {
+            CheckpointDirective::Restart(_) => None,
+            CheckpointDirective::Consensus(digest) => Some(digest),
+        }
+    }
+
+    pub fn height(&self) -> u64 {
+        match self {
+            CheckpointDirective::Restart(height) => *height,
+            CheckpointDirective::Consensus(digest) => digest.height,
+        }
+    }
 }

--- a/chain-signatures/primitives/src/lib.rs
+++ b/chain-signatures/primitives/src/lib.rs
@@ -15,7 +15,7 @@ mod requests;
 
 pub use signet_primitives::*;
 
-pub use backlog::{CheckpointDigest, ConsensusCheckpointDigest};
+pub use backlog::{CheckpointDigest, CheckpointDirective, ConsensusCheckpointDigest};
 pub use bidirectional::{
     BidirectionalTx, RespondBidirectionalEvent, RespondBidirectionalTx, SignBidirectionalEvent,
 };

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -15,7 +15,8 @@ use mpc_node::protocol::state::NodeStatus;
 use mpc_node::protocol::sync::{SyncChannel, SyncUpdate};
 use mpc_node::protocol::{Governance, MessageChannel, ProtocolState};
 use mpc_node::storage::{PresignatureStorage, TripleStorage};
-use mpc_primitives::{Chain, CheckpointDigest, IndexedSignRequest, SignCommand};
+use mpc_node::types::CheckpointDirective;
+use mpc_primitives::{Chain, IndexedSignRequest, SignCommand};
 use near_sdk::AccountId;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -43,7 +44,7 @@ pub struct MpcFixtureNode {
     pub mock_streams: HashMap<Chain, MockStream>,
 
     /// Keeps the per-node checkpoint watch sender alive for the test's lifetime.
-    pub checkpoint_tx: watch::Sender<Option<CheckpointDigest>>,
+    pub checkpoint_tx: watch::Sender<Option<CheckpointDirective>>,
     pub triple_storage: TripleStorage,
     pub presignature_storage: PresignatureStorage,
     pub backlog: Backlog,

--- a/integration-tests/tests/cases/checkpoint.rs
+++ b/integration-tests/tests/cases/checkpoint.rs
@@ -1,7 +1,7 @@
 //! Tests checkpoint consensus alignment via peer-to-peer HTTP fetch.
 
 use integration_tests::mpc_fixture::{mock_stream::MockStream, MpcFixtureBuilder};
-use mpc_node::backlog::consensus::align_backlog_with_consensus;
+use mpc_node::backlog::consensus::{align_backlog_with_consensus, Alignment};
 use mpc_node::backlog::Backlog;
 use mpc_node::mesh::connection::NodeStatus;
 use mpc_node::mesh::MeshState;
@@ -179,12 +179,11 @@ async fn test_consensus_alignment_peer_fetch() {
 
     let result = result.expect("align_backlog_with_consensus should not hang");
 
-    assert!(
-        result.is_some(),
-        "should have recovered to height {} from peer",
-        expected_height
+    assert_eq!(
+        result,
+        Alignment::Regressed(expected_height),
+        "should have recovered to height {expected_height} from peer"
     );
-    assert_eq!(result.unwrap(), expected_height);
 
     // Verify fresh backlog has the checkpoint
     let latest = fresh_backlog.latest_checkpoint(chain).await;
@@ -269,9 +268,10 @@ async fn test_consensus_alignment_consensus_changes_while_fetching() {
         .expect("align should complete within timeout")
         .expect("spawned task should not panic");
 
-    assert!(
-        result.is_none(),
-        "should return None when consensus digest changes to None"
+    assert_eq!(
+        result,
+        Alignment::Aligned,
+        "should report aligned when consensus digest changes to None"
     );
 
     assert!(fresh_backlog.latest_checkpoint(chain).await.is_none());

--- a/integration-tests/tests/cases/checkpoint.rs
+++ b/integration-tests/tests/cases/checkpoint.rs
@@ -8,7 +8,8 @@ use mpc_node::mesh::MeshState;
 use mpc_node::node_client::{NodeClient, Options as NodeClientOptions};
 use mpc_node::protocol::ParticipantInfo;
 use mpc_node::storage::CheckpointStorage;
-use mpc_primitives::{Chain, ChainConfig as _, CheckpointDigest};
+use mpc_node::types::CheckpointDirective;
+use mpc_primitives::{Chain, ChainConfig as _, ConsensusCheckpointDigest};
 use near_sdk::AccountId;
 use std::time::Duration;
 use test_log::test;
@@ -149,10 +150,10 @@ async fn test_consensus_alignment_peer_fetch() {
         info,
     );
 
-    let (_cp_tx, mut checkpoints_rx) = tokio::sync::watch::channel(Some(CheckpointDigest {
-        height: expected_height,
-        digest,
-    }));
+    let (_cp_tx, mut checkpoints_rx) =
+        tokio::sync::watch::channel(Some(CheckpointDirective::Consensus(
+            ConsensusCheckpointDigest::new(Chain::Ethereum, expected_height, digest),
+        )));
     let (_mesh_tx, mut mesh_rx) = tokio::sync::watch::channel(mesh_state);
 
     // Fresh persisted backlog (simulates a node that just started)
@@ -232,10 +233,10 @@ async fn test_consensus_alignment_consensus_changes_while_fetching() {
     );
 
     // Start with a non-matching digest; we'll change it to zero to abort the fetch loop.
-    let (cp_tx, mut checkpoints_rx) = tokio::sync::watch::channel(Some(CheckpointDigest {
-        height: 9999,
-        digest: [0xabu8; 32],
-    }));
+    let (cp_tx, mut checkpoints_rx) =
+        tokio::sync::watch::channel(Some(CheckpointDirective::Consensus(
+            ConsensusCheckpointDigest::new(Chain::Ethereum, 9999, [0xabu8; 32]),
+        )));
     let (_mesh_tx, mut mesh_rx) = tokio::sync::watch::channel(mesh_state);
 
     let fresh_storage = CheckpointStorage::in_memory();


### PR DESCRIPTION
Adds in the ability to reset checkpoints based on the governance contract `reset_checkpoint([(Chain, Height)])`.

* `Contract::latest_checkpoint` now returns `Option<CheckpointDirective>` where we have:
   ```rs
   enum CheckpointDirective {
       Restart(Height),
       Consensus(ConsensusCheckpointDigest),
   }
   ```
* Contract serialization breaking change with the above, so we need a new migration for current devnet
* Contract `vote_checkpoint` treats `Restart(h)` as a floor: digests below h are rejected (CheckpointBehind), anything ≥ h proceeds normally; once a digest settles it replaces the restart marker.
* A reset/restart follows somewhat of the same code path as regression.
* In-flight checkpoint-vote RPCs and sign tasks are aborted on reset, which is the same as divergence/regression.