### PR TITLE
chore/fix: do not create separate near rpc clients

### DIFF
--- a/chain-signatures/chain-near/src/publisher.rs
+++ b/chain-signatures/chain-near/src/publisher.rs
@@ -25,13 +25,13 @@ pub struct NearClient {
 
 impl NearClient {
     pub fn new(
-        near_rpc: &str,
+        client: near_fetch::Client,
         contract_id: &AccountId,
         signer: InMemorySigner,
         telemetry: Arc<dyn PublisherTelemetry>,
     ) -> Self {
         Self {
-            client: near_fetch::Client::new(near_rpc),
+            client,
             contract_id: contract_id.clone(),
             signer,
             telemetry,

--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -678,17 +678,15 @@ impl RpcHandles {
         stack: &ChainStack,
     ) -> Self {
         let publisher_telemetry = Arc::new(NodeTelemetry::new(Chain::NEAR));
-        // `NearClient` (publishing) and `NearGovernanceClient` (governance + contract
-        // reads) each open their own `near_fetch::Client` to the same RPC endpoint.
-        // TODO: two connection are negligible here, but consider sharing a single client if necessary.
+        let near_rpc = near_fetch::Client::new(near_rpc_url);
         let near_client = NearClient::new(
-            near_rpc_url,
+            near_rpc.clone(),
             mpc_contract_id,
             signer.clone(),
             publisher_telemetry,
         );
         let near_governance_client = NearGovernanceClient::new(
-            near_rpc_url,
+            near_rpc,
             my_address,
             &network.sign_sk,
             &network.cipher_sk,
@@ -1283,8 +1281,9 @@ mod tests {
             _ => unreachable!(),
         };
         // Never dialed: publishers() only stores the client in the registry.
+        let near = near_fetch::Client::new("http://127.0.0.1:1");
         let near = NearClient::new(
-            "http://127.0.0.1:1",
+            near,
             &account_id,
             signer,
             Arc::new(NodeTelemetry::new(Chain::NEAR)),

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -1111,14 +1111,9 @@ mod tests {
         let cipher_sk = mpc_keys::hpke::SecretKey::from_bytes(&[0; 32]);
         let my_addr = "http://127.0.0.1:3000".parse().unwrap();
         let contract_id: AccountId = "contract.testnet".parse().unwrap();
-        let near = NearGovernanceClient::new(
-            &server.url(),
-            &my_addr,
-            &sign_sk,
-            &cipher_sk,
-            &contract_id,
-            signer,
-        );
+        let near = near_fetch::Client::new(&server.url());
+        let near =
+            NearGovernanceClient::new(near, &my_addr, &sign_sk, &cipher_sk, &contract_id, signer);
 
         let (tx, mut rx) = mpsc::channel(16);
         let publishers = HashMap::new();

--- a/chain-signatures/node/src/rpc/near_governance.rs
+++ b/chain-signatures/node/src/rpc/near_governance.rs
@@ -49,7 +49,7 @@ pub struct NearGovernanceClient {
 
 impl NearGovernanceClient {
     pub fn new(
-        near_rpc: &str,
+        client: NearFetchClient,
         my_addr: &Url,
         sign_sk: &near_crypto::SecretKey,
         cipher_sk: &hpke::SecretKey,
@@ -57,7 +57,7 @@ impl NearGovernanceClient {
         signer: InMemorySigner,
     ) -> Self {
         Self {
-            client: NearFetchClient::new(near_rpc),
+            client,
             contract_id: contract_id.clone(),
             my_addr: my_addr.clone(),
             signer,


### PR DESCRIPTION
this was pretty low hanging fruit, but this would allow us to use the same near client underneath for rpc and governance related tasks. The issue is that since adding `vote_checkpoint`, they would likely interfere with each other over nonce access key caching underneath with the `near_fetch::Client`. We use the same access key for both so the amount of nonce collision would be quite real, needing to refetch the access key every time.