### PR TITLE
Remove `pause_proposing_until`

### DIFF
--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -2,7 +2,7 @@ use cait_sith::protocol::Participant;
 use serde::{Deserialize, Serialize};
 
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 use std::hash::Hash;
 use std::time::{Duration, Instant};
@@ -441,7 +441,8 @@ impl<Id: Copy + Hash + Eq + fmt::Debug, S> Posits<Id, S> {
 /// This is used by individual signature tasks instead of the global Posits mapping.
 pub struct SinglePositCounter {
     participants: HashSet<Participant>,
-    rejects: HashMap<Participant, PositRejectReason>,
+    /// Who rejected and why; kept ordered so logs render deterministically.
+    pub rejects: BTreeMap<Participant, PositRejectReason>,
     pub accepts: HashSet<Participant>,
 }
 
@@ -451,7 +452,7 @@ impl SinglePositCounter {
         accepts.insert(me);
         Self {
             participants: participants.iter().copied().collect(),
-            rejects: HashMap::new(),
+            rejects: BTreeMap::new(),
             accepts,
         }
     }
@@ -466,13 +467,6 @@ impl SinglePositCounter {
 
     pub fn meets_totality(&self) -> bool {
         self.accepts.len() + self.rejects.len() == self.participants.len()
-    }
-
-    pub fn num_peers_already_generating(&self) -> usize {
-        self.rejects
-            .values()
-            .filter(|reason| matches!(reason, PositRejectReason::AlreadyGenerating))
-            .count()
     }
 
     pub fn process_action(&mut self, from: Participant, action: &PositAction) -> bool {
@@ -680,48 +674,5 @@ mod tests {
         let actions = posits1.expire_and_start(threshold, base_delay, deliberator_extra_delay);
         assert_eq!(actions.len(), 0);
         assert_eq!(posits1.len(), 0);
-    }
-
-    #[test]
-    fn test_single_posit_counter_reason_counting() {
-        let me = Participant::from(0);
-        let participants = vec![
-            me,
-            Participant::from(1),
-            Participant::from(2),
-            Participant::from(3),
-        ];
-        let mut counter = SinglePositCounter::new(me, &participants);
-
-        assert_eq!(counter.num_peers_already_generating(), 0);
-
-        counter.process_action(
-            Participant::from(1),
-            &PositAction::RejectWithReason(PositRejectReason::AlreadyGenerating),
-        );
-        assert_eq!(counter.num_peers_already_generating(), 1);
-
-        counter.process_action(
-            Participant::from(3),
-            &PositAction::RejectWithReason(PositRejectReason::AlreadyGenerating),
-        );
-        assert_eq!(counter.num_peers_already_generating(), 2);
-
-        // Other reject reasons are not counted.
-        counter.process_action(
-            Participant::from(2),
-            &PositAction::RejectWithReason(PositRejectReason::InvalidRequest),
-        );
-        assert_eq!(counter.num_peers_already_generating(), 2);
-
-        counter.process_action(Participant::from(3), &PositAction::Accept);
-        assert_eq!(counter.num_peers_already_generating(), 2);
-
-        // Reject from the same peer is not counted again.
-        counter.process_action(
-            Participant::from(1),
-            &PositAction::RejectWithReason(PositRejectReason::AlreadyGenerating),
-        );
-        assert_eq!(counter.num_peers_already_generating(), 2);
     }
 }

--- a/chain-signatures/node/src/protocol/request/organize.rs
+++ b/chain-signatures/node/src/protocol/request/organize.rs
@@ -88,11 +88,7 @@ impl OrganizingPhase {
             // elect different proposers and diverge permanently (#907).
             let proposer = Self::proposer_per_round(state.round(), &participants, &entropy);
 
-            // If proposing is paused (generating already ongoing), we act as if we weren't a proposer.
-            let skip_proposing = state
-                .pause_proposing_until
-                .is_some_and(|until| until > std::time::Instant::now());
-            let is_proposer = proposer == me && !skip_proposing;
+            let is_proposer = proposer == me;
             ctx.is_proposer.store(is_proposer, Ordering::Relaxed);
 
             tracing::info!(
@@ -101,7 +97,6 @@ impl OrganizingPhase {
                 ?proposer,
                 ?me,
                 is_proposer,
-                skip_proposing,
                 active_count = active.len(),
                 "organized: selected proposer"
             );

--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -348,26 +348,13 @@ impl PositPhase {
                         }
 
                         if counter.enough_rejects(ctx.governance.threshold) {
-                            let peers_already_generating = counter.num_peers_already_generating();
-                            let too_few_available = ctx
-                                .governance
-                                .participants
-                                .len()
-                                .saturating_sub(peers_already_generating)
-                                < ctx.governance.threshold;
-                            let reason = if too_few_available {
-                                state.pause_proposing_until = Some(
-                                    Instant::now()
-                                        + Duration::from_millis(ctx.cfg.signature.generation_timeout),
-                                );
-                                "peers already generating this signature"
-                            } else {
-                                "received enough rejects"
-                            };
                             if let Some(_reservation) = presignature {
                                 tracing::warn!(?sign_id, "returning presignature to pool due to REJECTs");
                             }
-                            return state.reorganize(reason);
+                            return state.reorganize(&format!(
+                                "received enough rejects: {:?}",
+                                counter.rejects
+                            ));
                         }
 
                         // Starting as soon as we have enough accepts leaves

--- a/chain-signatures/node/src/protocol/request/state.rs
+++ b/chain-signatures/node/src/protocol/request/state.rs
@@ -21,9 +21,6 @@ pub struct SignState {
     /// INVARIANT: All messages stored here are for `highest_seen_round`. Must
     /// be cleared when `highest_seen_round` changes. One slot per sender.
     pub buffered_messages: HashMap<Participant, SignPositMessage>,
-    /// When Some, another group is already generating this signature.
-    /// The timestamp is when proposing can be resumed.
-    pub pause_proposing_until: Option<std::time::Instant>,
     /// Shared with `SignEntry` so a respawn resumes at the round it left off;
     /// peers rely on our rounds never going down.
     carried_round: Arc<AtomicUsize>,
@@ -43,7 +40,6 @@ impl SignState {
             permit: None,
             highest_seen_round: 0,
             buffered_messages: HashMap::new(),
-            pause_proposing_until: None,
             carried_round,
         }
     }

--- a/chain-signatures/node/src/protocol/request/task.rs
+++ b/chain-signatures/node/src/protocol/request/task.rs
@@ -53,9 +53,6 @@ impl GeneratingPhase {
         state: &mut SignState,
         mailbox: &PositMailbox,
     ) -> SignPhase {
-        // We successfully committed to generating; future rounds should be unrestricted.
-        state.pause_proposing_until = None;
-
         let sign_id = ctx.sign_id;
 
         tracing::info!(

--- a/doc/protocol_properties.md
+++ b/doc/protocol_properties.md
@@ -89,7 +89,7 @@ E1. Amortized ≈ 1 presignature consumed per settled signature.
 
 E2. ≈ 1 generation instance per request at a time. 
 
-Mechanisms striving towards these targets are deterministic proposer rotation, the posit round, and a backoff that pauses proposing when so many peers reject with "already generating" that no threshold set is left to work with.
+Mechanisms striving towards these targets are deterministic proposer rotation and the posit round.
 
 Duplicate instances, duplicate on-chain responses, and wasted rounds are correct but wasteful. The contract keeps no request state, so every response emits another event and the downstream consumer is the one that has to deduplicate (§1). Consequently, any mechanism that serves only E-properties may be lossy, heuristic, or deleted; it must be judged on cost, not correctness.
 

--- a/integration-tests/tests/cases/mpc.rs
+++ b/integration-tests/tests/cases/mpc.rs
@@ -1,22 +1,17 @@
 use cait_sith::protocol::Participant;
 use deadpool_redis::redis::AsyncCommands;
 use integration_tests::mpc_fixture::fixture_tasks::MessageFilter;
-use integration_tests::mpc_fixture::message_collector::CollectMessages;
 use integration_tests::mpc_fixture::message_collector::MessageCounter;
 use integration_tests::mpc_fixture::MpcFixtureBuilder;
 use mpc_node::protocol::message::SendMessage;
-use mpc_node::protocol::posit::{PositAction, PositRejectReason};
 use mpc_node::protocol::presignature::Presignature;
-use mpc_node::protocol::Message;
 use mpc_node::protocol::ProtocolState;
 use mpc_node::storage::triple_storage::TriplePair;
 use mpc_primitives::{Chain, IndexedSignRequest, SignCommand, SignId};
 use std::collections::BTreeMap;
 use std::fs;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use std::time::Instant;
 use test_log::test;
 use tokio::sync::oneshot;
 use tokio::sync::Mutex;
@@ -1150,187 +1145,6 @@ async fn test_sign_missing_presignature_after_posits() {
         action_str.contains("RpcAction::Publish"),
         "unexpected rpc action {action_str}"
     );
-}
-
-/// Verify that nodes that are not selected as participants for a signature
-/// generation pause after receiving enough AlreadyGenerating rejections.
-///
-/// Setup:
-/// - Nodes 0 and 1 enter the Generating phase together, messages are gated to freeze their progress
-/// - Node 2 is excluded, one ORGANIZE_POSIT_TIMEOUT later, it tries to be a proposer
-/// - Nodes 0 and 1 reply with AlreadyGenerating.
-/// - The gate is released, signature messages flow, and the signature completes
-/// - Assertion: AlreadyGenerating have been sent
-/// - Continue and observe node 2 not trying to be a proposer again until
-///   `signature_timeout_ms` has passed.
-#[test(tokio::test(flavor = "multi_thread"))]
-async fn test_non_participants_pause_posits() {
-    /// Observer struct just for this test
-    struct Tracker {
-        target: Participant,
-        already_generating_received: Arc<AtomicUsize>,
-        proposer_attempts: Arc<AtomicUsize>,
-    }
-    impl CollectMessages for Tracker {
-        fn observe_message(&mut self, msg: &SendMessage, _passed_filter: bool) {
-            let SendMessage {
-                message, from, to, ..
-            } = msg;
-            if *to == self.target {
-                if let Message::Posit(posit_msg) = message {
-                    if matches!(
-                        posit_msg.action,
-                        PositAction::RejectWithReason(PositRejectReason::AlreadyGenerating)
-                    ) {
-                        self.already_generating_received
-                            .fetch_add(1, Ordering::Relaxed);
-                    }
-                }
-            }
-            if *from == self.target {
-                if let Message::Posit(posit_msg) = message {
-                    if matches!(posit_msg.action, PositAction::Propose) {
-                        self.proposer_attempts.fetch_add(1, Ordering::Relaxed);
-                    }
-                }
-            }
-        }
-        fn print_summary(&self) {}
-    }
-
-    let gate_released = Arc::new(AtomicBool::new(false));
-    let gate_0 = Arc::clone(&gate_released);
-    let gate_1 = Arc::clone(&gate_released);
-    let already_gen_count = Arc::new(AtomicUsize::new(0));
-    let node_2_propose_count = Arc::new(AtomicUsize::new(0));
-    let tracker = Tracker {
-        target: Participant::from(2),
-        already_generating_received: Arc::clone(&already_gen_count),
-        proposer_attempts: Arc::clone(&node_2_propose_count),
-    };
-    let signature_timeout_ms = 16_000;
-
-    let network = MpcFixtureBuilder::new(3, 2)
-        .only_generate_signatures()
-        .with_signature_timeout_ms(signature_timeout_ms)
-        .with_outgoing_message_filter(
-            // Node 0: Hold signature messages until the gate is released.
-            0,
-            Box::new(move |msg: &SendMessage| {
-                let SendMessage { message, .. } = msg;
-                if matches!(message, Message::Signature(_)) {
-                    while !gate_0.load(Ordering::Acquire) {
-                        std::thread::sleep(std::time::Duration::from_millis(10));
-                    }
-                }
-                true
-            }),
-        )
-        .with_outgoing_message_filter(
-            // Node 1: Hold signature messages until the gate is released.
-            1,
-            Box::new(move |msg: &SendMessage| {
-                let SendMessage { message, .. } = msg;
-                if matches!(message, Message::Signature(_)) {
-                    while !gate_1.load(Ordering::Acquire) {
-                        std::thread::sleep(std::time::Duration::from_millis(10));
-                    }
-                }
-                true
-            }),
-        )
-        .with_outgoing_message_filter(
-            // Node 2: receives a PROPOSE from node 1 but we drop the ACCEPT, so node 2 is excluded from the signature.
-            2,
-            Box::new(move |msg: &SendMessage| {
-                let SendMessage { message, .. } = msg;
-                if let Message::Posit(posit_msg) = message {
-                    if matches!(posit_msg.action, PositAction::Accept) {
-                        return false;
-                    }
-                }
-                true
-            }),
-        )
-        .with_message_collector(Arc::new(Mutex::new(tracker)))
-        .build()
-        .await;
-
-    // For seed 0, SHA256([0,0,0,0])[0] = 0xdf = 223, and 223 % 3 = 1, so:
-    //   round 0 -> participant 1 (proposes immediately, generates with node 0)
-    //   round 1 -> participant 2 (target: excluded from round-0, proposes after 1 timeout)
-    //   round 2 -> participant 0
-    // Node 2's Accept to node 1's Propose is dropped, so generation is {0, 1}.
-    // After ORGANIZE_POSIT_TIMEOUT, node 2 becomes round-1 proposer and
-    // receives AlreadyGenerating from nodes 0 and 1.
-    // Send the request to all three nodes.
-    network.broadcast(&sign_request(0)).await;
-
-    // Wait for node 2 to propose once, sending a message to both other nodes.
-    // Should happen after ~1 ORGANIZE_POSIT_TIMEOUT (5s for tests)
-    tokio::time::timeout(Duration::from_secs(10), async {
-        loop {
-            tokio::time::sleep(Duration::from_millis(50)).await;
-            let count = node_2_propose_count.load(Ordering::Relaxed);
-            if count >= 2 {
-                return;
-            }
-        }
-    })
-    .await
-    .expect("node 2 never proposed in the first place");
-    let first_propose = Instant::now();
-
-    // Give some time for the PROPOSE to be rejected.
-    tokio::time::sleep(Duration::from_millis(200)).await;
-
-    // Release the gate: Signature messages between 0 and 1 are forwarded and
-    // they can complete the signature. The AlreadyGenerating replies are now
-    // in the outbox queue (ahead of the post-gate signature traffic), so they
-    // will be forwarded and counted before the signature finishes.
-    gate_released.store(true, Ordering::Release);
-
-    let actions = network.assert_actions(1, Duration::from_secs(20)).await;
-
-    assert_eq!(actions.len(), 1);
-    assert!(
-        actions
-            .iter()
-            .next()
-            .unwrap()
-            .contains("RpcAction::Publish"),
-        "expected a Publish action"
-    );
-
-    let count = already_gen_count.load(Ordering::Relaxed);
-    assert!(
-        count >= 1,
-        "expected AlreadyGenerating to be sent to node 2, but count was {count}"
-    );
-
-    // Node 2 still hasn't seen the signature. Wait until it proposes again:
-    // one generation timeout for the pause to lapse, plus a few rounds for
-    // node 2's turn in the rotation. Generous rather than exact — a round can
-    // outlast ORGANIZE_POSIT_TIMEOUT if it blocks on the mesh gate or reaches
-    // Generating.
-    let organize_timeout = mpc_node::protocol::request::organize_posit_timeout();
-    let second_wait = Duration::from_millis(signature_timeout_ms) + 4 * organize_timeout;
-    tokio::time::timeout(second_wait, async {
-        loop {
-            tokio::time::sleep(Duration::from_millis(50)).await;
-            let count = node_2_propose_count.load(Ordering::Relaxed);
-            if count > 2 {
-                return;
-            }
-        }
-    })
-    .await
-    .expect("node 2 never proposed again");
-
-    assert!(
-        first_propose.elapsed().as_millis() as u64 > signature_timeout_ms,
-        "node 2 started proposing again too early"
-    )
 }
 
 #[test(tokio::test(flavor = "multi_thread"))]


### PR DESCRIPTION
Removing `pause_proposing_until` (Added in [#832](https://github.com/sig-net/mpc/pull/832), built for [#793](https://github.com/sig-net/mpc/issues/793)).

It predates presignature reservations, which fixed the real problem — a rejected proposer now just returns its reservation.

This flow is effectively dormant (~44 hits/day on devnet vs ~90k reorganizes), while the pause itself can be a hidden node-local mode: a paused elected proposer silently sits out for a full generation_timeout.

Worst case without it is one cheap re-propose that gets rejected within a round trip. Reject reasons are no longer acted on, but now get logged in the reorganize reason instead of being dropped.