### PR TITLE
chore(mpc-node): stop logging two normal outcomes as warnings

### DIFF
--- a/chain-signatures/node/src/metrics/protocols.rs
+++ b/chain-signatures/node/src/metrics/protocols.rs
@@ -1,11 +1,35 @@
 use std::sync::LazyLock;
 
-use prometheus::{exponential_buckets, linear_buckets, Counter, Histogram, IntGauge};
+use prometheus::{exponential_buckets, linear_buckets, Counter, CounterVec, Histogram, IntGauge};
 
 use super::{
     try_create_counter_vec_with_node_account_id, try_create_histogram_vec_with_node_account_id,
     try_create_int_gauge_vec_with_node_account_id, Histogram as MetricsHistogram,
 };
+
+/// Posit replies that reject, by protocol and reason. Rejections are normal
+/// protocol outcomes rather than faults, so they are counted here instead of
+/// being logged at warn. Covers triple and presignature posits; the signature
+/// posit path is not instrumented yet and will appear under its own
+/// `protocol` label when it is.
+pub(crate) static POSIT_REJECTS: LazyLock<CounterVec> = LazyLock::new(|| {
+    try_create_counter_vec_with_node_account_id(
+        "multichain_posit_rejects_total",
+        "Number of posit rejections sent by this node, by protocol and reason.",
+        &["protocol", "reason"],
+    )
+    .unwrap()
+});
+
+/// Count `action` if it is a rejection; accepts and proposals are ignored so
+/// callers can pass whatever reply they are about to send.
+pub(crate) fn record_posit_reject(protocol: &str, action: &crate::protocol::posit::PositAction) {
+    if let crate::protocol::posit::PositAction::RejectWithReason(reason) = action {
+        POSIT_REJECTS
+            .with_label_values(&[protocol, reason.as_str()])
+            .inc();
+    }
+}
 
 // Triple metrics
 pub(crate) static TRIPLE_LATENCY: LazyLock<Histogram> = LazyLock::new(|| {

--- a/chain-signatures/node/src/protocol/message/inbox.rs
+++ b/chain-signatures/node/src/protocol/message/inbox.rs
@@ -226,14 +226,16 @@ impl MessageInbox {
 
             match decrypted {
                 Ok(batch) => batches.push(batch),
-                Err(err) => {
-                    if matches!(err, MessageError::UnknownParticipant(_)) {
-                        retry.push((encrypted, timestamp));
-                    } else {
-                        tracing::warn!(?err, "inbox: failed to decrypt/verify messages");
-                    }
-                    continue;
+                // Sender is not in our participant map yet; keep the batch and
+                // retry once the map catches up.
+                Err(MessageError::UnknownParticipant(_)) => retry.push((encrypted, timestamp)),
+                // A batch we have already ingested, resent because the peer's
+                // outbox retried a send that had in fact landed. Dropping it is
+                // the dedup working, not a decryption or signature failure.
+                Err(MessageError::Idempotent) => {
+                    tracing::debug!("inbox: dropped duplicate message batch");
                 }
+                Err(err) => tracing::warn!(?err, "inbox: failed to decrypt/verify messages"),
             };
         }
 

--- a/chain-signatures/node/src/protocol/posit.rs
+++ b/chain-signatures/node/src/protocol/posit.rs
@@ -72,6 +72,19 @@ pub enum PositRejectReason {
     StaleRound,
 }
 
+impl PositRejectReason {
+    /// Stable label for metrics; keep the values lowercase and snake_case.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::AlreadyGenerating => "already_generating",
+            Self::MissingArtifact => "missing_artifact",
+            Self::InvalidRequest => "invalid_request",
+            Self::StaleRound => "stale_round",
+        }
+    }
+}
+
 impl PositAction {
     pub fn is_accept(&self) -> bool {
         matches!(self, PositAction::Accept)

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -438,10 +438,6 @@ impl PresignatureSpawner {
             self.triples.contains_reserved(id.pair_id).await
                 || self.triples.contains(id.pair_id).await
         } {
-            // We do not hold the proposed triple pair: it has not reached us
-            // yet, or we already spent it. Rejecting is the designed answer
-            // here and the proposer retries with another pair, so this is a
-            // normal outcome rather than a fault.
             tracing::debug!(
                 ?id,
                 ?from,

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -438,11 +438,15 @@ impl PresignatureSpawner {
             self.triples.contains_reserved(id.pair_id).await
                 || self.triples.contains(id.pair_id).await
         } {
-            tracing::warn!(
+            // We do not hold the proposed triple pair: it has not reached us
+            // yet, or we already spent it. Rejecting is the designed answer
+            // here and the proposer retries with another pair, so this is a
+            // normal outcome rather than a fault.
+            tracing::debug!(
                 ?id,
                 ?from,
                 ?action,
-                "presignature required triples are not known"
+                "rejecting presignature posit: triple pair not held locally"
             );
             PositInternalAction::Reply(PositAction::RejectWithReason(
                 PositRejectReason::MissingArtifact,

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -465,6 +465,7 @@ impl PresignatureSpawner {
                 tracing::warn!(?id, "presignature posit aborted due to too many rejections");
             }
             PositInternalAction::Reply(action) => {
+                crate::metrics::protocols::record_posit_reject("presignature", &action);
                 self.msg
                     .send(
                         self.me,

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -425,6 +425,7 @@ impl TripleSpawner {
             PositInternalAction::None => {}
             PositInternalAction::Abort => {}
             PositInternalAction::Reply(action) => {
+                crate::metrics::protocols::record_posit_reject("triple", &action);
                 self.msg
                     .send(
                         self.me,


### PR DESCRIPTION
Two of the three most frequent warnings on devnet describe normal protocol outcomes, not failures. Both are phrased as errors, and together they account for thousands of WARN lines per hour under load, which makes the warning stream hard to read and buries real problems. The third commit replaces the visibility they were providing with a counter.

### `inbox: failed to decrypt/verify messages`

Every one of 500 sampled instances in a one-hour window carried `err=Idempotent`, which means the batch signature was already in the dedup LRU: a peer's outbox retried a send that had in fact landed. Nothing failed to decrypt, and no signature failed to verify. The message says otherwise.

It now gets its own arm at `debug` with a message that names what happened. Real decrypt/verify errors keep the WARN, and `UnknownParticipant` keeps its retry path (now an explicit arm rather than a `matches!` guard inside the error branch; the trailing `continue` was the last statement of the loop body, so dropping it does not change control flow).

### `presignature required triples are not known`

Fires when a peer proposes a presignature over a triple pair we do not hold, so we reply `RejectWithReason(MissingArtifact)` and the proposer retries with another pair.

Demoted to `debug` and reworded to state the decision. devnet runs `RUST_LOG=mpc_node=debug`, so the line is still there when someone reads the debug stream; it just leaves the WARNING severity bucket where alerting and Cloud Logging triage happen.

### `multichain_posit_rejects_total{protocol, reason}`

A per-line WARN was the wrong instrument for "how often do we refuse a posit" anyway. The new counter is incremented where the triple and presignature managers send their reply, so the rate is visible per reason (`missing_artifact`, `already_generating`, `stale_round`, `invalid_request`, `unknown`) without a log line per event, and it now covers reasons that were never logged at all. The signature posit path has several scattered send sites and is left for a follow-up; it slots in under the same `protocol` label without breaking anything built on this metric.

### Context, and what this does not fix

The rate is load-driven, not steady: on devnet it was >=10k/hour cluster-wide during load-test bursts and 0/hour when idle. The rejects are a symptom. In the 17:00-18:00 UTC hour on 2026-08-31 no posit was aborted for too many rejections, while 5934 presignature generations hit the 45s `generation_timeout` against 6729 completions, with container CPU limit utilization averaging 68-85% across all 12 pods and peaking over 100%. Each timeout burns a taken triple pair, which is what makes holder sets diverge in the first place. Issue to follow for that and for the reject-vs-wait asymmetry between `process_posit` and `PendingTriples::fetch`.

### Not touched

`presignature already generated` / `already generating` in the same handler are the same shape (a reject reply logged at WARN), but a duplicate proposal for a presignature we already have is arguably worth seeing, so I left the logs. They are counted by the new metric either way.

### Testing

`cargo check -p mpc-node --lib`, `cargo clippy -p mpc-node --lib` and `cargo fmt` pass. No behaviour outside logging and metrics changes.