### PR TITLE
feat: reset checkpoints by height

### DIFF
--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -1180,10 +1180,6 @@ impl MpcContract {
         &self.latest_checkpoints
     }
 
-    fn latest_checkpoints_mut(&mut self) -> &mut IterableMap<Chain, ConsensusCheckpointDigest> {
-        &mut self.latest_checkpoints
-    }
-
     fn insert_checkpoint(&mut self, chain: Chain, checkpoint: ConsensusCheckpointDigest) {
         self.latest_checkpoints.insert(chain, checkpoint);
     }

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -1252,14 +1252,14 @@ impl VersionedMpcContract {
     }
 
     /// Settle each chain's *canonical reset checkpoint*: the one asserting an
-    /// empty backlog at `resume_after`.
+    /// empty backlog just before `height`.
     ///
-    /// Its digest is derived from `(chain, resume_after)` alone, so every node
+    /// Its digest is derived from `(chain, height - 1)` alone, so every node
     /// can rebuild it locally and regress onto it through the ordinary
     /// divergence path. Votes for the chain are dropped, since they describe
     /// the abandoned history.
     ///
-    /// `resume_after` is exclusive: indexing resumes at `resume_after + 1`.
+    /// `height` is inclusive: indexing resumes at `height` itself.
     ///
     /// The resulting checkpoint is deliberately indistinguishable from one the
     /// network settled with an empty backlog at the same height, because it
@@ -1270,11 +1270,8 @@ impl VersionedMpcContract {
     #[private]
     pub fn reset_checkpoints(&mut self, resets: Vec<CheckpointReset>) {
         let mut chains = HashSet::new();
-        for CheckpointReset {
-            chain,
-            resume_after,
-        } in resets
-        {
+        for CheckpointReset { chain, height } in resets {
+            let resume_after = height.saturating_sub(1);
             chains.insert(chain);
             self.insert_checkpoint(
                 chain,
@@ -1288,6 +1285,7 @@ impl VersionedMpcContract {
                 &serde_json::json!({
                     "event": "checkpoint_reset",
                     "chain": chain,
+                    "height": height,
                     "resume_after": resume_after,
                 })
                 .to_string(),
@@ -1522,9 +1520,11 @@ mod tests {
 
         contract.reset_checkpoints(vec![CheckpointReset {
             chain: Chain::Solana,
-            resume_after: 5,
+            height: 6,
         }]);
 
+        // `height` is inclusive: indexing resumes at 6 itself, whose empty
+        // checkpoint lives at 5.
         // The reset is an ordinary settled checkpoint whose digest is derived
         // from the pair, which is what every node re-derives locally.
         assert_eq!(
@@ -1544,7 +1544,7 @@ mod tests {
         let mut contract = running_contract(1);
         contract.reset_checkpoints(vec![CheckpointReset {
             chain: Chain::Solana,
-            resume_after: 100,
+            height: 101,
         }]);
 
         // Below the reset height the ordinary "behind" rule already rejects.
@@ -1589,7 +1589,7 @@ mod tests {
         let mut contract = running_contract(1);
         contract.reset_checkpoints(vec![CheckpointReset {
             chain: Chain::Solana,
-            resume_after: 100,
+            height: 101,
         }]);
 
         // The settled checkpoint is deliberately indistinguishable from an
@@ -1603,6 +1603,7 @@ mod tests {
         let event: serde_json::Value = serde_json::from_str(event).expect("event must be JSON");
         assert_eq!(event["event"], "checkpoint_reset");
         assert_eq!(event["chain"], serde_json::json!(Chain::Solana));
+        assert_eq!(event["height"], 101);
         assert_eq!(event["resume_after"], 100);
     }
 
@@ -1611,13 +1612,13 @@ mod tests {
         let mut contract = running_contract(1);
         contract.reset_checkpoints(vec![CheckpointReset {
             chain: Chain::Solana,
-            resume_after: 100,
+            height: 101,
         }]);
         // Correcting an operator mistake: a second reset simply settles a
         // different checkpoint, including backwards.
         contract.reset_checkpoints(vec![CheckpointReset {
             chain: Chain::Solana,
-            resume_after: 30,
+            height: 31,
         }]);
 
         assert_eq!(

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -26,8 +26,9 @@ use near_sdk::{
     PublicKey,
 };
 use primitives::{
-    CandidateEntry, CandidateInfo, Candidates, CheckpointVotes, InternalSignRequest, Participants,
-    PendingRequest, PkVotes, Read, SignPoll, SignRequest, StorageKey, View, Votes, YieldIndex,
+    CandidateEntry, CandidateInfo, Candidates, CheckpointReset, CheckpointVotes,
+    InternalSignRequest, Participants, PendingRequest, PkVotes, Read, SignPoll, SignRequest,
+    StorageKey, View, Votes, YieldIndex,
 };
 use signet_primitives::{Chain, SignId, Signature, LATEST_MPC_KEY_VERSION};
 use std::collections::{BTreeMap, HashSet};
@@ -1236,12 +1237,6 @@ impl VersionedMpcContract {
         }
     }
 
-    fn latest_checkpoints_mut(&mut self) -> &mut IterableMap<Chain, ConsensusCheckpointDigest> {
-        match self {
-            Self::V0(mpc_contract) => &mut mpc_contract.latest_checkpoints,
-        }
-    }
-
     fn insert_checkpoint(&mut self, chain: Chain, checkpoint: ConsensusCheckpointDigest) {
         match self {
             Self::V0(mpc_contract) => {
@@ -1256,11 +1251,47 @@ impl VersionedMpcContract {
         }
     }
 
+    /// Settle each chain's *canonical reset checkpoint*: the one asserting an
+    /// empty backlog at `resume_after`.
+    ///
+    /// Its digest is derived from `(chain, resume_after)` alone, so every node
+    /// can rebuild it locally and regress onto it through the ordinary
+    /// divergence path. Votes for the chain are dropped, since they describe
+    /// the abandoned history.
+    ///
+    /// `resume_after` is exclusive: indexing resumes at `resume_after + 1`.
+    ///
+    /// The resulting checkpoint is deliberately indistinguishable from one the
+    /// network settled with an empty backlog at the same height, because it
+    /// describes the same state. What makes a reset recognisable is the event
+    /// logged here, not the state it leaves behind.
+    ///
+    /// Callable only by the contract account itself.
     #[private]
-    pub fn reset_checkpoint(&mut self, chains: Vec<Chain>) {
-        let chains: HashSet<Chain> = chains.into_iter().collect();
-        for chain in &chains {
-            self.latest_checkpoints_mut().remove(chain);
+    pub fn reset_checkpoints(&mut self, resets: Vec<CheckpointReset>) {
+        let mut chains = HashSet::new();
+        for CheckpointReset {
+            chain,
+            resume_after,
+        } in resets
+        {
+            chains.insert(chain);
+            self.insert_checkpoint(
+                chain,
+                ConsensusCheckpointDigest::new(
+                    chain,
+                    resume_after,
+                    mpc_primitives::reset_checkpoint_digest(chain, resume_after),
+                ),
+            );
+            env::log_str(
+                &serde_json::json!({
+                    "event": "checkpoint_reset",
+                    "chain": chain,
+                    "resume_after": resume_after,
+                })
+                .to_string(),
+            );
         }
         self.checkpoint_votes_mut()
             .votes
@@ -1430,8 +1461,51 @@ mod tests {
         assert_eq!(stored.digest, checkpoint.digest);
     }
 
+    // A Running-state contract with `alice.near` as sole participant, so that
+    // `vote_checkpoint` gets past the voter and protocol-state checks.
+    fn running_contract(threshold: usize) -> VersionedMpcContract {
+        use std::str::FromStr;
+
+        testing_env!(VMContextBuilder::new()
+            .current_account_id("contract.near".parse().unwrap())
+            .signer_account_id("alice.near".parse().unwrap())
+            .build());
+
+        let public_key =
+            PublicKey::from_str("ed25519:J75xXmF7WUPS3xCm3hy2tgwLCKdYM1iJd4BWF8sWVnae").unwrap();
+        let alice: AccountId = "alice.near".parse().unwrap();
+        let mut participants = Participants::new();
+        participants.insert(
+            alice.clone(),
+            primitives::ParticipantInfo {
+                account_id: alice,
+                url: "https://alice.example".to_owned(),
+                cipher_pk: [7; 32],
+                sign_pk: public_key.clone(),
+            },
+        );
+
+        VersionedMpcContract::V0(MpcContract {
+            protocol_state: ProtocolContractState::Running(RunningContractState {
+                epoch: 0,
+                participants,
+                threshold,
+                public_key,
+                candidates: Candidates::new(),
+                join_votes: Votes::new(),
+                leave_votes: Votes::new(),
+                threshold_votes: ThresholdVotes::new(),
+            }),
+            pending_requests: IterableMap::new(StorageKey::PendingRequests),
+            proposed_updates: ProposedUpdates::default(),
+            config: Config::default(),
+            latest_checkpoints: IterableMap::new(StorageKey::LatestCheckpointDigests),
+            checkpoint_votes: CheckpointVotes::new(),
+        })
+    }
+
     #[test]
-    fn reset_checkpoint_clears_votes_for_selected_chains() {
+    fn reset_settles_the_canonical_checkpoint_and_clears_votes() {
         let mut contract = VersionedMpcContract::V0(MpcContract::init(0, BTreeMap::new(), None));
         let solana_checkpoint = ConsensusCheckpointDigest::new(Chain::Solana, 10, [1u8; 32]);
         let ethereum_checkpoint = ConsensusCheckpointDigest::new(Chain::Ethereum, 20, [2u8; 32]);
@@ -1446,10 +1520,113 @@ mod tests {
             .entry(ethereum_checkpoint)
             .insert("voter.near".parse().unwrap());
 
-        contract.reset_checkpoint(vec![Chain::Solana]);
+        contract.reset_checkpoints(vec![CheckpointReset {
+            chain: Chain::Solana,
+            resume_after: 5,
+        }]);
 
-        assert_eq!(contract.latest_checkpoint(Chain::Solana), None);
+        // The reset is an ordinary settled checkpoint whose digest is derived
+        // from the pair, which is what every node re-derives locally.
+        assert_eq!(
+            contract.latest_checkpoint(Chain::Solana),
+            Some(&ConsensusCheckpointDigest::new(
+                Chain::Solana,
+                5,
+                mpc_primitives::reset_checkpoint_digest(Chain::Solana, 5),
+            ))
+        );
         assert!(contract.checkpoint_votes(Chain::Solana).is_empty());
         assert_eq!(contract.checkpoint_votes(Chain::Ethereum).len(), 1);
+    }
+
+    #[test]
+    fn reset_height_is_a_vote_floor_without_extra_logic() {
+        let mut contract = running_contract(1);
+        contract.reset_checkpoints(vec![CheckpointReset {
+            chain: Chain::Solana,
+            resume_after: 100,
+        }]);
+
+        // Below the reset height the ordinary "behind" rule already rejects.
+        let behind = ConsensusCheckpointDigest::new(Chain::Solana, 99, [1u8; 32]);
+        assert!(contract
+            .vote_checkpoint(behind)
+            .unwrap_err()
+            .to_string()
+            .contains(&CheckpointError::CheckpointBehind.to_string()));
+        assert!(contract.checkpoint_votes(Chain::Solana).is_empty());
+
+        // Re-submitting the reset checkpoint itself is an idempotent no-op,
+        // which is what lets nodes confirm it rather than fight over it.
+        let reset = ConsensusCheckpointDigest::new(
+            Chain::Solana,
+            100,
+            mpc_primitives::reset_checkpoint_digest(Chain::Solana, 100),
+        );
+        assert!(contract.vote_checkpoint(reset).unwrap());
+
+        // A competing digest at the reset height is a conflict, not a silent
+        // overwrite of the state the network was told to restart from.
+        let conflicting = ConsensusCheckpointDigest::new(Chain::Solana, 100, [2u8; 32]);
+        assert!(contract
+            .vote_checkpoint(conflicting)
+            .unwrap_err()
+            .to_string()
+            .contains(&CheckpointError::ConflictingCheckpoint.to_string()));
+
+        // Above it, voting resumes normally and settles past the reset.
+        let above = ConsensusCheckpointDigest::new(Chain::Solana, 101, [3u8; 32]);
+        assert!(contract.vote_checkpoint(above).unwrap());
+        assert_eq!(
+            contract.latest_checkpoint(Chain::Solana),
+            Some(&above),
+            "a settled checkpoint replaces the reset checkpoint"
+        );
+    }
+
+    #[test]
+    fn reset_logs_the_event_that_identifies_it() {
+        let mut contract = running_contract(1);
+        contract.reset_checkpoints(vec![CheckpointReset {
+            chain: Chain::Solana,
+            resume_after: 100,
+        }]);
+
+        // The settled checkpoint is deliberately indistinguishable from an
+        // ordinary empty-backlog one, so this log is the only record that a
+        // reset happened. Operators and indexers read it, hence the assertion.
+        let logs = near_sdk::test_utils::get_logs();
+        let event = logs
+            .iter()
+            .find(|line| line.contains("checkpoint_reset"))
+            .expect("a reset must log an event identifying it");
+        let event: serde_json::Value = serde_json::from_str(event).expect("event must be JSON");
+        assert_eq!(event["event"], "checkpoint_reset");
+        assert_eq!(event["chain"], serde_json::json!(Chain::Solana));
+        assert_eq!(event["resume_after"], 100);
+    }
+
+    #[test]
+    fn reset_can_be_reissued_at_a_different_height() {
+        let mut contract = running_contract(1);
+        contract.reset_checkpoints(vec![CheckpointReset {
+            chain: Chain::Solana,
+            resume_after: 100,
+        }]);
+        // Correcting an operator mistake: a second reset simply settles a
+        // different checkpoint, including backwards.
+        contract.reset_checkpoints(vec![CheckpointReset {
+            chain: Chain::Solana,
+            resume_after: 30,
+        }]);
+
+        assert_eq!(
+            contract.latest_checkpoint(Chain::Solana),
+            Some(&ConsensusCheckpointDigest::new(
+                Chain::Solana,
+                30,
+                mpc_primitives::reset_checkpoint_digest(Chain::Solana, 30),
+            ))
+        );
     }
 }

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -1537,6 +1537,20 @@ mod tests {
         );
         assert!(contract.checkpoint_votes(Chain::Solana).is_empty());
         assert_eq!(contract.checkpoint_votes(Chain::Ethereum).len(), 1);
+
+        // Reissuable, including backwards — it's just another settled checkpoint.
+        contract.reset_checkpoints(vec![CheckpointReset {
+            chain: Chain::Solana,
+            height: 31,
+        }]);
+        assert_eq!(
+            contract.latest_checkpoint(Chain::Solana),
+            Some(&ConsensusCheckpointDigest::new(
+                Chain::Solana,
+                30,
+                mpc_primitives::reset_checkpoint_digest(Chain::Solana, 30),
+            ))
+        );
     }
 
     #[test]
@@ -1605,29 +1619,5 @@ mod tests {
         assert_eq!(event["chain"], serde_json::json!(Chain::Solana));
         assert_eq!(event["height"], 101);
         assert_eq!(event["resume_after"], 100);
-    }
-
-    #[test]
-    fn reset_can_be_reissued_at_a_different_height() {
-        let mut contract = running_contract(1);
-        contract.reset_checkpoints(vec![CheckpointReset {
-            chain: Chain::Solana,
-            height: 101,
-        }]);
-        // Correcting an operator mistake: a second reset simply settles a
-        // different checkpoint, including backwards.
-        contract.reset_checkpoints(vec![CheckpointReset {
-            chain: Chain::Solana,
-            height: 31,
-        }]);
-
-        assert_eq!(
-            contract.latest_checkpoint(Chain::Solana),
-            Some(&ConsensusCheckpointDigest::new(
-                Chain::Solana,
-                30,
-                mpc_primitives::reset_checkpoint_digest(Chain::Solana, 30),
-            ))
-        );
     }
 }

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -1492,14 +1492,15 @@ mod tests {
 
     #[test]
     fn reset_height_is_a_vote_floor_without_extra_logic() {
+        let resume_at_height = 101;
         let mut contract = running_contract(1);
         contract.reset_checkpoints(vec![CheckpointReset {
             chain: Chain::Solana,
-            height: 101,
+            height: resume_at_height,
         }]);
 
         // Below the reset height the ordinary "behind" rule already rejects.
-        let behind = ConsensusCheckpointDigest::new(Chain::Solana, 99, [1u8; 32]);
+        let behind = ConsensusCheckpointDigest::new(Chain::Solana, resume_at_height - 2, [1u8; 32]);
         assert!(contract
             .vote_checkpoint(behind)
             .unwrap_err()
@@ -1511,14 +1512,15 @@ mod tests {
         // which is what lets nodes confirm it rather than fight over it.
         let reset = ConsensusCheckpointDigest::new(
             Chain::Solana,
-            100,
-            mpc_primitives::reset_checkpoint_digest(Chain::Solana, 100),
+            resume_at_height - 1,
+            mpc_primitives::reset_checkpoint_digest(Chain::Solana, resume_at_height - 1),
         );
         assert!(contract.vote_checkpoint(reset).unwrap());
 
         // A competing digest at the reset height is a conflict, not a silent
         // overwrite of the state the network was told to restart from.
-        let conflicting = ConsensusCheckpointDigest::new(Chain::Solana, 100, [2u8; 32]);
+        let conflicting =
+            ConsensusCheckpointDigest::new(Chain::Solana, resume_at_height - 1, [2u8; 32]);
         assert!(contract
             .vote_checkpoint(conflicting)
             .unwrap_err()
@@ -1526,7 +1528,7 @@ mod tests {
             .contains(&CheckpointError::ConflictingCheckpoint.to_string()));
 
         // Above it, voting resumes normally and settles past the reset.
-        let above = ConsensusCheckpointDigest::new(Chain::Solana, 101, [3u8; 32]);
+        let above = ConsensusCheckpointDigest::new(Chain::Solana, resume_at_height, [3u8; 32]);
         assert!(contract.vote_checkpoint(above).unwrap());
         assert_eq!(
             contract.latest_checkpoint(Chain::Solana),
@@ -1537,10 +1539,11 @@ mod tests {
 
     #[test]
     fn reset_logs_the_event_that_identifies_it() {
+        let resume_at_height = 101;
         let mut contract = running_contract(1);
         contract.reset_checkpoints(vec![CheckpointReset {
             chain: Chain::Solana,
-            height: 101,
+            height: resume_at_height,
         }]);
 
         // The settled checkpoint is deliberately indistinguishable from an
@@ -1554,7 +1557,7 @@ mod tests {
         let event: serde_json::Value = serde_json::from_str(event).expect("event must be JSON");
         assert_eq!(event["event"], "checkpoint_reset");
         assert_eq!(event["chain"], serde_json::json!(Chain::Solana));
-        assert_eq!(event["height"], 101);
-        assert_eq!(event["resume_after"], 100);
+        assert_eq!(event["height"], resume_at_height);
+        assert_eq!(event["resume_after"], resume_at_height - 1);
     }
 }

--- a/chain-signatures/contract/src/primitives.rs
+++ b/chain-signatures/contract/src/primitives.rs
@@ -25,6 +25,18 @@ pub enum StorageKey {
     Candidates,
 }
 
+/// One chain's entry in a checkpoint reset.
+///
+/// `resume_after` is exclusive, naming the last block treated as processed:
+/// indexing resumes at `resume_after + 1`. To re-process block `b`, pass
+/// `b - 1`.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(crate = "near_sdk::serde")]
+pub struct CheckpointReset {
+    pub chain: Chain,
+    pub resume_after: u64,
+}
+
 #[derive(
     BorshDeserialize,
     BorshSerialize,

--- a/chain-signatures/contract/src/primitives.rs
+++ b/chain-signatures/contract/src/primitives.rs
@@ -29,12 +29,14 @@ pub enum StorageKey {
 ///
 /// `resume_after` is exclusive, naming the last block treated as processed:
 /// indexing resumes at `resume_after + 1`. To re-process block `b`, pass
-/// `b - 1`.
+/// One chain's entry in a checkpoint reset.
+///
+/// `height` is inclusive: indexing resumes at `height` itself.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(crate = "near_sdk::serde")]
 pub struct CheckpointReset {
     pub chain: Chain,
-    pub resume_after: u64,
+    pub height: u64,
 }
 
 #[derive(

--- a/chain-signatures/node/src/backlog/checkpoints.rs
+++ b/chain-signatures/node/src/backlog/checkpoints.rs
@@ -47,27 +47,34 @@ impl fmt::Debug for Checkpoint {
 
 impl Checkpoint {
     pub fn empty(chain: Chain) -> Self {
+        Self::reset(chain, 0)
+    }
+
+    /// The canonical *reset* checkpoint for `(chain, block_height)`: an empty
+    /// backlog at that height, digesting to
+    /// [`mpc_primitives::reset_checkpoint_digest`].
+    pub fn reset(chain: Chain, block_height: u64) -> Self {
         Self {
             chain,
-            block_height: 0,
+            block_height,
             pending_requests: Vec::new(),
             cumulative_digest: Self::empty_cumulative_digest(),
         }
     }
 
     pub fn empty_cumulative_digest() -> [u8; 32] {
-        sha3::Sha3_256::new().finalize().into()
+        mpc_primitives::empty_cumulative_digest()
     }
 
     pub fn digest(&self) -> [u8; 32] {
-        let mut hasher = sha3::Sha3_256::new();
-        hasher.update(self.chain.caip2_chain_id().as_bytes());
-        hasher.update(self.block_height.to_le_bytes());
-        for entry in &self.pending_requests {
-            hasher.update(entry.sign_id().request_id);
-        }
-        hasher.update(self.cumulative_digest);
-        hasher.finalize().into()
+        mpc_primitives::checkpoint_digest(
+            self.chain,
+            self.block_height,
+            self.pending_requests
+                .iter()
+                .map(|entry| entry.sign_id().request_id),
+            self.cumulative_digest,
+        )
     }
 }
 
@@ -583,6 +590,20 @@ mod tests {
                 .unwrap(),
             Some(consensus)
         );
+    }
+
+    #[test]
+    fn reset_checkpoint_digest_is_the_shared_derivation() {
+        // The contract settles this digest without holding the checkpoint, so
+        // the two must agree exactly or a reset would look like a divergence
+        // that no peer can resolve.
+        let reset = Checkpoint::reset(Chain::Solana, 42);
+        assert_eq!(
+            reset.digest(),
+            mpc_primitives::reset_checkpoint_digest(Chain::Solana, 42)
+        );
+        assert!(reset.pending_requests.is_empty());
+        assert_eq!(reset.block_height, 42);
     }
 
     #[tokio::test]

--- a/chain-signatures/node/src/backlog/consensus.rs
+++ b/chain-signatures/node/src/backlog/consensus.rs
@@ -48,15 +48,30 @@ pub async fn align_backlog_with_consensus(
         ?checkpoint_digest.digest,
         "Consensus checkpoint mismatch/divergence detected: triggering regression"
     );
-    let fetched_checkpoint = find_consensus_checkpoint(
-        mesh_state,
-        node_client,
-        chain,
-        checkpoint_digest.digest,
-        checkpoints_rx,
-        my_account_id,
-    )
-    .await?;
+    // A reset settles this digest for a state no node has produced, so
+    // `find_consensus_checkpoint` would poll peers forever. Rebuild it instead
+    // and fall through to the ordinary regression path, which is what makes a
+    // reset idempotent: once regressed, the local checkpoint matches the
+    // settled digest and the next pass confirms it.
+    let reset_checkpoint = Checkpoint::reset(chain, checkpoint_digest.height);
+    let fetched_checkpoint = if reset_checkpoint.digest() == checkpoint_digest.digest {
+        tracing::warn!(
+            ?chain,
+            height = checkpoint_digest.height,
+            "consensus checkpoint was reset; rebuilding it locally"
+        );
+        reset_checkpoint
+    } else {
+        find_consensus_checkpoint(
+            mesh_state,
+            node_client,
+            chain,
+            checkpoint_digest.digest,
+            checkpoints_rx,
+            my_account_id,
+        )
+        .await?
+    };
 
     let height = fetched_checkpoint.block_height;
 
@@ -278,7 +293,7 @@ mod tests {
                 remote_use_peer_digest: true,
                 peer_has_checkpoint: true,
                 peer_checkpoint_height: 100,
-                peer_checkpoint_has_pending_tx: false,
+                peer_checkpoint_has_pending_tx: true,
                 expected_result: Some(100),
                 expected_persisted_height: Some(100),
             },
@@ -343,7 +358,7 @@ mod tests {
                 remote_use_peer_digest: true,
                 peer_has_checkpoint: true,
                 peer_checkpoint_height: 100,
-                peer_checkpoint_has_pending_tx: false,
+                peer_checkpoint_has_pending_tx: true,
                 expected_result: Some(100),
                 expected_persisted_height: Some(100),
             },
@@ -390,7 +405,9 @@ mod tests {
             if case.peer_has_checkpoint {
                 let pending_requests = if case.peer_checkpoint_has_pending_tx {
                     vec![BacklogEntry::new(Arc::new(IndexedSignRequest::sign(
-                        SignId::new([1u8; 32]),
+                        // Distinct from the local entry's id, so a peer
+                        // checkpoint holding a request diverges from ours.
+                        SignId::new([2u8; 32]),
                         SignArgs {
                             entropy: [1u8; 32],
                             epsilon: k256::Scalar::ONE,
@@ -586,6 +603,92 @@ mod tests {
         assert!(result.is_some());
         newer_mock.assert_async().await;
         current_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn align_applies_a_reset_without_any_peer() {
+        use mpc_chain_integration_core::StateManager as _;
+
+        let chain = Chain::Ethereum;
+        let mut fixture = AlignFixture::new(None);
+
+        // Pre-reset state: a confirmed local checkpoint at height 100 and a
+        // cursor to match.
+        fixture.backlog.set_processed_block(chain, 100).await;
+        let stale = fixture.backlog.checkpoint(chain).await.unwrap();
+        assert!(fixture
+            .backlog
+            .confirm_consensus(chain, stale.digest())
+            .await
+            .unwrap());
+
+        // The contract settles the canonical reset checkpoint for height 42.
+        // The mesh is empty, so any attempt to fetch this from a peer would
+        // block forever; the node must rebuild it locally instead.
+        fixture
+            .checkpoints_tx
+            .send(Some(CheckpointDigest {
+                height: 42,
+                digest: mpc_primitives::reset_checkpoint_digest(chain, 42),
+            }))
+            .unwrap();
+
+        let result = tokio::time::timeout(Duration::from_secs(5), fixture.run())
+            .await
+            .expect("align must not wait on peers for a reset checkpoint");
+
+        assert_eq!(result, Some(42));
+        assert_eq!(
+            fixture.backlog.latest_checkpoint(chain).await,
+            Some(Checkpoint::reset(chain, 42)),
+            "local state should be the canonical reset checkpoint"
+        );
+        assert_eq!(
+            fixture.backlog.get_processed_block(chain).await,
+            Some(42),
+            "cursor re-anchored at the reset height; indexing resumes at 43"
+        );
+
+        // Re-running while the same reset is settled is a no-op: no "have I
+        // applied this?" bookkeeping is needed, because the applied state
+        // matches the settled digest.
+        let again = tokio::time::timeout(Duration::from_secs(5), fixture.run())
+            .await
+            .expect("a re-applied reset must not wait on peers either");
+        assert_eq!(again, None, "an already-applied reset reports aligned");
+        assert_eq!(
+            fixture.backlog.get_processed_block(chain).await,
+            Some(42),
+            "a second pass must not rewind the cursor again"
+        );
+    }
+
+    #[tokio::test]
+    async fn align_applies_a_reset_over_a_node_with_no_local_state() {
+        use mpc_chain_integration_core::StateManager as _;
+
+        let chain = Chain::Ethereum;
+        let mut fixture = AlignFixture::new(None);
+        fixture.backlog.set_processed_block(chain, 500).await;
+
+        fixture
+            .checkpoints_tx
+            .send(Some(CheckpointDigest {
+                height: 42,
+                digest: mpc_primitives::reset_checkpoint_digest(chain, 42),
+            }))
+            .unwrap();
+
+        let result = tokio::time::timeout(Duration::from_secs(5), fixture.run())
+            .await
+            .expect("align must not wait on peers for a reset checkpoint");
+
+        assert_eq!(result, Some(42));
+        assert_eq!(
+            fixture.backlog.get_processed_block(chain).await,
+            Some(42),
+            "a node that never held a checkpoint must still re-anchor"
+        );
     }
 
     #[tokio::test]

--- a/chain-signatures/node/src/stream/supervisor.rs
+++ b/chain-signatures/node/src/stream/supervisor.rs
@@ -4,7 +4,7 @@
 use super::recovery::recover_backlog;
 use super::{handle_chain_event, StreamContext};
 
-use crate::backlog::Backlog;
+use crate::backlog::{Backlog, Checkpoint};
 use crate::types::CheckpointWatcher;
 use mpc_chain_integration_core::utils::stream::chain_event_channel;
 use mpc_chain_integration_core::{ChainIndexer, ChainTelemetry};
@@ -70,7 +70,11 @@ async fn detect_regression(
         return false;
     };
 
-    if backlog.latest_checkpoint(chain).await.is_none() {
+    // A node holding no checkpoint still has to re-anchor its cursor on a
+    // reset. Any other digest is unmatchable without one to compare against.
+    let is_reset =
+        Checkpoint::reset(chain, checkpoint_digest.height).digest() == checkpoint_digest.digest;
+    if !is_reset && backlog.latest_checkpoint(chain).await.is_none() {
         tracing::info!(?chain, "no local checkpoint; skipping regression check");
         return false;
     }
@@ -367,6 +371,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_reset_detected_without_a_local_checkpoint() {
+        let backlog = Backlog::new();
+        let chain = Chain::Ethereum;
+
+        // "I hold no checkpoint" is not evidence there is nothing to do.
+        let (_tx, mut rx) = make_digest(42, mpc_primitives::reset_checkpoint_digest(chain, 42));
+
+        assert!(
+            detect_regression(chain, &backlog, &mut rx).await,
+            "a reset must be applied even with no local checkpoint"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_applied_reset_is_not_a_regression() {
+        let backlog = Backlog::new();
+        let chain = Chain::Ethereum;
+
+        // The state a node is left in once it has applied the reset: an empty
+        // backlog confirmed at the reset height.
+        backlog.set_processed_block(chain, 42).await;
+        let applied = backlog.checkpoint(chain).await.unwrap();
+        assert_eq!(
+            applied.digest(),
+            mpc_primitives::reset_checkpoint_digest(chain, 42)
+        );
+        assert!(backlog
+            .confirm_consensus(chain, applied.digest())
+            .await
+            .unwrap());
+
+        let (_tx, mut rx) = make_digest(42, mpc_primitives::reset_checkpoint_digest(chain, 42));
+
+        assert!(
+            !detect_regression(chain, &backlog, &mut rx).await,
+            "an already-applied reset must not keep restarting the indexer"
+        );
+    }
+
+    #[tokio::test]
     async fn test_wait_detects_regression_after_consumed() {
         let backlog = Backlog::new();
         let chain = Chain::Ethereum;
@@ -566,6 +610,84 @@ mod tests {
             .await
             .expect("supervisor should shut down after second run() exits")
             .expect("supervisor task should not panic");
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    /// End to end: a reset settled while the indexer is running must abort
+    /// in-flight work, re-anchor the cursor during recovery with no peer
+    /// reachable, and then settle rather than restarting on every pass.
+    #[tokio::test]
+    async fn reset_cancels_restarts_and_settles_without_peers() {
+        let chain = Chain::Ethereum;
+        let backlog = Backlog::new();
+        backlog.set_processed_block(chain, 100).await.unwrap();
+        let stale = backlog.checkpoint(chain).await.unwrap();
+        assert!(backlog
+            .confirm_consensus(chain, stale.digest())
+            .await
+            .unwrap());
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let first_cancel = Arc::new(Notify::new());
+        let indexer = StalledRunIndexer {
+            attempts: attempts.clone(),
+            first_cancel: first_cancel.clone(),
+        };
+        let (sign_tx, mut sign_rx) = mpsc::channel(8);
+        let (ctx, cp_tx, _mesh_tx, mut rpc_rx) = test_ctx(backlog.clone(), sign_tx);
+
+        let task = tokio::spawn(run_supervised_with_watchdog(
+            indexer,
+            ctx,
+            NoopChainTelemetry,
+            Duration::from_secs(60),
+        ));
+
+        while attempts.load(Ordering::SeqCst) == 0 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        cp_tx
+            .send(Some(CheckpointDigest {
+                height: 42,
+                digest: mpc_primitives::reset_checkpoint_digest(chain, 42),
+            }))
+            .unwrap();
+
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(1), rpc_rx.recv())
+                .await
+                .expect("reset should abort RPC work immediately"),
+            Some(RpcAction::AbortCheckpoints(Chain::Ethereum))
+        ));
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(1), sign_rx.recv())
+                .await
+                .expect("reset should abort sign tasks immediately"),
+            Some(SignCommand::AbortChain(Chain::Ethereum))
+        ));
+        first_cancel.notified().await;
+
+        // Deliberately nothing is sent to unblock the restart, unlike the
+        // peer-served regression above: the reset checkpoint is rebuilt
+        // locally, so recovery completes with the same digest still settled
+        // and no peer reachable.
+        tokio::time::timeout(Duration::from_secs(10), task)
+            .await
+            .expect("recovery must not wait on peers for a reset")
+            .expect("supervisor task should not panic");
+
+        assert_eq!(
+            backlog.get_processed_block(chain).await,
+            Some(42),
+            "recovery must re-anchor the cursor at the reset height"
+        );
+        assert_eq!(
+            backlog.latest_checkpoint(chain).await,
+            Some(Checkpoint::reset(chain, 42)),
+            "local state must be the canonical reset checkpoint"
+        );
+        // Exactly two runs: the stalled original and the post-reset rerun. A
+        // third would mean the unchanged settled digest keeps restarting.
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
     }
 

--- a/chain-signatures/primitives/src/backlog.rs
+++ b/chain-signatures/primitives/src/backlog.rs
@@ -79,3 +79,39 @@ pub struct CheckpointDigest {
     pub height: u64,
     pub digest: [u8; 32],
 }
+
+/// Digest of a backlog checkpoint.
+///
+/// Shared so the node (hashing its live backlog) and the contract (deriving
+/// [`reset_checkpoint_digest`]) cannot drift apart.
+pub fn checkpoint_digest(
+    chain: Chain,
+    block_height: u64,
+    request_ids: impl IntoIterator<Item = [u8; 32]>,
+    cumulative_digest: [u8; 32],
+) -> [u8; 32] {
+    let mut hasher = sha3::Sha3_256::new();
+    hasher.update(chain.caip2_chain_id().as_bytes());
+    hasher.update(block_height.to_le_bytes());
+    for request_id in request_ids {
+        hasher.update(request_id);
+    }
+    hasher.update(cumulative_digest);
+    hasher.finalize().into()
+}
+
+/// The cumulative digest of a checkpoint holding no pending requests.
+pub fn empty_cumulative_digest() -> [u8; 32] {
+    sha3::Sha3_256::new().finalize().into()
+}
+
+/// Digest of the canonical *reset* checkpoint for `(chain, height)`: the one
+/// asserting an empty backlog at `height`.
+///
+/// Being a pure function of the pair is what lets a reset be an ordinary
+/// settled checkpoint. The contract can settle a digest for a state no node
+/// holds yet, and each node rebuilds the matching checkpoint locally instead
+/// of fetching it from a peer that would never have it.
+pub fn reset_checkpoint_digest(chain: Chain, height: u64) -> [u8; 32] {
+    checkpoint_digest(chain, height, std::iter::empty(), empty_cumulative_digest())
+}

--- a/chain-signatures/primitives/src/lib.rs
+++ b/chain-signatures/primitives/src/lib.rs
@@ -15,7 +15,10 @@ mod requests;
 
 pub use signet_primitives::*;
 
-pub use backlog::{CheckpointDigest, ConsensusCheckpointDigest};
+pub use backlog::{
+    checkpoint_digest, empty_cumulative_digest, reset_checkpoint_digest, CheckpointDigest,
+    ConsensusCheckpointDigest,
+};
 pub use bidirectional::{
     BidirectionalTx, RespondBidirectionalEvent, RespondBidirectionalTx, SignBidirectionalEvent,
 };

--- a/integration-tests/tests/cases/checkpoint.rs
+++ b/integration-tests/tests/cases/checkpoint.rs
@@ -338,7 +338,7 @@ async fn test_reset_converges_divergent_nodes() {
     assert_eq!(
         digests_before.len(),
         network.nodes.len(),
-        "test setup should leave every node on a different checkpoint"
+        "every node must produce a distinct checkpoint digest before reset"
     );
 
     // Governance settles the canonical reset checkpoint. Each node aligns

--- a/integration-tests/tests/cases/checkpoint.rs
+++ b/integration-tests/tests/cases/checkpoint.rs
@@ -8,8 +8,12 @@ use mpc_node::mesh::MeshState;
 use mpc_node::node_client::{NodeClient, Options as NodeClientOptions};
 use mpc_node::protocol::ParticipantInfo;
 use mpc_node::storage::CheckpointStorage;
-use mpc_primitives::{Chain, ChainConfig as _, CheckpointDigest};
+use mpc_primitives::{
+    Chain, ChainConfig as _, CheckpointDigest, IndexedSignRequest, SignArgs, SignId,
+};
 use near_sdk::AccountId;
+use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::Duration;
 use test_log::test;
 
@@ -276,4 +280,136 @@ async fn test_consensus_alignment_consensus_changes_while_fetching() {
     assert!(fresh_backlog.latest_checkpoint(chain).await.is_none());
     let persisted = fresh_storage.load_latest(chain).await.unwrap();
     assert!(persisted.is_none());
+}
+
+/// A reset must converge divergent nodes on byte-identical local state.
+///
+/// This is the property the canonical reset checkpoint buys. Every node
+/// rebuilds the same checkpoint from `(chain, height)` alone, so no node's
+/// pre-reset backlog can survive into the state it restarts from. A reset that
+/// merely rewound the cursor would leave each node holding whatever it had,
+/// and their first post-reset checkpoints would not agree.
+///
+/// The mesh is left empty throughout: no peer has ever held this checkpoint,
+/// so convergence must not depend on fetching it from one.
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_reset_converges_divergent_nodes() {
+    let chain = Chain::Ethereum;
+    let interval = chain.checkpoint_interval().unwrap();
+    let resume_after = interval * 2;
+
+    let network = MpcFixtureBuilder::default()
+        .only_generate_signatures()
+        .with_mock_stream(chain, MockStream::default())
+        .await
+        .build()
+        .await;
+    network.wait_for_running().await;
+
+    // Diverge every node: a different pending request and a different cursor,
+    // which is exactly the state that makes post-reset digests disagree if a
+    // reset preserves it.
+    for (index, node) in network.nodes.iter().enumerate() {
+        let request = IndexedSignRequest::sign(
+            SignId::new([index as u8 + 1; 32]),
+            SignArgs {
+                entropy: [index as u8 + 1; 32],
+                epsilon: k256::Scalar::ONE,
+                payload: k256::Scalar::ONE,
+                path: "reset".to_string(),
+                key_version: 0,
+            },
+            chain,
+            0,
+        );
+        node.backlog.insert(Arc::new(request)).await;
+        node.backlog
+            .set_processed_block(chain, interval * (index as u64 + 3))
+            .await;
+    }
+
+    let digests_before: HashSet<[u8; 32]> = {
+        let mut digests = HashSet::new();
+        for node in &network.nodes {
+            digests.insert(node.backlog.checkpoint(chain).await.unwrap().digest());
+        }
+        digests
+    };
+    assert_eq!(
+        digests_before.len(),
+        network.nodes.len(),
+        "test setup should leave every node on a different checkpoint"
+    );
+
+    // Governance settles the canonical reset checkpoint. Each node aligns
+    // against it with no peer reachable.
+    let settled = CheckpointDigest {
+        height: resume_after,
+        digest: mpc_primitives::reset_checkpoint_digest(chain, resume_after),
+    };
+    let my_account_id: AccountId = "aligning.near".parse().unwrap();
+    let node_client = NodeClient::new(&NodeClientOptions::default());
+
+    for node in &network.nodes {
+        let (_cp_tx, mut checkpoints_rx) = tokio::sync::watch::channel(Some(settled.clone()));
+        let (_mesh_tx, mut mesh_rx) = tokio::sync::watch::channel(MeshState::default());
+
+        let applied = tokio::time::timeout(
+            Duration::from_secs(5),
+            align_backlog_with_consensus(
+                chain,
+                &node.backlog,
+                &mut checkpoints_rx,
+                &mut mesh_rx,
+                &node_client,
+                &my_account_id,
+            ),
+        )
+        .await
+        .expect("a reset must not wait on peers");
+
+        assert_eq!(applied, Some(resume_after));
+    }
+
+    // Every node now holds the same checkpoint, byte for byte, with an empty
+    // backlog and the same cursor.
+    let mut checkpoints_after = Vec::new();
+    for node in &network.nodes {
+        checkpoints_after.push(
+            node.backlog
+                .latest_checkpoint(chain)
+                .await
+                .expect("every node should hold the reset checkpoint"),
+        );
+    }
+    assert_eq!(
+        checkpoints_after
+            .iter()
+            .map(|checkpoint| checkpoint.digest())
+            .collect::<HashSet<_>>(),
+        HashSet::from([mpc_primitives::reset_checkpoint_digest(chain, resume_after)]),
+        "all nodes must converge on the canonical reset checkpoint"
+    );
+    for checkpoint in &checkpoints_after {
+        assert_eq!(checkpoint.block_height, resume_after);
+        assert!(
+            checkpoint.pending_requests.is_empty(),
+            "a node's pre-reset backlog must not survive the reset"
+        );
+    }
+
+    // And the next checkpoint each produces agrees too, which is what lets
+    // consensus settle again after a reset.
+    let mut next_digests = HashSet::new();
+    for node in &network.nodes {
+        node.backlog
+            .set_processed_block(chain, resume_after + interval)
+            .await;
+        next_digests.insert(node.backlog.checkpoint(chain).await.unwrap().digest());
+    }
+    assert_eq!(
+        next_digests.len(),
+        1,
+        "post-reset checkpoints must agree across nodes"
+    );
 }


### PR DESCRIPTION
based on the work done @yvonneanne.

This resets the contract and nodes' checkpoint back to empty, by triggering a regression based on an empty digest overwritten to the near governance contract.

Previous work was done at https://github.com/sig-net/mpc/pull/1173 but that was more complex introducing a contract serialization change with a new `CheckpointDirective` enum. We avoid that here in this PR with what I mentioned above with just using an empty digest. This is safe to do since we follow the same code path for regression, so doing a reset here is basically a regression. A regression today already clears out local and pending checkpoints.