### PR TITLE
fix(bidirectional): reject invalid requests at admission, quarantine stuck ones

### DIFF
--- a/chain-signatures/chain-integration-core/src/publish.rs
+++ b/chain-signatures/chain-integration-core/src/publish.rs
@@ -18,8 +18,6 @@ pub trait ChainPublisher: Send + Sync + 'static {
 /// Represents a signature that is ready to be published to a blockchain.
 #[derive(Clone)]
 pub struct PublishAction {
-    /// The public key associated with the signature.
-    pub public_key: PublicKey,
     /// The indexed sign request that this signature corresponds to.
     pub request: Arc<IndexedSignRequest>,
     /// The actual signature to be published.
@@ -46,7 +44,6 @@ impl PublishAction {
         )
         .ok()?;
         Some(Self {
-            public_key,
             request,
             signature,
             participants,

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -289,7 +289,9 @@ impl Backlog {
         &self,
         chain: Chain,
     ) -> Vec<(Arc<IndexedSignRequest>, Arc<PublishState>)> {
-        let pending = self.pending(&chain).write().await;
+        // Read-only scan; the backup sweep calls this every second per chain, so a
+        // write lock here would serialize against the signing hot path for nothing.
+        let pending = self.pending(&chain).read().await;
 
         let mut publishable: Vec<_> = pending
             .requests

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -6,11 +6,12 @@ use crate::storage::checkpoint_storage::CheckpointStorage;
 pub(crate) use checkpoints::CheckpointError;
 use checkpoints::Checkpoints;
 
+use anyhow::Context as _;
 use enum_map::EnumMap;
 use mpc_chain_integration_core::StateManager;
 use mpc_primitives::{
-    BidirectionalTx, BidirectionalTxId, Chain, ChainConfig as _, IndexedSignRequest, SignId,
-    SignKind,
+    BidirectionalTx, BidirectionalTxId, Chain, ChainConfig as _, IndexedSignRequest, PublicKey,
+    SignId, SignKind, Signature,
 };
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -761,6 +762,26 @@ impl BacklogEntry {
 
     pub fn sign_id(&self) -> SignId {
         self.request.id
+    }
+
+    /// Check that a respond event's signature is the one this entry asked for.
+    pub fn verify_signature(
+        &self,
+        root_public_key: PublicKey,
+        signature: &Signature,
+    ) -> anyhow::Result<()> {
+        mpc_crypto::verify_signature(
+            root_public_key,
+            self.request.args.epsilon,
+            self.request.args.payload,
+            signature,
+        )
+        .with_context(|| {
+            format!(
+                "respond event carried invalid signature for sign id {:?}",
+                self.sign_id()
+            )
+        })
     }
 
     /// Get the request ID for this transaction

--- a/chain-signatures/node/src/protocol/test_setup.rs
+++ b/chain-signatures/node/src/protocol/test_setup.rs
@@ -24,11 +24,15 @@ pub struct TestProtocolChannels {
 }
 
 impl MpcSignProtocol {
+    /// `backlog` is the one the caller's chain streams write to. Handing the sign
+    /// side its own would leave every request `NotFound` when it marks publishing,
+    /// which silently skips the backlog half of the sign path in every fixture.
     pub async fn new_test(
         my_account_id: AccountId,
         storage: TestProtocolStorage,
         channels: TestProtocolChannels,
         contract: ContractStateWatcher,
+        backlog: Backlog,
     ) -> Self {
         let generating = channels.msg_channel.subscribe_generation().await;
         let resharing = channels.msg_channel.subscribe_resharing().await;
@@ -42,7 +46,7 @@ impl MpcSignProtocol {
             channels.mesh_state.clone(),
             channels.msg_channel.clone(),
             channels.rpc_channel.clone(),
-            Backlog::new(),
+            backlog,
         );
         Self {
             my_account_id,

--- a/chain-signatures/node/src/protocol/test_setup.rs
+++ b/chain-signatures/node/src/protocol/test_setup.rs
@@ -24,9 +24,6 @@ pub struct TestProtocolChannels {
 }
 
 impl MpcSignProtocol {
-    /// `backlog` is the one the caller's chain streams write to. Handing the sign
-    /// side its own would leave every request `NotFound` when it marks publishing,
-    /// which silently skips the backlog half of the sign path in every fixture.
     pub async fn new_test(
         my_account_id: AccountId,
         storage: TestProtocolStorage,

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -125,7 +125,6 @@ impl RpcChannel {
 
     pub fn publish_signature(
         &self,
-        public_key: mpc_crypto::PublicKey,
         request: Arc<IndexedSignRequest>,
         signature: Signature,
         participants: Vec<Participant>,
@@ -135,7 +134,6 @@ impl RpcChannel {
             if let Err(err) = rpc
                 .tx
                 .send(RpcAction::Publish(PublishAction {
-                    public_key,
                     request,
                     signature,
                     participants,
@@ -148,18 +146,8 @@ impl RpcChannel {
         });
     }
 
-    pub fn publish_with_state(
-        &self,
-        public_key: mpc_crypto::PublicKey,
-        request: Arc<IndexedSignRequest>,
-        publish: &PublishState,
-    ) {
-        self.publish_signature(
-            public_key,
-            request,
-            publish.signature,
-            publish.participants.clone(),
-        );
+    pub fn publish_with_state(&self, request: Arc<IndexedSignRequest>, publish: &PublishState) {
+        self.publish_signature(request, publish.signature, publish.participants.clone());
     }
 }
 

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -1,5 +1,6 @@
 use crate::protocol::{Chain, IndexedSignRequest};
 use alloy::primitives::{keccak256, Address, Bytes};
+use anyhow::Context as _;
 use cait_sith::protocol::Participant;
 use k256::elliptic_curve::point::AffineCoordinates;
 use k256::elliptic_curve::sec1::ToEncodedPoint as _;
@@ -81,6 +82,12 @@ pub trait SignBidirectionalEventExt {
     fn sender_string(&self) -> anyhow::Result<String>;
     fn epsilon(&self) -> anyhow::Result<Scalar>;
     fn target_chain(&self) -> Result<Chain, ChainFromError>;
+
+    /// The deterministic derivations respond processing runs for every bidirectional
+    /// request. Shared between admission (reject before the backlog) and the respond
+    /// path's failure handling (quarantine): both must agree on what "can never
+    /// advance" means.
+    fn validate(&self) -> anyhow::Result<()>;
 }
 
 impl SignBidirectionalEventExt for SignBidirectionalEvent {
@@ -119,6 +126,19 @@ impl SignBidirectionalEventExt for SignBidirectionalEvent {
 
     fn target_chain(&self) -> Result<Chain, mpc_primitives::ChainFromError> {
         Chain::from_caip2_chain_id(&self.caip2_id)
+    }
+
+    fn validate(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !self.serialized_transaction.is_empty(),
+            "empty serialized_transaction"
+        );
+        self.target_chain()
+            .map_err(|err| anyhow::anyhow!("bad target chain: {err:?}"))?;
+        self.epsilon().context("cannot derive epsilon")?;
+        validate_unsigned_transaction(&self.serialized_transaction)
+            .context("undecodable serialized_transaction")?;
+        Ok(())
     }
 }
 
@@ -191,7 +211,7 @@ pub fn decode_rlp(rlp_data: Vec<u8>, is_eip1559: bool) -> anyhow::Result<Vec<Byt
 /// respond time is rejected before it enters the backlog; running the actual
 /// function (with a placeholder signature, whose bytes are only appended, never
 /// interpreted) is what keeps admission structurally equal to respond processing.
-pub fn validate_unsigned_transaction(unsigned_rlp: &[u8]) -> anyhow::Result<()> {
+fn validate_unsigned_transaction(unsigned_rlp: &[u8]) -> anyhow::Result<()> {
     let placeholder = Signature::new(
         k256::ProjectivePoint::GENERATOR.to_affine(),
         k256::Scalar::ONE,

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -186,6 +186,20 @@ pub fn decode_rlp(rlp_data: Vec<u8>, is_eip1559: bool) -> anyhow::Result<Vec<Byt
     Ok(result)
 }
 
+/// Check that `unsigned_rlp` would survive [`sign_and_hash_transaction`], without a
+/// real signature. Admission calls this so a transaction that cannot be signed at
+/// respond time is rejected before it enters the backlog; running the actual
+/// function (with a placeholder signature, whose bytes are only appended, never
+/// interpreted) is what keeps admission structurally equal to respond processing.
+pub fn validate_unsigned_transaction(unsigned_rlp: &[u8]) -> anyhow::Result<()> {
+    let placeholder = Signature::new(
+        k256::ProjectivePoint::GENERATOR.to_affine(),
+        k256::Scalar::ONE,
+        0,
+    );
+    sign_and_hash_transaction(unsigned_rlp, placeholder).map(|_| ())
+}
+
 pub fn sign_and_hash_transaction(
     unsigned_rlp: &[u8],
     signature: Signature,
@@ -276,7 +290,14 @@ pub fn sign_and_hash_legacy_from_unsigned(
     for i in 0..6 {
         out.append_raw_field(rlp.at(i)?.as_raw());
     }
-    let v: u64 = 35 + 2 * chain_id.unwrap_or(0) + if y_parity { 1 } else { 0 };
+    // Checked: `chain_id` is attacker-controlled bytes (admission runs this decode
+    // on every observed request event), and 35 + 2 * chain_id overflows for ids
+    // near u64::MAX.
+    let v: u64 = chain_id
+        .unwrap_or(0)
+        .checked_mul(2)
+        .and_then(|doubled| doubled.checked_add(35 + u64::from(y_parity)))
+        .ok_or_else(|| anyhow::anyhow!("legacy chain_id too large"))?;
     out.append_u64(v);
     out.append_uint_bytes(r);
     out.append_uint_bytes(s);

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -21,18 +21,16 @@ pub(crate) async fn process_sign_request(
         anyhow::bail!("Unexpected sign request kind");
     }
 
-    // Reject malformed bidirectional requests at ingestion: an empty
-    // `serialized_transaction` cannot be RLP-decoded and would otherwise be
-    // stored in the backlog and only blow up later when the respond event
-    // advances it to execution (see `sign_and_hash_transaction`). Drop it here
-    // so a poison-pill request never enters the backlog.
+    // Reject malformed bidirectional requests at ingestion, running the same
+    // deterministic derivations the respond event will need later. A request
+    // admitted here but failing there is worse than one never admitted: its entry
+    // sticks in pending-publish forever, and every backup's sweep fires into a
+    // duplicate-publish retry loop that no cancellation ever ends, because the
+    // failing respond processing is where the cancel lives.
     if let SignKind::SignBidirectional(event) = &sign_request.kind {
-        if event.serialized_transaction.is_empty() {
-            anyhow::bail!(
-                "rejecting bidirectional sign request {:?} with empty serialized_transaction",
-                sign_request.id
-            );
-        }
+        validate_bidirectional_event(event).with_context(|| {
+            format!("rejecting bidirectional sign request {:?}", sign_request.id)
+        })?;
     }
 
     // `Backlog::insert` returns `None` if the request is new, or `Some(_)` if it was already present.
@@ -45,6 +43,26 @@ pub(crate) async fn process_sign_request(
     ctx.try_enqueue(SignCommand::Request(sign_request)).await?;
 
     Ok(is_new)
+}
+
+/// The deterministic derivations respond processing runs for every bidirectional
+/// request. Shared between admission (reject before the backlog) and the respond
+/// path's failure handling (quarantine, see `process_respond_event`): both must
+/// agree on what "can never advance" means.
+fn validate_bidirectional_event(
+    event: &mpc_primitives::SignBidirectionalEvent,
+) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        !event.serialized_transaction.is_empty(),
+        "empty serialized_transaction"
+    );
+    event
+        .target_chain()
+        .map_err(|err| anyhow::anyhow!("bad target chain: {err:?}"))?;
+    event.epsilon().context("cannot derive epsilon")?;
+    crate::sign_bidirectional::validate_unsigned_transaction(&event.serialized_transaction)
+        .context("undecodable serialized_transaction")?;
+    Ok(())
 }
 
 pub(crate) async fn requeue_pending_sign_requests(
@@ -147,6 +165,23 @@ async fn advance_bidirectional_to_execution(
             entry_type = %entry.typename(),
             "respond event backlog entry is already advanced; treating as processed"
         );
+        return Ok(());
+    }
+
+    // Admission validates the same derivations, but entries can enter the backlog
+    // without passing admission (checkpoint recovery restores them wholesale). One
+    // that fails here fails identically on every node and on every replay, so it
+    // can never advance: leaving it would park it in pending-publish forever, with
+    // every backup's sweep republishing a response that is already on chain.
+    // Removing it is deterministic across the network, so checkpoints stay aligned.
+    if let Err(err) = validate_bidirectional_event(event) {
+        tracing::error!(
+            ?sign_id,
+            ?source_chain,
+            ?err,
+            "quarantining bidirectional request that can never advance"
+        );
+        ctx.backlog.remove(source_chain, &sign_id).await;
         return Ok(());
     }
 
@@ -283,6 +318,19 @@ pub async fn process_execution_confirmed(
     if unwatched_sign_id != sign_id {
         tracing::warn!(?tx_id, expected = ?unwatched_sign_id, actual = ?sign_id, "sign_id mismatch between event and watcher");
     }
+    // The watched transaction is the source of truth for the source chain. The
+    // follow-up request's chain decides which backlog bucket, publish key, and
+    // cancellation key it lives under, and all of them must agree; an execution
+    // watcher filling the event's field differently must not split them.
+    if source_chain != pending_tx.source_chain {
+        tracing::warn!(
+            ?tx_id,
+            event = ?source_chain,
+            watcher = ?pending_tx.source_chain,
+            "source_chain mismatch between event and watcher; using the watcher's"
+        );
+    }
+    let source_chain = pending_tx.source_chain;
 
     let chain_ctx = ctx
         .backlog

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -67,23 +67,13 @@ pub(crate) async fn requeue_pending_sign_requests(
 }
 
 pub(crate) async fn resume_pending_publish_requests(ctx: &StreamContext, source_chain: Chain) {
-    let publishable = ctx.backlog.publishable_requests(source_chain).await;
-    if publishable.is_empty() {
-        return;
-    }
-
-    let Some(public_key) = ctx.contract_watcher.public_key().await else {
-        tracing::warn!(%source_chain, count = publishable.len(), "cannot resume pending publish requests without a public key");
-        return;
-    };
-    for (sign_request, publish) in publishable {
+    for (sign_request, publish) in ctx.backlog.publishable_requests(source_chain).await {
         if !publish.is_proposer {
             continue;
         }
 
         let sign_id = sign_request.id;
-        ctx.rpc
-            .publish_with_state(public_key, sign_request, &publish);
+        ctx.rpc.publish_with_state(sign_request, &publish);
         tracing::info!(?sign_id, %source_chain, "resumed pending publish request after catchup");
     }
 }

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -9,7 +9,7 @@ use mpc_chain_integration_core::ChainTelemetry;
 use mpc_chain_solana::Pubkey;
 use mpc_primitives::{
     BidirectionalTx, BidirectionalTxId, Chain, ExecutionOutcome, IndexedSignRequest,
-    RespondBidirectionalEvent, SignBidirectionalEvent, SignCommand, SignId, SignKind, Signature,
+    RespondBidirectionalEvent, SignBidirectionalEvent, SignCommand, SignId, SignKind,
     SignatureRespondedEvent,
 };
 
@@ -28,7 +28,7 @@ pub(crate) async fn process_sign_request(
     // duplicate-publish retry loop that no cancellation ever ends, because the
     // failing respond processing is where the cancel lives.
     if let SignKind::SignBidirectional(event) = &sign_request.kind {
-        validate_bidirectional_event(event).with_context(|| {
+        event.validate().with_context(|| {
             format!("rejecting bidirectional sign request {:?}", sign_request.id)
         })?;
     }
@@ -43,26 +43,6 @@ pub(crate) async fn process_sign_request(
     ctx.try_enqueue(SignCommand::Request(sign_request)).await?;
 
     Ok(is_new)
-}
-
-/// The deterministic derivations respond processing runs for every bidirectional
-/// request. Shared between admission (reject before the backlog) and the respond
-/// path's failure handling (quarantine, see `process_respond_event`): both must
-/// agree on what "can never advance" means.
-fn validate_bidirectional_event(
-    event: &mpc_primitives::SignBidirectionalEvent,
-) -> anyhow::Result<()> {
-    anyhow::ensure!(
-        !event.serialized_transaction.is_empty(),
-        "empty serialized_transaction"
-    );
-    event
-        .target_chain()
-        .map_err(|err| anyhow::anyhow!("bad target chain: {err:?}"))?;
-    event.epsilon().context("cannot derive epsilon")?;
-    crate::sign_bidirectional::validate_unsigned_transaction(&event.serialized_transaction)
-        .context("undecodable serialized_transaction")?;
-    Ok(())
 }
 
 pub(crate) async fn requeue_pending_sign_requests(
@@ -96,21 +76,6 @@ pub(crate) async fn resume_pending_publish_requests(ctx: &StreamContext, source_
     }
 }
 
-fn verify_entry_signature(
-    root_public_key: mpc_primitives::PublicKey,
-    entry: &crate::backlog::BacklogEntry,
-    signature: &Signature,
-    sign_id: SignId,
-) -> anyhow::Result<()> {
-    mpc_crypto::verify_signature(
-        root_public_key,
-        entry.request.args.epsilon,
-        entry.request.args.payload,
-        signature,
-    )
-    .with_context(|| format!("respond event carried invalid signature for sign id {sign_id:?}"))
-}
-
 pub(crate) async fn process_respond_event(
     respond_event: SignatureRespondedEvent,
     ctx: &StreamContext,
@@ -127,7 +92,7 @@ pub(crate) async fn process_respond_event(
         return Ok(());
     };
 
-    verify_entry_signature(root_pk, &entry, &respond_event.signature, sign_id)?;
+    entry.verify_signature(root_pk, &respond_event.signature)?;
 
     match &entry.request.kind {
         SignKind::Sign => {
@@ -174,7 +139,7 @@ async fn advance_bidirectional_to_execution(
     // can never advance: leaving it would park it in pending-publish forever, with
     // every backup's sweep republishing a response that is already on chain.
     // Removing it is deterministic across the network, so checkpoints stay aligned.
-    if let Err(err) = validate_bidirectional_event(event) {
+    if let Err(err) = event.validate() {
         tracing::error!(
             ?sign_id,
             ?source_chain,
@@ -271,7 +236,7 @@ pub(crate) async fn process_respond_bidirectional_event(
         );
     }
 
-    verify_entry_signature(root_pk, &entry, &event.signature, sign_id)?;
+    entry.verify_signature(root_pk, &event.signature)?;
 
     if ctx.backlog.remove(source_chain, &sign_id).await.is_some() {
         tracing::info!(?sign_id, "bidirectional tx completed");

--- a/chain-signatures/node/src/stream/ops_tests.rs
+++ b/chain-signatures/node/src/stream/ops_tests.rs
@@ -8,9 +8,9 @@ use crate::sign_bidirectional::{PublishState, SignStatus};
 use crate::storage::checkpoint_storage::CheckpointStorage;
 use crate::stream::ops::process_execution_confirmed;
 use crate::stream::test_utils::{
-    make_test_stream_context_with_generator_pk, make_test_stream_context_with_rpc, respond_event,
-    test_bidirectional_tx, test_canton_sign_bidirectional_request, test_indexed_request,
-    test_sign_args,
+    make_test_stream_context, make_test_stream_context_with_generator_pk,
+    make_test_stream_context_with_rpc, respond_event, test_bidirectional_tx,
+    test_canton_sign_bidirectional_request, test_indexed_request, test_sign_args,
 };
 use alloy::primitives::B256;
 use cait_sith::protocol::Participant;
@@ -422,7 +422,7 @@ async fn process_execution_confirmed_recovery_requeues_final_respond_after_send_
 }
 
 #[tokio::test]
-async fn process_respond_event_rejects_invalid_bidirectional_target_chain() {
+async fn process_respond_event_quarantines_invalid_bidirectional_target_chain() {
     let backlog = Backlog::new();
     let sign_id = SignId::new([11u8; 32]);
     let args = SignArgs {
@@ -484,16 +484,16 @@ async fn process_respond_event_rejects_invalid_bidirectional_target_chain() {
     let (sign_tx, _sign_rx) = mpsc::channel(4);
     let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
 
-    let err = process_respond_event(event, &ctx, public_key)
+    // An unknown target chain fails the same deterministic derivation on every
+    // node and every replay, so the entry is quarantined rather than errored:
+    // leaving it would park it in pending-publish with backups republishing it.
+    process_respond_event(event, &ctx, public_key)
         .await
-        .expect_err("invalid chain should fail");
-    // The underlying `UnknownCaip2Id` cause is carried in the error's source chain.
-    let cause = err
-        .chain()
-        .map(|e| e.to_string())
-        .collect::<Vec<_>>()
-        .join("\n");
-    assert!(cause.contains("unknown CAIP-2 chain ID: not-a-chain"));
+        .expect("quarantining is not an error");
+    assert!(
+        ctx.backlog.get(Chain::Ethereum, &sign_id).await.is_none(),
+        "an entry with an unknown target chain must leave the backlog"
+    );
 }
 
 #[tokio::test]
@@ -528,17 +528,56 @@ async fn process_sign_request_rejects_respond_bidirectional_kind() {
     assert!(err.to_string().contains("Unexpected sign request kind"));
 }
 
+/// Admission cannot be the only gate: checkpoint recovery restores backlog entries
+/// wholesale, so a poison entry can exist without ever passing admission. The
+/// respond path must then quarantine it (deterministically, on every node), or it
+/// parks in pending-publish forever with every backup's sweep republishing it.
 #[tokio::test]
-async fn process_sign_request_rejects_empty_bidirectional_serialized_transaction() {
+async fn process_respond_event_quarantines_a_bidirectional_entry_that_cannot_advance() {
     let backlog = Backlog::new();
-    let sign_id = SignId::new([13u8; 32]);
+    let sign_id = SignId::new([23u8; 32]);
+    let args = test_sign_args(23);
 
-    // A bidirectional request with an empty `serialized_transaction`. If accepted
-    // it would sit in the backlog and later panic in `sign_and_hash_transaction`
-    // (empty RLP) when the respond event advances it to execution.
-    let event = SignBidirectionalEvent {
+    // Inserted directly, as checkpoint recovery would: never passed admission.
+    backlog
+        .insert(test_indexed_request(
+            sign_id,
+            Chain::Solana,
+            args.clone(),
+            current_unix_timestamp(),
+            SignKind::SignBidirectional(bidirectional_event(vec![0xde, 0xad])),
+        ))
+        .await;
+
+    let root_sk = k256::SecretKey::random(&mut rand::thread_rng());
+    let signature = mpc_crypto::generate_signature(&root_sk, &args);
+    let event = SignatureRespondedEvent {
+        request_id: sign_id.request_id,
+        signature,
+        chain: Chain::Solana,
+    };
+
+    let public_key = root_sk.public_key().into();
+    let (sign_tx, _sign_rx) = mpsc::channel(4);
+    let (ctx, _cp, _mesh, _rpc_rx) =
+        make_test_stream_context(backlog, sign_tx, true, public_key, 1);
+
+    process_respond_event(event, &ctx, public_key)
+        .await
+        .expect("quarantining is not an error");
+
+    assert!(
+        ctx.backlog.get(Chain::Solana, &sign_id).await.is_none(),
+        "an entry that can never advance must leave the backlog"
+    );
+}
+
+/// A Solana-sourced bidirectional event targeting Ethereum; `serialized_transaction`
+/// is the part the admission tests vary.
+fn bidirectional_event(serialized_transaction: Vec<u8>) -> SignBidirectionalEvent {
+    SignBidirectionalEvent {
         sender: [0u8; 32],
-        serialized_transaction: vec![],
+        serialized_transaction,
         caip2_id: Chain::Ethereum.caip2_chain_id().to_string(),
         key_version: 0,
         deposit: 0,
@@ -550,7 +589,49 @@ async fn process_sign_request_rejects_empty_bidirectional_serialized_transaction
         chain_ctx: None,
         output_deserialization_schema: vec![],
         respond_serialization_schema: vec![],
-    };
+    }
+}
+
+/// A non-empty but undecodable transaction is the same poison pill as an empty one,
+/// with a worse blast radius: admitted, it signs, publishes leg 1, then fails
+/// deterministically in respond processing before the cancel, leaving the entry in
+/// pending-publish forever while every backup's sweep fires into a retry loop that
+/// nothing ends. Admission runs the same derivations respond processing will need.
+#[tokio::test]
+async fn process_sign_request_rejects_undecodable_bidirectional_transaction() {
+    let backlog = Backlog::new();
+    let sign_id = SignId::new([14u8; 32]);
+
+    let event = bidirectional_event(vec![0xde, 0xad, 0xbe, 0xef]);
+    let request = test_indexed_request(
+        sign_id,
+        Chain::Solana,
+        test_sign_args(14),
+        current_unix_timestamp(),
+        SignKind::SignBidirectional(event),
+    );
+
+    let (sign_tx, _sign_rx) = mpsc::channel(4);
+    let ctx = make_test_stream_context_with_generator_pk(backlog.clone(), sign_tx, true);
+    let err = process_sign_request(request, &ctx)
+        .await
+        .expect_err("undecodable serialized_transaction should be rejected at ingestion");
+    assert!(format!("{err:#}").contains("undecodable serialized_transaction"));
+    assert!(
+        backlog.get(Chain::Solana, &sign_id).await.is_none(),
+        "rejected request must not be stored in the backlog"
+    );
+}
+
+#[tokio::test]
+async fn process_sign_request_rejects_empty_bidirectional_serialized_transaction() {
+    let backlog = Backlog::new();
+    let sign_id = SignId::new([13u8; 32]);
+
+    // A bidirectional request with an empty `serialized_transaction`. If accepted
+    // it would sit in the backlog and later panic in `sign_and_hash_transaction`
+    // (empty RLP) when the respond event advances it to execution.
+    let event = bidirectional_event(vec![]);
     let request = test_indexed_request(
         sign_id,
         Chain::Solana,
@@ -564,7 +645,7 @@ async fn process_sign_request_rejects_empty_bidirectional_serialized_transaction
     let err = process_sign_request(request, &ctx)
         .await
         .expect_err("empty serialized_transaction should be rejected at ingestion");
-    assert!(err.to_string().contains("empty serialized_transaction"));
+    assert!(format!("{err:#}").contains("empty serialized_transaction"));
 
     // The poison-pill request must not have entered the backlog.
     assert!(

--- a/chain-signatures/node/src/stream/ops_tests.rs
+++ b/chain-signatures/node/src/stream/ops_tests.rs
@@ -18,7 +18,7 @@ use k256::{ProjectivePoint, Scalar};
 use mpc_chain_canton::CantonChainCtx;
 use mpc_chain_integration_core::{NoopChainTelemetry, StateManager};
 use mpc_primitives::{
-    ChainConfig as _, RespondBidirectionalTx, SignArgs, SignBidirectionalEvent, SignKind,
+    ChainConfig as _, RespondBidirectionalTx, SignArgs, SignBidirectionalEvent, SignKind, Signature,
 };
 use mpc_utils::time::current_unix_timestamp;
 use near_primitives::types::AccountId;

--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -463,10 +463,22 @@ impl Redis {
 
         let external_address = format!("redis://{}:{}", network_ip, Self::DEFAULT_REDIS_PORT);
 
-        let host_port = container
-            .get_host_port_ipv4(Self::DEFAULT_REDIS_PORT)
-            .await
-            .unwrap();
+        // The port mapping can lag the container start when several containers come
+        // up at once (PortNotExposed), so give Docker a moment before giving up.
+        let host_port = {
+            let mut attempts = 0;
+            loop {
+                match container.get_host_port_ipv4(Self::DEFAULT_REDIS_PORT).await {
+                    Ok(port) => break port,
+                    Err(err) if attempts < 5 => {
+                        attempts += 1;
+                        tracing::warn!(?err, attempts, "redis port not mapped yet; retrying");
+                        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                    }
+                    Err(err) => panic!("redis container port mapping failed: {err:?}"),
+                }
+            }
+        };
         let internal_address = format!("redis://127.0.0.1:{host_port}");
 
         Self::wait_for_host_port_readiness(&internal_address).await;

--- a/integration-tests/src/mpc_fixture/builder.rs
+++ b/integration-tests/src/mpc_fixture/builder.rs
@@ -561,11 +561,14 @@ impl MpcFixtureNodeBuilder {
                 .run(config_rx.clone(), context.contract_state.clone()),
         );
 
+        let backlog = Backlog::new();
+
         let protocol = MpcSignProtocol::new_test(
             self.participant_info.account_id.clone(),
             storage,
             channels,
             context.contract_state.clone(),
+            backlog.clone(),
         )
         .await;
 
@@ -582,8 +585,6 @@ impl MpcFixtureNodeBuilder {
             context.contract_state.clone(),
             mesh_rx.clone(),
         ));
-
-        let backlog = Backlog::new();
 
         let flat_mock_streams = self.mock_streams.values().cloned().collect::<Vec<_>>();
         let (checkpoint_tx, checkpoints_rx) = watch::channel(None);

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -667,7 +667,6 @@ async fn test_solana_respond_round_trip() -> Result<()> {
     // Publish a signature for the request
     publisher
         .publish_signature(&PublishAction {
-            public_key: AffinePoint::GENERATOR,
             request: request.clone(),
             signature: Signature::new(AffinePoint::GENERATOR, Scalar::ONE, 0),
             participants: vec![Participant::from(0u32)],


### PR DESCRIPTION
A bidirectional request whose deterministic derivations fail (unknown target chain, underivable epsilon, undecodable transaction) is admitted today, signed, and half-answered: every node's respond processing then fails at the same spot forever, and the entry sits in pending-publish for good. Admission now runs the same derivations respond processing needs and rejects such requests before they enter the backlog.

Requests can also re-enter the backlog through checkpoint recovery, skipping admission. Those get the same treatment one step later: the first time such a request provably cannot be completed, it is dropped. Every node reaches that verdict at the same point from the same data, so the network stays in agreement about which requests are pending.

Note for applications: a request with an undecodable `serialized_transaction` now gets no response at all instead of a leg-1 response and a permanently stuck leg 2. The request was unfulfillable either way; it now fails fast and identically on every node.

The decode check makes `sign_and_hash_transaction` reachable from any observed request event, so the legacy `35 + 2 * chain_id` computation switches to checked arithmetic instead of panicking on a crafted chain id.

The remaining commits are groundwork for the #1175 rework, which builds on this branch:

* `PublishAction.public_key` is removed: no chain publisher reads it, publishers sign with their own payer keys, and `PublishAction::new` keeps taking the key it actually needs for signature reconstruction.
* The fixture protocol and its chain streams now share one `Backlog`. They each had their own, so `mark_publishing` failed with `NotFound` in every fixture test and the backlog half of the sign path was silently skipped.
* `publishable_requests` takes the read lock; it never mutates.
* The redis container helper retries a lagging port mapping instead of unwrapping, which flaked under parallel container starts.
