### PR TITLE
fix(mpc-node): exchange rounds on a late-Propose reject

### DIFF
--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -453,7 +453,7 @@ impl PositPhase {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::protocol::message::{Message, MessageInbox, MessageOutbox};
     use crate::protocol::presignature::Presignature;
@@ -463,16 +463,16 @@ mod tests {
 
     /// A posit-phase harness; the unused channel ends are held alive so sends
     /// keep working. The redis pool is lazy and never actually connected.
-    struct TestSetup {
-        ctx: SignTask,
-        state: SignState,
-        outbox: MessageOutbox,
+    pub(crate) struct TestSetup {
+        pub(crate) ctx: SignTask,
+        pub(crate) state: SignState,
+        pub(crate) outbox: MessageOutbox,
         _inbox: MessageInbox,
         _rpc_rx: mpsc::Receiver<RpcAction>,
         _mesh_tx: watch::Sender<MeshState>,
     }
 
-    fn setup(me: Participant, other: Participant, threshold: usize) -> TestSetup {
+    pub(crate) fn setup(me: Participant, other: Participant, threshold: usize) -> TestSetup {
         let account_id: near_account_id::AccountId = "p-1".parse().unwrap();
         let governance = GovernanceInfo {
             me,
@@ -531,7 +531,7 @@ mod tests {
 
     /// The single message sitting in the outbox, which must be a posit from
     /// `from` to `to`; returns its stamped round, action, and stale_round.
-    fn sent_posit(
+    pub(crate) fn sent_posit(
         outbox: &mut MessageOutbox,
         from: Participant,
         to: Participant,

--- a/chain-signatures/node/src/protocol/request/task.rs
+++ b/chain-signatures/node/src/protocol/request/task.rs
@@ -106,7 +106,7 @@ impl GeneratingPhase {
             tokio::select! {
                 result = &mut generation => break result,
                 task_msg = mailbox.recv() => {
-                    Self::reject_late_propose(ctx, task_msg).await;
+                    Self::reject_late_propose(ctx, state, task_msg).await;
                 }
             }
         };
@@ -119,7 +119,11 @@ impl GeneratingPhase {
 
     /// Reject a `Propose` that arrives while we are already generating; drop
     /// stale Accept/Reject/Start messages.
-    async fn reject_late_propose(ctx: &SignTask, task_msg: SignPositMessage) {
+    async fn reject_late_propose(
+        ctx: &SignTask,
+        state: &mut SignState,
+        task_msg: SignPositMessage,
+    ) {
         let SignPositMessage {
             presignature_id,
             round,
@@ -131,10 +135,18 @@ impl GeneratingPhase {
             return;
         }
         let me = ctx.governance.me;
+        let (reason, stale_round) = if state.round() > round {
+            (PositRejectReason::StaleRound, Some(state.round()))
+        } else {
+            state.record_peer_round(round);
+            (PositRejectReason::AlreadyGenerating, None)
+        };
         tracing::info!(
             sign_id = ?ctx.sign_id,
             ?from,
             round,
+            my_round = state.round(),
+            ?reason,
             "received Propose while already generating, rejecting"
         );
         ctx.msg
@@ -144,8 +156,8 @@ impl GeneratingPhase {
                 PositMessage {
                     id: PositProtocolId::Signature(ctx.sign_id, presignature_id, round),
                     from: me,
-                    action: PositAction::RejectWithReason(PositRejectReason::AlreadyGenerating),
-                    stale_round: None,
+                    action: PositAction::RejectWithReason(reason),
+                    stale_round,
                 },
             )
             .await;

--- a/chain-signatures/node/src/protocol/request/task.rs
+++ b/chain-signatures/node/src/protocol/request/task.rs
@@ -240,3 +240,64 @@ impl SignTask {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::posit::tests::{sent_posit, setup};
+    use super::*;
+
+    fn propose(from: Participant, round: usize) -> SignPositMessage {
+        SignPositMessage {
+            presignature_id: 42,
+            round,
+            from,
+            action: PositAction::Propose,
+            stale_round: None,
+        }
+    }
+
+    /// A behind peer is answered the way every other phase answers one, with
+    /// StaleRound carrying our round, so it catches up in a single bump.
+    #[tokio::test]
+    async fn late_propose_from_behind_peer_carries_our_round() {
+        let me = Participant::from(0);
+        let behind = Participant::from(1);
+        let mut t = setup(me, behind, 2);
+        t.state.set_round(5);
+
+        GeneratingPhase::reject_late_propose(&t.ctx, &mut t.state, propose(behind, 2)).await;
+
+        let (round, action, stale_round) = sent_posit(&mut t.outbox, me, behind);
+        // The id echoes the rejected round; ours rides in `stale_round`.
+        assert_eq!(round, 2);
+        assert!(matches!(
+            action,
+            PositAction::RejectWithReason(PositRejectReason::StaleRound)
+        ));
+        assert_eq!(stale_round, Some(5));
+        assert_eq!(t.state.round(), 5);
+    }
+
+    /// An ahead peer's round is recorded, so the reorganize after a failed
+    /// generation lands on it instead of climbing one round at a time.
+    #[tokio::test]
+    async fn late_propose_from_ahead_peer_is_recorded() {
+        let me = Participant::from(0);
+        let ahead = Participant::from(1);
+        let mut t = setup(me, ahead, 2);
+        t.state.set_round(3);
+
+        GeneratingPhase::reject_late_propose(&t.ctx, &mut t.state, propose(ahead, 12)).await;
+
+        let (_, action, stale_round) = sent_posit(&mut t.outbox, me, ahead);
+        assert!(matches!(
+            action,
+            PositAction::RejectWithReason(PositRejectReason::AlreadyGenerating)
+        ));
+        assert_eq!(stale_round, None);
+
+        // Caught up in one bump: max(3 + 1, 12) = 12.
+        t.state.reorganize("generation failed");
+        assert_eq!(t.state.round(), 12);
+    }
+}


### PR DESCRIPTION
`reject_late_propose` is the only phase that neither tells a behind peer its round nor records an ahead peer's. [#1082](https://github.com/sig-net/mpc/pull/1082) added `PositMessage::stale_round` for exactly this and routed the two posit-phase sites through `record_peer_round`, but left this one at `None`. Checked the other 12 `stale_round: None` sites, all correct.

Now a behind peer gets `StaleRound` carrying our round, which the existing receiver logic already picks up, and an ahead peer's round is recorded. Nothing changes outside this function, and rounds still only go up.

Two tests, one per direction, both fail against the previous unconditional `AlreadyGenerating`/`None`. They reuse the harness already in `posit.rs`, which is the only reason that file changes.