### PR TITLE
feat: have CI invoke just

### DIFF
--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -21,6 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -81,17 +86,13 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/develop' }}
 
       - name: Build eth contract
-        working-directory: ./chain-signatures/contract-eth
-        run: npm ci && npx hardhat compile
-
-      - name: Presetup binaries
-        run: ./setup.sh
+        run: just build eth
 
       - name: Build integration tests
-        run: cargo build -p integration-tests --tests
+        run: just build tests
 
       - name: Run Canton stream tests
-        run: cargo test -p integration-tests --test lib -- canton_stream --ignored --nocapture --test-threads 1
+        run: just test-canton
         env:
           RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1
@@ -102,6 +103,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Install just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
@@ -163,17 +169,13 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/develop' }}
 
       - name: Build eth contract
-        working-directory: ./chain-signatures/contract-eth
-        run: npm ci && npx hardhat compile
-
-      - name: Presetup binaries
-        run: ./setup.sh
+        run: just build eth
 
       - name: Build integration tests
-        run: cargo build -p integration-tests --tests
+        run: just build tests
 
       - name: Run Canton E2E tests
-        run: cargo test -p integration-tests --test lib -- cases::canton --ignored --nocapture --test-threads 1
+        run: just test-canton cases::canton
         env:
           RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1

--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -33,7 +33,8 @@ jobs:
 
       - name: Install just
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          mkdir -p "$HOME/.cargo/bin"
+          curl --proto '=https' --tlsv1.2 -sSfL "https://github.com/casey/just/releases/download/1.54.0/just-1.54.0-x86_64-unknown-linux-musl.tar.gz" | tar zxf - -C "$HOME/.cargo/bin"
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/deploy-dev-contract.yml
+++ b/.github/workflows/deploy-dev-contract.yml
@@ -17,6 +17,11 @@ jobs:
         run: mkdir -p ~/.near-credentials/testnet && echo '${{ secrets.DEV_CONTRACT_JSON }}' > ~/.near-credentials/testnet/dev.sig-net.testnet.json
 
       - uses: actions/checkout@v6
+
+      - name: Install just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -46,6 +51,6 @@ jobs:
 
       - name: Build & Deploy Dev Contract
         run: |
-          ./build-contract.sh
+          just build contract
           (yes || true) | near deploy dev.sig-net.testnet target/near/mpc_contract/mpc_contract.wasm
           near call dev.sig-net.testnet migrate '{}' --accountId dev.sig-net.testnet --gas 300000000000000

--- a/.github/workflows/deploy-dev-contract.yml
+++ b/.github/workflows/deploy-dev-contract.yml
@@ -20,7 +20,8 @@ jobs:
 
       - name: Install just
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          mkdir -p "$HOME/.cargo/bin"
+          curl --proto '=https' --tlsv1.2 -sSfL "https://github.com/casey/just/releases/download/1.54.0/just-1.54.0-x86_64-unknown-linux-musl.tar.gz" | tar zxf - -C "$HOME/.cargo/bin"
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Use Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,7 +38,8 @@ jobs:
 
       - name: Install just
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          mkdir -p "$HOME/.cargo/bin"
+          curl --proto '=https' --tlsv1.2 -sSfL "https://github.com/casey/just/releases/download/1.54.0/just-1.54.0-x86_64-unknown-linux-musl.tar.gz" | tar zxf - -C "$HOME/.cargo/bin"
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Login to GitHub Container Registry
@@ -121,7 +122,8 @@ jobs:
 
       - name: Install just
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          mkdir -p "$HOME/.cargo/bin"
+          curl --proto '=https' --tlsv1.2 -sSfL "https://github.com/casey/just/releases/download/1.54.0/just-1.54.0-x86_64-unknown-linux-musl.tar.gz" | tar zxf - -C "$HOME/.cargo/bin"
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Login to GitHub Container Registry
@@ -207,7 +209,8 @@ jobs:
 
       - name: Install just
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          mkdir -p "$HOME/.cargo/bin"
+          curl --proto '=https' --tlsv1.2 -sSfL "https://github.com/casey/just/releases/download/1.54.0/just-1.54.0-x86_64-unknown-linux-musl.tar.gz" | tar zxf - -C "$HOME/.cargo/bin"
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Install Rust (1.93.0)

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,6 +36,11 @@ jobs:
 
       - uses: actions/checkout@v6
 
+      - name: Install just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -77,16 +82,13 @@ jobs:
             curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/latest/download/cargo-near-installer.sh | sh
           fi
 
-      - name: Build integration test artifacts
-        run: ./setup.sh
-
-      # Build the tests before actually running them to see how long the tests take to run by itself
-      # instead of including the build time in the test time report on Github.
       - name: Build Chain-Signatures Integration Tests
-        run: cargo build -p integration-tests --tests
+        run: just build tests
 
+      # Artifacts (contract wasm + node binary) build inside the test recipe via its setup dependency,
+      # so setup.sh runs exactly once per job.
       - name: Test
-        run: cargo nextest run -p integration-tests --profile fixture
+        run: just test-fixture
         env:
           RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1
@@ -117,6 +119,11 @@ jobs:
             });
 
       - uses: actions/checkout@v6
+
+      - name: Install just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Install Docker
         if: ${{ matrix.os == 'macos-latest-xl' }}
@@ -181,23 +188,17 @@ jobs:
             curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/latest/download/cargo-near-installer.sh | sh
           fi
 
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
-
-      - name: Build integration test artifacts
-        run: ./setup.sh
-
       - name: Build eth contract
-        working-directory: ./chain-signatures/contract-eth
-        run: npm ci && npx hardhat compile
+        run: just build eth
 
       # Build the tests before actually running them to see how long the tests take to run by itself
       # instead of including the build time in the test time report on Github.
+      # Artifacts build inside the test recipe via its setup dependency.
       - name: Build Chain-Signatures Integration Tests
-        run: cargo build -p integration-tests --tests
+        run: just build tests
 
       - name: Test
-        run: cargo nextest run -p integration-tests --profile cluster
+        run: just test-cluster
         env:
           RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1
@@ -213,6 +214,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Install just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Install Rust (1.93.0)
         uses: actions-rs/toolchain@v1
@@ -237,15 +243,11 @@ jobs:
           node-version: '18'
           cache: 'npm'
           cache-dependency-path: chain-signatures/contract-eth/package-lock.json
-      - name: Build eth contract artifact   # required by deploy_chain_signatures' include_bytes!
-        working-directory: ./chain-signatures/contract-eth
-        run: npm ci && npx hardhat compile
-
       - name: Install Foundry (anvil)
         uses: foundry-rs/foundry-toolchain@v1
 
       - name: Clippy (integration-gated code)
-        run: cargo clippy -p mpc-chain-ethereum --tests --features integration -- -Dclippy::all
+        run: just lint-eth
 
       - name: Test
-        run: cargo test -p mpc-chain-ethereum --features integration --tests
+        run: just test-eth

--- a/.github/workflows/midnight-publisher-ts.yml
+++ b/.github/workflows/midnight-publisher-ts.yml
@@ -35,7 +35,8 @@ jobs:
 
       - name: Install just
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          mkdir -p "$HOME/.cargo/bin"
+          curl --proto '=https' --tlsv1.2 -sSfL "https://github.com/casey/just/releases/download/1.54.0/just-1.54.0-x86_64-unknown-linux-musl.tar.gz" | tar zxf - -C "$HOME/.cargo/bin"
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Install Node.js

--- a/.github/workflows/midnight-publisher-ts.yml
+++ b/.github/workflows/midnight-publisher-ts.yml
@@ -33,6 +33,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
@@ -81,4 +86,4 @@ jobs:
       # matches against test names and selects nothing.
       - name: Rust intent seam differential
         working-directory: .
-        run: cargo nextest run -p mpc-chain-midnight --run-ignored all -E 'binary(intent_seam)'
+        run: just test-midnight-seam

--- a/.github/workflows/midnight.yml
+++ b/.github/workflows/midnight.yml
@@ -25,7 +25,8 @@ jobs:
 
       - name: Install just
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          mkdir -p "$HOME/.cargo/bin"
+          curl --proto '=https' --tlsv1.2 -sSfL "https://github.com/casey/just/releases/download/1.54.0/just-1.54.0-x86_64-unknown-linux-musl.tar.gz" | tar zxf - -C "$HOME/.cargo/bin"
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Install Node.js

--- a/.github/workflows/midnight.yml
+++ b/.github/workflows/midnight.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
@@ -68,12 +73,7 @@ jobs:
           compact compile --version
 
       - name: Build real-stack TypeScript fixtures
-        working-directory: chain-signatures/midnight-publisher-ts
-        run: |
-          npm ci
-          npm run build
-          npm run compile:real-stack-caller
-          npm run typecheck:real-stack
+        run: just build midnight
 
       - name: Install Rust (1.93.0)
         uses: actions-rs/toolchain@v1
@@ -107,16 +107,13 @@ jobs:
             sh /tmp/cargo-near-installer.sh
           fi
 
-      - name: Build integration artifacts
-        run: ./setup.sh
-
       - name: Build integration tests
-        run: cargo build -p integration-tests --tests
+        run: just build tests
 
       # nextest fails on an empty selection, so a renamed test cannot turn this
       # step into a silent no-op.
       - name: Test Midnight end-to-end stream
-        run: cargo nextest run -p integration-tests --test lib --run-ignored only --no-capture -E 'test(=cases::midnight_stream::midnight_to_ethereum_to_midnight_consumes_caller_response)'
+        run: just test-midnight
         env:
           RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,6 +35,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Install Docker
         if: ${{ matrix.os == 'macos-latest-xl' }}
         run: |
@@ -89,19 +94,13 @@ jobs:
         run: echo "OPENSSL_NO_VENDOR=1" >> $GITHUB_ENV
 
       - name: Build eth contract
-        working-directory: ./chain-signatures/contract-eth
-        run: npm ci && npx hardhat compile
-
-      - name: Presetup binaries
-        run: ./setup.sh
-        env:
-          MPC_ENABLE_HELIOS: 1
+        run: just build eth
 
       - name: Build nightly
-        run: cargo build -p integration-tests --tests --features helios
+        run: just build tests helios=1
 
       - name: Run nightly
-        run: cargo test -p integration-tests --features helios --test lib -- cases::nightly --show-output --ignored
+        run: just test-nightly
         env:
           RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,8 @@ jobs:
 
       - name: Install just
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          mkdir -p "$HOME/.cargo/bin"
+          curl --proto '=https' --tlsv1.2 -sSfL "https://github.com/casey/just/releases/download/1.54.0/just-1.54.0-x86_64-unknown-linux-musl.tar.gz" | tar zxf - -C "$HOME/.cargo/bin"
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4

--- a/.github/workflows/prod-compatibility.yml
+++ b/.github/workflows/prod-compatibility.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -64,22 +69,19 @@ jobs:
         run: echo "OPENSSL_NO_VENDOR=1" >> $GITHUB_ENV
 
       - name: Build governance contract
-        run: |
-          ./build-contract.sh
-          mkdir -p target/wasm32-unknown-unknown/release
-          cp target/near/mpc_contract/mpc_contract.wasm target/wasm32-unknown-unknown/release/mpc_contract.wasm
+        run: just build contract
 
       - name: Build node with stable toolchain
         run: cargo build-node
 
       - name: Build compatibility binaries from tags
-        run: ./scripts/build-compat-binaries.sh
+        run: just build compat
 
       - name: Build integration tests
-        run: cargo build -p integration-tests --tests
+        run: just build tests
 
       - name: Run production compatibility tests
-        run: ./scripts/test-prod-compat.sh
+        run: just test-compat
         env:
           RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1

--- a/.github/workflows/prod-compatibility.yml
+++ b/.github/workflows/prod-compatibility.yml
@@ -25,7 +25,8 @@ jobs:
 
       - name: Install just
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          mkdir -p "$HOME/.cargo/bin"
+          curl --proto '=https' --tlsv1.2 -sSfL "https://github.com/casey/just/releases/download/1.54.0/just-1.54.0-x86_64-unknown-linux-musl.tar.gz" | tar zxf - -C "$HOME/.cargo/bin"
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -25,7 +25,8 @@ jobs:
 
       - name: Install just
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          mkdir -p "$HOME/.cargo/bin"
+          curl --proto '=https' --tlsv1.2 -sSfL "https://github.com/casey/just/releases/download/1.54.0/just-1.54.0-x86_64-unknown-linux-musl.tar.gz" | tar zxf - -C "$HOME/.cargo/bin"
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Install Rust (1.93.0)

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Install Rust (1.93.0)
         uses: actions-rs/toolchain@v1
         with:
@@ -58,24 +63,21 @@ jobs:
           fi
 
       - name: Compile Contract
-        run: |
-          ./build-contract.sh
-          mkdir -p target/wasm32-unknown-unknown/release
-          cp target/near/mpc_contract/mpc_contract.wasm target/wasm32-unknown-unknown/release/mpc_contract.wasm
+        run: just build contract
       - name: Compile eth contract
-        run: cd chain-signatures/contract-eth && npm ci && npx hardhat compile
+        run: just build eth
       
       - name: Eth contract unit tests
-        run: cd chain-signatures/contract-eth && npx hardhat test
+        run: just test-eth-unit
       
       - name: Test format
-        run: cargo fmt -- --check
+        run: just fmt-check
       
       - name: Test clippy
-        run: cargo clippy --tests -- -Dclippy::all
+        run: just lint
       
       - name: Unit tests
-        run: cargo test --workspace --exclude integration-tests
+        run: just test-unit
 
   audit:
     name: Audit

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -80,22 +80,13 @@ In addition to the prerequisites above, it requires:
 - [cargo-near](https://github.com/near/cargo-near)
 - Compact launcher 0.5.1 with `compactc` 0.33.0-rc.2 available as `compact`; see the [Midnight CI workflow](../.github/workflows/midnight.yml) for the pinned Linux installation
 
-From the repository root, prepare the TypeScript publisher and test caller:
+From the repository root, prepare the TypeScript publisher and test caller,
+then build the MPC contract and host node and run the ignored test:
 
 ```bash
-cd chain-signatures/midnight-publisher-ts
-npm ci
-npm run build
-npm run compile:real-stack-caller
-npm run typecheck:real-stack
-cd ../..
-```
-
-Build the MPC contract and host node, then run the ignored test:
-
-```bash
-./setup.sh
-cargo nextest run -p integration-tests --test lib --run-ignored only --no-capture -E 'test(=cases::midnight_stream::midnight_to_ethereum_to_midnight_consumes_caller_response)'
+just build midnight
+just setup
+just test-midnight
 ```
 
 The test requires the host `mpc-node` binary. Midnight node, indexer, proof-server, and fixture-driver logs are written under `target/tmp_*/midnight`.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -2,6 +2,11 @@
 
 ## Prerequisites
 
+Run `just setup-check` to verify your system (Linux/macOS) without installing
+anything, or `just setup` to install missing dependencies automatically
+(`just setup-check all` / `just setup "" all` cover extended chain tooling:
+Solana/Anchor, Java/dpm, Compact). Manual install notes follow.
+
 1. Install [cargo-nextest](https://nexte.st) for race-free parallelization:
 
 ```bash
@@ -31,7 +36,9 @@ cargo install just
 
 ## Basic guide
 
-Running integration tests requires you to have redis and sandbox docker images present on your machine:
+Running integration tests requires a running Docker daemon (`just setup` installs
+Docker Desktop on macOS, docker.io on Linux). The `redis:7.4.2` image is pulled
+automatically by testcontainers on first run; prefetch it to avoid waiting:
 
 ```BASH
 docker pull redis:7.4.2

--- a/justfile
+++ b/justfile
@@ -5,9 +5,17 @@
 default:
     @just --list
 
-# Build WASM contract + local mpc-node binary
+# Check system dependencies without installing (Linux/macOS)
+# Usage: just setup-check [scope] (scope="" core, or "all" for Solana/Anchor/Java/dpm/Compact too)
+setup-check scope="":
+    ./scripts/setup-deps.sh --check {{scope}}
+alias sc := setup-check
+
+# Install missing system deps (if needed), then build WASM contract + local mpc-node binary
 # Pass helios=1 to enable Helios: just setup helios=1
-setup helios="":
+# Pass scope="all" to also install extended chain tooling; SETUP_DEPS_SKIP=1 skips the install pass
+setup helios="" scope="":
+    ./scripts/setup-deps.sh --install {{scope}}
     {{ if helios != "" { "MPC_ENABLE_HELIOS=1 ./setup.sh" } else { "./setup.sh" } }}
 alias s := setup
 
@@ -41,8 +49,57 @@ test-keep filter="" helios="": (setup helios)
     TESTCONTAINERS=keep cargo nextest run -p integration-tests {{ if filter != "" { "-E 'test(" + filter + ")'" } else { "" } }}
 alias tk := test-keep
 
+# Run clippy (mirrors CI: cargo clippy --tests -- -Dclippy::all)
+lint:
+    cargo clippy --tests -- -Dclippy::all
+
+# Check formatting without modifying files (mirrors CI)
+fmt-check:
+    cargo fmt -- --check
+
+# Format code with rustfmt
+fmt:
+    cargo fmt
+
+# Fast unit tests (mirrors CI: no integration-tests, no Docker)
+# Usage: just test-unit [filter]
+test-unit filter="":
+    cargo test --workspace --exclude integration-tests {{filter}}
+alias tu := test-unit
+
+# Full CI gate locally: format check + clippy + unit tests
+ci: fmt-check lint
+    cargo test --workspace --exclude integration-tests
+alias c := ci
+
+# Security audit of dependencies (mirrors CI audit job)
+audit:
+    @if ! command -v cargo-audit >/dev/null; then cargo install cargo-audit --locked; fi
+    cargo audit
+
 # Run all tests sequentially (single-threaded)
 # Usage: just ts [filter] [helios=1]
 test-seq filter="" helios="": (setup helios)
     cargo test -p integration-tests --jobs 1 -- --test-threads 1 {{ if filter != "" { filter } else { "" } }}
 alias ts := test-seq
+
+# Build whole Rust workspace (via setup); use `just build eth` for EVM artifacts only
+# Usage: just build [target] [helios=1] (target="" or "eth")
+build target="" helios="":
+    @if [ "{{target}}" = "eth" ]; then \
+      cd chain-signatures/contract-eth && npm ci && npx hardhat compile; \
+    elif [ -z "{{target}}" ]; then \
+      just setup {{helios}} && cargo build --workspace; \
+    else \
+      echo "Unknown build target: {{target}} (expected '' or 'eth')" >&2; exit 1; \
+    fi
+
+# Anvil-backed EVM tests: real EVM + real contract bytecode (needs anvil + eth-build output)
+# Usage: just test-eth [filter]
+test-eth filter="": (build "eth")
+    cargo test -p mpc-chain-ethereum --features integration --tests {{filter}}
+alias te := test-eth
+
+# Clippy for integration-gated EVM code (mirrors CI)
+lint-eth: (build "eth")
+    cargo clippy -p mpc-chain-ethereum --tests --features integration -- -Dclippy::all

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ alias sc := setup-check
 
 # Install missing system deps (if needed), then build WASM contract + local mpc-node binary
 # Pass helios=1 to enable Helios: just setup helios=1
-# Pass scope="all" to also install extended chain tooling; SETUP_DEPS_SKIP=1 skips the install pass
+# Pass scope="all" to also install extended chain tooling; install auto-skips on CI (SETUP_DEPS_FORCE=1 to override) and with SETUP_DEPS_SKIP=1
 setup helios="" scope="":
     ./scripts/setup-deps.sh --install {{scope}}
     {{ if helios != "" { "MPC_ENABLE_HELIOS=1 ./setup.sh" } else { "./setup.sh" } }}
@@ -83,15 +83,27 @@ test-seq filter="" helios="": (setup helios)
     cargo test -p integration-tests --jobs 1 -- --test-threads 1 {{ if filter != "" { filter } else { "" } }}
 alias ts := test-seq
 
-# Build whole Rust workspace (via setup); use `just build eth` for EVM artifacts only
-# Usage: just build [target] [helios=1] (target="" or "eth")
+# Build artifacts: `just build` = whole Rust workspace (via setup),
+# `just build eth` = EVM artifacts, `just build contract` = NEAR contract wasm,
+# `just build midnight` = midnight-publisher-ts fixtures,
+# `just build tests` = integration test binaries without running them,
+# `just build compat` = historical prod-compat node binaries
+# Usage: just build [target] [helios=1] (target="" | eth | contract | midnight | tests | compat)
 build target="" helios="":
     @if [ "{{target}}" = "eth" ]; then \
       cd chain-signatures/contract-eth && npm ci && npx hardhat compile; \
+    elif [ "{{target}}" = "contract" ]; then \
+      ./build-contract.sh && mkdir -p target/wasm32-unknown-unknown/release && cp target/near/mpc_contract/mpc_contract.wasm target/wasm32-unknown-unknown/release/mpc_contract.wasm; \
+    elif [ "{{target}}" = "midnight" ]; then \
+      cd chain-signatures/midnight-publisher-ts && npm ci && npm run build && npm run compile:real-stack-caller && npm run typecheck:real-stack; \
+    elif [ "{{target}}" = "tests" ]; then \
+      cargo build -p integration-tests --tests{{ if helios != "" { " --features helios" } else { "" } }}; \
+    elif [ "{{target}}" = "compat" ]; then \
+      ./scripts/build-compat-binaries.sh; \
     elif [ -z "{{target}}" ]; then \
       just setup {{helios}} && cargo build --workspace; \
     else \
-      echo "Unknown build target: {{target}} (expected '' or 'eth')" >&2; exit 1; \
+      echo "Unknown build target: {{target}} (expected '' | eth | contract | midnight | tests | compat)" >&2; exit 1; \
     fi
 
 # Anvil-backed EVM tests: real EVM + real contract bytecode (needs anvil + eth-build output)
@@ -103,3 +115,27 @@ alias te := test-eth
 # Clippy for integration-gated EVM code (mirrors CI)
 lint-eth: (build "eth")
     cargo clippy -p mpc-chain-ethereum --tests --features integration -- -Dclippy::all
+
+# EVM contract unit tests (hardhat, no anvil needed)
+test-eth-unit:
+    cd chain-signatures/contract-eth && npx hardhat test
+
+# Midnight real-stack test (ignored by default; needs Midnight node/indexer/proof-server + anvil)
+test-midnight: (setup "")
+    cargo nextest run -p integration-tests --test lib --run-ignored only --no-capture -E 'test(=cases::midnight_stream::midnight_to_ethereum_to_midnight_consumes_caller_response)'
+
+# Midnight TS/Rust seam differential (needs dist/ built via npm test in midnight-publisher-ts)
+test-midnight-seam:
+    cargo nextest run -p mpc-chain-midnight --run-ignored all -E 'binary(intent_seam)'
+
+# Canton tests (default: stream; e2e via `just test-canton cases::canton`)
+test-canton filter="canton_stream": (setup "")
+    cargo test -p integration-tests --test lib -- {{filter}} --ignored --nocapture --test-threads 1
+
+# Nightly helios suite
+test-nightly: (setup "1")
+    cargo test -p integration-tests --features helios --test lib -- cases::nightly --show-output --ignored
+
+# Prod-compat suite (needs `just build compat` output)
+test-compat:
+    ./scripts/test-prod-compat.sh

--- a/justfile
+++ b/justfile
@@ -14,10 +14,21 @@ alias sc := setup-check
 # Install missing system deps (if needed), then build WASM contract + local mpc-node binary
 # Pass helios=1 to enable Helios: just setup helios=1
 # Pass scope="all" to also install extended chain tooling; install auto-skips on CI (SETUP_DEPS_FORCE=1 to override) and with SETUP_DEPS_SKIP=1
+# just setup act installs the act CI runner only (no dep check, no artifact build)
 setup helios="" scope="":
-    ./scripts/setup-deps.sh --install {{scope}}
-    {{ if helios != "" { "MPC_ENABLE_HELIOS=1 ./setup.sh" } else { "./setup.sh" } }}
+    @if [ "{{helios}}" = "act" ]; then \
+      ./scripts/setup-deps.sh --install-act; \
+    elif [ -n "{{helios}}" ]; then \
+      ./scripts/setup-deps.sh --install {{scope}} && MPC_ENABLE_HELIOS=1 ./setup.sh; \
+    else \
+      ./scripts/setup-deps.sh --install {{scope}} && ./setup.sh; \
+    fi
 alias s := setup
+
+# Run GitHub workflows locally via act (needs Docker; pulls runner images on first run)
+# Usage: just run-ci [args] (e.g. just run-ci "-l" to list, just run-ci "-j 'Unit Check & Test'")
+run-ci args="": (setup "act")
+    act -P warp-ubuntu-latest-x64-4x=catthehacker/ubuntu:act-latest -P ubuntu-latest=catthehacker/ubuntu:act-latest {{args}}
 
 # Run all integration tests
 # Usage: just t [filter] [helios=1]

--- a/scripts/setup-deps.sh
+++ b/scripts/setup-deps.sh
@@ -239,6 +239,10 @@ case "$MODE" in
         ;;
     --install)
         if [ "${SETUP_DEPS_SKIP:-0}" = "1" ]; then printf 'skipping dependency install (SETUP_DEPS_SKIP=1)\n'; exit 0; fi
+        if [ "${SETUP_DEPS_FORCE:-0}" != "1" ] && { [ "${GITHUB_ACTIONS:-}" = "true" ] || [ "${CI:-}" = "true" ]; }; then
+            printf 'skipping dependency install (CI detected; SETUP_DEPS_FORCE=1 to override)\n'
+            exit 0
+        fi
         case "$OS" in
             Linux) apt_install ;;
             Darwin) brew_install ;;

--- a/scripts/setup-deps.sh
+++ b/scripts/setup-deps.sh
@@ -4,6 +4,7 @@
 # Usage:
 #   ./scripts/setup-deps.sh --check [scope]
 #   ./scripts/setup-deps.sh --install [scope]
+#   ./scripts/setup-deps.sh --install-act   # act CI runner only (never part of --check/--install)
 #   SETUP_DEPS_SKIP=1 ./scripts/setup-deps.sh --install  # no-op for fast loops
 #
 # scope is "" (core) or "all" / "extended" (core + Solana, Anchor, Java,
@@ -151,6 +152,15 @@ ensure_foundry() {
     note_path_dir "$HOME/.foundry/bin"
 }
 
+ensure_act() {
+    have act && return 0
+    case "$OS" in
+        Darwin) brew install act ;;
+        Linux) curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash ;;
+        *) return 1 ;;
+    esac
+}
+
 ensure_node() {
     if have node; then
         MAJOR="$(node -v 2>/dev/null | sed 's/^v\([0-9]*\).*/\1/')"
@@ -265,8 +275,15 @@ case "$MODE" in
         if [ "$FAIL" -gt 0 ]; then printf '%d missing requirement(s) remain\n' "$FAIL"; exit 1; fi
         printf 'all requirements met\n'
         ;;
+    --install-act)
+        if have act; then printf 'ok - act %s\n' "$(act --version 2>/dev/null | head -n 1)"; exit 0; fi
+        ensure_act
+        if have act; then printf 'ok - act %s\n' "$(act --version 2>/dev/null | head -n 1)"; exit 0; fi
+        printf 'act install failed\n'
+        exit 1
+        ;;
     *)
-        printf 'usage: %s --check|--install [all|extended]\n' "$0"
+        printf 'usage: %s --check|--install [all|extended]|--install-act\n' "$0"
         exit 2
         ;;
 esac

--- a/scripts/setup-deps.sh
+++ b/scripts/setup-deps.sh
@@ -1,0 +1,268 @@
+#!/bin/sh
+# Check or install local dev dependencies (Linux + macOS).
+#
+# Usage:
+#   ./scripts/setup-deps.sh --check [scope]
+#   ./scripts/setup-deps.sh --install [scope]
+#   SETUP_DEPS_SKIP=1 ./scripts/setup-deps.sh --install  # no-op for fast loops
+#
+# scope is "" (core) or "all" / "extended" (core + Solana, Anchor, Java,
+# dpm/Canton SDK, Compact). Core covers building the workspace, unit tests,
+# fixture/cluster integration tests, and Anvil EVM tests.
+
+set -u
+
+RUST_VERSION="1.93.0"
+WASM_TARGET="wasm32-unknown-unknown"
+REDIS_IMAGE="redis:7.4.2"
+SOLANA_VERSION="2.3.9"
+ANCHOR_VERSION="0.30.1"
+CANTON_SDK="3.5.1"
+COMPACT_RC="0.33.0-rc.2"
+
+MODE="${1:-}"
+SCOPE="${2:-}"
+EXTENDED=0
+if [ "$SCOPE" = "all" ] || [ "$SCOPE" = "extended" ] || [ "$SCOPE" = "--extended" ]; then
+    EXTENDED=1
+fi
+
+OS="$(uname -s)"
+FAIL=0
+PATH_HINT=0
+
+ok() { printf 'ok - %s\n' "$1"; }
+miss() { FAIL=$((FAIL + 1)); printf 'missing - %s\n' "$1"; }
+hint() { printf '  fix: %s\n' "$1"; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+on_path() {
+    case ":$PATH:" in
+        *":$1:"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+note_path_dir() {
+    if [ -d "$1" ] && ! on_path "$1"; then
+        PATH_HINT=1
+    fi
+}
+
+check_core() {
+    if have rustup; then ok "rustup $(rustup --version 2>/dev/null | head -n 1)"; else miss "rustup"; hint "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal"; fi
+    if have cargo; then ok "cargo $(cargo --version)"; else miss "cargo (via rustup)"; fi
+    if rustup toolchain list 2>/dev/null | grep -q "^${RUST_VERSION}"; then ok "rust ${RUST_VERSION} toolchain"; else miss "rust ${RUST_VERSION} toolchain"; hint "rustup toolchain install ${RUST_VERSION}"; fi
+    if rustup component list --toolchain "$RUST_VERSION" 2>/dev/null | grep -q "clippy.*(installed)"; then ok "clippy ${RUST_VERSION}"; else miss "clippy ${RUST_VERSION}"; hint "rustup component add --toolchain ${RUST_VERSION} clippy"; fi
+    if rustup component list --toolchain "$RUST_VERSION" 2>/dev/null | grep -q "rustfmt.*(installed)"; then ok "rustfmt ${RUST_VERSION}"; else miss "rustfmt ${RUST_VERSION}"; hint "rustup component add --toolchain ${RUST_VERSION} rustfmt"; fi
+    if rustup target list --toolchain "$RUST_VERSION" 2>/dev/null | grep -q "${WASM_TARGET} (installed)"; then ok "${WASM_TARGET} target"; else miss "${WASM_TARGET} target"; hint "rustup target add --toolchain ${RUST_VERSION} ${WASM_TARGET}"; fi
+    if have cargo-near; then ok "cargo-near $(cargo-near --version 2>/dev/null | head -n 1)"; else miss "cargo-near"; hint "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/latest/download/cargo-near-installer.sh | sh"; fi
+    if have cargo-nextest; then ok "cargo-nextest $(cargo-nextest --version 2>/dev/null | head -n 1)"; else miss "cargo-nextest"; hint "curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ~/.cargo/bin (macos: .../latest/mac)"; fi
+    if have cargo-audit; then ok "cargo-audit $(cargo-audit --version 2>/dev/null | head -n 1)"; else miss "cargo-audit"; hint "cargo install cargo-audit --locked"; fi
+    if have just; then ok "just $(just --version)"; else miss "just"; hint "curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/.cargo/bin"; fi
+    if have git; then ok "git"; else miss "git"; fi
+    if have curl; then ok "curl"; else miss "curl"; fi
+    if have pkg-config; then ok "pkg-config"; else miss "pkg-config"; fi
+    if pkg-config --exists openssl 2>/dev/null || have openssl; then ok "openssl"; else miss "openssl (system libssl)"; fi
+    if have protoc; then ok "protoc"; else miss "protoc"; fi
+    if have clang || have cc; then ok "clang ($({ command -v clang || command -v cc; } 2>/dev/null))"; else miss "clang"; fi
+    if [ "$OS" = "Darwin" ] && [ ! -x "/opt/homebrew/opt/llvm/bin/clang" ]; then miss "homebrew llvm clang (wasm builds)"; hint "brew install llvm"; fi
+    if have docker && docker info >/dev/null 2>&1; then ok "docker"; else miss "docker daemon"; hint "rerun just setup to install Docker (Desktop on macOS, docker.io on Linux), then launch/start it"; fi
+    if have docker && docker info >/dev/null 2>&1; then
+        if docker images -q "$REDIS_IMAGE" 2>/dev/null | grep -q .; then ok "${REDIS_IMAGE} image"; else printf 'note - %s image not cached; testcontainers pulls it on first run\n' "$REDIS_IMAGE"; fi
+    fi
+    if have node; then
+        MAJOR="$(node -v 2>/dev/null | sed 's/^v\([0-9]*\).*/\1/')"
+        if [ -n "$MAJOR" ] && [ "$MAJOR" -ge 18 ]; then ok "node $(node -v)"; else miss "node >= 18 (found $(node -v))"; fi
+    else
+        miss "node >= 18"
+    fi
+    if have npm; then ok "npm"; else miss "npm (ships with node)"; fi
+    if have anvil; then ok "anvil"; else miss "anvil (foundry)"; hint "curl -L https://foundry.paradigm.xyz | bash && foundryup"; fi
+}
+
+check_extended() {
+    if have solana && solana --version 2>/dev/null | grep -q "$SOLANA_VERSION"; then ok "solana $(solana --version)"; else miss "solana ${SOLANA_VERSION}"; fi
+    if have anchor && anchor --version 2>/dev/null | grep -q "$ANCHOR_VERSION"; then ok "anchor $(anchor --version)"; else miss "anchor ${ANCHOR_VERSION}"; hint "cargo install --git https://github.com/coral-xyz/anchor avm --locked && avm install ${ANCHOR_VERSION}"; fi
+    if java -version 2>&1 | grep -q "21"; then ok "java 21"; else miss "java 21 (temurin)"; fi
+    if have dpm; then ok "dpm $(dpm --version 2>/dev/null | head -n 1)"; else miss "dpm (Canton SDK ${CANTON_SDK})"; hint "curl -fsSL https://get.digitalasset.com/install/install.sh | sh && dpm install ${CANTON_SDK}"; fi
+    if have compact; then ok "compact"; else miss "compact launcher 0.5.1 + compactc ${COMPACT_RC}"; hint "see .github/workflows/midnight.yml (Linux pins)"; fi
+}
+
+apt_install() {
+    PKGS=""
+    have curl || PKGS="$PKGS curl"
+    have git || PKGS="$PKGS git"
+    have pkg-config || PKGS="$PKGS pkg-config"
+    pkg-config --exists openssl 2>/dev/null || PKGS="$PKGS libssl-dev"
+    have protoc || PKGS="$PKGS protobuf-compiler"
+    if ! have clang && ! have cc; then PKGS="$PKGS clang"; fi
+    if [ -z "$PKGS" ]; then return 0; fi
+    # shellcheck disable=SC2086
+    sudo apt-get update && sudo apt-get install -y $PKGS
+}
+
+brew_install() {
+    have brew || { miss "homebrew"; hint "/bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""; return 1; }
+    have pkg-config || brew install pkg-config
+    pkg-config --exists openssl 2>/dev/null || brew install openssl@3
+    have protoc || brew install protobuf
+    if [ ! -x "/opt/homebrew/opt/llvm/bin/clang" ]; then brew install llvm; fi
+}
+
+ensure_rust() {
+    if ! have rustup; then curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal; fi
+    # shellcheck disable=SC1091
+    [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+    if ! rustup toolchain list 2>/dev/null | grep -q "^${RUST_VERSION}"; then
+        rustup toolchain install "$RUST_VERSION" --component clippy rustfmt --target "$WASM_TARGET"
+        return 0
+    fi
+    rustup component list --toolchain "$RUST_VERSION" 2>/dev/null | grep -q "clippy.*(installed)" || rustup component add --toolchain "$RUST_VERSION" clippy
+    rustup component list --toolchain "$RUST_VERSION" 2>/dev/null | grep -q "rustfmt.*(installed)" || rustup component add --toolchain "$RUST_VERSION" rustfmt
+    rustup target list --toolchain "$RUST_VERSION" 2>/dev/null | grep -q "${WASM_TARGET} (installed)" || rustup target add --toolchain "$RUST_VERSION" "$WASM_TARGET"
+}
+
+ensure_nextest() {
+    have cargo-nextest && return 0
+    mkdir -p "$HOME/.cargo/bin"
+    case "$OS" in
+        Linux) NEXTEST_OS="linux" ;;
+        Darwin) NEXTEST_OS="mac" ;;
+        *) return 1 ;;
+    esac
+    curl -LsSf "https://get.nexte.st/latest/${NEXTEST_OS}" | tar zxf - -C "$HOME/.cargo/bin"
+}
+
+ensure_cargo_near() {
+    have cargo-near && return 0
+    curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/latest/download/cargo-near-installer.sh | sh
+}
+
+ensure_cargo_audit() {
+    have cargo-audit && return 0
+    cargo install cargo-audit --locked
+}
+
+ensure_foundry() {
+    have anvil && return 0
+    curl -L https://foundry.paradigm.xyz | bash
+    "$HOME/.foundry/bin/foundryup"
+    note_path_dir "$HOME/.foundry/bin"
+}
+
+ensure_node() {
+    if have node; then
+        MAJOR="$(node -v 2>/dev/null | sed 's/^v\([0-9]*\).*/\1/')"
+        if [ -n "$MAJOR" ] && [ "$MAJOR" -ge 18 ]; then return 0; fi
+    fi
+    case "$OS" in
+        Darwin) brew install node ;;
+        Linux) curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - && sudo apt-get install -y nodejs ;;
+        *) return 1 ;;
+    esac
+}
+
+ensure_docker() {
+    if have docker && docker info >/dev/null 2>&1; then return 0; fi
+    case "$OS" in
+        Darwin)
+            if [ ! -d "/Applications/Docker.app" ] && [ ! -d "$HOME/Applications/Docker.app" ]; then brew install --cask docker; fi
+            pgrep -x "Docker" >/dev/null 2>&1 || open -a Docker 2>/dev/null || true
+            printf 'waiting for docker daemon...'
+            i=0
+            while [ "$i" -lt 36 ]; do
+                if docker info >/dev/null 2>&1; then printf ' up\n'; return 0; fi
+                sleep 5
+                printf '.'
+                i=$((i + 1))
+            done
+            printf '\nnote - launch Docker Desktop and re-run\n'
+            return 1
+            ;;
+        Linux)
+            have docker || { sudo apt-get update && sudo apt-get install -y docker.io; }
+            sudo systemctl enable --now docker 2>/dev/null || sudo service docker start 2>/dev/null || true
+            if docker info >/dev/null 2>&1; then return 0; fi
+            printf 'note - start the daemon (sudo systemctl start docker) and ensure your user can reach it\n'
+            return 1
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+ensure_extended() {
+    case "$OS" in
+        Linux) sh -c "$(curl -sSfL "https://release.solana.com/v${SOLANA_VERSION}/solana-install-init-x86_64-unknown-linux-gnu")" ;;
+        Darwin) sh -c "$(curl -sSfL "https://release.solana.com/v${SOLANA_VERSION}/solana-install-init-x86_64-apple-darwin")" ;;
+        *) return 1 ;;
+    esac
+    note_path_dir "$HOME/.local/share/solana/install/active_release/bin"
+    if ! have anchor; then
+        cargo install --git https://github.com/coral-xyz/anchor avm --locked
+        "$HOME/.cargo/bin/avm" install "$ANCHOR_VERSION" || avm install "$ANCHOR_VERSION"
+    fi
+    if ! java -version 2>&1 | grep -q "21"; then
+        case "$OS" in
+            Darwin) brew install --cask temurin@21 ;;
+            Linux) printf 'note - install Temurin 21: https://adoptium.net/installation/linux/\n' ;;
+        esac
+    fi
+    if ! have dpm; then
+        curl -fsSL https://get.digitalasset.com/install/install.sh | sh
+        "$HOME/.dpm/bin/dpm" install "$CANTON_SDK" || dpm install "$CANTON_SDK"
+        note_path_dir "$HOME/.dpm/bin"
+    fi
+    if [ "$OS" = "Linux" ] && ! have compact; then
+        curl --proto '=https' --tlsv1.2 -LsSf --retry 4 -o /tmp/compact-installer.sh https://github.com/midnightntwrk/compact/releases/download/compact-v0.5.1/compact-installer.sh
+        sh /tmp/compact-installer.sh
+        RC_DIR="$HOME/.compact/versions/${COMPACT_RC}/x86_64-unknown-linux-musl"
+        mkdir -p "$RC_DIR"
+        curl -fsSL --retry 4 -o /tmp/compactc-rc.zip "https://github.com/LFDT-Minokawa/compact/releases/download/compactc-v${COMPACT_RC}/compactc_v${COMPACT_RC}_x86_64-unknown-linux-musl.zip"
+        unzip -qo /tmp/compactc-rc.zip -d "$RC_DIR"
+        chmod +x "$RC_DIR"/*
+        compact update "$COMPACT_RC" || ln -sfn "$RC_DIR"/* "$HOME/.compact/bin/"
+        note_path_dir "$HOME/.local/bin"
+        note_path_dir "$HOME/.compact/bin"
+    fi
+}
+
+case "$MODE" in
+    --check)
+        printf 'checking %s dependencies on %s...\n' "$([ "$EXTENDED" = 1 ] && echo core+extended || echo core)" "$OS"
+        check_core
+        [ "$EXTENDED" = 1 ] && check_extended
+        if [ "$FAIL" -gt 0 ]; then printf '%d missing requirement(s)\n' "$FAIL"; exit 1; fi
+        printf 'all requirements met\n'
+        ;;
+    --install)
+        if [ "${SETUP_DEPS_SKIP:-0}" = "1" ]; then printf 'skipping dependency install (SETUP_DEPS_SKIP=1)\n'; exit 0; fi
+        case "$OS" in
+            Linux) apt_install ;;
+            Darwin) brew_install ;;
+            *) printf 'unsupported OS: %s (Linux/macOS only)\n' "$OS"; exit 1 ;;
+        esac
+        ensure_rust
+        ensure_nextest
+        ensure_cargo_near
+        ensure_cargo_audit
+        ensure_node
+        ensure_foundry
+        ensure_docker || true
+        [ "$EXTENDED" = 1 ] && ensure_extended
+        note_path_dir "$HOME/.cargo/bin"
+        printf 'install pass done, re-checking...\n'
+        FAIL=0
+        check_core
+        [ "$EXTENDED" = 1 ] && check_extended
+        if [ "$PATH_HINT" = 1 ]; then hint "export PATH=\"\$HOME/.cargo/bin:\$HOME/.foundry/bin:\$HOME/.local/bin:\$PATH\""; fi
+        if [ "$FAIL" -gt 0 ]; then printf '%d missing requirement(s) remain\n' "$FAIL"; exit 1; fi
+        printf 'all requirements met\n'
+        ;;
+    *)
+        printf 'usage: %s --check|--install [all|extended]\n' "$0"
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
With this change, we now have a single source for invoking all the common commands to build and run tests against our repo. This is so we do not drift from what our CI is telling us. 

## New commands

| Command | What it does |
|---|---|
| `just setup-check [all]` (`sc`) | Verify system deps without installing; `all` adds Solana/Anchor/Java/dpm/Compact |
| `just setup [helios=1] [all]` (`s`) | Install missing deps (auto-skips on CI), then contract wasm + node binary |
| `just build [target] [helios=1]` | `""` workspace · `eth` EVM artifacts · `contract` NEAR wasm · `midnight` TS fixtures · `tests` integration test binaries · `compat` prod-compat binaries |
| `just test-unit [filter]` (`tu`) | Workspace unit tests, no Docker |
| `just test-eth [filter]` (`te`) | Anvil EVM tests (builds EVM artifacts first) |
| `just test-eth-unit` | Hardhat contract unit tests, no anvil |
| `just test-midnight` | Ignored Midnight real-stack stream test |
| `just test-midnight-seam` | Ignored TS/Rust intent-seam differential |
| `just test-canton [filter]` | Canton tests (default stream, `cases::canton` for e2e) |
| `just test-nightly` | Nightly helios suite |
| `just test-compat` | Prod-compat suite (needs `just build compat`) |
| `just lint` | Clippy, mirrors CI |
| `just lint-eth` | Clippy for integration-gated EVM code |
| `just fmt` / `just fmt-check` | Format / check formatting |
| `just ci` (`c`) | `fmt-check` + `lint` + unit tests |
| `just audit` | `cargo-audit`, mirrors CI audit job |
