### PR TITLE
chore(mpc-node): quiet duplicate inbox batch log

### DIFF
--- a/chain-signatures/node/src/protocol/message/inbox.rs
+++ b/chain-signatures/node/src/protocol/message/inbox.rs
@@ -230,7 +230,7 @@ impl MessageInbox {
                 // retry once the map catches up.
                 Err(MessageError::UnknownParticipant(_)) => retry.push((encrypted, timestamp)),
                 // A batch we have already ingested, resent because the peer's
-                // outbox retried a send that had in fact landed. 
+                // outbox retried a send that had in fact landed.
                 Err(MessageError::Idempotent) => {
                     tracing::debug!("inbox: dropped duplicate message batch");
                 }

--- a/chain-signatures/node/src/protocol/message/inbox.rs
+++ b/chain-signatures/node/src/protocol/message/inbox.rs
@@ -226,14 +226,16 @@ impl MessageInbox {
 
             match decrypted {
                 Ok(batch) => batches.push(batch),
-                Err(err) => {
-                    if matches!(err, MessageError::UnknownParticipant(_)) {
-                        retry.push((encrypted, timestamp));
-                    } else {
-                        tracing::warn!(?err, "inbox: failed to decrypt/verify messages");
-                    }
-                    continue;
+                // Sender is not in our participant map yet; keep the batch and
+                // retry once the map catches up.
+                Err(MessageError::UnknownParticipant(_)) => retry.push((encrypted, timestamp)),
+                // A batch we have already ingested, resent because the peer's
+                // outbox retried a send that had in fact landed. Dropping it is
+                // the dedup working, not a decryption or signature failure.
+                Err(MessageError::Idempotent) => {
+                    tracing::debug!("inbox: dropped duplicate message batch");
                 }
+                Err(err) => tracing::warn!(?err, "inbox: failed to decrypt/verify messages"),
             };
         }
 

--- a/chain-signatures/node/src/protocol/message/inbox.rs
+++ b/chain-signatures/node/src/protocol/message/inbox.rs
@@ -230,8 +230,7 @@ impl MessageInbox {
                 // retry once the map catches up.
                 Err(MessageError::UnknownParticipant(_)) => retry.push((encrypted, timestamp)),
                 // A batch we have already ingested, resent because the peer's
-                // outbox retried a send that had in fact landed. Dropping it is
-                // the dedup working, not a decryption or signature failure.
+                // outbox retried a send that had in fact landed. 
                 Err(MessageError::Idempotent) => {
                     tracing::debug!("inbox: dropped duplicate message batch");
                 }


### PR DESCRIPTION
### `inbox: failed to decrypt/verify messages`

Every one of 500 sampled warning instances with this message in a one-hour window carried `err=Idempotent`, which means the batch signature was already in the dedup LRU: a peer's outbox retried a send that had in fact landed. Nothing failed to decrypt, and no signature failed to verify. The message says otherwise.

It now gets its own arm at `debug` with a message that names what happened. Real decrypt/verify errors keep the WARN, and `UnknownParticipant` keeps its retry path (now an explicit arm rather than a `matches!` guard inside the error branch; the trailing `continue` was the last statement of the loop body, so dropping it does not change control flow).

### Testing

`cargo check -p mpc-node --lib` passes. No behaviour outside logging changes.
