### PR TITLE
fix(solana): accept versioned transactions in block fetches

### DIFF
--- a/chain-signatures/chain-solana/src/client.rs
+++ b/chain-signatures/chain-solana/src/client.rs
@@ -182,7 +182,7 @@ impl SolanaClient {
             transaction_details: Some(TransactionDetails::Full),
             rewards: Some(false),
             commitment: Some(CommitmentConfig::finalized()),
-            max_supported_transaction_version: Some(0),
+            max_supported_transaction_version: Some(u8::MAX),
         }
     }
 
@@ -612,7 +612,7 @@ mod tests {
             config.commitment.map(|c| c.commitment),
             Some(solana_sdk::commitment_config::CommitmentLevel::Finalized)
         );
-        assert_eq!(config.max_supported_transaction_version, Some(0));
+        assert_eq!(config.max_supported_transaction_version, Some(u8::MAX));
     }
 
     #[tokio::test]

--- a/chain-signatures/chain-solana/src/client.rs
+++ b/chain-signatures/chain-solana/src/client.rs
@@ -179,7 +179,7 @@ impl SolanaClient {
             transaction_details: Some(TransactionDetails::Full),
             rewards: Some(false),
             commitment: Some(CommitmentConfig::finalized()),
-            max_supported_transaction_version: Some(u8::MAX),
+            max_supported_transaction_version: Some(1),
         }
     }
 

--- a/chain-signatures/chain-solana/src/client.rs
+++ b/chain-signatures/chain-solana/src/client.rs
@@ -608,7 +608,7 @@ mod tests {
             config.commitment.map(|c| c.commitment),
             Some(solana_sdk::commitment_config::CommitmentLevel::Finalized)
         );
-        assert_eq!(config.max_supported_transaction_version, Some(u8::MAX));
+        assert_eq!(config.max_supported_transaction_version, Some(1));
     }
 
     #[tokio::test]

--- a/chain-signatures/chain-solana/src/indexer.rs
+++ b/chain-signatures/chain-solana/src/indexer.rs
@@ -828,7 +828,7 @@ mod tests {
     fn block_fetch_config_sets_max_supported_transaction_version() {
         let config = SolanaClient::block_fetch_config();
 
-        assert_eq!(config.max_supported_transaction_version, Some(0));
+        assert_eq!(config.max_supported_transaction_version, Some(u8::MAX));
         assert_eq!(config.transaction_details, Some(TransactionDetails::Full));
         assert_eq!(config.encoding, Some(UiTransactionEncoding::JsonParsed));
         assert_eq!(config.rewards, Some(false));

--- a/chain-signatures/chain-solana/src/indexer.rs
+++ b/chain-signatures/chain-solana/src/indexer.rs
@@ -826,7 +826,7 @@ mod tests {
     fn block_fetch_config_sets_max_supported_transaction_version() {
         let config = SolanaClient::block_fetch_config();
 
-        assert_eq!(config.max_supported_transaction_version, Some(u8::MAX));
+        assert_eq!(config.max_supported_transaction_version, Some(1));
         assert_eq!(config.transaction_details, Some(TransactionDetails::Full));
         assert_eq!(config.encoding, Some(UiTransactionEncoding::JsonParsed));
         assert_eq!(config.rewards, Some(false));


### PR DESCRIPTION
This should fix current problem with Solana:
```
failed to fetch Solana block; retrying in 10.3s
   err: RPC response error -32015: Transaction version (1) is not supported by the
        requesting client. Please try the request again with:
        "maxSupportedTransactionVersion": 1
   attempt=32 maxAttempts=u64::MAX
   ```
   
`SolanaClient::block_fetch_config()` declared `max_supported_transaction_version: Some(0)` (client parses legacy and v0 transactions only). Error is deterministic for a given block - the retry loop (`retry_until_ok` unbounded attempts) spun on it indefinitely

