### PR TITLE
feat(sign): publish failover

### DIFF
--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -284,12 +284,13 @@ impl Backlog {
         requeueable
     }
 
-    /// Returns backlog requests for a chain that are ready to be published.
+    /// Returns backlog requests for a chain that are ready to be published, each
+    /// with whether this node already dispatched a publish for it.
     /// Sorted by indexed timestamp and request id.
     pub async fn publishable_requests(
         &self,
         chain: Chain,
-    ) -> Vec<(Arc<IndexedSignRequest>, Arc<PublishState>)> {
+    ) -> Vec<(Arc<IndexedSignRequest>, Arc<PublishState>, bool)> {
         // Read-only scan; the publish failover sweep calls this on every block, so a
         // write lock here would serialize against the signing hot path for nothing.
         let pending = self.pending(&chain).read().await;
@@ -299,9 +300,11 @@ impl Backlog {
             .values()
             .filter_map(|entry| match &entry.status {
                 SignStatus::PendingPublish { publish }
-                | SignStatus::PendingPublishBidirectional { publish } => {
-                    Some((Arc::clone(&entry.request), Arc::clone(publish)))
-                }
+                | SignStatus::PendingPublishBidirectional { publish } => Some((
+                    Arc::clone(&entry.request),
+                    Arc::clone(publish),
+                    entry.publish_dispatched,
+                )),
                 _ => None,
             })
             .collect();
@@ -360,6 +363,18 @@ impl Backlog {
         };
 
         entry.mark_publishing(publish)
+    }
+
+    /// Record that this node dispatched a publish for `id`'s current
+    /// pending-publish episode, returning `false` if one was already dispatched or
+    /// the entry is gone.
+    pub async fn mark_publish_dispatched(&self, chain: Chain, id: &SignId) -> bool {
+        let mut pending = self.pending(&chain).write().await;
+
+        pending
+            .requests
+            .get_mut(id)
+            .is_some_and(BacklogEntry::mark_publish_dispatched)
     }
 
     // TODO: the backlog is a bit bloated with transition functions, so we need to do a proper cleanup
@@ -738,22 +753,34 @@ pub enum BacklogError {
     InvalidBidirectionalResponseTransition,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Eq, serde::Serialize, serde::Deserialize)]
 pub struct BacklogEntry {
     pub request: Arc<IndexedSignRequest>,
     pub status: SignStatus,
+    /// Whether this node has dispatched a publish for this entry. Node-local, so it
+    /// is not serialized, and checkpoint recovery resets it.
+    #[serde(skip)]
+    publish_dispatched: bool,
+}
+
+/// Node-local state is not part of an entry's identity to avoid divergence.
+impl PartialEq for BacklogEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.request == other.request && self.status == other.status
+    }
 }
 
 impl BacklogEntry {
     pub fn new(request: Arc<IndexedSignRequest>) -> Self {
-        Self {
-            request,
-            status: SignStatus::PendingGeneration,
-        }
+        Self::with_status(request, SignStatus::PendingGeneration)
     }
 
     pub fn with_status(request: Arc<IndexedSignRequest>, status: SignStatus) -> Self {
-        Self { request, status }
+        Self {
+            request,
+            status,
+            publish_dispatched: false,
+        }
     }
 
     pub fn pending_execution(request: Arc<IndexedSignRequest>, tx: Arc<BidirectionalTx>) -> Self {
@@ -799,12 +826,25 @@ impl BacklogEntry {
         self.status.clone()
     }
 
+    /// The single place a status is assigned. Every transition ends the current
+    /// pending-publish episode, so no dispatch flag may survive one.
+    fn enter_status(&mut self, status: SignStatus) {
+        self.status = status;
+        self.publish_dispatched = false;
+    }
+
+    /// Record that this node dispatched a publish for the current episode,
+    /// returning `false` if one was already dispatched.
+    fn mark_publish_dispatched(&mut self) -> bool {
+        !std::mem::replace(&mut self.publish_dispatched, true)
+    }
+
     /// Set the status of this transaction
     ///
     /// Test-only; see the note on [`Backlog::set_request`].
     #[cfg(any(test, feature = "test-feature"))]
     pub fn set_status(&mut self, status: SignStatus) {
-        self.status = status;
+        self.enter_status(status);
     }
 
     /// Test-only; see the note on [`Backlog::set_request`].
@@ -832,18 +872,18 @@ impl BacklogEntry {
         }
 
         self.request = request;
-        self.status = SignStatus::PendingGenerationBidirectional;
+        self.enter_status(SignStatus::PendingGenerationBidirectional);
         Ok(())
     }
 
     pub fn mark_publishing(&mut self, publish: Arc<PublishState>) -> Result<(), BacklogError> {
         match (&self.request.kind, &self.status) {
             (SignKind::Sign | SignKind::SignBidirectional(_), SignStatus::PendingGeneration) => {
-                self.status = SignStatus::PendingPublish { publish };
+                self.enter_status(SignStatus::PendingPublish { publish });
                 Ok(())
             }
             (SignKind::RespondBidirectional(_), SignStatus::PendingGenerationBidirectional) => {
-                self.status = SignStatus::PendingPublishBidirectional { publish };
+                self.enter_status(SignStatus::PendingPublishBidirectional { publish });
                 Ok(())
             }
             _ => Err(BacklogError::InvalidPublishingTransition),
@@ -859,9 +899,9 @@ impl BacklogEntry {
                 SignKind::SignBidirectional(_),
                 SignStatus::PendingGeneration | SignStatus::PendingPublish { .. },
             ) => {
-                self.status = SignStatus::PendingExecution {
+                self.enter_status(SignStatus::PendingExecution {
                     tx: bidirectional_tx,
-                };
+                });
                 Ok(())
             }
             _ => Err(BacklogError::InvalidAdvanceTransition),
@@ -1964,6 +2004,70 @@ mod tests {
             .await
             .expect("entry should remain in backlog");
         assert!(matches!(entry.status(), SignStatus::PendingPublish { .. }));
+    }
+
+    /// The flag keeps the per-block sweep to one publish per pending-publish
+    /// episode. Entering pending-publish again, as the second bidirectional leg
+    /// does, starts a new one.
+    #[tokio::test]
+    async fn test_mark_publish_dispatched_is_once_per_episode() {
+        let backlog = Backlog::new();
+        let sign_id = SignId::new([45u8; 32]);
+
+        assert!(
+            !backlog
+                .mark_publish_dispatched(Chain::Solana, &sign_id)
+                .await,
+            "an entry that is not in the backlog cannot be dispatched"
+        );
+
+        backlog
+            .insert(create_bidirectional_request(
+                sign_id,
+                Chain::Solana,
+                "ethereum",
+                0,
+            ))
+            .await;
+        backlog
+            .mark_publishing(Chain::Solana, &sign_id, test_publish_state(false))
+            .await
+            .expect("pending generation should transition to pending publish");
+
+        let dispatched = |backlog: Backlog| async move {
+            let publishable = backlog.publishable_requests(Chain::Solana).await;
+            assert_eq!(publishable.len(), 1, "the entry stays in the scan");
+            publishable[0].2
+        };
+
+        assert!(!dispatched(backlog.clone()).await);
+        assert!(
+            backlog
+                .mark_publish_dispatched(Chain::Solana, &sign_id)
+                .await
+        );
+        assert!(
+            !backlog
+                .mark_publish_dispatched(Chain::Solana, &sign_id)
+                .await,
+            "the second dispatch is refused"
+        );
+        assert!(
+            dispatched(backlog.clone()).await,
+            "the scan reports it, so the sweep skips it and the resume still sees it"
+        );
+
+        backlog
+            .set_status(Chain::Solana, &sign_id, SignStatus::PendingGeneration)
+            .await;
+        backlog
+            .mark_publishing(Chain::Solana, &sign_id, test_publish_state(false))
+            .await
+            .expect("re-entering pending publish starts a new episode");
+        assert!(
+            !dispatched(backlog.clone()).await,
+            "a new episode is scheduled afresh"
+        );
     }
 
     #[tokio::test]

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -290,7 +290,7 @@ impl Backlog {
         &self,
         chain: Chain,
     ) -> Vec<(Arc<IndexedSignRequest>, Arc<PublishState>)> {
-        // Read-only scan; the deliberator sweep calls this on every block, so a
+        // Read-only scan; the publish failover sweep calls this on every block, so a
         // write lock here would serialize against the signing hot path for nothing.
         let pending = self.pending(&chain).read().await;
 

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -290,7 +290,7 @@ impl Backlog {
         &self,
         chain: Chain,
     ) -> Vec<(Arc<IndexedSignRequest>, Arc<PublishState>)> {
-        // Read-only scan; the backup sweep calls this every second per chain, so a
+        // Read-only scan; the deliberator sweep calls this on every block, so a
         // write lock here would serialize against the signing hot path for nothing.
         let pending = self.pending(&chain).read().await;
 
@@ -934,11 +934,11 @@ mod tests {
     }
 
     fn test_publish_state(is_proposer: bool) -> Arc<PublishState> {
-        Arc::new(PublishState {
-            signature: test_signature(),
-            participants: vec![Participant::from(0u32), Participant::from(1u32)],
+        Arc::new(PublishState::new(
+            test_signature(),
+            vec![Participant::from(0u32), Participant::from(1u32)],
             is_proposer,
-        })
+        ))
     }
 
     fn pending_execution_status(tx: &BidirectionalTx) -> SignStatus {

--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -913,6 +913,7 @@ async fn spawn_indexers(
             mesh_state.clone(),
             node_client.clone(),
             checkpoints_rx[Chain::Hydration].clone(),
+            rpc_channel.clone(),
         ));
     }
 

--- a/chain-signatures/node/src/indexer_hydration/mod.rs
+++ b/chain-signatures/node/src/indexer_hydration/mod.rs
@@ -656,7 +656,7 @@ pub async fn run<T: ChainTelemetry>(
                 }
             }
 
-            crate::stream::ops::publish_failover_due(&mut ctx, Chain::Hydration).await;
+            crate::stream::ops::publish_failover_due(&ctx, Chain::Hydration).await;
             telemetry.block_indexed(number.into());
         }
 

--- a/chain-signatures/node/src/indexer_hydration/mod.rs
+++ b/chain-signatures/node/src/indexer_hydration/mod.rs
@@ -656,7 +656,7 @@ pub async fn run<T: ChainTelemetry>(
                 }
             }
 
-            crate::stream::ops::deliberator_publish_due(&mut ctx, Chain::Hydration).await;
+            crate::stream::ops::publish_failover_due(&mut ctx, Chain::Hydration).await;
             telemetry.block_indexed(number.into());
         }
 

--- a/chain-signatures/node/src/indexer_hydration/mod.rs
+++ b/chain-signatures/node/src/indexer_hydration/mod.rs
@@ -324,6 +324,7 @@ pub async fn run<T: ChainTelemetry>(
     mut mesh_state: watch::Receiver<MeshState>,
     node_client: NodeClient,
     mut checkpoints_rx: CheckpointWatcher,
+    rpc: crate::rpc::RpcChannel,
 ) {
     // Hydrate the local checkpoint before aligning: the web server (spawned
     // independently) can then serve durable pending bodies to peers during
@@ -362,22 +363,16 @@ pub async fn run<T: ChainTelemetry>(
     )
     .await;
 
-    // Create a StreamContext with a dummy RpcChannel (Hydration does not publish)
-    let ctx = {
-        let (rpc_tx, _rpc_rx) = mpsc::channel(1);
-        let rpc = crate::rpc::RpcChannel { tx: rpc_tx };
-        let mut ctx = StreamContext::new(
-            backlog.clone(),
-            sign_tx.clone(),
-            rpc,
-            contract_watcher.clone(),
-            mesh_state.clone(),
-            node_client.clone(),
-            checkpoints_rx.clone(),
-        );
-        ctx.caught_up = true;
-        ctx
-    };
+    let mut ctx = StreamContext::new(
+        backlog.clone(),
+        sign_tx.clone(),
+        rpc,
+        contract_watcher.clone(),
+        mesh_state.clone(),
+        node_client.clone(),
+        checkpoints_rx.clone(),
+    );
+    ctx.caught_up = true;
 
     let ws_url: &str = hydration.rpc_ws_url.as_str();
     const RECONNECT_DELAY: Duration = Duration::from_secs(5);
@@ -661,6 +656,7 @@ pub async fn run<T: ChainTelemetry>(
                 }
             }
 
+            crate::stream::ops::deliberator_publish_due(&mut ctx, Chain::Hydration).await;
             telemetry.block_indexed(number.into());
         }
 

--- a/chain-signatures/node/src/protocol/deliberator_publish.rs
+++ b/chain-signatures/node/src/protocol/deliberator_publish.rs
@@ -1,0 +1,170 @@
+//! Deliberator publish: fail over the response publish when the proposer stays silent.
+//!
+//! Every participant stores the [`PublishState`] when it marks the entry
+//! publishing, so failover needs no protocol change, only someone acting on that
+//! stored state. The schedule is a pure function of the entry: the stamp it
+//! carries plus a per-node jitter, so nothing has to be tracked between sweeps
+//! and a restart does not restart the clock.
+//!
+//! The sweep itself lives in the chain stream, on block events. Having observed
+//! the chain through block N is the precondition for concluding the proposer's
+//! response did not land, so the catch-up gate is structural rather than a flag
+//! that can drift: no blocks observed, no failover.
+
+use crate::sign_bidirectional::PublishState;
+
+use mpc_primitives::{Chain, ChainConfig as _, SignId};
+use near_account_id::AccountId;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::time::Duration;
+
+/// Duplicate responses per silent proposer that we are willing to pay for failover.
+const DELIBERATOR_DUPLICATE_RATE: f64 = 2.0;
+
+/// Extra time beyond chain finality for a published response to be observed
+/// (submission, a few publish retries, indexer lag) before deliberators take over.
+pub const DEFAULT_OBSERVE_MARGIN: Duration = Duration::from_secs(15);
+
+/// The lag from one node publishing a response until another node has observed it.
+///
+/// `override_lag` is `None` in production, giving chain finality plus the margin.
+/// A fixture pins it so its timing does not move when a finality constant does.
+fn observe_lag(chain: Chain, override_lag: Option<Duration>) -> Duration {
+    override_lag.unwrap_or_else(|| {
+        Duration::from_secs(chain.expected_finality_time_secs()) + DEFAULT_OBSERVE_MARGIN
+    })
+}
+
+/// The longest a deliberator can wait before publishing, for fixtures that outlast
+/// the schedule without restating it.
+#[cfg(any(test, feature = "test-feature"))]
+pub fn max_deliberator_publish_delay(
+    chain: Chain,
+    deliberators: usize,
+    override_lag: Option<Duration>,
+) -> Duration {
+    deliberator_publish_delay(deliberators, 1.0, observe_lag(chain, override_lag))
+}
+
+/// This node's position in the failover schedule for one request: uniform in
+/// [0, 1) as a pure function of sign id and account id.
+///
+/// Identical draws would put every deliberator on chain at once (`E[responses]`
+/// of `m`, not `1 + d`); determinism is what lets the schedule survive restarts.
+fn deliberator_jitter(sign_id: &SignId, me: &AccountId) -> f64 {
+    let mut hasher = DefaultHasher::new();
+    (sign_id.request_id, me.as_str()).hash(&mut hasher);
+    // Top 53 bits: exact in an f64, so the result stays strictly below 1.
+    (hasher.finish() >> 11) as f64 / (1u64 << 53) as f64
+}
+
+/// How long a non-proposer waits before publishing: `L + jitter * m*L/d`, for `L`
+/// the observe lag, `m` the number of deliberators and `d` [`DELIBERATOR_DUPLICATE_RATE`].
+///
+/// The `L` offset keeps the happy path at one response: a proposer that publishes
+/// is observed before the earliest deliberator can fire. The window prices failover:
+/// the lowest draw publishes, and so does every draw within `L` of it, which over
+/// a window of `m*L/d` is `d` deliberators in expectation. Slow-finality chains fail
+/// over in tens of minutes; accepted, since the alternative is no response at all.
+fn deliberator_publish_delay(deliberators: usize, jitter: f64, lag: Duration) -> Duration {
+    let window = lag.mul_f64(deliberators as f64 / DELIBERATOR_DUPLICATE_RATE);
+    lag + window.mul_f64(jitter)
+}
+
+/// Unix second from which `me` may publish `request` itself, if the proposer's
+/// response has still not been observed by then. `None` for an entry that
+/// carries no stamp, which never fails over; see [`PublishState::publishing_since`].
+pub(crate) fn publish_deadline(
+    sign_id: &SignId,
+    publish: &PublishState,
+    me: &AccountId,
+    chain: Chain,
+    override_lag: Option<Duration>,
+) -> Option<u64> {
+    let deliberators = publish.participants.len().saturating_sub(1);
+    let delay = deliberator_publish_delay(
+        deliberators,
+        deliberator_jitter(sign_id, me),
+        observe_lag(chain, override_lag),
+    );
+    Some(publish.publishing_since? + delay.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cait_sith::protocol::Participant;
+    use k256::{ProjectivePoint, Scalar};
+    use mpc_primitives::Signature;
+
+    fn account(name: &str) -> AccountId {
+        name.parse().unwrap()
+    }
+
+    fn publish_state(participants: usize, publishing_since: Option<u64>) -> PublishState {
+        PublishState {
+            signature: Signature::new(ProjectivePoint::GENERATOR.to_affine(), Scalar::ONE, 0),
+            participants: (0..participants as u32).map(Participant::from).collect(),
+            is_proposer: false,
+            publishing_since,
+        }
+    }
+
+    const LAG: Option<Duration> = None;
+
+    /// A proposer whose first attempt failed must still land inside the margin.
+    #[test]
+    fn observe_margin_outlasts_the_first_publish_retry() {
+        assert!(DEFAULT_OBSERVE_MARGIN > crate::rpc::PUBLISH_MIN_DELAY);
+    }
+
+    #[test]
+    fn deliberator_jitter_is_deterministic_and_spread() {
+        let me = account("node0.near");
+        let id = SignId::new([7u8; 32]);
+        assert_eq!(deliberator_jitter(&id, &me), deliberator_jitter(&id, &me));
+
+        let mut draws: Vec<f64> = (0u8..20)
+            .map(|byte| deliberator_jitter(&SignId::new([byte; 32]), &me))
+            .collect();
+        draws.extend(
+            (0u8..20).map(|byte| deliberator_jitter(&id, &account(&format!("node{byte}.near")))),
+        );
+        assert!(draws.iter().all(|draw| (0.0..1.0).contains(draw)));
+        let first = draws[0];
+        assert!(draws.iter().any(|draw| *draw != first));
+    }
+
+    /// The deadline is anchored on the entry's own stamp, so an entry recovered
+    /// after a restart resumes its schedule instead of starting a new one, and
+    /// two nodes reach different deadlines for the same entry.
+    #[test]
+    fn publish_deadline_follows_the_stamp_and_the_node() {
+        let sign_id = SignId::new([1u8; 32]);
+        let lag = observe_lag(Chain::Solana, LAG).as_secs();
+        let me = account("node0.near");
+
+        let deadline = |since, who: &AccountId| {
+            publish_deadline(&sign_id, &publish_state(3, since), who, Chain::Solana, LAG)
+        };
+
+        let at_zero = deadline(Some(0), &me).expect("a stamped entry has a deadline");
+        assert!(at_zero >= lag, "never fires before one observe lag");
+
+        let later = deadline(Some(1_000), &me).expect("a stamped entry has a deadline");
+        assert_eq!(
+            later,
+            at_zero + 1_000,
+            "the stamp shifts the whole schedule"
+        );
+
+        let peer =
+            deadline(Some(0), &account("node1.near")).expect("a stamped entry has a deadline");
+        assert_ne!(peer, at_zero, "nodes draw different positions");
+
+        assert!(
+            deadline(None, &me).is_none(),
+            "an entry written before the stamp existed never fails over"
+        );
+    }
+}

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -1,6 +1,7 @@
 pub mod consensus;
 pub mod contract;
 pub mod cryptography;
+pub mod deliberator_publish;
 pub mod error;
 pub mod message;
 pub mod posit;

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -1,11 +1,11 @@
 pub mod consensus;
 pub mod contract;
 pub mod cryptography;
-pub mod deliberator_publish;
 pub mod error;
 pub mod message;
 pub mod posit;
 pub mod presignature;
+pub mod publish_failover;
 pub mod request;
 pub mod signature;
 pub mod state;

--- a/chain-signatures/node/src/protocol/publish_failover.rs
+++ b/chain-signatures/node/src/protocol/publish_failover.rs
@@ -1,22 +1,17 @@
 //! Publish failover: republish a response the proposer never got on chain.
 //!
 //! Every participant stores the [`PublishState`] when it marks the entry
-//! publishing, so failover needs no protocol change, only someone acting on that
-//! stored state. The schedule is a pure function of the entry: the stamp it
-//! carries plus a per-node jitter, so nothing has to be tracked between sweeps
-//! and a restart does not restart the clock.
+//! publishing. The schedule is a pure function of that entry, its stamp plus a
+//! per-node jitter, so a restart does not restart the clock.
 //!
-//! The sweep itself lives in the chain stream, on block events. Having observed
-//! the chain through block N is the precondition for concluding the proposer's
-//! response did not land, so the catch-up gate is structural rather than a flag
-//! that can drift: no blocks observed, no failover.
+//! The sweep lives in the chain stream, on block events: having observed the
+//! chain through block N is what licenses concluding the response did not land,
+//! so the catch-up gate is structural rather than a flag that can drift.
 //!
-//! Every participant is scheduled, the proposer included. Its own deadline is one
-//! observe lag away, by which point its response has either been observed, so the
-//! entry is gone and the sweep finds nothing, or it has not, and a second attempt
-//! is what we wanted anyway. Skipping it would buy nothing and would make the
-//! schedule depend on `is_proposer`, which is the writing node's local role and
-//! is replaced wholesale by whichever peer serves a checkpoint recovery.
+//! The proposer is scheduled too. Its own deadline is one observe lag away, by
+//! which point its response is either observed, so the entry is gone, or it is
+//! not, and a second attempt is wanted. Skipping it would make the schedule
+//! depend on `is_proposer`, a local role that checkpoint recovery overwrites.
 
 use crate::sign_bidirectional::PublishState;
 
@@ -32,18 +27,17 @@ const FAILOVER_DUPLICATE_RATE: f64 = 2.0;
 /// (submission, a few publish retries, indexer lag) before the failover takes over.
 pub const DEFAULT_OBSERVE_MARGIN: Duration = Duration::from_secs(15);
 
-/// The lag from one node publishing a response until another node has observed it.
-///
-/// `override_lag` is `None` in production, giving chain finality plus the margin.
-/// A fixture pins it so its timing does not move when a finality constant does.
+/// The lag from one node publishing a response until another has observed it.
+/// `None` in production, giving chain finality plus the margin; a fixture pins it
+/// so its timing does not move when a finality constant does.
 fn observe_lag(chain: Chain, override_lag: Option<Duration>) -> Duration {
     override_lag.unwrap_or_else(|| {
         Duration::from_secs(chain.expected_finality_time_secs()) + DEFAULT_OBSERVE_MARGIN
     })
 }
 
-/// The longest any participant can wait before publishing, for fixtures that
-/// outlast the schedule without restating it.
+/// The longest any participant can wait, for fixtures that outlast the schedule
+/// without restating it.
 #[cfg(any(test, feature = "test-feature"))]
 pub fn max_publish_failover_delay(
     chain: Chain,
@@ -53,11 +47,9 @@ pub fn max_publish_failover_delay(
     failover_delay(participants, 1.0, observe_lag(chain, override_lag))
 }
 
-/// This node's position in the failover schedule for one request: uniform in
-/// [0, 1) as a pure function of sign id and account id.
-///
-/// Identical draws would put every participant on chain at once (`E[responses]`
-/// of `m`, not `1 + d`); determinism is what lets the schedule survive restarts.
+/// This node's position in the schedule for one request: uniform in [0, 1) as a
+/// pure function of sign id and account id. Identical draws would put every
+/// participant on chain at once (`E[responses]` of `m`, not `1 + d`).
 fn failover_jitter(sign_id: &SignId, me: &AccountId) -> f64 {
     let mut hasher = DefaultHasher::new();
     (sign_id.request_id, me.as_str()).hash(&mut hasher);
@@ -66,22 +58,20 @@ fn failover_jitter(sign_id: &SignId, me: &AccountId) -> f64 {
 }
 
 /// How long a node waits before publishing: `L + jitter * m*L/d`, for `L` the
-/// observe lag, `m` the number of participants that could publish and `d`
-/// [`FAILOVER_DUPLICATE_RATE`].
+/// observe lag, `m` the participants and `d` [`FAILOVER_DUPLICATE_RATE`].
 ///
-/// The `L` offset keeps the happy path at one response: a proposer that publishes
-/// is observed before the earliest failover can fire. The window prices failover:
-/// the lowest draw publishes, and so does every draw within `L` of it, which over
-/// a window of `m*L/d` is `d` nodes in expectation. Slow-finality chains fail
-/// over in tens of minutes; accepted, since the alternative is no response at all.
+/// The `L` offset keeps the happy path at one response, since a proposer that
+/// publishes is observed before the earliest failover fires. The window prices
+/// failover: the lowest draw publishes, and so does every draw within `L` of it,
+/// which over `m*L/d` is `d` nodes in expectation.
 fn failover_delay(participants: usize, jitter: f64, lag: Duration) -> Duration {
     let window = lag.mul_f64(participants as f64 / FAILOVER_DUPLICATE_RATE);
     lag + window.mul_f64(jitter)
 }
 
-/// Unix second from which `me` may publish `request` itself, if the proposer's
-/// response has still not been observed by then. `None` for an entry that
-/// carries no stamp, which never fails over; see [`PublishState::publishing_since`].
+/// Unix second from which `me` may publish this entry itself. `None` for an entry
+/// carrying no stamp, which never fails over; see
+/// [`PublishState::publishing_since`].
 pub(crate) fn publish_deadline(
     sign_id: &SignId,
     publish: &PublishState,

--- a/chain-signatures/node/src/protocol/publish_failover.rs
+++ b/chain-signatures/node/src/protocol/publish_failover.rs
@@ -4,9 +4,12 @@
 //! publishing. The schedule is a pure function of that entry, its stamp plus a
 //! per-node jitter, so a restart does not restart the clock.
 //!
-//! The sweep lives in the chain stream, on block events: having observed the
-//! chain through block N is what licenses concluding the response did not land,
-//! so the catch-up gate is structural rather than a flag that can drift.
+//! The sweep lives in the chain stream on block events, gated on a completed
+//! catchup.
+//!
+//! The `1 + d` cost assumes the failover response lands, so the nodes still
+//! waiting observe it and drop their entries. If none can land, all `m` fire, once
+//! each, spread over the window.
 //!
 //! The proposer is scheduled too. Its own deadline is one observe lag away, by
 //! which point its response is either observed, so the entry is gone, or it is
@@ -30,7 +33,7 @@ pub const DEFAULT_OBSERVE_MARGIN: Duration = Duration::from_secs(15);
 /// The lag from one node publishing a response until another has observed it.
 /// `None` in production, giving chain finality plus the margin; a fixture pins it
 /// so its timing does not move when a finality constant does.
-fn observe_lag(chain: Chain, override_lag: Option<Duration>) -> Duration {
+pub(crate) fn observe_lag(chain: Chain, override_lag: Option<Duration>) -> Duration {
     override_lag.unwrap_or_else(|| {
         Duration::from_secs(chain.expected_finality_time_secs()) + DEFAULT_OBSERVE_MARGIN
     })
@@ -76,13 +79,12 @@ pub(crate) fn publish_deadline(
     sign_id: &SignId,
     publish: &PublishState,
     me: &AccountId,
-    chain: Chain,
-    override_lag: Option<Duration>,
+    lag: Duration,
 ) -> Option<u64> {
     let delay = failover_delay(
         publish.participants.len(),
         failover_jitter(sign_id, me),
-        observe_lag(chain, override_lag),
+        lag,
     );
     Some(publish.publishing_since? + delay.as_secs())
 }
@@ -142,7 +144,12 @@ mod tests {
         let me = account("node0.near");
 
         let deadline = |since, who: &AccountId| {
-            publish_deadline(&sign_id, &publish_state(3, since), who, Chain::Solana, LAG)
+            publish_deadline(
+                &sign_id,
+                &publish_state(3, since),
+                who,
+                observe_lag(Chain::Solana, LAG),
+            )
         };
 
         let at_zero = deadline(Some(0), &me).expect("a stamped entry has a deadline");

--- a/chain-signatures/node/src/protocol/publish_failover.rs
+++ b/chain-signatures/node/src/protocol/publish_failover.rs
@@ -1,4 +1,4 @@
-//! Deliberator publish: fail over the response publish when the proposer stays silent.
+//! Publish failover: republish a response the proposer never got on chain.
 //!
 //! Every participant stores the [`PublishState`] when it marks the entry
 //! publishing, so failover needs no protocol change, only someone acting on that
@@ -10,6 +10,13 @@
 //! the chain through block N is the precondition for concluding the proposer's
 //! response did not land, so the catch-up gate is structural rather than a flag
 //! that can drift: no blocks observed, no failover.
+//!
+//! Every participant is scheduled, the proposer included. Its own deadline is one
+//! observe lag away, by which point its response has either been observed, so the
+//! entry is gone and the sweep finds nothing, or it has not, and a second attempt
+//! is what we wanted anyway. Skipping it would buy nothing and would make the
+//! schedule depend on `is_proposer`, which is the writing node's local role and
+//! is replaced wholesale by whichever peer serves a checkpoint recovery.
 
 use crate::sign_bidirectional::PublishState;
 
@@ -19,10 +26,10 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::time::Duration;
 
 /// Duplicate responses per silent proposer that we are willing to pay for failover.
-const DELIBERATOR_DUPLICATE_RATE: f64 = 2.0;
+const FAILOVER_DUPLICATE_RATE: f64 = 2.0;
 
 /// Extra time beyond chain finality for a published response to be observed
-/// (submission, a few publish retries, indexer lag) before deliberators take over.
+/// (submission, a few publish retries, indexer lag) before the failover takes over.
 pub const DEFAULT_OBSERVE_MARGIN: Duration = Duration::from_secs(15);
 
 /// The lag from one node publishing a response until another node has observed it.
@@ -35,39 +42,40 @@ fn observe_lag(chain: Chain, override_lag: Option<Duration>) -> Duration {
     })
 }
 
-/// The longest a deliberator can wait before publishing, for fixtures that outlast
-/// the schedule without restating it.
+/// The longest any participant can wait before publishing, for fixtures that
+/// outlast the schedule without restating it.
 #[cfg(any(test, feature = "test-feature"))]
-pub fn max_deliberator_publish_delay(
+pub fn max_publish_failover_delay(
     chain: Chain,
-    deliberators: usize,
+    participants: usize,
     override_lag: Option<Duration>,
 ) -> Duration {
-    deliberator_publish_delay(deliberators, 1.0, observe_lag(chain, override_lag))
+    failover_delay(participants, 1.0, observe_lag(chain, override_lag))
 }
 
 /// This node's position in the failover schedule for one request: uniform in
 /// [0, 1) as a pure function of sign id and account id.
 ///
-/// Identical draws would put every deliberator on chain at once (`E[responses]`
+/// Identical draws would put every participant on chain at once (`E[responses]`
 /// of `m`, not `1 + d`); determinism is what lets the schedule survive restarts.
-fn deliberator_jitter(sign_id: &SignId, me: &AccountId) -> f64 {
+fn failover_jitter(sign_id: &SignId, me: &AccountId) -> f64 {
     let mut hasher = DefaultHasher::new();
     (sign_id.request_id, me.as_str()).hash(&mut hasher);
     // Top 53 bits: exact in an f64, so the result stays strictly below 1.
     (hasher.finish() >> 11) as f64 / (1u64 << 53) as f64
 }
 
-/// How long a non-proposer waits before publishing: `L + jitter * m*L/d`, for `L`
-/// the observe lag, `m` the number of deliberators and `d` [`DELIBERATOR_DUPLICATE_RATE`].
+/// How long a node waits before publishing: `L + jitter * m*L/d`, for `L` the
+/// observe lag, `m` the number of participants that could publish and `d`
+/// [`FAILOVER_DUPLICATE_RATE`].
 ///
 /// The `L` offset keeps the happy path at one response: a proposer that publishes
-/// is observed before the earliest deliberator can fire. The window prices failover:
+/// is observed before the earliest failover can fire. The window prices failover:
 /// the lowest draw publishes, and so does every draw within `L` of it, which over
-/// a window of `m*L/d` is `d` deliberators in expectation. Slow-finality chains fail
+/// a window of `m*L/d` is `d` nodes in expectation. Slow-finality chains fail
 /// over in tens of minutes; accepted, since the alternative is no response at all.
-fn deliberator_publish_delay(deliberators: usize, jitter: f64, lag: Duration) -> Duration {
-    let window = lag.mul_f64(deliberators as f64 / DELIBERATOR_DUPLICATE_RATE);
+fn failover_delay(participants: usize, jitter: f64, lag: Duration) -> Duration {
+    let window = lag.mul_f64(participants as f64 / FAILOVER_DUPLICATE_RATE);
     lag + window.mul_f64(jitter)
 }
 
@@ -81,10 +89,9 @@ pub(crate) fn publish_deadline(
     chain: Chain,
     override_lag: Option<Duration>,
 ) -> Option<u64> {
-    let deliberators = publish.participants.len().saturating_sub(1);
-    let delay = deliberator_publish_delay(
-        deliberators,
-        deliberator_jitter(sign_id, me),
+    let delay = failover_delay(
+        publish.participants.len(),
+        failover_jitter(sign_id, me),
         observe_lag(chain, override_lag),
     );
     Some(publish.publishing_since? + delay.as_secs())
@@ -119,16 +126,16 @@ mod tests {
     }
 
     #[test]
-    fn deliberator_jitter_is_deterministic_and_spread() {
+    fn failover_jitter_is_deterministic_and_spread() {
         let me = account("node0.near");
         let id = SignId::new([7u8; 32]);
-        assert_eq!(deliberator_jitter(&id, &me), deliberator_jitter(&id, &me));
+        assert_eq!(failover_jitter(&id, &me), failover_jitter(&id, &me));
 
         let mut draws: Vec<f64> = (0u8..20)
-            .map(|byte| deliberator_jitter(&SignId::new([byte; 32]), &me))
+            .map(|byte| failover_jitter(&SignId::new([byte; 32]), &me))
             .collect();
         draws.extend(
-            (0u8..20).map(|byte| deliberator_jitter(&id, &account(&format!("node{byte}.near")))),
+            (0u8..20).map(|byte| failover_jitter(&id, &account(&format!("node{byte}.near")))),
         );
         assert!(draws.iter().all(|draw| (0.0..1.0).contains(draw)));
         let first = draws[0];

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -353,11 +353,7 @@ fn build_publish_state(
         request.args.payload,
     )
     .ok()?;
-    let publish = PublishState {
-        signature,
-        participants: participants.to_vec(),
-        is_proposer,
-    };
+    let publish = PublishState::new(signature, participants.to_vec(), is_proposer);
 
     Some(Arc::new(publish))
 }

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -50,9 +50,10 @@ const VOTE_CHECKPOINT_RETRY: RetryConfig = RetryConfig {
 };
 
 /// Which response a publish carries. The two legs of a bidirectional request
-/// share a sign id, so this is what keeps them apart wherever a publish is keyed.
+/// share a sign id, so this is what keeps the dispatch loop's in-flight set from
+/// treating a second leg as a duplicate of its first.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum PublishKind {
+enum PublishKind {
     /// The signed transaction (an ordinary request's only response, or leg 1).
     Response,
     /// The signed execution outcome (leg 2).
@@ -60,7 +61,7 @@ pub enum PublishKind {
 }
 
 impl PublishKind {
-    pub fn of(kind: &SignKind) -> Self {
+    fn of(kind: &SignKind) -> Self {
         match kind {
             SignKind::Sign | SignKind::SignBidirectional(_) => PublishKind::Response,
             SignKind::RespondBidirectional(_) => PublishKind::BidirectionalResponse,

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -23,7 +23,7 @@ use mpc_chain_integration_core::{
     ChainPublisher, PublishAction,
 };
 pub use mpc_contract::primitives::{Read, View};
-use mpc_primitives::{CheckpointDigest, ConsensusCheckpointDigest, SignId, Signature};
+use mpc_primitives::{CheckpointDigest, ConsensusCheckpointDigest, SignId, SignKind, Signature};
 
 use near_account_id::AccountId;
 use std::collections::HashMap;
@@ -37,7 +37,7 @@ const MAX_CONCURRENT_RPC_REQUESTS: usize = 1024;
 const UPDATE_INTERVAL: Duration = Duration::from_secs(10);
 
 // Publish retry constants
-const PUBLISH_MIN_DELAY: Duration = Duration::from_secs(5);
+pub(crate) const PUBLISH_MIN_DELAY: Duration = Duration::from_secs(5);
 const PUBLISH_MAX_DELAY: Duration = Duration::from_secs(60); // Cap to 1 min so backoff doesn't get too long for infinite retries
 
 /// The maximum time to wait for a checkpoint vote to complete before retrying
@@ -48,6 +48,25 @@ const VOTE_CHECKPOINT_RETRY: RetryConfig = RetryConfig {
     max_delay: PUBLISH_MAX_DELAY,
     jitter: true,
 };
+
+/// Which response a publish carries. The two legs of a bidirectional request
+/// share a sign id, so this is what keeps them apart wherever a publish is keyed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PublishKind {
+    /// The signed transaction (an ordinary request's only response, or leg 1).
+    Response,
+    /// The signed execution outcome (leg 2).
+    BidirectionalResponse,
+}
+
+impl PublishKind {
+    pub fn of(kind: &SignKind) -> Self {
+        match kind {
+            SignKind::Sign | SignKind::SignBidirectional(_) => PublishKind::Response,
+            SignKind::RespondBidirectional(_) => PublishKind::BidirectionalResponse,
+        }
+    }
+}
 
 // `PublishAction` makes this enum relatively large, but boxing it is not worth
 // the indirection: the RPC channel is bounded to 1024 actions (under 1 MiB of
@@ -446,8 +465,10 @@ impl RpcExecutor {
     ) {
         let mut checkpoint_cancellation_tokens = HashMap::<Chain, CancellationToken>::new();
         let mut checkpoint_abort_times = HashMap::<Chain, Instant>::new();
-        // Keep track of in-flight publish requests to avoid duplicate publishes for the same sign_id.
-        let in_flight: Arc<DashSet<SignId>> = Arc::new(DashSet::new());
+        // Keep track of in-flight publish requests to avoid duplicate publishes.
+        // Keyed by publish kind too: the two legs of a bidirectional request share
+        // a sign id, and a first leg still retrying must not block its second.
+        let in_flight: Arc<DashSet<(Chain, SignId, PublishKind)>> = Arc::new(DashSet::new());
         loop {
             let Some(action) = action_rx.recv().await else {
                 tracing::error!("rpc channel closed unexpectedly");
@@ -463,7 +484,8 @@ impl RpcExecutor {
                     };
 
                     let sign_id = action.request.id;
-                    if !in_flight.insert(sign_id) {
+                    let key = (chain, sign_id, PublishKind::of(&action.request.kind));
+                    if !in_flight.insert(key) {
                         tracing::info!(
                             ?sign_id,
                             ?chain,
@@ -475,10 +497,7 @@ impl RpcExecutor {
                     let publisher = publisher.clone();
                     let in_flight = in_flight.clone();
                     tokio::spawn(async move {
-                        let _guard = InFlightGuard {
-                            in_flight,
-                            id: sign_id,
-                        };
+                        let _guard = InFlightGuard { in_flight, id: key };
                         execute_publish(publisher, action).await;
                     });
                 }
@@ -598,8 +617,8 @@ async fn update_contract_data(
 /// Releases a `SignId` from the dispatch loop's in-flight set when dropped,
 /// including during a panic unwind, so the slot is always freed for re-publish.
 struct InFlightGuard {
-    in_flight: Arc<DashSet<SignId>>,
-    id: SignId,
+    in_flight: Arc<DashSet<(Chain, SignId, PublishKind)>>,
+    id: (Chain, SignId, PublishKind),
 }
 
 impl Drop for InFlightGuard {

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -17,6 +17,32 @@ pub struct PublishState {
     pub signature: Signature,
     pub participants: Vec<Participant>,
     pub is_proposer: bool,
+    /// Unix seconds at which this entry entered pending-publish, which is when
+    /// the proposer's publish was dispatched. Anchoring the deliberator schedule
+    /// here rather than at indexing keeps the observe window whole, since
+    /// generation has already happened by this point, and lets the schedule
+    /// survive a restart: an entry recovered from storage keeps its clock.
+    ///
+    /// `None` on entries written before this field existed, and those never fail
+    /// over. Nothing prunes a pending-publish entry, so at upgrade this set is
+    /// every request that never saw an indexed response, and a numeric default
+    /// would put all of them past their deadline at once: the jitter cannot
+    /// spread deadlines that are already in the past, so every deliberator would
+    /// fire on every one of them. Declining to fail over leaves exactly today's
+    /// behaviour for that set, and only for one request lifetime.
+    #[serde(default)]
+    pub publishing_since: Option<u64>,
+}
+
+impl PublishState {
+    pub fn new(signature: Signature, participants: Vec<Participant>, is_proposer: bool) -> Self {
+        Self {
+            signature,
+            participants,
+            is_proposer,
+            publishing_since: Some(mpc_utils::time::current_unix_timestamp()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -209,13 +235,15 @@ pub fn decode_rlp(rlp_data: Vec<u8>, is_eip1559: bool) -> anyhow::Result<Vec<Byt
 /// Check that `unsigned_rlp` would survive [`sign_and_hash_transaction`], without a
 /// real signature. Admission calls this so a transaction that cannot be signed at
 /// respond time is rejected before it enters the backlog; running the actual
-/// function (with a placeholder signature, whose bytes are only appended, never
-/// interpreted) is what keeps admission structurally equal to respond processing.
+/// function is what keeps admission structurally equal to respond processing. The
+/// placeholder's recovery id is 1, the strict case: the legacy `v` computation adds
+/// `y_parity`, so validating with 0 would admit the one chain id whose `v` only
+/// overflows when the real signature draws parity 1.
 fn validate_unsigned_transaction(unsigned_rlp: &[u8]) -> anyhow::Result<()> {
     let placeholder = Signature::new(
         k256::ProjectivePoint::GENERATOR.to_affine(),
         k256::Scalar::ONE,
-        0,
+        1,
     );
     sign_and_hash_transaction(unsigned_rlp, placeholder).map(|_| ())
 }
@@ -461,6 +489,26 @@ mod tests {
         assert_eq!(nonce, 3);
     }
 
+    /// At `chain_id = (u64::MAX - 35) / 2` the legacy `v = 2c + 35 + y_parity`
+    /// overflows only for parity 1. Admission must reject it, not admit a request
+    /// that then fails at respond time whenever the signature draws parity 1.
+    #[test]
+    fn validate_rejects_the_legacy_chain_id_that_only_overflows_on_parity_one() {
+        let legacy_tx = |chain_id: u64| {
+            let mut rlp = super::EthereumTxRlp::new_list(9);
+            for _ in 0..6 {
+                rlp.append_u64(0);
+            }
+            rlp.append_u64(chain_id);
+            rlp.append_u64(0);
+            rlp.append_u64(0);
+            rlp.into_vec()
+        };
+        let boundary = (u64::MAX - 35) / 2;
+        assert!(super::validate_unsigned_transaction(&legacy_tx(boundary)).is_err());
+        assert!(super::validate_unsigned_transaction(&legacy_tx(boundary - 1)).is_ok());
+    }
+
     #[test]
     fn test_checkpoint_consensus_bytes_deterministic_across_publish_states() {
         use super::{PublishState, SignStatus};
@@ -490,13 +538,7 @@ mod tests {
             from_address: [0u8; 20],
             nonce: 0,
         });
-        let publish = || {
-            Arc::new(PublishState {
-                signature: dummy_sig,
-                participants: vec![],
-                is_proposer: true,
-            })
-        };
+        let publish = || Arc::new(PublishState::new(dummy_sig, vec![], true));
 
         let generation_tag = SignStatus::PendingGeneration.consensus_tag();
         let publish_tag = SignStatus::PendingPublish { publish: publish() }.consensus_tag();

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -17,19 +17,15 @@ pub struct PublishState {
     pub signature: Signature,
     pub participants: Vec<Participant>,
     pub is_proposer: bool,
-    /// Unix seconds at which this entry entered pending-publish, which is when
-    /// the proposer's publish was dispatched. Anchoring the failover schedule
-    /// here rather than at indexing keeps the observe window whole, since
-    /// generation has already happened by this point, and lets the schedule
-    /// survive a restart: an entry recovered from storage keeps its clock.
+    /// Unix seconds at which this entry entered pending-publish, which is when the
+    /// proposer's publish was dispatched. Anchoring the failover schedule here
+    /// rather than at indexing keeps the observe window whole and lets a recovered
+    /// entry keep its clock across a restart.
     ///
-    /// `None` on entries written before this field existed, and those never fail
-    /// over. Nothing prunes a pending-publish entry, so at upgrade this set is
-    /// every request that never saw an indexed response, and a numeric default
-    /// would put all of them past their deadline at once: the jitter cannot
-    /// spread deadlines that are already in the past, so every node would
-    /// fire on every one of them. Declining to fail over leaves exactly today's
-    /// behaviour for that set, and only for one request lifetime.
+    /// `None` on entries written before this field existed, which never fail over.
+    /// Nothing prunes pending-publish, so at upgrade that set is every request
+    /// that never saw a response, and a numeric default would put all of them past
+    /// their deadline at once: jitter cannot spread deadlines already in the past.
     #[serde(default)]
     pub publishing_since: Option<u64>,
 }

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -18,7 +18,7 @@ pub struct PublishState {
     pub participants: Vec<Participant>,
     pub is_proposer: bool,
     /// Unix seconds at which this entry entered pending-publish, which is when
-    /// the proposer's publish was dispatched. Anchoring the deliberator schedule
+    /// the proposer's publish was dispatched. Anchoring the failover schedule
     /// here rather than at indexing keeps the observe window whole, since
     /// generation has already happened by this point, and lets the schedule
     /// survive a restart: an entry recovered from storage keeps its clock.
@@ -27,7 +27,7 @@ pub struct PublishState {
     /// over. Nothing prunes a pending-publish entry, so at upgrade this set is
     /// every request that never saw an indexed response, and a numeric default
     /// would put all of them past their deadline at once: the jitter cannot
-    /// spread deadlines that are already in the past, so every deliberator would
+    /// spread deadlines that are already in the past, so every node would
     /// fire on every one of them. Declining to fail over leaves exactly today's
     /// behaviour for that set, and only for one request lifetime.
     #[serde(default)]

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -17,15 +17,13 @@ pub struct PublishState {
     pub signature: Signature,
     pub participants: Vec<Participant>,
     pub is_proposer: bool,
-    /// Unix seconds at which this entry entered pending-publish, which is when the
-    /// proposer's publish was dispatched. Anchoring the failover schedule here
-    /// rather than at indexing keeps the observe window whole and lets a recovered
-    /// entry keep its clock across a restart.
+    /// Unix seconds at which this entry entered pending-publish on this node.
+    /// On the proposer this is when it dispatched its publish and elsewhere is
+    /// when that node finished generation.
     ///
-    /// `None` on entries written before this field existed, which never fail over.
-    /// Nothing prunes pending-publish, so at upgrade that set is every request
-    /// that never saw a response, and a numeric default would put all of them past
-    /// their deadline at once: jitter cannot spread deadlines already in the past.
+    /// `None` on entries written before this field existed, which never fail over:
+    /// a numeric default would put every entry already stuck in pending-publish
+    /// past its deadline at once, and jitter cannot spread deadlines in the past.
     #[serde(default)]
     pub publishing_since: Option<u64>,
 }

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -7,8 +7,8 @@ use crate::mesh::MeshState;
 use crate::node_client::NodeClient;
 use crate::rpc::{ContractStateWatcher, RpcChannel};
 use crate::stream::ops::{
-    deliberator_publish_due, process_block_event, process_execution_confirmed,
-    process_respond_bidirectional_event, process_respond_event, process_sign_request,
+    process_block_event, process_execution_confirmed, process_respond_bidirectional_event,
+    process_respond_event, process_sign_request, publish_failover_due,
     requeue_pending_sign_requests, resume_pending_publish_requests,
 };
 use crate::types::CheckpointWatcher;
@@ -31,15 +31,16 @@ pub struct StreamContext {
     pub node_client: NodeClient,
     pub checkpoints_rx: CheckpointWatcher,
     pub caught_up: bool,
-    /// Overrides the deliberator schedule's observe lag; `None` is production
+    /// Overrides the publish failover schedule's observe lag; `None` is production
     /// (chain finality plus a margin). Fixtures pin it.
     pub observe_lag: Option<Duration>,
-    /// Entries this node has already deliberator-published, so a sweep that runs
-    /// on every block fires each one once. Pruned against the pending set each
-    /// sweep, so an entry that leaves the backlog and returns is scheduled afresh.
-    /// Keyed by publish kind as well: the two legs of a bidirectional request
-    /// share a sign id and must not inherit each other's history.
-    pub(crate) deliberator_published: HashSet<(SignId, PublishKind)>,
+    /// Entries this node has already dispatched a publish for, whether from the
+    /// catchup resume or the failover sweep, so a sweep that runs on every block
+    /// fires each one once. Pruned against the pending set each sweep, so an entry
+    /// that leaves the backlog and returns is scheduled afresh. Keyed by publish
+    /// kind as well: the two legs of a bidirectional request share a sign id and
+    /// must not inherit each other's history.
+    pub(crate) published: HashSet<(SignId, PublishKind)>,
 }
 
 impl StreamContext {
@@ -62,11 +63,11 @@ impl StreamContext {
             checkpoints_rx,
             caught_up: false,
             observe_lag: None,
-            deliberator_published: HashSet::new(),
+            published: HashSet::new(),
         }
     }
 
-    /// Pin the deliberator publish schedule's observe lag, for fixtures that assert
+    /// Pin the publish failover schedule's observe lag, for fixtures that assert
     /// the failover itself rather than its production timing.
     pub fn with_observe_lag(mut self, lag: Option<Duration>) -> Self {
         self.observe_lag = lag;
@@ -144,7 +145,7 @@ pub(crate) async fn handle_chain_event<T: ChainTelemetry>(
             // Observing the chain through this block is the precondition for
             // concluding that the proposer's response did not land, so the sweep
             // rides the block stream rather than a timer of its own.
-            deliberator_publish_due(ctx, chain).await;
+            publish_failover_due(ctx, chain).await;
             process_block_event(chain, block, ctx, telemetry)
                 .await
                 .context("failed to process block event")?;

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -13,11 +13,9 @@ use crate::stream::ops::{
 };
 use crate::types::CheckpointWatcher;
 
-use crate::rpc::PublishKind;
 use anyhow::Context;
 use mpc_chain_integration_core::ChainTelemetry;
-use mpc_primitives::{Chain, ChainEvent, SignCommand, SignId};
-use std::collections::HashSet;
+use mpc_primitives::{Chain, ChainEvent, SignCommand};
 use std::time::Duration;
 use tokio::sync::{mpsc, watch};
 
@@ -34,11 +32,6 @@ pub struct StreamContext {
     /// Overrides the failover schedule's observe lag; `None` is production. Fixtures
     /// pin it.
     pub observe_lag: Option<Duration>,
-    /// Entries this node has dispatched a publish for, from the catchup resume or
-    /// the failover sweep, so a per-block sweep fires each one once. Pruned against
-    /// the pending set each sweep, so an entry that leaves and returns is scheduled
-    /// afresh. Keyed by publish kind too: the two legs share a sign id.
-    pub(crate) published: HashSet<(SignId, PublishKind)>,
 }
 
 impl StreamContext {
@@ -61,7 +54,6 @@ impl StreamContext {
             checkpoints_rx,
             caught_up: false,
             observe_lag: None,
-            published: HashSet::new(),
         }
     }
 
@@ -140,7 +132,6 @@ pub(crate) async fn handle_chain_event<T: ChainTelemetry>(
                 .context("failed to process respond bidirectional event")?;
         }
         ChainEvent::Block(block) => {
-            // A block observed is what licenses concluding the response did not land.
             publish_failover_due(ctx, chain).await;
             process_block_event(chain, block, ctx, telemetry)
                 .await

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -31,15 +31,13 @@ pub struct StreamContext {
     pub node_client: NodeClient,
     pub checkpoints_rx: CheckpointWatcher,
     pub caught_up: bool,
-    /// Overrides the publish failover schedule's observe lag; `None` is production
-    /// (chain finality plus a margin). Fixtures pin it.
+    /// Overrides the failover schedule's observe lag; `None` is production. Fixtures
+    /// pin it.
     pub observe_lag: Option<Duration>,
-    /// Entries this node has already dispatched a publish for, whether from the
-    /// catchup resume or the failover sweep, so a sweep that runs on every block
-    /// fires each one once. Pruned against the pending set each sweep, so an entry
-    /// that leaves the backlog and returns is scheduled afresh. Keyed by publish
-    /// kind as well: the two legs of a bidirectional request share a sign id and
-    /// must not inherit each other's history.
+    /// Entries this node has dispatched a publish for, from the catchup resume or
+    /// the failover sweep, so a per-block sweep fires each one once. Pruned against
+    /// the pending set each sweep, so an entry that leaves and returns is scheduled
+    /// afresh. Keyed by publish kind too: the two legs share a sign id.
     pub(crate) published: HashSet<(SignId, PublishKind)>,
 }
 
@@ -142,9 +140,7 @@ pub(crate) async fn handle_chain_event<T: ChainTelemetry>(
                 .context("failed to process respond bidirectional event")?;
         }
         ChainEvent::Block(block) => {
-            // Observing the chain through this block is the precondition for
-            // concluding that the proposer's response did not land, so the sweep
-            // rides the block stream rather than a timer of its own.
+            // A block observed is what licenses concluding the response did not land.
             publish_failover_due(ctx, chain).await;
             process_block_event(chain, block, ctx, telemetry)
                 .await

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -7,15 +7,18 @@ use crate::mesh::MeshState;
 use crate::node_client::NodeClient;
 use crate::rpc::{ContractStateWatcher, RpcChannel};
 use crate::stream::ops::{
-    process_block_event, process_execution_confirmed, process_respond_bidirectional_event,
-    process_respond_event, process_sign_request, requeue_pending_sign_requests,
-    resume_pending_publish_requests,
+    deliberator_publish_due, process_block_event, process_execution_confirmed,
+    process_respond_bidirectional_event, process_respond_event, process_sign_request,
+    requeue_pending_sign_requests, resume_pending_publish_requests,
 };
 use crate::types::CheckpointWatcher;
 
+use crate::rpc::PublishKind;
 use anyhow::Context;
 use mpc_chain_integration_core::ChainTelemetry;
-use mpc_primitives::{Chain, ChainEvent, SignCommand};
+use mpc_primitives::{Chain, ChainEvent, SignCommand, SignId};
+use std::collections::HashSet;
+use std::time::Duration;
 use tokio::sync::{mpsc, watch};
 
 /// Shared, per-chain dependencies
@@ -28,6 +31,15 @@ pub struct StreamContext {
     pub node_client: NodeClient,
     pub checkpoints_rx: CheckpointWatcher,
     pub caught_up: bool,
+    /// Overrides the deliberator schedule's observe lag; `None` is production
+    /// (chain finality plus a margin). Fixtures pin it.
+    pub observe_lag: Option<Duration>,
+    /// Entries this node has already deliberator-published, so a sweep that runs
+    /// on every block fires each one once. Pruned against the pending set each
+    /// sweep, so an entry that leaves the backlog and returns is scheduled afresh.
+    /// Keyed by publish kind as well: the two legs of a bidirectional request
+    /// share a sign id and must not inherit each other's history.
+    pub(crate) deliberator_published: HashSet<(SignId, PublishKind)>,
 }
 
 impl StreamContext {
@@ -49,7 +61,16 @@ impl StreamContext {
             node_client,
             checkpoints_rx,
             caught_up: false,
+            observe_lag: None,
+            deliberator_published: HashSet::new(),
         }
+    }
+
+    /// Pin the deliberator publish schedule's observe lag, for fixtures that assert
+    /// the failover itself rather than its production timing.
+    pub fn with_observe_lag(mut self, lag: Option<Duration>) -> Self {
+        self.observe_lag = lag;
+        self
     }
 
     /// Forward a sign command to the signing pipeline, but only when caught up.
@@ -120,6 +141,10 @@ pub(crate) async fn handle_chain_event<T: ChainTelemetry>(
                 .context("failed to process respond bidirectional event")?;
         }
         ChainEvent::Block(block) => {
+            // Observing the chain through this block is the precondition for
+            // concluding that the proposer's response did not land, so the sweep
+            // rides the block stream rather than a timer of its own.
+            deliberator_publish_due(ctx, chain).await;
             process_block_event(chain, block, ctx, telemetry)
                 .await
                 .context("failed to process block event")?;

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -1,8 +1,11 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use anyhow::Context;
 
+use crate::protocol::deliberator_publish::publish_deadline;
 use crate::respond_bidirectional::CompletedTx;
+use crate::rpc::PublishKind;
 use crate::sign_bidirectional::SignBidirectionalEventExt;
 use crate::stream::StreamContext;
 use mpc_chain_integration_core::ChainTelemetry;
@@ -23,10 +26,9 @@ pub(crate) async fn process_sign_request(
 
     // Reject malformed bidirectional requests at ingestion, running the same
     // deterministic derivations the respond event will need later. A request
-    // admitted here but failing there is worse than one never admitted: its entry
-    // sticks in pending-publish forever, and every backup's sweep fires into a
-    // duplicate-publish retry loop that no cancellation ever ends, because the
-    // failing respond processing is where the cancel lives.
+    // admitted here but failing there can never advance: its entry sticks in
+    // pending-publish forever, and every deliberator publishes a leg-1 response
+    // whose second leg will never come.
     if let SignKind::SignBidirectional(event) = &sign_request.kind {
         event.validate().with_context(|| {
             format!("rejecting bidirectional sign request {:?}", sign_request.id)
@@ -73,6 +75,63 @@ pub(crate) async fn resume_pending_publish_requests(ctx: &StreamContext, source_
         let sign_id = sign_request.id;
         ctx.rpc.publish_with_state(sign_request, &publish);
         tracing::info!(?sign_id, %source_chain, "resumed pending publish request after catchup");
+    }
+}
+
+/// Publish entries whose proposer stayed silent past this node's deadline.
+///
+/// Runs on every block rather than on a timer: a chain observed through block N
+/// is exactly the state in which "the response did not land" is a conclusion
+/// rather than a guess, so a stream that is not delivering blocks holds fire
+/// instead of publishing blind. Only one of the `m` deliberators needs a healthy
+/// stream for failover to happen.
+pub(crate) async fn deliberator_publish_due(ctx: &mut StreamContext, chain: Chain) {
+    if !ctx.caught_up {
+        return;
+    }
+
+    let publishable = ctx.backlog.publishable_requests(chain).await;
+    if publishable.is_empty() {
+        ctx.deliberator_published.clear();
+        return;
+    }
+
+    // Only worth building when something has fired: an entry that left the backlog
+    // and came back is marked publishing afresh and must be scheduled afresh.
+    if !ctx.deliberator_published.is_empty() {
+        let live: HashSet<(SignId, PublishKind)> = publishable
+            .iter()
+            .map(|(request, _)| (request.id, PublishKind::of(&request.kind)))
+            .collect();
+        ctx.deliberator_published.retain(|key| live.contains(key));
+    }
+
+    let me = ctx.contract_watcher.account_id().clone();
+    let now = mpc_utils::time::current_unix_timestamp();
+    for (request, publish) in &publishable {
+        if publish.is_proposer {
+            continue;
+        }
+        let key = (request.id, PublishKind::of(&request.kind));
+        if ctx.deliberator_published.contains(&key) {
+            continue;
+        }
+        let Some(deadline) = publish_deadline(&request.id, publish, &me, chain, ctx.observe_lag)
+        else {
+            continue;
+        };
+        if now < deadline {
+            continue;
+        }
+
+        ctx.deliberator_published.insert(key);
+        let sign_id = request.id;
+        tracing::warn!(
+            ?sign_id,
+            %chain,
+            "proposer response not observed in time; publishing as deliberator"
+        );
+        ctx.rpc.publish_with_state(Arc::clone(request), publish);
     }
 }
 
@@ -137,7 +196,7 @@ async fn advance_bidirectional_to_execution(
     // without passing admission (checkpoint recovery restores them wholesale). One
     // that fails here fails identically on every node and on every replay, so it
     // can never advance: leaving it would park it in pending-publish forever, with
-    // every backup's sweep republishing a response that is already on chain.
+    // every deliberator publishing a response that is already on chain.
     // Removing it is deterministic across the network, so checkpoints stay aligned.
     if let Err(err) = event.validate() {
         tracing::error!(

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 
-use crate::protocol::deliberator_publish::publish_deadline;
+use crate::protocol::publish_failover::publish_deadline;
 use crate::respond_bidirectional::CompletedTx;
 use crate::rpc::PublishKind;
 use crate::sign_bidirectional::SignBidirectionalEventExt;
@@ -27,7 +27,7 @@ pub(crate) async fn process_sign_request(
     // Reject malformed bidirectional requests at ingestion, running the same
     // deterministic derivations the respond event will need later. A request
     // admitted here but failing there can never advance: its entry sticks in
-    // pending-publish forever, and every deliberator publishes a leg-1 response
+    // pending-publish forever, and every node publishes a leg-1 response
     // whose second leg will never come.
     if let SignKind::SignBidirectional(event) = &sign_request.kind {
         event.validate().with_context(|| {
@@ -66,13 +66,18 @@ pub(crate) async fn requeue_pending_sign_requests(
     Ok(())
 }
 
-pub(crate) async fn resume_pending_publish_requests(ctx: &StreamContext, source_chain: Chain) {
+pub(crate) async fn resume_pending_publish_requests(ctx: &mut StreamContext, source_chain: Chain) {
     for (sign_request, publish) in ctx.backlog.publishable_requests(source_chain).await {
         if !publish.is_proposer {
             continue;
         }
 
         let sign_id = sign_request.id;
+        // Recorded so the failover sweep does not publish this entry a second time
+        // on the next block: it is already dispatched, and its deadline, anchored
+        // on a stamp from before the restart, is long past.
+        ctx.published
+            .insert((sign_id, PublishKind::of(&sign_request.kind)));
         ctx.rpc.publish_with_state(sign_request, &publish);
         tracing::info!(?sign_id, %source_chain, "resumed pending publish request after catchup");
     }
@@ -83,37 +88,34 @@ pub(crate) async fn resume_pending_publish_requests(ctx: &StreamContext, source_
 /// Runs on every block rather than on a timer: a chain observed through block N
 /// is exactly the state in which "the response did not land" is a conclusion
 /// rather than a guess, so a stream that is not delivering blocks holds fire
-/// instead of publishing blind. Only one of the `m` deliberators needs a healthy
+/// instead of publishing blind. Only one of the `m` participants needs a healthy
 /// stream for failover to happen.
-pub(crate) async fn deliberator_publish_due(ctx: &mut StreamContext, chain: Chain) {
+pub(crate) async fn publish_failover_due(ctx: &mut StreamContext, chain: Chain) {
     if !ctx.caught_up {
         return;
     }
 
     let publishable = ctx.backlog.publishable_requests(chain).await;
     if publishable.is_empty() {
-        ctx.deliberator_published.clear();
+        ctx.published.clear();
         return;
     }
 
     // Only worth building when something has fired: an entry that left the backlog
     // and came back is marked publishing afresh and must be scheduled afresh.
-    if !ctx.deliberator_published.is_empty() {
+    if !ctx.published.is_empty() {
         let live: HashSet<(SignId, PublishKind)> = publishable
             .iter()
             .map(|(request, _)| (request.id, PublishKind::of(&request.kind)))
             .collect();
-        ctx.deliberator_published.retain(|key| live.contains(key));
+        ctx.published.retain(|key| live.contains(key));
     }
 
     let me = ctx.contract_watcher.account_id().clone();
     let now = mpc_utils::time::current_unix_timestamp();
     for (request, publish) in &publishable {
-        if publish.is_proposer {
-            continue;
-        }
         let key = (request.id, PublishKind::of(&request.kind));
-        if ctx.deliberator_published.contains(&key) {
+        if ctx.published.contains(&key) {
             continue;
         }
         let Some(deadline) = publish_deadline(&request.id, publish, &me, chain, ctx.observe_lag)
@@ -124,12 +126,12 @@ pub(crate) async fn deliberator_publish_due(ctx: &mut StreamContext, chain: Chai
             continue;
         }
 
-        ctx.deliberator_published.insert(key);
+        ctx.published.insert(key);
         let sign_id = request.id;
         tracing::warn!(
             ?sign_id,
             %chain,
-            "proposer response not observed in time; publishing as deliberator"
+            "proposer response not observed in time; publishing failover response"
         );
         ctx.rpc.publish_with_state(Arc::clone(request), publish);
     }
@@ -196,7 +198,7 @@ async fn advance_bidirectional_to_execution(
     // without passing admission (checkpoint recovery restores them wholesale). One
     // that fails here fails identically on every node and on every replay, so it
     // can never advance: leaving it would park it in pending-publish forever, with
-    // every deliberator publishing a response that is already on chain.
+    // every node publishing a response that is already on chain.
     // Removing it is deterministic across the network, so checkpoints stay aligned.
     if let Err(err) = event.validate() {
         tracing::error!(

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -1,11 +1,9 @@
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use anyhow::Context;
 
-use crate::protocol::publish_failover::publish_deadline;
+use crate::protocol::publish_failover::{observe_lag, publish_deadline};
 use crate::respond_bidirectional::CompletedTx;
-use crate::rpc::PublishKind;
 use crate::sign_bidirectional::SignBidirectionalEventExt;
 use crate::stream::StreamContext;
 use mpc_chain_integration_core::ChainTelemetry;
@@ -66,17 +64,21 @@ pub(crate) async fn requeue_pending_sign_requests(
     Ok(())
 }
 
-pub(crate) async fn resume_pending_publish_requests(ctx: &mut StreamContext, source_chain: Chain) {
-    for (sign_request, publish) in ctx.backlog.publishable_requests(source_chain).await {
+pub(crate) async fn resume_pending_publish_requests(ctx: &StreamContext, source_chain: Chain) {
+    for (sign_request, publish, _dispatched) in ctx.backlog.publishable_requests(source_chain).await
+    {
         if !publish.is_proposer {
             continue;
         }
 
         let sign_id = sign_request.id;
-        // Recorded so the sweep does not republish it on the next block: its
-        // deadline, anchored before the restart, is long past.
-        ctx.published
-            .insert((sign_id, PublishKind::of(&sign_request.kind)));
+        // This is the proposer's only retry for a publish that reported success but
+        // never landed, so it republishes even if it already dispatched one. Marking
+        // stops the sweep from putting a second copy on chain on the next block: the
+        // deadline was anchored before the restart, so it is already past.
+        ctx.backlog
+            .mark_publish_dispatched(source_chain, &sign_id)
+            .await;
         ctx.rpc.publish_with_state(sign_request, &publish);
         tracing::info!(?sign_id, %source_chain, "resumed pending publish request after catchup");
     }
@@ -85,50 +87,35 @@ pub(crate) async fn resume_pending_publish_requests(ctx: &mut StreamContext, sou
 /// Publish entries whose proposer stayed silent past this node's deadline.
 ///
 /// Only one of the `m` participants needs a healthy stream for failover to happen.
-pub(crate) async fn publish_failover_due(ctx: &mut StreamContext, chain: Chain) {
+pub(crate) async fn publish_failover_due(ctx: &StreamContext, chain: Chain) {
     if !ctx.caught_up {
         return;
     }
-
-    let publishable = ctx.backlog.publishable_requests(chain).await;
-    if publishable.is_empty() {
-        ctx.published.clear();
-        return;
-    }
-
-    // Only worth building when something has fired: an entry that left the backlog
-    // and came back is marked publishing afresh and must be scheduled afresh.
-    if !ctx.published.is_empty() {
-        let live: HashSet<(SignId, PublishKind)> = publishable
-            .iter()
-            .map(|(request, _)| (request.id, PublishKind::of(&request.kind)))
-            .collect();
-        ctx.published.retain(|key| live.contains(key));
-    }
+    let lag = observe_lag(chain, ctx.observe_lag);
 
     let me = ctx.contract_watcher.account_id().clone();
     let now = mpc_utils::time::current_unix_timestamp();
-    for (request, publish) in &publishable {
-        let key = (request.id, PublishKind::of(&request.kind));
-        if ctx.published.contains(&key) {
+    for (request, publish, dispatched) in ctx.backlog.publishable_requests(chain).await {
+        if dispatched {
             continue;
         }
-        let Some(deadline) = publish_deadline(&request.id, publish, &me, chain, ctx.observe_lag)
-        else {
+        let Some(deadline) = publish_deadline(&request.id, &publish, &me, lag) else {
             continue;
         };
         if now < deadline {
             continue;
         }
-
-        ctx.published.insert(key);
         let sign_id = request.id;
+        if !ctx.backlog.mark_publish_dispatched(chain, &sign_id).await {
+            continue;
+        }
+
         tracing::warn!(
             ?sign_id,
             %chain,
             "proposer response not observed in time; publishing failover response"
         );
-        ctx.rpc.publish_with_state(Arc::clone(request), publish);
+        ctx.rpc.publish_with_state(request, &publish);
     }
 }
 

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -73,9 +73,8 @@ pub(crate) async fn resume_pending_publish_requests(ctx: &mut StreamContext, sou
         }
 
         let sign_id = sign_request.id;
-        // Recorded so the failover sweep does not publish this entry a second time
-        // on the next block: it is already dispatched, and its deadline, anchored
-        // on a stamp from before the restart, is long past.
+        // Recorded so the sweep does not republish it on the next block: its
+        // deadline, anchored before the restart, is long past.
         ctx.published
             .insert((sign_id, PublishKind::of(&sign_request.kind)));
         ctx.rpc.publish_with_state(sign_request, &publish);
@@ -85,11 +84,7 @@ pub(crate) async fn resume_pending_publish_requests(ctx: &mut StreamContext, sou
 
 /// Publish entries whose proposer stayed silent past this node's deadline.
 ///
-/// Runs on every block rather than on a timer: a chain observed through block N
-/// is exactly the state in which "the response did not land" is a conclusion
-/// rather than a guess, so a stream that is not delivering blocks holds fire
-/// instead of publishing blind. Only one of the `m` participants needs a healthy
-/// stream for failover to happen.
+/// Only one of the `m` participants needs a healthy stream for failover to happen.
 pub(crate) async fn publish_failover_due(ctx: &mut StreamContext, chain: Chain) {
     if !ctx.caught_up {
         return;

--- a/chain-signatures/node/src/stream/ops_tests.rs
+++ b/chain-signatures/node/src/stream/ops_tests.rs
@@ -3,7 +3,7 @@ use crate::backlog::Backlog;
 use crate::mesh::connection::NodeStatus;
 use crate::mesh::{wait_threshold_active, MeshState};
 use crate::protocol::contract::primitives::ParticipantInfo;
-use crate::rpc::ContractStateWatcher;
+use crate::rpc::{ContractStateWatcher, RpcAction};
 use crate::sign_bidirectional::{PublishState, SignStatus};
 use crate::storage::checkpoint_storage::CheckpointStorage;
 use crate::stream::ops::process_execution_confirmed;
@@ -486,7 +486,7 @@ async fn process_respond_event_quarantines_invalid_bidirectional_target_chain() 
 
     // An unknown target chain fails the same deterministic derivation on every
     // node and every replay, so the entry is quarantined rather than errored:
-    // leaving it would park it in pending-publish with backups republishing it.
+    // leaving it would park it in pending-publish with deliberators republishing it.
     process_respond_event(event, &ctx, public_key)
         .await
         .expect("quarantining is not an error");
@@ -531,7 +531,7 @@ async fn process_sign_request_rejects_respond_bidirectional_kind() {
 /// Admission cannot be the only gate: checkpoint recovery restores backlog entries
 /// wholesale, so a poison entry can exist without ever passing admission. The
 /// respond path must then quarantine it (deterministically, on every node), or it
-/// parks in pending-publish forever with every backup's sweep republishing it.
+/// parks in pending-publish forever with every deliberator publishing it.
 #[tokio::test]
 async fn process_respond_event_quarantines_a_bidirectional_entry_that_cannot_advance() {
     let backlog = Backlog::new();
@@ -595,7 +595,7 @@ fn bidirectional_event(serialized_transaction: Vec<u8>) -> SignBidirectionalEven
 /// A non-empty but undecodable transaction is the same poison pill as an empty one,
 /// with a worse blast radius: admitted, it signs, publishes leg 1, then fails
 /// deterministically in respond processing before the cancel, leaving the entry in
-/// pending-publish forever while every backup's sweep fires into a retry loop that
+/// pending-publish forever while every deliberator fires into a retry loop that
 /// nothing ends. Admission runs the same derivations respond processing will need.
 #[tokio::test]
 async fn process_sign_request_rejects_undecodable_bidirectional_transaction() {
@@ -972,6 +972,7 @@ async fn process_respond_event_advances_bidirectional_from_pending_publish() {
                     ),
                     participants: vec![],
                     is_proposer: true,
+                    publishing_since: Some(mpc_utils::time::current_unix_timestamp()),
                 }),
             },
         )
@@ -1369,4 +1370,103 @@ async fn live_block_votes_for_checkpoint() {
     assert!(timeout(Duration::from_millis(100), sign_rx.recv())
         .await
         .is_err());
+}
+
+/// The sweep fires each entry once, and the two legs of a bidirectional request
+/// share a sign id, so only the publish kind in the key keeps a fired first leg
+/// from suppressing the second.
+#[tokio::test]
+async fn deliberator_sweep_fires_once_per_leg() {
+    let backlog = Backlog::new();
+    let sign_id = mpc_primitives::SignId::new([21u8; 32]);
+    let args = test_sign_args(21);
+
+    // `publishing_since: 0` puts the deadline far in the past, whatever the draw.
+    let publish = || {
+        Arc::new(PublishState {
+            signature: Signature::new(ProjectivePoint::GENERATOR.to_affine(), Scalar::ONE, 0),
+            participants: vec![Participant::from(0u32), Participant::from(1u32)],
+            is_proposer: false,
+            publishing_since: Some(0),
+        })
+    };
+
+    backlog
+        .insert(Arc::new(IndexedSignRequest::sign(
+            sign_id,
+            args.clone(),
+            Chain::Solana,
+            current_unix_timestamp(),
+        )))
+        .await;
+    backlog
+        .set_status(
+            Chain::Solana,
+            &sign_id,
+            SignStatus::PendingPublish { publish: publish() },
+        )
+        .await;
+
+    let (sign_tx, _sign_rx) = mpsc::channel(4);
+    let (mut ctx, mut rpc_rx) = make_test_stream_context_with_rpc(
+        backlog.clone(),
+        sign_tx,
+        true,
+        ProjectivePoint::GENERATOR.to_affine(),
+    );
+
+    deliberator_publish_due(&mut ctx, Chain::Solana).await;
+    assert!(
+        next_publish(&mut rpc_rx).await.is_some(),
+        "leg 1 publishes once past its deadline"
+    );
+
+    deliberator_publish_due(&mut ctx, Chain::Solana).await;
+    assert!(
+        next_publish(&mut rpc_rx).await.is_none(),
+        "the same entry does not fire twice"
+    );
+
+    // Same sign id, second-leg kind, as the backlog holds after
+    // `transition_to_bidirectional_response`.
+    backlog
+        .set_request(
+            Chain::Solana,
+            &sign_id,
+            Arc::new(IndexedSignRequest::respond_bidirectional(
+                sign_id,
+                args,
+                Chain::Solana,
+                current_unix_timestamp(),
+                RespondBidirectionalTx {
+                    tx_id: mpc_primitives::BidirectionalTxId([0u8; 32]),
+                    output: vec![],
+                    chain_ctx: None,
+                },
+            )),
+        )
+        .await
+        .unwrap();
+    backlog
+        .set_status(
+            Chain::Solana,
+            &sign_id,
+            SignStatus::PendingPublishBidirectional { publish: publish() },
+        )
+        .await;
+
+    deliberator_publish_due(&mut ctx, Chain::Solana).await;
+    assert!(
+        next_publish(&mut rpc_rx).await.is_some(),
+        "leg 2 fires on its own key, not leg 1's history"
+    );
+}
+
+/// The rpc channel is fed from a spawned task, so a publish is not visible the
+/// instant the sweep returns.
+async fn next_publish(rx: &mut mpsc::Receiver<RpcAction>) -> Option<RpcAction> {
+    tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+        .await
+        .ok()
+        .flatten()
 }

--- a/chain-signatures/node/src/stream/ops_tests.rs
+++ b/chain-signatures/node/src/stream/ops_tests.rs
@@ -1372,9 +1372,8 @@ async fn live_block_votes_for_checkpoint() {
         .is_err());
 }
 
-/// The sweep fires each entry once, and the two legs of a bidirectional request
-/// share a sign id, so only the publish kind in the key keeps a fired first leg
-/// from suppressing the second.
+/// The sweep fires each entry once, and the two legs share a sign id, so only the
+/// publish kind in the key keeps a fired first leg from suppressing the second.
 #[tokio::test]
 async fn publish_failover_fires_once_per_leg() {
     let backlog = Backlog::new();
@@ -1471,9 +1470,9 @@ async fn next_publish(rx: &mut mpsc::Receiver<RpcAction>) -> Option<RpcAction> {
         .flatten()
 }
 
-/// A proposer that restarts republishes from the catchup resume, and its own
-/// deadline is long past by then. The resume records what it dispatched, so the
-/// first block afterwards does not put a second copy of the same response on chain.
+/// A restarting proposer republishes from the catchup resume, and its deadline is
+/// long past by then. The resume records what it sent, so the next block does not
+/// put a second copy of the same response on chain.
 #[tokio::test]
 async fn catchup_resume_suppresses_the_sweep_for_the_same_entry() {
     let backlog = Backlog::new();

--- a/chain-signatures/node/src/stream/ops_tests.rs
+++ b/chain-signatures/node/src/stream/ops_tests.rs
@@ -486,7 +486,7 @@ async fn process_respond_event_quarantines_invalid_bidirectional_target_chain() 
 
     // An unknown target chain fails the same deterministic derivation on every
     // node and every replay, so the entry is quarantined rather than errored:
-    // leaving it would park it in pending-publish with deliberators republishing it.
+    // leaving it would park it in pending-publish with every node republishing it.
     process_respond_event(event, &ctx, public_key)
         .await
         .expect("quarantining is not an error");
@@ -531,7 +531,7 @@ async fn process_sign_request_rejects_respond_bidirectional_kind() {
 /// Admission cannot be the only gate: checkpoint recovery restores backlog entries
 /// wholesale, so a poison entry can exist without ever passing admission. The
 /// respond path must then quarantine it (deterministically, on every node), or it
-/// parks in pending-publish forever with every deliberator publishing it.
+/// parks in pending-publish forever with every node publishing it.
 #[tokio::test]
 async fn process_respond_event_quarantines_a_bidirectional_entry_that_cannot_advance() {
     let backlog = Backlog::new();
@@ -595,7 +595,7 @@ fn bidirectional_event(serialized_transaction: Vec<u8>) -> SignBidirectionalEven
 /// A non-empty but undecodable transaction is the same poison pill as an empty one,
 /// with a worse blast radius: admitted, it signs, publishes leg 1, then fails
 /// deterministically in respond processing before the cancel, leaving the entry in
-/// pending-publish forever while every deliberator fires into a retry loop that
+/// pending-publish forever while every node fires into a retry loop that
 /// nothing ends. Admission runs the same derivations respond processing will need.
 #[tokio::test]
 async fn process_sign_request_rejects_undecodable_bidirectional_transaction() {
@@ -1376,7 +1376,7 @@ async fn live_block_votes_for_checkpoint() {
 /// share a sign id, so only the publish kind in the key keeps a fired first leg
 /// from suppressing the second.
 #[tokio::test]
-async fn deliberator_sweep_fires_once_per_leg() {
+async fn publish_failover_fires_once_per_leg() {
     let backlog = Backlog::new();
     let sign_id = mpc_primitives::SignId::new([21u8; 32]);
     let args = test_sign_args(21);
@@ -1415,13 +1415,13 @@ async fn deliberator_sweep_fires_once_per_leg() {
         ProjectivePoint::GENERATOR.to_affine(),
     );
 
-    deliberator_publish_due(&mut ctx, Chain::Solana).await;
+    publish_failover_due(&mut ctx, Chain::Solana).await;
     assert!(
         next_publish(&mut rpc_rx).await.is_some(),
         "leg 1 publishes once past its deadline"
     );
 
-    deliberator_publish_due(&mut ctx, Chain::Solana).await;
+    publish_failover_due(&mut ctx, Chain::Solana).await;
     assert!(
         next_publish(&mut rpc_rx).await.is_none(),
         "the same entry does not fire twice"
@@ -1455,7 +1455,7 @@ async fn deliberator_sweep_fires_once_per_leg() {
         )
         .await;
 
-    deliberator_publish_due(&mut ctx, Chain::Solana).await;
+    publish_failover_due(&mut ctx, Chain::Solana).await;
     assert!(
         next_publish(&mut rpc_rx).await.is_some(),
         "leg 2 fires on its own key, not leg 1's history"
@@ -1469,4 +1469,61 @@ async fn next_publish(rx: &mut mpsc::Receiver<RpcAction>) -> Option<RpcAction> {
         .await
         .ok()
         .flatten()
+}
+
+/// A proposer that restarts republishes from the catchup resume, and its own
+/// deadline is long past by then. The resume records what it dispatched, so the
+/// first block afterwards does not put a second copy of the same response on chain.
+#[tokio::test]
+async fn catchup_resume_suppresses_the_sweep_for_the_same_entry() {
+    let backlog = Backlog::new();
+    let sign_id = mpc_primitives::SignId::new([22u8; 32]);
+
+    backlog
+        .insert(Arc::new(IndexedSignRequest::sign(
+            sign_id,
+            test_sign_args(22),
+            Chain::Solana,
+            current_unix_timestamp(),
+        )))
+        .await;
+    backlog
+        .set_status(
+            Chain::Solana,
+            &sign_id,
+            SignStatus::PendingPublish {
+                publish: Arc::new(PublishState {
+                    signature: Signature::new(
+                        ProjectivePoint::GENERATOR.to_affine(),
+                        Scalar::ONE,
+                        0,
+                    ),
+                    participants: vec![Participant::from(0u32), Participant::from(1u32)],
+                    is_proposer: true,
+                    // Deadline far in the past, whatever this node's draw.
+                    publishing_since: Some(0),
+                }),
+            },
+        )
+        .await;
+
+    let (sign_tx, _sign_rx) = mpsc::channel(4);
+    let (mut ctx, mut rpc_rx) = make_test_stream_context_with_rpc(
+        backlog.clone(),
+        sign_tx,
+        true,
+        ProjectivePoint::GENERATOR.to_affine(),
+    );
+
+    resume_pending_publish_requests(&mut ctx, Chain::Solana).await;
+    assert!(
+        next_publish(&mut rpc_rx).await.is_some(),
+        "the proposer republishes on catchup"
+    );
+
+    publish_failover_due(&mut ctx, Chain::Solana).await;
+    assert!(
+        next_publish(&mut rpc_rx).await.is_none(),
+        "the sweep must not republish what the resume already dispatched"
+    );
 }

--- a/chain-signatures/node/src/stream/ops_tests.rs
+++ b/chain-signatures/node/src/stream/ops_tests.rs
@@ -1372,8 +1372,9 @@ async fn live_block_votes_for_checkpoint() {
         .is_err());
 }
 
-/// The sweep fires each entry once, and the two legs share a sign id, so only the
-/// publish kind in the key keeps a fired first leg from suppressing the second.
+/// The sweep fires each entry once, and the two legs share a sign id, so only
+/// clearing the dispatch flag on re-entry keeps a fired leg 1 from suppressing
+/// leg 2.
 #[tokio::test]
 async fn publish_failover_fires_once_per_leg() {
     let backlog = Backlog::new();
@@ -1407,20 +1408,22 @@ async fn publish_failover_fires_once_per_leg() {
         .await;
 
     let (sign_tx, _sign_rx) = mpsc::channel(4);
-    let (mut ctx, mut rpc_rx) = make_test_stream_context_with_rpc(
+    let (ctx, mut rpc_rx) = make_test_stream_context_with_rpc(
         backlog.clone(),
         sign_tx,
         true,
         ProjectivePoint::GENERATOR.to_affine(),
     );
+    // No observe lag: this test is about the once-per-leg property, not the gate.
+    let ctx = ctx.with_observe_lag(Some(Duration::ZERO));
 
-    publish_failover_due(&mut ctx, Chain::Solana).await;
+    publish_failover_due(&ctx, Chain::Solana).await;
     assert!(
         next_publish(&mut rpc_rx).await.is_some(),
         "leg 1 publishes once past its deadline"
     );
 
-    publish_failover_due(&mut ctx, Chain::Solana).await;
+    publish_failover_due(&ctx, Chain::Solana).await;
     assert!(
         next_publish(&mut rpc_rx).await.is_none(),
         "the same entry does not fire twice"
@@ -1454,10 +1457,10 @@ async fn publish_failover_fires_once_per_leg() {
         )
         .await;
 
-    publish_failover_due(&mut ctx, Chain::Solana).await;
+    publish_failover_due(&ctx, Chain::Solana).await;
     assert!(
         next_publish(&mut rpc_rx).await.is_some(),
-        "leg 2 fires on its own key, not leg 1's history"
+        "leg 2 fires on its own episode, not leg 1's history"
     );
 }
 
@@ -1507,22 +1510,84 @@ async fn catchup_resume_suppresses_the_sweep_for_the_same_entry() {
         .await;
 
     let (sign_tx, _sign_rx) = mpsc::channel(4);
-    let (mut ctx, mut rpc_rx) = make_test_stream_context_with_rpc(
+    let (ctx, mut rpc_rx) = make_test_stream_context_with_rpc(
         backlog.clone(),
         sign_tx,
         true,
         ProjectivePoint::GENERATOR.to_affine(),
     );
+    let ctx = ctx.with_observe_lag(Some(Duration::ZERO));
 
-    resume_pending_publish_requests(&mut ctx, Chain::Solana).await;
+    resume_pending_publish_requests(&ctx, Chain::Solana).await;
     assert!(
         next_publish(&mut rpc_rx).await.is_some(),
         "the proposer republishes on catchup"
     );
 
-    publish_failover_due(&mut ctx, Chain::Solana).await;
+    publish_failover_due(&ctx, Chain::Solana).await;
     assert!(
         next_publish(&mut rpc_rx).await.is_none(),
         "the sweep must not republish what the resume already dispatched"
+    );
+}
+
+/// Put an entry in pending-publish with a deadline in the past, whatever the draw.
+async fn insert_publishable(backlog: &Backlog, seed: u8) {
+    let sign_id = mpc_primitives::SignId::new([seed; 32]);
+    backlog
+        .insert(Arc::new(IndexedSignRequest::sign(
+            sign_id,
+            test_sign_args(seed),
+            Chain::Solana,
+            current_unix_timestamp(),
+        )))
+        .await;
+    backlog
+        .set_status(
+            Chain::Solana,
+            &sign_id,
+            SignStatus::PendingPublish {
+                publish: Arc::new(PublishState {
+                    signature: Signature::new(
+                        ProjectivePoint::GENERATOR.to_affine(),
+                        Scalar::ONE,
+                        0,
+                    ),
+                    participants: vec![Participant::from(0u32), Participant::from(1u32)],
+                    is_proposer: false,
+                    publishing_since: Some(0),
+                }),
+            },
+        )
+        .await;
+}
+
+/// The deadline being past is not enough: a node that has not caught up is not
+/// reading its chain, so it holds fire rather than guessing.
+#[tokio::test]
+async fn publish_failover_needs_catchup() {
+    let backlog = Backlog::new();
+    insert_publishable(&backlog, 23).await;
+
+    let (sign_tx, _sign_rx) = mpsc::channel(4);
+    let (mut ctx, mut rpc_rx) = make_test_stream_context_with_rpc(
+        backlog.clone(),
+        sign_tx,
+        false,
+        ProjectivePoint::GENERATOR.to_affine(),
+    );
+    ctx.observe_lag = Some(Duration::ZERO);
+
+    publish_failover_due(&ctx, Chain::Solana).await;
+    assert!(
+        next_publish(&mut rpc_rx).await.is_none(),
+        "a node that has not caught up does not fail over"
+    );
+
+    ctx.caught_up = true;
+    publish_failover_due(&ctx, Chain::Solana).await;
+    assert!(
+        next_publish(&mut rpc_rx).await.is_some(),
+        "the deadline was past all along; catchup is what held it back"
     );
 }

--- a/chain-signatures/node/src/stream/stream_tests.rs
+++ b/chain-signatures/node/src/stream/stream_tests.rs
@@ -287,11 +287,7 @@ async fn test_respond_event_advances_to_pending_execution() {
             Chain::Solana,
             &sign_id,
             SignStatus::PendingPublish {
-                publish: Arc::new(PublishState {
-                    signature: mpc_sig,
-                    participants: vec![],
-                    is_proposer: true,
-                }),
+                publish: Arc::new(PublishState::new(mpc_sig, vec![], true)),
             },
         )
         .await;
@@ -558,11 +554,11 @@ async fn test_stream_resumes_pending_publish_after_catchup() {
             Chain::Solana,
             &sign_id,
             SignStatus::PendingPublish {
-                publish: Arc::new(PublishState {
+                publish: Arc::new(PublishState::new(
                     signature,
-                    participants: vec![Participant::from(0u32)],
-                    is_proposer: true,
-                }),
+                    vec![Participant::from(0u32)],
+                    true,
+                )),
             },
         )
         .await;
@@ -642,11 +638,11 @@ async fn test_stream_does_not_resume_non_proposer_pending_publish_after_catchup(
             Chain::Solana,
             &sign_id,
             SignStatus::PendingPublish {
-                publish: Arc::new(PublishState {
+                publish: Arc::new(PublishState::new(
                     signature,
-                    participants: vec![Participant::from(0u32)],
-                    is_proposer: false,
-                }),
+                    vec![Participant::from(0u32)],
+                    false,
+                )),
             },
         )
         .await;

--- a/chain-signatures/node/src/stream/supervisor.rs
+++ b/chain-signatures/node/src/stream/supervisor.rs
@@ -140,6 +140,9 @@ async fn run_supervised_with_watchdog<I: ChainIndexer, T: ChainTelemetry>(
 
     let mut load_local = true;
     loop {
+        // Cleared before recovery, not after: checkpoint creation and deliberator
+        // publishing must not act on a backlog being recovered or replayed into.
+        ctx.caught_up = false;
         recover_backlog(
             chain,
             load_local,
@@ -160,7 +163,6 @@ async fn run_supervised_with_watchdog<I: ChainIndexer, T: ChainTelemetry>(
             async move { indexer.run(events_tx, cancel).await }
         });
 
-        ctx.caught_up = false;
         let mut last_block_event = Instant::now();
         let mut run_finished = false;
 

--- a/chain-signatures/node/src/stream/supervisor.rs
+++ b/chain-signatures/node/src/stream/supervisor.rs
@@ -140,8 +140,8 @@ async fn run_supervised_with_watchdog<I: ChainIndexer, T: ChainTelemetry>(
 
     let mut load_local = true;
     loop {
-        // Cleared before recovery, not after: checkpoint creation and deliberator
-        // publishing must not act on a backlog being recovered or replayed into.
+        // Cleared before recovery, not after: checkpoint creation and publish
+        // failover must not act on a backlog being recovered or replayed into.
         ctx.caught_up = false;
         recover_backlog(
             chain,

--- a/doc/protocol_properties.md
+++ b/doc/protocol_properties.md
@@ -180,8 +180,9 @@ Generation is skipped entirely while \< t nodes are in the active set, so the fa
 
 *Enforcement*: The proposer publishes when generation finishes and retries indefinitely with backoff capped at 60 s. Every other participant holds the same finished signature, and publishes it itself once its own deadline passes without the response being observed on chain: a delay drawn uniformly from `[L, L + m·L/d]`, for `L` the lag until a published response is observed, `m` the participants and `d` the duplicate responses accepted per failover. The `L` offset keeps the happy path at one response; the window costs `d` extra in expectation when the proposer is silent. Duplicates are harmless, since both chains' respond entrypoints are bare event emitters and a repeated response is ignored on every node.
 
-The draw is anchored on a stamp stored with the entry, so it survives a restart rather than restarting the clock, and the sweep runs on block arrival, so a node that is not observing its chain holds fire instead of publishing blind. One participant with a healthy stream is enough.
+The draw is anchored on a stamp stored with the entry, so it survives a restart rather than restarting the clock, and the sweep runs on block arrival, once the node has caught up: it is the catchup backfill that covers the window being judged, so a node that has not read that window holds fire instead of publishing blind. One participant with a healthy stream is enough.
 
+The `1 + d` cost is what a failover pays when the failover response lands, since every node still waiting observes it within `L` and drops the entry. If no response can land at all, each of the `m` participants publishes once as its own deadline passes, spread over the window.
 
 ### L4. Mesh convergence
 

--- a/doc/protocol_properties.md
+++ b/doc/protocol_properties.md
@@ -174,12 +174,15 @@ Generation is skipped entirely while \< t nodes are in the active set, so the fa
 
 ### L3. Settlement
 
-*Property.* Once a signature is produced with a correct, online owner, it is eventually accepted on-chain.
+*Property.* Once a signature is produced, it is eventually accepted on-chain, whether or not the instance's proposer stays online.
 
 *Rationale.* A signature that never reaches the chain is worth no more to the user than no signature at all, while the presignature spent producing it is gone either way.
 
-*Enforcement*: The owner republishes on a timer, retrying indefinitely with backoff capped at 60 s.
-Currently not guaranteed, for two reasons. Only the successful instance's proposer publishes, and no other participant takes over, even though every participant holds the finished signature. And the retry itself lives in the publishing process, so what survives a restart is only what reached a confirmed checkpoint: on the checkpointed chains that includes the pending publish and its signature.
+*Enforcement*: The proposer publishes when generation finishes and retries indefinitely with backoff capped at 60 s. Every other participant holds the same finished signature, and publishes it itself once its own deadline passes without the response being observed on chain: a delay drawn uniformly from `[L, L + m·L/d]`, for `L` the lag until a published response is observed, `m` the participants and `d` the duplicate responses accepted per failover. The `L` offset keeps the happy path at one response; the window costs `d` extra in expectation when the proposer is silent. Duplicates are harmless, since both chains' respond entrypoints are bare event emitters and a repeated response is ignored on every node.
+
+The draw is anchored on a stamp stored with the entry, so it survives a restart rather than restarting the clock, and the sweep runs on block arrival, so a node that is not observing its chain holds fire instead of publishing blind. One participant with a healthy stream is enough.
+
+Two gaps remain. The delay follows chain finality, so a silent proposer costs a first failover of about `1.5·L`, tens of minutes on Ethereum. And entries checkpointed before the stamp existed carry no anchor and never fail over, which leaves the old behaviour for that set until it drains.
 
 ### L4. Mesh convergence
 

--- a/doc/protocol_properties.md
+++ b/doc/protocol_properties.md
@@ -182,7 +182,6 @@ Generation is skipped entirely while \< t nodes are in the active set, so the fa
 
 The draw is anchored on a stamp stored with the entry, so it survives a restart rather than restarting the clock, and the sweep runs on block arrival, so a node that is not observing its chain holds fire instead of publishing blind. One participant with a healthy stream is enough.
 
-Two gaps remain. The delay follows chain finality, so a silent proposer costs a first failover of about `1.5·L`, tens of minutes on Ethereum. And entries checkpointed before the stamp existed carry no anchor and never fail over, which leaves the old behaviour for that set until it drains.
 
 ### L4. Mesh convergence
 

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -85,6 +85,9 @@ struct FixtureConfig {
     signature_timeout_ms: u64,
     presignature_timeout_ms: u64,
     triple_timeout_ms: u64,
+
+    /// Overrides the deliberator publish schedule's observe lag; `None` is production.
+    deliberator_observe_lag: Option<std::time::Duration>,
 }
 
 /// Context required to start a fixture node.
@@ -97,6 +100,7 @@ struct MockedNodeContext {
     redis_pool: deadpool_redis::Pool,
     init_mesh: MeshState,
     contract_state: ContractStateWatcher,
+    deliberator_observe_lag: Option<std::time::Duration>,
 
     #[allow(dead_code)]
     node_account_id: AccountId,
@@ -135,6 +139,7 @@ impl FixtureConfig {
             max_concurrent_generation: defaults.max_concurrent_generation,
             signature_timeout_ms: 10_000,
             presignature_timeout_ms: 10_000,
+            deliberator_observe_lag: None,
             triple_timeout_ms: min_to_ms(10),
         }
     }
@@ -266,6 +271,7 @@ impl MpcFixtureBuilder {
                 redis_pool: redis_container.pool(),
                 init_mesh: initial_mesh_state.clone(),
                 contract_state,
+                deliberator_observe_lag: self.fixture_config.deliberator_observe_lag,
                 node_account_id: node.participant_info.account_id.clone(),
             };
 
@@ -409,6 +415,13 @@ impl MpcFixtureBuilder {
     /// Specify a method that acts as message filter for all sent messages the given node.
     pub fn with_outgoing_message_filter(mut self, node_idx: usize, filter: MessageFilter) -> Self {
         self.prepared_nodes[node_idx].messaging.filter = filter;
+        self
+    }
+
+    /// Pin the deliberator publish schedule's observe lag for every node, for tests
+    /// that assert the failover itself rather than its production timing.
+    pub fn with_deliberator_observe_lag(mut self, lag: std::time::Duration) -> Self {
+        self.fixture_config.deliberator_observe_lag = Some(lag);
         self
     }
 
@@ -596,6 +609,7 @@ impl MpcFixtureNodeBuilder {
             context.contract_state.clone(),
             &mesh_rx,
             checkpoints_rx,
+            context.deliberator_observe_lag,
         );
 
         // handle outbox messages manually, we want them before they are

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -34,6 +34,7 @@ use mpc_node::protocol::sync::SyncTask;
 use mpc_node::protocol::{self, MessageChannel, MpcSignProtocol, ProtocolState};
 use mpc_node::rpc::{ContractStateWatcher, RpcChannel};
 use mpc_node::storage::{secret_storage, triple_storage::TriplePair, Options};
+use mpc_node::stream::StreamContext;
 use mpc_primitives::Chain;
 use near_sdk::AccountId;
 use std::collections::HashMap;
@@ -601,16 +602,18 @@ impl MpcFixtureNodeBuilder {
 
         let flat_mock_streams = self.mock_streams.values().cloned().collect::<Vec<_>>();
         let (checkpoint_tx, checkpoints_rx) = watch::channel(None);
-        fixture_tasks::start_mock_stream_tasks(
-            &flat_mock_streams,
-            sign_tx.clone(),
-            rpc_channel.clone(),
-            backlog.clone(),
-            context.contract_state.clone(),
-            &mesh_rx,
-            checkpoints_rx,
-            context.deliberator_observe_lag,
-        );
+        fixture_tasks::start_mock_stream_tasks(&flat_mock_streams, || {
+            StreamContext::new(
+                backlog.clone(),
+                sign_tx.clone(),
+                rpc_channel.clone(),
+                context.contract_state.clone(),
+                mesh_rx.clone(),
+                NodeClient::new(&Default::default()),
+                checkpoints_rx.clone(),
+            )
+            .with_observe_lag(context.deliberator_observe_lag)
+        });
 
         // handle outbox messages manually, we want them before they are
         // encrypted and we want to send them directly to other node's inboxes

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -87,8 +87,8 @@ struct FixtureConfig {
     presignature_timeout_ms: u64,
     triple_timeout_ms: u64,
 
-    /// Overrides the deliberator publish schedule's observe lag; `None` is production.
-    deliberator_observe_lag: Option<std::time::Duration>,
+    /// Overrides the publish failover schedule's observe lag; `None` is production.
+    observe_lag: Option<std::time::Duration>,
 }
 
 /// Context required to start a fixture node.
@@ -101,7 +101,7 @@ struct MockedNodeContext {
     redis_pool: deadpool_redis::Pool,
     init_mesh: MeshState,
     contract_state: ContractStateWatcher,
-    deliberator_observe_lag: Option<std::time::Duration>,
+    observe_lag: Option<std::time::Duration>,
 
     #[allow(dead_code)]
     node_account_id: AccountId,
@@ -140,7 +140,7 @@ impl FixtureConfig {
             max_concurrent_generation: defaults.max_concurrent_generation,
             signature_timeout_ms: 10_000,
             presignature_timeout_ms: 10_000,
-            deliberator_observe_lag: None,
+            observe_lag: None,
             triple_timeout_ms: min_to_ms(10),
         }
     }
@@ -272,7 +272,7 @@ impl MpcFixtureBuilder {
                 redis_pool: redis_container.pool(),
                 init_mesh: initial_mesh_state.clone(),
                 contract_state,
-                deliberator_observe_lag: self.fixture_config.deliberator_observe_lag,
+                observe_lag: self.fixture_config.observe_lag,
                 node_account_id: node.participant_info.account_id.clone(),
             };
 
@@ -419,10 +419,10 @@ impl MpcFixtureBuilder {
         self
     }
 
-    /// Pin the deliberator publish schedule's observe lag for every node, for tests
+    /// Pin the publish failover schedule's observe lag for every node, for tests
     /// that assert the failover itself rather than its production timing.
-    pub fn with_deliberator_observe_lag(mut self, lag: std::time::Duration) -> Self {
-        self.fixture_config.deliberator_observe_lag = Some(lag);
+    pub fn with_observe_lag(mut self, lag: std::time::Duration) -> Self {
+        self.fixture_config.observe_lag = Some(lag);
         self
     }
 
@@ -612,7 +612,7 @@ impl MpcFixtureNodeBuilder {
                 NodeClient::new(&Default::default()),
                 checkpoints_rx.clone(),
             )
-            .with_observe_lag(context.deliberator_observe_lag)
+            .with_observe_lag(context.observe_lag)
         });
 
         // handle outbox messages manually, we want them before they are

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -334,9 +334,8 @@ impl MpcFixture {
     /// Advance every node's stream by one empty block.
     ///
     /// Real indexers emit `ChainEvent::Block` whether or not the block held
-    /// anything (the supervisor's watchdog restarts a chain that stops), and work
-    /// that rides the block stream, like the publish failover sweep, only runs
-    /// when one arrives. Tests that wait on such work have to keep the chain
+    /// anything, and work riding the block stream, like the publish failover sweep,
+    /// only runs when one arrives. Tests waiting on such work must keep the chain
     /// moving rather than only sleeping.
     pub async fn tick_block(&self, chain: Chain) {
         for node in &self.nodes {

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -18,6 +18,7 @@ use mpc_node::storage::{PresignatureStorage, TripleStorage};
 use mpc_primitives::{Chain, CheckpointDigest, IndexedSignRequest, SignCommand};
 use near_sdk::AccountId;
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -59,6 +60,9 @@ pub struct SharedOutput {
     /// Signaled whenever an RPC action is recorded, so `wait_for_actions`
     /// reacts on the event instead of polling.
     pub actions_changed: Arc<Notify>,
+    /// Publishes across all nodes. `rpc_actions` is a set keyed by the request,
+    /// so it cannot tell one node publishing from several.
+    pub publishes: Arc<AtomicUsize>,
 }
 
 impl MpcFixture {
@@ -173,6 +177,11 @@ impl MpcFixture {
         for node in &self.nodes {
             node.wait_for_presignatures(threshold_per_node).await;
         }
+    }
+
+    /// How many publishes every node has made in total.
+    pub fn publishes(&self) -> usize {
+        self.output.publishes.load(Ordering::Relaxed)
     }
 
     pub async fn wait_for_actions(&self, threshold: usize) -> HashSet<String> {
@@ -319,6 +328,24 @@ impl MpcFixture {
                 stream.prepare_block_of_sign_requests(requests).await;
                 stream.progress_block_height(1).await;
             }
+        }
+    }
+
+    /// Advance every node's stream by one empty block.
+    ///
+    /// Real indexers emit `ChainEvent::Block` whether or not the block held
+    /// anything (the supervisor's watchdog restarts a chain that stops), and work
+    /// that rides the block stream, like the deliberator publish sweep, only runs
+    /// when one arrives. Tests that wait on such work have to keep the chain
+    /// moving rather than only sleeping.
+    pub async fn tick_block(&self, chain: Chain) {
+        for node in &self.nodes {
+            let stream = node
+                .mock_streams
+                .get(&chain)
+                .expect("must have mock stream configured");
+            stream.prepare_block_of_events(&[]).await;
+            stream.progress_block_height(1).await;
         }
     }
 }
@@ -477,6 +504,7 @@ impl SharedOutput {
             msg_log: Arc::new(Mutex::new(M::default())),
             rpc_actions: Arc::new(Mutex::new(HashSet::new())),
             actions_changed: Arc::new(Notify::new()),
+            publishes: Default::default(),
         }
     }
 }
@@ -487,6 +515,7 @@ impl Default for SharedOutput {
             msg_log: Arc::new(Mutex::new(MessagePrinter)),
             rpc_actions: Default::default(),
             actions_changed: Arc::new(Notify::new()),
+            publishes: Default::default(),
         }
     }
 }

--- a/integration-tests/src/mpc_fixture/fixture_interface.rs
+++ b/integration-tests/src/mpc_fixture/fixture_interface.rs
@@ -335,7 +335,7 @@ impl MpcFixture {
     ///
     /// Real indexers emit `ChainEvent::Block` whether or not the block held
     /// anything (the supervisor's watchdog restarts a chain that stops), and work
-    /// that rides the block stream, like the deliberator publish sweep, only runs
+    /// that rides the block stream, like the publish failover sweep, only runs
     /// when one arrives. Tests that wait on such work have to keep the chain
     /// moving rather than only sleeping.
     pub async fn tick_block(&self, chain: Chain) {

--- a/integration-tests/src/mpc_fixture/fixture_tasks.rs
+++ b/integration-tests/src/mpc_fixture/fixture_tasks.rs
@@ -7,18 +7,15 @@ use crate::mpc_fixture::mock_stream::{MockIndexer, MockStream};
 use cait_sith::protocol::Participant;
 use mpc_chain_integration_core::NoopChainTelemetry;
 use mpc_keys::hpke::Ciphered;
-use mpc_node::backlog::Backlog;
 use mpc_node::config::Config;
 use mpc_node::mesh::MeshState;
-use mpc_node::node_client::NodeClient;
 use mpc_node::protocol::message::{MessageOutbox, SendMessage, SignedMessage};
-use mpc_node::rpc::{ContractStateWatcher, RpcAction, RpcChannel};
+use mpc_node::rpc::RpcAction;
 use mpc_node::stream::{supervisor::run_supervised, StreamContext};
-use mpc_primitives::SignCommand;
 use std::collections::HashMap;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
@@ -124,30 +121,17 @@ pub(super) fn test_mock_network(
     })
 }
 
+/// Supervise one chain indexer per mock stream. `make_ctx` builds a fresh
+/// [`StreamContext`] per stream, so the caller decides what the streams share
+/// without every dependency travelling through this signature.
 pub(super) fn start_mock_stream_tasks(
     mock_streams: &[MockStream],
-    sign_tx: mpsc::Sender<SignCommand>,
-    rpc: RpcChannel,
-    backlog: Backlog,
-    contract_watcher: ContractStateWatcher,
-    mesh_state: &watch::Receiver<MeshState>,
-    checkpoints_rx: mpc_node::types::CheckpointWatcher,
-    observe_lag: Option<std::time::Duration>,
+    make_ctx: impl Fn() -> StreamContext,
 ) {
     for stream in mock_streams {
-        let indexer = MockIndexer::from_stream(stream);
         tokio::spawn(run_supervised(
-            indexer,
-            StreamContext::new(
-                backlog.clone(),
-                sign_tx.clone(),
-                rpc.clone(),
-                contract_watcher.clone(),
-                mesh_state.clone(),
-                NodeClient::new(&Default::default()),
-                checkpoints_rx.clone(),
-            )
-            .with_observe_lag(observe_lag),
+            MockIndexer::from_stream(stream),
+            make_ctx(),
             NoopChainTelemetry,
         ));
     }

--- a/integration-tests/src/mpc_fixture/fixture_tasks.rs
+++ b/integration-tests/src/mpc_fixture/fixture_tasks.rs
@@ -16,6 +16,7 @@ use mpc_node::rpc::{ContractStateWatcher, RpcAction, RpcChannel};
 use mpc_node::stream::{supervisor::run_supervised, StreamContext};
 use mpc_primitives::SignCommand;
 use std::collections::HashMap;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::watch;
@@ -37,6 +38,7 @@ pub(super) fn test_mock_network(
     let msg_log = Arc::clone(&shared_output.msg_log);
     let rpc_actions = Arc::clone(&shared_output.rpc_actions);
     let actions_changed = Arc::clone(&shared_output.actions_changed);
+    let publishes = Arc::clone(&shared_output.publishes);
     // Participant info as of network start, consulted for recipient's encryption key
     let initial_participants = mesh.borrow().active().clone();
 
@@ -82,25 +84,30 @@ pub(super) fn test_mock_network(
                 }
 
                 Some(rpc) = rpc_rx.recv() => {
+                    // `None` for anything that is not an action on a chain: the log is
+                    // what tests count responses with, so bookkeeping must stay out of it.
                     let action_str = match &rpc {
                         RpcAction::Publish(publish_action) => {
-                            format!(
+                            publishes.fetch_add(1, Ordering::Relaxed);
+                            Some(format!(
                                 "RpcAction::Publish({:?})",
                                 publish_action.request,
-                            )
+                            ))
                         },
                         RpcAction::VoteCheckpoint { checkpoint, .. } => {
-                            format!("RpcAction::VoteCheckpoint({checkpoint:?})")
+                            Some(format!("RpcAction::VoteCheckpoint({checkpoint:?})"))
                         },
                         RpcAction::AbortCheckpoints(chain) => {
-                            format!("RpcAction::AbortCheckpoints({chain:?})")
+                            Some(format!("RpcAction::AbortCheckpoints({chain:?})"))
                         }
                     };
-                    tracing::info!(target: "mock_network", ?action_str, "Received RPC action");
-                    let mut actions_log = rpc_actions.lock().await;
-                    actions_log.insert(action_str);
-                    drop(actions_log);
-                    actions_changed.notify_one();
+                    if let Some(action_str) = action_str {
+                        tracing::info!(target: "mock_network", ?action_str, "Received RPC action");
+                        let mut actions_log = rpc_actions.lock().await;
+                        actions_log.insert(action_str);
+                        drop(actions_log);
+                        actions_changed.notify_one();
+                    }
 
                     if let Some(chain) = &mock_chain {
                         chain.on_rpc_publish(&rpc).await;
@@ -125,6 +132,7 @@ pub(super) fn start_mock_stream_tasks(
     contract_watcher: ContractStateWatcher,
     mesh_state: &watch::Receiver<MeshState>,
     checkpoints_rx: mpc_node::types::CheckpointWatcher,
+    observe_lag: Option<std::time::Duration>,
 ) {
     for stream in mock_streams {
         let indexer = MockIndexer::from_stream(stream);
@@ -138,7 +146,8 @@ pub(super) fn start_mock_stream_tasks(
                 mesh_state.clone(),
                 NodeClient::new(&Default::default()),
                 checkpoints_rx.clone(),
-            ),
+            )
+            .with_observe_lag(observe_lag),
             NoopChainTelemetry,
         ));
     }

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -563,6 +563,7 @@ async fn test_ethereum_stream_linear_catchup_from_checkpoint() -> Result<()> {
                     ),
                     participants: vec![Participant::from(0u32), Participant::from(1u32)],
                     is_proposer: true,
+                    publishing_since: Some(mpc_utils::time::current_unix_timestamp()),
                 }),
             },
         )
@@ -908,6 +909,7 @@ async fn test_ethereum_stream_backfills_late_execution_watcher_after_catchup() -
                     ),
                     participants: vec![Participant::from(0u32), Participant::from(1u32)],
                     is_proposer: true,
+                    publishing_since: Some(mpc_utils::time::current_unix_timestamp()),
                 }),
             },
         )
@@ -1051,6 +1053,7 @@ async fn test_ethereum_stream_respond_tx_replacement_resolves_watcher() -> Resul
                     ),
                     participants: vec![Participant::from(0u32), Participant::from(1u32)],
                     is_proposer: true,
+                    publishing_since: Some(mpc_utils::time::current_unix_timestamp()),
                 }),
             },
         )
@@ -1111,6 +1114,7 @@ async fn test_ethereum_stream_respond_tx_replacement_resolves_watcher() -> Resul
                     ),
                     participants: vec![Participant::from(0u32), Participant::from(1u32)],
                     is_proposer: true,
+                    publishing_since: Some(mpc_utils::time::current_unix_timestamp()),
                 }),
             },
         )

--- a/integration-tests/tests/cases/mpc_with_stream.rs
+++ b/integration-tests/tests/cases/mpc_with_stream.rs
@@ -50,23 +50,22 @@ async fn test_sign() {
 }
 
 /// Pinned observe lag: fast, immune to chain finality constants changing, and far
-/// enough past in-process event propagation that no deliberator fires on the happy path.
+/// enough past in-process event propagation that no failover fires on the happy path.
 const TEST_OBSERVE_LAG: Duration = Duration::from_secs(5);
 
-/// Upper bound on any deliberator's delay, derived from the schedule so the control
+/// Upper bound on any node's failover delay, derived from the schedule so the control
 /// test cannot silently sleep through less than the real delay.
-fn max_deliberator_delay(network: &integration_tests::mpc_fixture::MpcFixture) -> Duration {
-    let deliberators = network.sorted_participants().len().saturating_sub(1);
-    mpc_node::protocol::deliberator_publish::max_deliberator_publish_delay(
+fn max_failover_delay(network: &integration_tests::mpc_fixture::MpcFixture) -> Duration {
+    mpc_node::protocol::publish_failover::max_publish_failover_delay(
         Chain::Solana,
-        deliberators,
+        network.sorted_participants().len(),
         Some(TEST_OBSERVE_LAG),
     )
 }
 
 /// Wait for `count` publishes across all nodes, keeping the chain moving.
 ///
-/// The deliberator sweep runs on block events, so a test that only slept would
+/// The failover sweep runs on block events, so a test that only slept would
 /// wait forever: it is the arrival of a block, not the passage of time, that lets
 /// a node conclude the proposer's response did not land. The first publish (the
 /// proposer's) is the timing anchor: deadlines start at marking, not submission.
@@ -98,10 +97,10 @@ async fn tick_blocks_for(network: &integration_tests::mpc_fixture::MpcFixture, d
     }
 }
 
-/// No respond event ever arrives, so a deliberator has to publish, or nobody answers.
+/// No respond event ever arrives, so the failover has to publish, or nobody answers.
 #[test(tokio::test(flavor = "multi_thread"))]
-async fn test_deliberator_publishes_when_the_response_never_lands() {
-    let network = deliberator_publish_fixture(RespondEvents::Dropped).await;
+async fn test_failover_publishes_when_the_response_never_lands() {
+    let network = publish_failover_fixture(RespondEvents::Dropped).await;
     network
         .process_sign_requests(Chain::Solana, &[sign_request(0)])
         .await;
@@ -110,31 +109,31 @@ async fn test_deliberator_publishes_when_the_response_never_lands() {
     wait_for_publishes(
         &network,
         2,
-        max_deliberator_delay(&network) + Duration::from_secs(5),
-        "deliberator publish",
+        max_failover_delay(&network) + Duration::from_secs(5),
+        "failover publish",
     )
     .await;
 }
 
-/// The control: an observed response stands the deliberators down, so one response total.
+/// The control: an observed response stands the failover down, so one response total.
 #[test(tokio::test(flavor = "multi_thread"))]
-async fn test_observed_response_stands_down_the_deliberators() {
-    let network = deliberator_publish_fixture(RespondEvents::Delivered).await;
+async fn test_observed_response_stands_down_failover() {
+    let network = publish_failover_fixture(RespondEvents::Delivered).await;
     network
         .process_sign_requests(Chain::Solana, &[sign_request(0)])
         .await;
 
-    // Outlast the longest delay a deliberator could have drawn from the anchor.
+    // Outlast the longest delay any node could have drawn from the anchor.
     wait_for_publishes(&network, 1, Duration::from_secs(60), "proposer publish").await;
     tick_blocks_for(
         &network,
-        max_deliberator_delay(&network) + Duration::from_secs(5),
+        max_failover_delay(&network) + Duration::from_secs(5),
     )
     .await;
     assert_eq!(
         network.publishes(),
         1,
-        "a deliberator published despite the response landing"
+        "a node published a failover response despite the response landing"
     );
 }
 
@@ -145,15 +144,15 @@ enum RespondEvents {
     Dropped,
 }
 
-/// Three nodes signing on Solana, deliberator schedule pinned to [`TEST_OBSERVE_LAG`].
-async fn deliberator_publish_fixture(
+/// Three nodes signing on Solana, failover schedule pinned to [`TEST_OBSERVE_LAG`].
+async fn publish_failover_fixture(
     responds: RespondEvents,
 ) -> integration_tests::mpc_fixture::MpcFixture {
     use integration_tests::mpc_fixture::mock_chain::EventDelivery;
     use mpc_primitives::ChainEvent;
 
     let mut builder = MpcFixtureBuilder::default()
-        .with_deliberator_observe_lag(TEST_OBSERVE_LAG)
+        .with_observe_lag(TEST_OBSERVE_LAG)
         .only_generate_signatures()
         .with_mock_stream(Chain::Solana, MockStream::default())
         .await;

--- a/integration-tests/tests/cases/mpc_with_stream.rs
+++ b/integration-tests/tests/cases/mpc_with_stream.rs
@@ -49,12 +49,12 @@ async fn test_sign() {
     );
 }
 
-/// Pinned observe lag: fast, immune to chain finality constants changing, and far
-/// enough past in-process event propagation that no failover fires on the happy path.
+/// Pinned observe lag: fast, immune to finality constants changing, and far enough
+/// past in-process event propagation that no failover fires on the happy path.
 const TEST_OBSERVE_LAG: Duration = Duration::from_secs(5);
 
-/// Upper bound on any node's failover delay, derived from the schedule so the control
-/// test cannot silently sleep through less than the real delay.
+/// Upper bound on any node's failover delay, derived from the schedule so the
+/// control test cannot silently sleep through less than the real delay.
 fn max_failover_delay(network: &integration_tests::mpc_fixture::MpcFixture) -> Duration {
     mpc_node::protocol::publish_failover::max_publish_failover_delay(
         Chain::Solana,
@@ -65,10 +65,9 @@ fn max_failover_delay(network: &integration_tests::mpc_fixture::MpcFixture) -> D
 
 /// Wait for `count` publishes across all nodes, keeping the chain moving.
 ///
-/// The failover sweep runs on block events, so a test that only slept would
-/// wait forever: it is the arrival of a block, not the passage of time, that lets
-/// a node conclude the proposer's response did not land. The first publish (the
-/// proposer's) is the timing anchor: deadlines start at marking, not submission.
+/// The sweep runs on block events, so a test that only slept would wait forever.
+/// The first publish (the proposer's) is the timing anchor: deadlines start at
+/// marking, not submission.
 async fn wait_for_publishes(
     network: &integration_tests::mpc_fixture::MpcFixture,
     count: usize,
@@ -87,8 +86,8 @@ async fn wait_for_publishes(
     }
 }
 
-/// Keep the chain moving for `duration`, so work that rides the block stream has
-/// every chance to run before a test concludes that it did not.
+/// Keep the chain moving for `duration`, so work riding the block stream has every
+/// chance to run before a test concludes it did not.
 async fn tick_blocks_for(network: &integration_tests::mpc_fixture::MpcFixture, duration: Duration) {
     let deadline = std::time::Instant::now() + duration;
     while std::time::Instant::now() < deadline {
@@ -137,8 +136,8 @@ async fn test_observed_response_stands_down_failover() {
     );
 }
 
-/// `Dropped` withholds respond events from every node: what a proposer dying
-/// before its response lands looks like to the others.
+/// `Dropped` withholds respond events from every node: what a proposer dying before
+/// its response lands looks like to the others.
 enum RespondEvents {
     Delivered,
     Dropped,

--- a/integration-tests/tests/cases/mpc_with_stream.rs
+++ b/integration-tests/tests/cases/mpc_with_stream.rs
@@ -49,6 +49,130 @@ async fn test_sign() {
     );
 }
 
+/// Pinned observe lag: fast, immune to chain finality constants changing, and far
+/// enough past in-process event propagation that no deliberator fires on the happy path.
+const TEST_OBSERVE_LAG: Duration = Duration::from_secs(5);
+
+/// Upper bound on any deliberator's delay, derived from the schedule so the control
+/// test cannot silently sleep through less than the real delay.
+fn max_deliberator_delay(network: &integration_tests::mpc_fixture::MpcFixture) -> Duration {
+    let deliberators = network.sorted_participants().len().saturating_sub(1);
+    mpc_node::protocol::deliberator_publish::max_deliberator_publish_delay(
+        Chain::Solana,
+        deliberators,
+        Some(TEST_OBSERVE_LAG),
+    )
+}
+
+/// Wait for `count` publishes across all nodes, keeping the chain moving.
+///
+/// The deliberator sweep runs on block events, so a test that only slept would
+/// wait forever: it is the arrival of a block, not the passage of time, that lets
+/// a node conclude the proposer's response did not land. The first publish (the
+/// proposer's) is the timing anchor: deadlines start at marking, not submission.
+async fn wait_for_publishes(
+    network: &integration_tests::mpc_fixture::MpcFixture,
+    count: usize,
+    timeout: Duration,
+    what: &str,
+) {
+    let deadline = std::time::Instant::now() + timeout;
+    while network.publishes() < count {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "{what}: expected {count} publishes, saw {} within {timeout:?}",
+            network.publishes()
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        network.tick_block(Chain::Solana).await;
+    }
+}
+
+/// Keep the chain moving for `duration`, so work that rides the block stream has
+/// every chance to run before a test concludes that it did not.
+async fn tick_blocks_for(network: &integration_tests::mpc_fixture::MpcFixture, duration: Duration) {
+    let deadline = std::time::Instant::now() + duration;
+    while std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        network.tick_block(Chain::Solana).await;
+    }
+}
+
+/// No respond event ever arrives, so a deliberator has to publish, or nobody answers.
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_deliberator_publishes_when_the_response_never_lands() {
+    let network = deliberator_publish_fixture(RespondEvents::Dropped).await;
+    network
+        .process_sign_requests(Chain::Solana, &[sign_request(0)])
+        .await;
+
+    wait_for_publishes(&network, 1, Duration::from_secs(60), "proposer publish").await;
+    wait_for_publishes(
+        &network,
+        2,
+        max_deliberator_delay(&network) + Duration::from_secs(5),
+        "deliberator publish",
+    )
+    .await;
+}
+
+/// The control: an observed response stands the deliberators down, so one response total.
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_observed_response_stands_down_the_deliberators() {
+    let network = deliberator_publish_fixture(RespondEvents::Delivered).await;
+    network
+        .process_sign_requests(Chain::Solana, &[sign_request(0)])
+        .await;
+
+    // Outlast the longest delay a deliberator could have drawn from the anchor.
+    wait_for_publishes(&network, 1, Duration::from_secs(60), "proposer publish").await;
+    tick_blocks_for(
+        &network,
+        max_deliberator_delay(&network) + Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(
+        network.publishes(),
+        1,
+        "a deliberator published despite the response landing"
+    );
+}
+
+/// `Dropped` withholds respond events from every node: what a proposer dying
+/// before its response lands looks like to the others.
+enum RespondEvents {
+    Delivered,
+    Dropped,
+}
+
+/// Three nodes signing on Solana, deliberator schedule pinned to [`TEST_OBSERVE_LAG`].
+async fn deliberator_publish_fixture(
+    responds: RespondEvents,
+) -> integration_tests::mpc_fixture::MpcFixture {
+    use integration_tests::mpc_fixture::mock_chain::EventDelivery;
+    use mpc_primitives::ChainEvent;
+
+    let mut builder = MpcFixtureBuilder::default()
+        .with_deliberator_observe_lag(TEST_OBSERVE_LAG)
+        .only_generate_signatures()
+        .with_mock_stream(Chain::Solana, MockStream::default())
+        .await;
+
+    if matches!(responds, RespondEvents::Dropped) {
+        for node_idx in 0..3 {
+            builder = builder.with_chain_event_filter(
+                node_idx,
+                Box::new(|event: &ChainEvent| match event {
+                    ChainEvent::Respond(_) => EventDelivery::Drop,
+                    _ => EventDelivery::Deliver,
+                }),
+            );
+        }
+    }
+
+    builder.build().await
+}
+
 /// Common checker function called with different parameters in test cases below.
 async fn check_channel_contention(
     // number of blocks with requests to send

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -532,11 +532,11 @@ async fn test_solana_stream_republishes_pending_publish_after_checkpoint_recover
             Chain::Solana,
             &sign_id,
             SignStatus::PendingPublish {
-                publish: Arc::new(PublishState {
+                publish: Arc::new(PublishState::new(
                     signature,
-                    participants: vec![Participant::from(0u32)],
-                    is_proposer: true,
-                }),
+                    vec![Participant::from(0u32)],
+                    true,
+                )),
             },
         )
         .await;


### PR DESCRIPTION
**Problem.** Only the proposer publishes a completed signature, so a proposer that dies after generation leaves it unpublished for good, even though every participant holds it. #1063.

**Solution.** The randomized schedule from #1063: each node draws a delay uniformly from `[L, L + m·L/d]` and publishes any entry still in pending-publish when it expires, giving one response on the happy path and `1 + d` when the proposer is silent. `L` is the lag until a published response is observed, chain finality plus a 15s margin; `m` is the number of participants; `d` is the duplicate responses accepted per failover, 2 here.

The sweep runs on block arrival rather than a timer, because a node can only conclude a response is missing if it has been watching the chain: one whose stream is down stays quiet instead of guessing. A restarting proposer republishes from the catchup resume, which records what it sent so the next sweep does not repeat it.

**History.** Reworked since the first review round, which rightly noted that the original design (a waiting task parked inside each sign generator) pinned the generator for the whole window and did not survive restarts. A second round moved the sweep off its own once-a-second task onto the stream's block arm, and dropped the proposer exclusion. Builds on #1186, which carries the independent hardening and cleanups this rework surfaced.
