### PR TITLE
feat(midnight): cache execution outputs in GCS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,12 +1051,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,7 +2061,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper 1.10.1",
  "hyper-util",
@@ -2100,7 +2094,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -2123,7 +2117,7 @@ dependencies = [
  "fastrand 2.3.0",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "mime",
  "multer",
@@ -2208,6 +2202,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -2519,7 +2519,7 @@ dependencies = [
  "hyperlocal",
  "log",
  "pin-project-lite",
- "rustls 0.23.28",
+ "rustls 0.23.43",
  "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -2881,17 +2881,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.1.1",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2991,6 +2990,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -3420,6 +3425,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version 0.4.1",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3578,6 +3592,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -3837,7 +3860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3868,6 +3891,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 dependencies = [
  "tokio",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote 1.0.47",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4073,6 +4127,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -5427,6 +5482,226 @@ dependencies = [
 ]
 
 [[package]]
+name = "google-cloud-auth"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff461519b1a948200f163574be072753bcfb462a323f0eb426629d89872dd685"
+dependencies = [
+ "async-trait",
+ "base64 0.23.1",
+ "bytes",
+ "google-cloud-gax",
+ "hex",
+ "hmac 0.13.0",
+ "http 1.3.1",
+ "jiff",
+ "reqwest 0.13.4",
+ "rustc_version 0.4.1",
+ "rustls 0.23.43",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "time",
+ "tokio",
+ "url 2.5.4",
+]
+
+[[package]]
+name = "google-cloud-gax"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5615cff28ee59cfe52fbb4c11b8b1e77f650296e2ea4f4c2b7757ac6b19e752"
+dependencies = [
+ "bytes",
+ "futures",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "http 1.3.1",
+ "pin-project",
+ "rand 0.10.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "google-cloud-gax-internal"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2766757d877a7a8ac23da9884cb0e3f10ed9b75a0ce59801ce6b19bf9d5819e"
+dependencies = [
+ "bytes",
+ "futures",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "h2 0.4.16",
+ "http 1.3.1",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper 1.10.1",
+ "lazy_static",
+ "opentelemetry 0.32.0",
+ "opentelemetry-semantic-conventions 0.32.1",
+ "opentelemetry_sdk 0.32.1",
+ "percent-encoding 2.3.1",
+ "pin-project",
+ "prost 0.14.4",
+ "prost-types",
+ "reqwest 0.13.4",
+ "rustc_version 0.4.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "tower 0.5.2",
+ "tracing",
+ "tracing-opentelemetry 0.33.0",
+]
+
+[[package]]
+name = "google-cloud-iam-v1"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f962b40234b1531e6ef73f7558871c96e117231e962086c98804323fb8d2c82"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-type",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-longrunning"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c0363c5389ffda2b55cd8a86eef4b19a3481a48467c91dc5d77f626a9572766"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-lro"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47af3deef75c14a2983c430898d960c765bddbcc9f9188ca0563108e9227cfe7"
+dependencies = [
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-longrunning",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "serde",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-rpc"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2162c08a89118130979ba261080e960e44cdcb2d6e2ab8ca9b1da245285d353"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9227f65175fa91a6e41f246797917697efdadfe09dd8ea84ad8b737a71efbd28"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc32c",
+ "futures",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-iam-v1",
+ "google-cloud-longrunning",
+ "google-cloud-lro",
+ "google-cloud-rpc",
+ "google-cloud-type",
+ "google-cloud-wkt",
+ "hex",
+ "http 1.3.1",
+ "http-body 1.1.0",
+ "md5",
+ "percent-encoding 2.3.1",
+ "prost 0.14.4",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url 2.5.4",
+ "uuid",
+]
+
+[[package]]
+name = "google-cloud-type"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63acc3a92a85f96bab021c3a3e29b53bbacc97651e1b524d4c2991960a63eb82"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-wkt"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fccf98cfd5481a5f5a285181ab0c62123d7d47cd2bb7299448440649349e4e7"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.19",
+ "time",
+ "url 2.5.4",
+]
+
+[[package]]
 name = "google-secretmanager1"
 version = "5.0.5+20240621"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5806,7 +6081,7 @@ dependencies = [
  "ssz_types",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.20",
+ "tracing-subscriber 0.3.23",
  "typenum",
  "unsigned-varint",
  "url 2.5.4",
@@ -6002,6 +6277,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "hmac-drbg"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6090,9 +6374,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http 1.3.1",
@@ -6107,7 +6391,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -6155,7 +6439,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6174,7 +6458,7 @@ dependencies = [
  "futures-core",
  "h2 0.4.16",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "httparse",
  "httpdate",
  "itoa",
@@ -6243,7 +6527,7 @@ dependencies = [
  "hyper 1.10.1",
  "hyper-util",
  "log",
- "rustls 0.23.28",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -6304,7 +6588,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "hyper 1.10.1",
  "ipnet",
  "libc",
@@ -6762,7 +7046,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-subscriber 0.3.20",
+ "tracing-subscriber 0.3.23",
  "url 2.5.4",
  "uuid",
 ]
@@ -6914,6 +7198,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "319af585c4c8a6b5552a52b7787a1ab3e4d59df7614190b1f85b9b842488789d"
 dependencies = [
  "proc-macro-crate 3.3.0",
+ "proc-macro2",
+ "quote 1.0.47",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote 1.0.47",
  "syn 2.0.119",
@@ -7093,7 +7413,7 @@ dependencies = [
  "http 1.3.1",
  "jsonrpsee-core 0.24.10",
  "pin-project",
- "rustls 0.23.28",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "rustls-platform-verifier 0.5.2",
  "soketto 0.8.1",
@@ -7144,7 +7464,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "jsonrpsee-types 0.24.10",
  "parking_lot 0.12.5",
@@ -7186,13 +7506,13 @@ checksum = "f50c389d6e6a52eb7c3548a6600c90cf74d9b71cb5912209833f00a5479e9a01"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "hyper 1.10.1",
  "hyper-rustls 0.27.5",
  "hyper-util",
  "jsonrpsee-core 0.24.10",
  "jsonrpsee-types 0.24.10",
- "rustls 0.23.28",
+ "rustls 0.23.43",
  "rustls-platform-verifier 0.5.2",
  "serde",
  "serde_json",
@@ -7244,7 +7564,7 @@ checksum = "21429bcdda37dcf2d43b68621b994adede0e28061f816b038b0f18c70c143d51"
 dependencies = [
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper 1.10.1",
  "hyper-util",
@@ -8063,6 +8383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8327,7 +8653,7 @@ dependencies = [
  "sha2 0.11.0",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.20",
+ "tracing-subscriber 0.3.23",
  "zeroize",
 ]
 
@@ -8699,6 +9025,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8736,7 +9072,7 @@ dependencies = [
  "colored",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper 1.10.1",
  "hyper-util",
@@ -8822,7 +9158,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-subscriber 0.3.20",
+ "tracing-subscriber 0.3.23",
  "url 2.5.4",
 ]
 
@@ -8876,6 +9212,9 @@ dependencies = [
  "alloy",
  "anyhow",
  "async-trait",
+ "bytes",
+ "google-cloud-auth",
+ "google-cloud-storage",
  "hex",
  "jsonrpsee 0.24.10",
  "k256",
@@ -8887,6 +9226,7 @@ dependencies = [
  "midnight-serialize",
  "midnight-storage",
  "midnight-transient-crypto 3.0.0",
+ "mockito",
  "mpc-chain-integration-core",
  "mpc-crypto",
  "mpc-primitives",
@@ -8948,7 +9288,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-subscriber 0.3.20",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -9084,7 +9424,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry 0.30.0",
  "tracing-stackdriver",
- "tracing-subscriber 0.3.20",
+ "tracing-subscriber 0.3.23",
  "url 2.5.4",
 ]
 
@@ -9463,7 +9803,7 @@ dependencies = [
  "near-primitives-core",
  "opentelemetry 0.30.0",
  "opentelemetry-otlp 0.30.0",
- "opentelemetry-semantic-conventions",
+ "opentelemetry-semantic-conventions 0.30.0",
  "opentelemetry_sdk 0.30.0",
  "prometheus 0.14.0",
  "serde",
@@ -9472,7 +9812,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry 0.31.0",
- "tracing-subscriber 0.3.20",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -10465,6 +10805,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.19",
+ "tracing",
+]
+
+[[package]]
 name = "opentelemetry-appender-tracing"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10473,7 +10827,7 @@ dependencies = [
  "opentelemetry 0.29.1",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.20",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -10502,7 +10856,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto 0.29.0",
  "opentelemetry_sdk 0.29.0",
- "prost",
+ "prost 0.13.5",
  "reqwest 0.12.28",
  "thiserror 2.0.19",
  "tracing",
@@ -10518,7 +10872,7 @@ dependencies = [
  "opentelemetry 0.30.0",
  "opentelemetry-proto 0.30.0",
  "opentelemetry_sdk 0.30.0",
- "prost",
+ "prost 0.13.5",
  "thiserror 2.0.19",
  "tokio",
  "tonic 0.13.1",
@@ -10532,7 +10886,7 @@ checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
 dependencies = [
  "opentelemetry 0.29.1",
  "opentelemetry_sdk 0.29.0",
- "prost",
+ "prost 0.13.5",
  "tonic 0.12.3",
 ]
 
@@ -10544,7 +10898,7 @@ checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
 dependencies = [
  "opentelemetry 0.30.0",
  "opentelemetry_sdk 0.30.0",
- "prost",
+ "prost 0.13.5",
  "tonic 0.13.1",
 ]
 
@@ -10553,6 +10907,12 @@ name = "opentelemetry-semantic-conventions"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -10589,6 +10949,22 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.32.0",
+ "percent-encoding 2.3.1",
+ "portable-atomic",
+ "rand 0.9.5",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -10921,18 +11297,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",
@@ -11102,6 +11478,15 @@ name = "portable-atomic"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "postcard"
@@ -11393,7 +11778,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -11407,6 +11802,28 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.47",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote 1.0.47",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -11510,7 +11927,7 @@ dependencies = [
  "quinn-proto 0.11.14",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.28",
+ "rustls 0.23.43",
  "socket2 0.6.4",
  "thiserror 2.0.19",
  "tokio",
@@ -11550,7 +11967,7 @@ dependencies = [
  "rand 0.9.5",
  "ring 0.17.14",
  "rustc-hash 2.1.1",
- "rustls 0.23.28",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "rustls-platform-verifier 0.6.2",
  "slab",
@@ -11968,7 +12385,7 @@ dependencies = [
  "h2 0.4.16",
  "hickory-resolver",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper 1.10.1",
  "hyper-rustls 0.27.5",
@@ -11982,7 +12399,7 @@ dependencies = [
  "percent-encoding 2.3.1",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.28",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -12012,21 +12429,23 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper 1.10.1",
  "hyper-rustls 0.27.5",
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding 2.3.1",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.28",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "rustls-platform-verifier 0.6.2",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -12599,9 +13018,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -12689,7 +13108,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.28",
+ "rustls 0.23.43",
  "rustls-native-certs 0.8.1",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.12",
@@ -12710,7 +13129,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.28",
+ "rustls 0.23.43",
  "rustls-native-certs 0.8.1",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.12",
@@ -15102,7 +15521,7 @@ dependencies = [
  "log",
  "quinn",
  "quinn-proto 0.11.14",
- "rustls 0.23.28",
+ "rustls 0.23.43",
  "solana-connection-cache",
  "solana-keypair",
  "solana-measure",
@@ -15639,7 +16058,7 @@ dependencies = [
  "quinn",
  "quinn-proto 0.11.14",
  "rand 0.8.5",
- "rustls 0.23.28",
+ "rustls 0.23.43",
  "smallvec",
  "socket2 0.5.10",
  "solana-keypair",
@@ -15787,7 +16206,7 @@ version = "2.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14494aa87a75a883d1abcfee00f1278a28ecc594a2f030084879eb40570728f6"
 dependencies = [
- "rustls 0.23.28",
+ "rustls 0.23.43",
  "solana-keypair",
  "solana-pubkey",
  "solana-signer",
@@ -16338,7 +16757,7 @@ dependencies = [
  "regex",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.20",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -17408,7 +17827,7 @@ checksum = "e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f"
 dependencies = [
  "env_logger 0.11.8",
  "test-log-macros",
- "tracing-subscriber 0.3.20",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -17662,7 +18081,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.28",
+ "rustls 0.23.43",
  "tokio",
 ]
 
@@ -17797,11 +18216,11 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "percent-encoding 2.3.1",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "tokio-stream",
  "tower-layer",
  "tower-service",
@@ -17818,20 +18237,58 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper 1.10.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding 2.3.1",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "tokio",
  "tokio-stream",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "http 1.3.1",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding 2.3.1",
+ "pin-project",
+ "rustls-native-certs 0.8.1",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost 0.14.4",
+ "tonic 0.14.6",
 ]
 
 [[package]]
@@ -17880,7 +18337,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "pin-project-lite",
  "tokio",
@@ -17905,9 +18362,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -17925,14 +18382,14 @@ dependencies = [
  "symlink",
  "thiserror 2.0.19",
  "time",
- "tracing-subscriber 0.3.20",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",
@@ -17941,9 +18398,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -17974,7 +18431,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber 0.3.20",
+ "tracing-subscriber 0.3.23",
  "web-time",
 ]
 
@@ -17992,7 +18449,21 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber 0.3.20",
+ "tracing-subscriber 0.3.23",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry 0.32.0",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.3.23",
  "web-time",
 ]
 
@@ -18018,7 +18489,7 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
  "tracing-core",
- "tracing-subscriber 0.3.20",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -18032,9 +18503,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -18206,7 +18677,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.7",
  "rand 0.8.5",
  "static_assertions",
@@ -18274,6 +18745,12 @@ checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"
@@ -18380,7 +18857,7 @@ dependencies = [
  "cookie_store",
  "log",
  "percent-encoding 2.3.1",
- "rustls 0.23.28",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -18466,11 +18943,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/chain-signatures/chain-midnight/Cargo.toml
+++ b/chain-signatures/chain-midnight/Cargo.toml
@@ -9,6 +9,9 @@ alloy.workspace = true
 # TODO: replace with thiserror
 anyhow.workspace = true
 async-trait.workspace = true
+bytes = "1"
+google-cloud-storage = "=1.17.0"
+google-cloud-auth = { version = "1.15", default-features = false, optional = true }
 hex.workspace = true
 jsonrpsee = { version = "0.24.10", features = ["http-client"] }
 k256.workspace = true
@@ -36,8 +39,10 @@ url.workspace = true
 
 [features]
 # Gate for the node-readiness probe integration-tests use to bring up a sandbox.
-sandbox = []
+sandbox = ["dep:google-cloud-auth"]
 
 [dev-dependencies]
+google-cloud-auth = { version = "1.15", default-features = false }
+mockito.workspace = true
 jsonrpsee = { version = "0.24.10", features = ["server"] }
 tokio = { workspace = true, features = ["test-util"] }

--- a/chain-signatures/chain-midnight/src/config.rs
+++ b/chain-signatures/chain-midnight/src/config.rs
@@ -57,6 +57,13 @@ impl Default for IndexerConfig {
 /// Runs the out-of-process intent builder, the piece that stays TypeScript for its proving stack.
 #[derive(Clone, PartialEq)]
 pub struct PublisherConfig {
+    /// Optional GCS bucket; when absent, final responses only publish on-chain.
+    pub output_storage_bucket: Option<String>,
+    /// Object namespace; use a distinct prefix for deployments that reset chain state.
+    pub output_storage_prefix: String,
+    pub output_storage_timeout: Duration,
+    #[cfg(feature = "sandbox")]
+    pub output_storage_emulator_endpoint: Option<String>,
     /// argv of the builder, program first: a list so no operator path is word-split.
     pub intent_gen_command: Vec<String>,
     /// Funds respond transactions.
@@ -77,6 +84,11 @@ pub struct PublisherConfig {
 impl Default for PublisherConfig {
     fn default() -> Self {
         Self {
+            output_storage_bucket: None,
+            output_storage_prefix: "v1".to_string(),
+            output_storage_timeout: Duration::from_secs(30),
+            #[cfg(feature = "sandbox")]
+            output_storage_emulator_endpoint: None,
             // The `bin` name the TypeScript package installs, resolved on the fixed child PATH.
             intent_gen_command: vec!["midnight-publisher".to_string()],
             funding_seed: String::new(),
@@ -102,6 +114,9 @@ impl Default for PublisherConfig {
 impl fmt::Debug for PublisherConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PublisherConfig")
+            .field("output_storage_bucket", &self.output_storage_bucket)
+            .field("output_storage_prefix", &self.output_storage_prefix)
+            .field("output_storage_timeout", &self.output_storage_timeout)
             .field("intent_gen_command", &self.intent_gen_command)
             .field("funding_seed", &"<redacted>")
             .field("proof_server_url", &self.proof_server_url)
@@ -167,6 +182,28 @@ impl MidnightConfig {
 }
 
 impl PublisherConfig {
+    pub fn validate_output_storage(&self) -> anyhow::Result<()> {
+        if let Some(bucket) = &self.output_storage_bucket {
+            anyhow::ensure!(
+                !bucket.trim().is_empty(),
+                "midnight config: publisher.output_storage_bucket must not be empty"
+            );
+        }
+        anyhow::ensure!(
+            !self
+                .output_storage_prefix
+                .trim_matches('/')
+                .trim()
+                .is_empty(),
+            "midnight config: publisher.output_storage_prefix is required"
+        );
+        anyhow::ensure!(
+            !self.output_storage_timeout.is_zero(),
+            "midnight config: publisher.output_storage_timeout must be greater than zero"
+        );
+        Ok(())
+    }
+
     fn validate(&self) -> anyhow::Result<()> {
         let program = self
             .intent_gen_command

--- a/chain-signatures/chain-midnight/src/config.rs
+++ b/chain-signatures/chain-midnight/src/config.rs
@@ -113,10 +113,17 @@ impl Default for PublisherConfig {
 /// than skipped, so a later `derive(Debug)` cannot silently restore the leak.
 impl fmt::Debug for PublisherConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PublisherConfig")
+        let mut debug = f.debug_struct("PublisherConfig");
+        debug
             .field("output_storage_bucket", &self.output_storage_bucket)
             .field("output_storage_prefix", &self.output_storage_prefix)
-            .field("output_storage_timeout", &self.output_storage_timeout)
+            .field("output_storage_timeout", &self.output_storage_timeout);
+        #[cfg(feature = "sandbox")]
+        debug.field(
+            "output_storage_emulator_endpoint",
+            &self.output_storage_emulator_endpoint,
+        );
+        debug
             .field("intent_gen_command", &self.intent_gen_command)
             .field("funding_seed", &"<redacted>")
             .field("proof_server_url", &self.proof_server_url)
@@ -205,6 +212,7 @@ impl PublisherConfig {
     }
 
     fn validate(&self) -> anyhow::Result<()> {
+        self.validate_output_storage()?;
         let program = self
             .intent_gen_command
             .first()
@@ -360,9 +368,75 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "sandbox")]
+    #[test]
+    fn debug_includes_the_output_storage_emulator_endpoint_without_exposing_the_funding_seed() {
+        let seed = "0123456789abcdef0123456789abcdef";
+        let endpoint = "http://127.0.0.1:4443";
+        let mut config = valid_config();
+        config.publisher.funding_seed = seed.to_string();
+        config.publisher.output_storage_emulator_endpoint = Some(endpoint.to_string());
+
+        let rendered = format!("{config:?}");
+        assert!(
+            rendered.contains("output_storage_emulator_endpoint"),
+            "the sandbox-only field is missing from Debug: {rendered}"
+        );
+        assert!(
+            rendered.contains(endpoint),
+            "the emulator endpoint is missing from Debug: {rendered}"
+        );
+        assert!(
+            !rendered.contains(seed),
+            "the funding seed reached Debug: {rendered}"
+        );
+        assert!(
+            rendered.contains("<redacted>"),
+            "the funding seed must remain visibly redacted: {rendered}"
+        );
+    }
+
     #[test]
     fn a_complete_config_validates() {
         valid_config().validate().expect("every field is valid");
+    }
+
+    #[test]
+    fn output_storage_settings_are_validated_from_the_top_level() {
+        valid_config()
+            .validate()
+            .expect("output storage is optional by default");
+
+        let mut configured = valid_config();
+        configured.publisher.output_storage_bucket = Some("outputs".to_string());
+        configured.publisher.output_storage_prefix = "v1/test-deployment".to_string();
+        configured.publisher.output_storage_timeout = Duration::from_secs(1);
+        configured
+            .validate()
+            .expect("configured output storage is valid");
+
+        for (field, apply) in [
+            (
+                "output_storage_bucket",
+                (|config: &mut MidnightConfig| {
+                    config.publisher.output_storage_bucket = Some(" ".to_string());
+                }) as fn(&mut MidnightConfig),
+            ),
+            ("output_storage_prefix", |config: &mut MidnightConfig| {
+                config.publisher.output_storage_prefix = String::new();
+            }),
+            ("output_storage_timeout", |config: &mut MidnightConfig| {
+                config.publisher.output_storage_timeout = Duration::ZERO;
+            }),
+        ] {
+            let mut invalid = valid_config();
+            apply(&mut invalid);
+            let error = invalid.validate().unwrap_err().to_string();
+            assert!(
+                error.contains(field),
+                "unexpected error for {field}: {error}"
+            );
+        }
     }
 
     #[test]

--- a/chain-signatures/chain-midnight/src/config.rs
+++ b/chain-signatures/chain-midnight/src/config.rs
@@ -54,16 +54,49 @@ impl Default for IndexerConfig {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct OutputStorageConfig {
+    pub bucket: String,
+    /// Object namespace; use a distinct prefix for deployments that reset chain state.
+    pub prefix: String,
+    pub timeout: Duration,
+    #[cfg(feature = "sandbox")]
+    pub emulator_endpoint: Option<String>,
+}
+
+impl OutputStorageConfig {
+    pub fn new(bucket: String, prefix: String, timeout: Duration) -> Self {
+        Self {
+            bucket,
+            prefix,
+            timeout,
+            #[cfg(feature = "sandbox")]
+            emulator_endpoint: None,
+        }
+    }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !self.bucket.trim().is_empty(),
+            "midnight config: publisher.output_storage.bucket must not be empty"
+        );
+        anyhow::ensure!(
+            !self.prefix.trim_matches('/').trim().is_empty(),
+            "midnight config: publisher.output_storage.prefix is required"
+        );
+        anyhow::ensure!(
+            !self.timeout.is_zero(),
+            "midnight config: publisher.output_storage.timeout must be greater than zero"
+        );
+        Ok(())
+    }
+}
+
 /// Runs the out-of-process intent builder, the piece that stays TypeScript for its proving stack.
 #[derive(Clone, PartialEq)]
 pub struct PublisherConfig {
-    /// Optional GCS bucket; when absent, final responses only publish on-chain.
-    pub output_storage_bucket: Option<String>,
-    /// Object namespace; use a distinct prefix for deployments that reset chain state.
-    pub output_storage_prefix: String,
-    pub output_storage_timeout: Duration,
-    #[cfg(feature = "sandbox")]
-    pub output_storage_emulator_endpoint: Option<String>,
+    /// When absent, final responses only publish on-chain.
+    pub output_storage: Option<OutputStorageConfig>,
     /// argv of the builder, program first: a list so no operator path is word-split.
     pub intent_gen_command: Vec<String>,
     /// Funds respond transactions.
@@ -84,11 +117,7 @@ pub struct PublisherConfig {
 impl Default for PublisherConfig {
     fn default() -> Self {
         Self {
-            output_storage_bucket: None,
-            output_storage_prefix: "v1".to_string(),
-            output_storage_timeout: Duration::from_secs(30),
-            #[cfg(feature = "sandbox")]
-            output_storage_emulator_endpoint: None,
+            output_storage: None,
             // The `bin` name the TypeScript package installs, resolved on the fixed child PATH.
             intent_gen_command: vec!["midnight-publisher".to_string()],
             funding_seed: String::new(),
@@ -113,17 +142,8 @@ impl Default for PublisherConfig {
 /// than skipped, so a later `derive(Debug)` cannot silently restore the leak.
 impl fmt::Debug for PublisherConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut debug = f.debug_struct("PublisherConfig");
-        debug
-            .field("output_storage_bucket", &self.output_storage_bucket)
-            .field("output_storage_prefix", &self.output_storage_prefix)
-            .field("output_storage_timeout", &self.output_storage_timeout);
-        #[cfg(feature = "sandbox")]
-        debug.field(
-            "output_storage_emulator_endpoint",
-            &self.output_storage_emulator_endpoint,
-        );
-        debug
+        f.debug_struct("PublisherConfig")
+            .field("output_storage", &self.output_storage)
             .field("intent_gen_command", &self.intent_gen_command)
             .field("funding_seed", &"<redacted>")
             .field("proof_server_url", &self.proof_server_url)
@@ -190,24 +210,9 @@ impl MidnightConfig {
 
 impl PublisherConfig {
     pub fn validate_output_storage(&self) -> anyhow::Result<()> {
-        if let Some(bucket) = &self.output_storage_bucket {
-            anyhow::ensure!(
-                !bucket.trim().is_empty(),
-                "midnight config: publisher.output_storage_bucket must not be empty"
-            );
+        if let Some(config) = &self.output_storage {
+            config.validate()?;
         }
-        anyhow::ensure!(
-            !self
-                .output_storage_prefix
-                .trim_matches('/')
-                .trim()
-                .is_empty(),
-            "midnight config: publisher.output_storage_prefix is required"
-        );
-        anyhow::ensure!(
-            !self.output_storage_timeout.is_zero(),
-            "midnight config: publisher.output_storage_timeout must be greater than zero"
-        );
         Ok(())
     }
 
@@ -375,11 +380,14 @@ mod tests {
         let endpoint = "http://127.0.0.1:4443";
         let mut config = valid_config();
         config.publisher.funding_seed = seed.to_string();
-        config.publisher.output_storage_emulator_endpoint = Some(endpoint.to_string());
+        config.publisher.output_storage = Some(OutputStorageConfig {
+            emulator_endpoint: Some(endpoint.to_string()),
+            ..OutputStorageConfig::new("outputs".into(), "v1".into(), Duration::from_secs(30))
+        });
 
         let rendered = format!("{config:?}");
         assert!(
-            rendered.contains("output_storage_emulator_endpoint"),
+            rendered.contains("emulator_endpoint"),
             "the sandbox-only field is missing from Debug: {rendered}"
         );
         assert!(
@@ -408,29 +416,37 @@ mod tests {
             .expect("output storage is optional by default");
 
         let mut configured = valid_config();
-        configured.publisher.output_storage_bucket = Some("outputs".to_string());
-        configured.publisher.output_storage_prefix = "v1/test-deployment".to_string();
-        configured.publisher.output_storage_timeout = Duration::from_secs(1);
+        configured.publisher.output_storage = Some(OutputStorageConfig::new(
+            "outputs".into(),
+            "v1/test-deployment".into(),
+            Duration::from_secs(1),
+        ));
         configured
             .validate()
             .expect("configured output storage is valid");
 
         for (field, apply) in [
             (
-                "output_storage_bucket",
-                (|config: &mut MidnightConfig| {
-                    config.publisher.output_storage_bucket = Some(" ".to_string());
-                }) as fn(&mut MidnightConfig),
+                "output_storage.bucket",
+                (|config: &mut OutputStorageConfig| {
+                    config.bucket = " ".to_string();
+                }) as fn(&mut OutputStorageConfig),
             ),
-            ("output_storage_prefix", |config: &mut MidnightConfig| {
-                config.publisher.output_storage_prefix = String::new();
-            }),
-            ("output_storage_timeout", |config: &mut MidnightConfig| {
-                config.publisher.output_storage_timeout = Duration::ZERO;
-            }),
+            (
+                "output_storage.prefix",
+                |config: &mut OutputStorageConfig| {
+                    config.prefix = String::new();
+                },
+            ),
+            (
+                "output_storage.timeout",
+                |config: &mut OutputStorageConfig| {
+                    config.timeout = Duration::ZERO;
+                },
+            ),
         ] {
-            let mut invalid = valid_config();
-            apply(&mut invalid);
+            let mut invalid = configured.clone();
+            apply(invalid.publisher.output_storage.as_mut().unwrap());
             let error = invalid.validate().unwrap_err().to_string();
             assert!(
                 error.contains(field),

--- a/chain-signatures/chain-midnight/src/lib.rs
+++ b/chain-signatures/chain-midnight/src/lib.rs
@@ -10,6 +10,7 @@ pub mod emissions;
 mod hashing;
 mod indexer;
 mod intent_gen;
+mod output_storage;
 mod publisher;
 mod reader;
 pub mod records;

--- a/chain-signatures/chain-midnight/src/lib.rs
+++ b/chain-signatures/chain-midnight/src/lib.rs
@@ -21,7 +21,9 @@ mod state;
 mod test_utils;
 mod tx;
 
-pub use config::{IndexerConfig, MidnightAddress, MidnightConfig, PublisherConfig, RpcConfig};
+pub use config::{
+    IndexerConfig, MidnightAddress, MidnightConfig, OutputStorageConfig, PublisherConfig, RpcConfig,
+};
 pub use indexer::MidnightIndexer;
 pub use intent_gen::{IntentGen, IntentRequest, WirePoint, WireSignature};
 pub use publisher::MidnightPublisher;

--- a/chain-signatures/chain-midnight/src/output_storage.rs
+++ b/chain-signatures/chain-midnight/src/output_storage.rs
@@ -1,0 +1,315 @@
+use std::time::Duration;
+
+use anyhow::Context as _;
+use async_trait::async_trait;
+use bytes::Bytes;
+use google_cloud_storage::client::Storage;
+
+use crate::config::{MidnightAddress, PublisherConfig};
+
+#[async_trait]
+pub(crate) trait OutputStore: Send + Sync {
+    async fn ensure_output(&self, request_id: &[u8; 32], output: &[u8]) -> anyhow::Result<()>;
+}
+
+pub(crate) struct GcsOutputStore {
+    client: Storage,
+    bucket: String,
+    prefix: String,
+    timeout: Duration,
+}
+
+impl GcsOutputStore {
+    pub(crate) async fn connect(
+        config: &PublisherConfig,
+        network_id: &str,
+        central_address: MidnightAddress,
+    ) -> anyhow::Result<Option<Self>> {
+        config.validate_output_storage()?;
+        if config.output_storage_bucket.is_none() {
+            return Ok(None);
+        }
+        #[cfg(feature = "sandbox")]
+        if let Some(endpoint) = &config.output_storage_emulator_endpoint {
+            return Self::connect_emulator(config, network_id, central_address, endpoint)
+                .await
+                .map(Some);
+        }
+        let client = Storage::builder().build().await?;
+        Self::new(config, network_id, central_address, client).map(Some)
+    }
+
+    #[cfg(feature = "sandbox")]
+    async fn connect_emulator(
+        config: &PublisherConfig,
+        network_id: &str,
+        central_address: MidnightAddress,
+        endpoint: &str,
+    ) -> anyhow::Result<Self> {
+        let client = Storage::builder()
+            .with_endpoint(endpoint)
+            .with_credentials(google_cloud_auth::credentials::anonymous::Builder::new().build())
+            .build()
+            .await?;
+        Self::new(config, network_id, central_address, client)
+    }
+
+    pub(crate) fn new(
+        config: &PublisherConfig,
+        network_id: &str,
+        central_address: MidnightAddress,
+        client: Storage,
+    ) -> anyhow::Result<Self> {
+        config.validate_output_storage()?;
+        Ok(Self {
+            client,
+            bucket: format!(
+                "projects/_/buckets/{}",
+                config
+                    .output_storage_bucket
+                    .as_deref()
+                    .context("GCS output storage requires a bucket")?
+            ),
+            prefix: format!(
+                "{}/{}/{}",
+                config.output_storage_prefix.trim_matches('/'),
+                network_id,
+                central_address.to_hex(),
+            ),
+            timeout: config.output_storage_timeout,
+        })
+    }
+
+    async fn upload(&self, object: &str, output: &[u8]) -> anyhow::Result<()> {
+        let result = self
+            .client
+            .write_object(&self.bucket, object, Bytes::copy_from_slice(output))
+            .set_content_type("application/octet-stream")
+            .set_if_generation_match(0)
+            .send_unbuffered()
+            .await;
+        match result {
+            Ok(_) => Ok(()),
+            Err(error) if error.http_status_code() == Some(412) => {
+                // A lost upload reply or another publisher can create this object first.
+                // Only identical bytes satisfy the precondition for publishing on-chain.
+                let mut response = self.client.read_object(&self.bucket, object).send().await?;
+                let mut offset = 0;
+                while let Some(chunk) = response.next().await.transpose()? {
+                    let end = offset + chunk.len();
+                    anyhow::ensure!(
+                        output.get(offset..end) == Some(chunk.as_ref()),
+                        "stored Midnight output differs from the attested bytes"
+                    );
+                    offset = end;
+                }
+                anyhow::ensure!(
+                    offset == output.len(),
+                    "stored Midnight output is truncated"
+                );
+                Ok(())
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+}
+
+#[async_trait]
+impl OutputStore for GcsOutputStore {
+    async fn ensure_output(&self, request_id: &[u8; 32], output: &[u8]) -> anyhow::Result<()> {
+        let object = format!("{}/{}.bin", self.prefix, hex::encode(request_id));
+        let result = tokio::time::timeout(self.timeout, self.upload(&object, output))
+            .await
+            .context("Midnight output upload timed out")
+            .and_then(|result| result);
+        if let Err(error) = &result {
+            tracing::error!(%object, ?error, "Midnight output is unavailable; withholding on-chain response");
+        }
+        // The shared RPC retry policy inspects the outer error's text for HTTP codes.
+        // Keep all storage failures pending, retaining provider details in the cause.
+        result.context("Midnight output storage unavailable")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use google_cloud_auth::credentials::anonymous;
+    use mockito::{Matcher, Server};
+
+    const REQUEST_ID: [u8; 32] = [0x5c; 32];
+
+    async fn store(server: &Server) -> GcsOutputStore {
+        let client = Storage::builder()
+            .with_endpoint(server.url())
+            .with_credentials(anonymous::Builder::new().build())
+            .build()
+            .await
+            .unwrap();
+        GcsOutputStore::new(
+            &PublisherConfig {
+                output_storage_bucket: Some("outputs".into()),
+                output_storage_prefix: "v1/test-deployment".into(),
+                output_storage_timeout: Duration::from_secs(2),
+                ..Default::default()
+            },
+            "preprod",
+            MidnightAddress::from_bytes([0xab; 32]),
+            client,
+        )
+        .unwrap()
+    }
+
+    fn object_name() -> String {
+        format!(
+            "v1/test-deployment/preprod/{}/{}.bin",
+            "ab".repeat(32),
+            "5c".repeat(32)
+        )
+    }
+
+    fn upload(server: &mut Server) -> mockito::Mock {
+        server
+            .mock("POST", "/upload/storage/v1/b/outputs/o")
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("name".into(), object_name()),
+                Matcher::UrlEncoded("ifGenerationMatch".into(), "0".into()),
+                Matcher::UrlEncoded("uploadType".into(), "multipart".into()),
+            ]))
+    }
+
+    fn download(server: &mut Server) -> mockito::Mock {
+        let encoded: String =
+            url::form_urlencoded::byte_serialize(object_name().as_bytes()).collect();
+        server
+            .mock("GET", format!("/storage/v1/b/outputs/o/{encoded}").as_str())
+            .match_query(Matcher::UrlEncoded("alt".into(), "media".into()))
+            .with_header("x-goog-generation", "1")
+    }
+
+    #[tokio::test]
+    async fn uploads_exact_binary_output_at_the_request_location() {
+        let mut server = Server::new_async().await;
+        let store = store(&server).await;
+        let output = [0, 0xff, 0xde, 0xad, 0xbe, 0xef, 1, 0];
+        let write = upload(&mut server)
+            .match_request(move |request| {
+                let headers = request.header("content-type");
+                let boundary = headers[0]
+                    .to_str()
+                    .unwrap()
+                    .split("boundary=")
+                    .nth(1)
+                    .unwrap();
+                let suffix = [
+                    b"\r\n\r\n".as_slice(),
+                    &output,
+                    format!("\r\n--{boundary}--\r\n").as_bytes(),
+                ]
+                .concat();
+                request.body().unwrap().ends_with(&suffix)
+            })
+            .with_status(200)
+            .with_body(r#"{"bucket":"outputs","generation":"1"}"#)
+            .create_async()
+            .await;
+        store.ensure_output(&REQUEST_ID, &output).await.unwrap();
+        write.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn an_existing_object_must_match_every_byte() {
+        let mut server = Server::new_async().await;
+        let store = store(&server).await;
+        let write = upload(&mut server)
+            .with_status(412)
+            .expect(5)
+            .create_async()
+            .await;
+        for (existing, output, accepted) in [
+            (vec![0, 255, 0], vec![0, 255, 0], true),
+            (vec![], vec![], true),
+            (vec![0, 255, 0], vec![0, 254, 0], false),
+            (vec![0, 255], vec![0, 255, 0], false),
+            (vec![0, 255, 0, 0], vec![0, 255, 0], false),
+        ] {
+            let read = download(&mut server)
+                .with_status(200)
+                .with_body(existing)
+                .create_async()
+                .await;
+            let result = store.ensure_output(&REQUEST_ID, &output).await;
+            assert_eq!(result.is_ok(), accepted, "{result:#?}");
+            read.assert_async().await;
+            read.remove_async().await;
+        }
+        write.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn storage_errors_keep_the_response_retryable() {
+        let mut server = Server::new_async().await;
+        let store = store(&server).await;
+        let write = upload(&mut server).with_status(403).create_async().await;
+        let error = store.ensure_output(&REQUEST_ID, &[1]).await.unwrap_err();
+        assert!(mpc_chain_integration_core::utils::retry::is_retryable(
+            &error
+        ));
+        assert!(format!("{error:#}").contains("403"));
+        write.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn an_unresponsive_store_is_bounded_by_the_upload_budget() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let client = Storage::builder()
+            .with_endpoint(format!("http://{}", listener.local_addr().unwrap()))
+            .with_credentials(anonymous::Builder::new().build())
+            .build()
+            .await
+            .unwrap();
+        let store = GcsOutputStore::new(
+            &PublisherConfig {
+                output_storage_bucket: Some("outputs".into()),
+                output_storage_timeout: Duration::from_millis(100),
+                ..Default::default()
+            },
+            "preprod",
+            MidnightAddress::from_bytes([0xab; 32]),
+            client,
+        )
+        .unwrap();
+        let error = store.ensure_output(&REQUEST_ID, &[1]).await.unwrap_err();
+        assert!(format!("{error:#}").contains("timed out"));
+        assert!(mpc_chain_integration_core::utils::retry::is_retryable(
+            &error
+        ));
+    }
+
+    #[tokio::test]
+    async fn no_bucket_disables_storage_before_client_initialization() {
+        let store = GcsOutputStore::connect(
+            &PublisherConfig::default(),
+            "preprod",
+            MidnightAddress::from_bytes([0xab; 32]),
+        )
+        .await
+        .unwrap();
+        assert!(store.is_none());
+    }
+
+    #[test]
+    fn output_storage_configuration_rejects_empty_buckets_and_invalid_tuning() {
+        let mut config = PublisherConfig::default();
+        config.validate_output_storage().unwrap();
+        config.output_storage_bucket = Some(" ".into());
+        assert!(config.validate_output_storage().is_err());
+        config.output_storage_bucket = Some("outputs".into());
+        config.validate_output_storage().unwrap();
+        config.output_storage_timeout = Duration::ZERO;
+        assert!(config.validate_output_storage().is_err());
+        config.output_storage_timeout = Duration::from_secs(1);
+        config.output_storage_prefix = String::new();
+        assert!(config.validate_output_storage().is_err());
+    }
+}

--- a/chain-signatures/chain-midnight/src/output_storage.rs
+++ b/chain-signatures/chain-midnight/src/output_storage.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use google_cloud_storage::client::Storage;
 
-use crate::config::{MidnightAddress, PublisherConfig};
+use crate::config::{MidnightAddress, OutputStorageConfig};
 
 #[async_trait]
 pub(crate) trait OutputStore: Send + Sync {
@@ -21,16 +21,16 @@ pub(crate) struct GcsOutputStore {
 
 impl GcsOutputStore {
     pub(crate) async fn connect(
-        config: &PublisherConfig,
+        config: Option<&OutputStorageConfig>,
         network_id: &str,
         central_address: MidnightAddress,
     ) -> anyhow::Result<Option<Self>> {
-        config.validate_output_storage()?;
-        if config.output_storage_bucket.is_none() {
+        let Some(config) = config else {
             return Ok(None);
-        }
+        };
+        config.validate()?;
         #[cfg(feature = "sandbox")]
-        if let Some(endpoint) = &config.output_storage_emulator_endpoint {
+        if let Some(endpoint) = &config.emulator_endpoint {
             return Self::connect_emulator(config, network_id, central_address, endpoint)
                 .await
                 .map(Some);
@@ -41,7 +41,7 @@ impl GcsOutputStore {
 
     #[cfg(feature = "sandbox")]
     async fn connect_emulator(
-        config: &PublisherConfig,
+        config: &OutputStorageConfig,
         network_id: &str,
         central_address: MidnightAddress,
         endpoint: &str,
@@ -55,28 +55,22 @@ impl GcsOutputStore {
     }
 
     pub(crate) fn new(
-        config: &PublisherConfig,
+        config: &OutputStorageConfig,
         network_id: &str,
         central_address: MidnightAddress,
         client: Storage,
     ) -> anyhow::Result<Self> {
-        config.validate_output_storage()?;
+        config.validate()?;
         Ok(Self {
             client,
-            bucket: format!(
-                "projects/_/buckets/{}",
-                config
-                    .output_storage_bucket
-                    .as_deref()
-                    .context("GCS output storage requires a bucket")?
-            ),
+            bucket: format!("projects/_/buckets/{}", config.bucket),
             prefix: format!(
                 "{}/{}/{}",
-                config.output_storage_prefix.trim_matches('/'),
+                config.prefix.trim_matches('/'),
                 network_id,
                 central_address.to_hex(),
             ),
-            timeout: config.output_storage_timeout,
+            timeout: config.timeout,
         })
     }
 
@@ -147,12 +141,11 @@ mod tests {
             .await
             .unwrap();
         GcsOutputStore::new(
-            &PublisherConfig {
-                output_storage_bucket: Some("outputs".into()),
-                output_storage_prefix: "v1/test-deployment".into(),
-                output_storage_timeout: Duration::from_secs(2),
-                ..Default::default()
-            },
+            &OutputStorageConfig::new(
+                "outputs".into(),
+                "v1/test-deployment".into(),
+                Duration::from_secs(2),
+            ),
             "preprod",
             MidnightAddress::from_bytes([0xab; 32]),
             client,
@@ -269,11 +262,7 @@ mod tests {
             .await
             .unwrap();
         let store = GcsOutputStore::new(
-            &PublisherConfig {
-                output_storage_bucket: Some("outputs".into()),
-                output_storage_timeout: Duration::from_millis(100),
-                ..Default::default()
-            },
+            &OutputStorageConfig::new("outputs".into(), "v1".into(), Duration::from_millis(100)),
             "preprod",
             MidnightAddress::from_bytes([0xab; 32]),
             client,
@@ -288,28 +277,23 @@ mod tests {
 
     #[tokio::test]
     async fn no_bucket_disables_storage_before_client_initialization() {
-        let store = GcsOutputStore::connect(
-            &PublisherConfig::default(),
-            "preprod",
-            MidnightAddress::from_bytes([0xab; 32]),
-        )
-        .await
-        .unwrap();
+        let store =
+            GcsOutputStore::connect(None, "preprod", MidnightAddress::from_bytes([0xab; 32]))
+                .await
+                .unwrap();
         assert!(store.is_none());
     }
 
     #[test]
     fn output_storage_configuration_rejects_empty_buckets_and_invalid_tuning() {
-        let mut config = PublisherConfig::default();
-        config.validate_output_storage().unwrap();
-        config.output_storage_bucket = Some(" ".into());
-        assert!(config.validate_output_storage().is_err());
-        config.output_storage_bucket = Some("outputs".into());
-        config.validate_output_storage().unwrap();
-        config.output_storage_timeout = Duration::ZERO;
-        assert!(config.validate_output_storage().is_err());
-        config.output_storage_timeout = Duration::from_secs(1);
-        config.output_storage_prefix = String::new();
-        assert!(config.validate_output_storage().is_err());
+        let mut config = OutputStorageConfig::new(" ".into(), "v1".into(), Duration::from_secs(30));
+        assert!(config.validate().is_err());
+        config.bucket = "outputs".into();
+        config.validate().unwrap();
+        config.timeout = Duration::ZERO;
+        assert!(config.validate().is_err());
+        config.timeout = Duration::from_secs(1);
+        config.prefix = String::new();
+        assert!(config.validate().is_err());
     }
 }

--- a/chain-signatures/chain-midnight/src/publisher.rs
+++ b/chain-signatures/chain-midnight/src/publisher.rs
@@ -153,6 +153,9 @@ impl ChainPublisher for MidnightPublisher {
         if let (Some(store), SignKind::RespondBidirectional(response)) =
             (&self.output_store, &action.request.kind)
         {
+            // Compact circuit byte payloads need a compile-time size, but serialized
+            // execution outcomes vary in length across requests. Cache the exact attested
+            // bytes off-chain before publishing the fixed-size signature on-chain.
             store
                 .ensure_output(&call.request_id, &response.output)
                 .await?;

--- a/chain-signatures/chain-midnight/src/publisher.rs
+++ b/chain-signatures/chain-midnight/src/publisher.rs
@@ -12,6 +12,7 @@ use mpc_utils::time::current_unix_timestamp;
 
 use crate::config::{MidnightAddress, MidnightConfig, PublisherConfig};
 use crate::intent_gen::{IntentGen, IntentRequest, WirePoint, WireSignature};
+use crate::output_storage::{GcsOutputStore, OutputStore};
 use crate::rpc::{MidnightPublisherRpc, PinnedReads};
 
 const RESPOND: &str = "respond";
@@ -75,6 +76,7 @@ pub struct MidnightPublisher {
     config: PublisherConfig,
     reads: Arc<dyn PinnedReads>,
     client: Arc<dyn IntentClient>,
+    output_store: Option<Arc<dyn OutputStore>>,
     central_address: MidnightAddress,
     telemetry: Arc<dyn PublisherTelemetry>,
     /// One funding wallet and one DUST UTXO mean build-to-submit is one serial flow.
@@ -88,13 +90,19 @@ impl MidnightPublisher {
         config: &MidnightConfig,
         telemetry: Arc<dyn PublisherTelemetry>,
     ) -> anyhow::Result<Self> {
+        config.publisher.validate_output_storage()?;
         let rpc = Arc::new(MidnightPublisherRpc::connect(config).await?);
+        let output_store =
+            GcsOutputStore::connect(&config.publisher, rpc.network_id(), config.central_address)
+                .await?
+                .map(|store| Arc::new(store) as Arc<dyn OutputStore>);
         let intent_gen = Arc::new(IntentGen::spawn(config, rpc.network_id()).await?);
         Ok(Self::new(
             &config.publisher,
             config.central_address,
             rpc,
             intent_gen,
+            output_store,
             telemetry,
         ))
     }
@@ -104,6 +112,7 @@ impl MidnightPublisher {
         central_address: MidnightAddress,
         reads: Arc<dyn PinnedReads>,
         client: Arc<dyn IntentClient>,
+        output_store: Option<Arc<dyn OutputStore>>,
         telemetry: Arc<dyn PublisherTelemetry>,
     ) -> Self {
         Self {
@@ -111,6 +120,7 @@ impl MidnightPublisher {
             central_address,
             reads,
             client,
+            output_store,
             telemetry,
             flow: tokio::sync::Mutex::new(()),
         }
@@ -140,6 +150,13 @@ impl ChainPublisher for MidnightPublisher {
     // Retries currently operate per request.
     async fn publish_signature(&self, action: &PublishAction) -> anyhow::Result<()> {
         let call = respond_call(action)?;
+        if let (Some(store), SignKind::RespondBidirectional(response)) =
+            (&self.output_store, &action.request.kind)
+        {
+            store
+                .ensure_output(&call.request_id, &response.output)
+                .await?;
+        }
         let _flow = self.flow.lock().await;
         let central_address = self.central_address.to_hex();
         let sign_id = action.request.id;
@@ -210,8 +227,8 @@ fn respond_call(action: &PublishAction) -> anyhow::Result<RespondCall> {
                 signature,
             })
         }
-        // The output never travels: the contract stores a bare signature, and the
-        // attestation already commits to the output.
+        // The on-chain event carries only the signature; output storage is handled
+        // by the publisher, when configured, before it builds this circuit call.
         SignKind::RespondBidirectional(_) => Ok(RespondCall {
             circuit: RespondCircuit::RespondBidirectional,
             request_id,
@@ -484,8 +501,27 @@ mod tests {
             MidnightAddress::from_hex(CENTRAL).expect("CENTRAL is a 32-byte hex address"),
             reads,
             client,
+            Some(Arc::new(StubOutputStore::default())),
             Arc::new(NoopPublisherTelemetry),
         )
+    }
+
+    #[derive(Default)]
+    struct StubOutputStore {
+        outputs: Mutex<Vec<([u8; 32], Vec<u8>)>>,
+        failure: bool,
+    }
+
+    #[async_trait]
+    impl OutputStore for StubOutputStore {
+        async fn ensure_output(&self, request_id: &[u8; 32], output: &[u8]) -> anyhow::Result<()> {
+            anyhow::ensure!(!self.failure, "output storage unavailable");
+            self.outputs
+                .lock()
+                .unwrap()
+                .push((*request_id, output.to_vec()));
+            Ok(())
+        }
     }
 
     fn sign_event(chain: Chain) -> SignBidirectionalEvent {
@@ -524,6 +560,103 @@ mod tests {
             }),
             SignId::new(REQUEST_ID),
         )
+    }
+
+    #[tokio::test]
+    async fn final_response_requires_output_storage_before_reading_the_chain() {
+        let reads = StubReads::new();
+        let client = StubClient::new();
+        let mut publisher = publisher(reads.clone(), client.clone());
+        publisher.output_store = Some(Arc::new(StubOutputStore {
+            failure: true,
+            ..Default::default()
+        }));
+        let result = publisher
+            .publish_signature(&bidirectional_action(vec![0xde, 0xad, 0xbe, 0xef, 1]))
+            .await;
+
+        assert!(result.is_err(), "final response needs an output store");
+        assert!(reads.reads().is_empty());
+        assert!(client.built().is_empty());
+        assert_eq!(client.submissions(), 0);
+    }
+
+    #[tokio::test]
+    async fn final_response_publishes_when_output_storage_is_disabled() {
+        let client = StubClient::new();
+        let mut publisher = publisher(StubReads::new(), client.clone());
+        publisher.output_store = None;
+        publisher
+            .publish_signature(&bidirectional_action(vec![0, 255, 0]))
+            .await
+            .unwrap();
+        assert_eq!(client.submissions(), 1);
+    }
+
+    #[tokio::test]
+    async fn only_final_responses_store_the_exact_output() {
+        let store = Arc::new(StubOutputStore::default());
+        let mut publisher = publisher(StubReads::new(), StubClient::new());
+        publisher.output_store = Some(store.clone());
+        publisher
+            .publish_signature(&respond_action())
+            .await
+            .unwrap();
+        assert!(store.outputs.lock().unwrap().is_empty());
+        for output in [vec![], vec![0, 255, 0], vec![0xde, 0xad, 0xbe, 0xef, 1]] {
+            publisher
+                .publish_signature(&bidirectional_action(output.clone()))
+                .await
+                .unwrap();
+            assert_eq!(
+                store.outputs.lock().unwrap().pop(),
+                Some((REQUEST_ID, output))
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn storage_finishes_before_chain_reads_without_holding_the_wallet_lock() {
+        #[derive(Default)]
+        struct BlockingStore {
+            entered: tokio::sync::Notify,
+            release: tokio::sync::Notify,
+        }
+        #[async_trait]
+        impl OutputStore for BlockingStore {
+            async fn ensure_output(&self, _: &[u8; 32], _: &[u8]) -> anyhow::Result<()> {
+                self.entered.notify_one();
+                self.release.notified().await;
+                Ok(())
+            }
+        }
+        let store = Arc::new(BlockingStore::default());
+        let reads = StubReads::new();
+        let client = StubClient::new();
+        let mut publisher = publisher(reads.clone(), client.clone());
+        publisher.output_store = Some(store.clone());
+        let publisher = Arc::new(publisher);
+        let task_publisher = publisher.clone();
+        let task = tokio::spawn(async move {
+            task_publisher
+                .publish_signature(&bidirectional_action(vec![1]))
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), store.entered.notified())
+            .await
+            .unwrap();
+        assert!(reads.reads().is_empty());
+        assert!(client.built().is_empty());
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            publisher.publish_signature(&respond_action()),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        store.release.notify_one();
+        task.await.unwrap().unwrap();
+        assert_eq!(client.submissions(), 2);
     }
 
     #[tokio::test]
@@ -784,8 +917,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_bidirectional_action_names_the_other_circuit_on_the_same_request() {
-        // The contract's RespondBidirectionalEvent is a bare Signature: the output never
-        // travels, so the two circuits differ in the request by name alone.
+        // Output storage does not change the signature-only circuit arguments.
         let client = StubClient::new();
         let publisher = publisher(StubReads::new(), client.clone());
 

--- a/chain-signatures/chain-midnight/src/publisher.rs
+++ b/chain-signatures/chain-midnight/src/publisher.rs
@@ -92,10 +92,13 @@ impl MidnightPublisher {
     ) -> anyhow::Result<Self> {
         config.publisher.validate_output_storage()?;
         let rpc = Arc::new(MidnightPublisherRpc::connect(config).await?);
-        let output_store =
-            GcsOutputStore::connect(&config.publisher, rpc.network_id(), config.central_address)
-                .await?
-                .map(|store| Arc::new(store) as Arc<dyn OutputStore>);
+        let output_store = GcsOutputStore::connect(
+            config.publisher.output_storage.as_ref(),
+            rpc.network_id(),
+            config.central_address,
+        )
+        .await?
+        .map(|store| Arc::new(store) as Arc<dyn OutputStore>);
         let intent_gen = Arc::new(IntentGen::spawn(config, rpc.network_id()).await?);
         Ok(Self::new(
             &config.publisher,

--- a/chain-signatures/midnight-publisher-ts/devtools/real-stack/driver.ts
+++ b/chain-signatures/midnight-publisher-ts/devtools/real-stack/driver.ts
@@ -23,7 +23,6 @@ import {
   parseSecp256k1PublicKey,
   requestIdBytes,
   respondBidirectionalEventToCircuitInput,
-  serializeRespondOutput,
   signetEventSourceFromPublicDataProvider,
   SignetRequestResponseReader,
   type RequestIdHex,
@@ -71,6 +70,7 @@ interface SignedTransactionRequest {
 interface SettleResponseRequest {
   op: "settleResponse";
   requestId: string;
+  serializedOutput: string;
 }
 
 interface ShutdownRequest {
@@ -283,9 +283,7 @@ async function dispatch(request: Request): Promise<unknown> {
     const responseKey = active.responseKey;
     if (responseKey === undefined) throw new Error("caller is not initialised");
     const requestId = parseRequestIdHex(request.requestId);
-    const serializedOutput = serializeRespondOutput([{ name: "success", type: "bool" }], {
-      success: true,
-    });
+    const serializedOutput = bytes(request.serializedOutput);
     const response = await waitFor("a verified respondBidirectional entry", () =>
       active.reader.getVerifiedRespondBidirectionalEvent(requestId, serializedOutput, responseKey),
     );

--- a/chain-signatures/midnight-publisher-ts/tests/main.test.ts
+++ b/chain-signatures/midnight-publisher-ts/tests/main.test.ts
@@ -155,7 +155,7 @@ describe("dist/main.js over a pipe", () => {
 
     expect(run.code).toBe(0);
     expect(run.stderr).toContain(`node=http://127.0.0.1:${blackHole.port}`);
-  });
+  }, 10_000);
 
   it("flushes ready and exits when its publisher warmup never settles", async () => {
     const blackHole = await openBlackHole();

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -100,7 +100,7 @@ default = []
 # utilized for benchmarking the node:
 bench = []
 # utilized by "integration-tests" package:
-test-feature = []
+test-feature = ["mpc-chain-midnight/sandbox"]
 # Show a debug page
 debug-page = ["maud"]
 # Enable Helios light client for Ethereum

--- a/chain-signatures/node/src/cli/args/midnight.rs
+++ b/chain-signatures/node/src/cli/args/midnight.rs
@@ -210,9 +210,6 @@ impl MidnightArgs {
                             output_storage_timeout,
                             #[cfg(feature = "test-feature")]
                             output_storage_emulator_endpoint,
-                            request_timeout: _,
-                            submit_timeout: _,
-                            restart_backoff: _,
                             ..
                         },
                     rpc: _,

--- a/chain-signatures/node/src/cli/args/midnight.rs
+++ b/chain-signatures/node/src/cli/args/midnight.rs
@@ -1,9 +1,10 @@
 use anyhow::Context as _;
 use mpc_chain_midnight::{MidnightAddress, MidnightConfig, PublisherConfig};
 use secrecy::{ExposeSecret as _, SecretString};
+use std::time::Duration;
 
 /// CLI arguments for the Midnight integration. The node url requires the whole
-/// publisher group; only `--midnight-intent-gen-command` has a default.
+/// required publisher group. GCS output storage is optional.
 #[derive(Debug, Clone, clap::Parser)]
 #[group(id = "indexer_midnight_options")]
 pub struct MidnightArgs {
@@ -60,11 +61,36 @@ pub struct MidnightArgs {
         requires = "midnight_node_url"
     )]
     pub midnight_indexer_ws_url: Option<String>,
+    /// Optional GCS bucket. When set, execution output uploads before the on-chain response.
+    #[arg(
+        long,
+        env("MPC_MIDNIGHT_OUTPUT_STORAGE_BUCKET"),
+        requires = "midnight_node_url"
+    )]
+    pub midnight_output_storage_bucket: Option<String>,
+    /// Object prefix within the bucket (default: v1).
+    #[arg(
+        long,
+        env("MPC_MIDNIGHT_OUTPUT_STORAGE_PREFIX"),
+        requires = "midnight_node_url"
+    )]
+    pub midnight_output_storage_prefix: Option<String>,
+    /// Maximum time for storing one output, in seconds (default: 30).
+    #[arg(
+        long,
+        env("MPC_MIDNIGHT_OUTPUT_STORAGE_TIMEOUT_SECS"),
+        requires = "midnight_node_url"
+    )]
+    pub midnight_output_storage_timeout_secs: Option<u64>,
+    /// Local GCS emulator endpoint for integration tests; uses anonymous credentials.
+    #[cfg(feature = "test-feature")]
+    #[arg(long, requires = "midnight_node_url")]
+    pub midnight_output_storage_emulator_endpoint: Option<String>,
 }
 
 impl MidnightArgs {
     pub fn into_str_args(self) -> Vec<String> {
-        let mut args = Vec::with_capacity(14);
+        let mut args = Vec::with_capacity(20);
         if let Some(v) = self.midnight_node_url {
             args.extend(["--midnight-node-url".to_string(), v]);
         }
@@ -88,6 +114,22 @@ impl MidnightArgs {
         }
         if let Some(v) = self.midnight_indexer_ws_url {
             args.extend(["--midnight-indexer-ws-url".to_string(), v]);
+        }
+        if let Some(v) = self.midnight_output_storage_bucket {
+            args.extend(["--midnight-output-storage-bucket".to_string(), v]);
+        }
+        if let Some(v) = self.midnight_output_storage_prefix {
+            args.extend(["--midnight-output-storage-prefix".to_string(), v]);
+        }
+        if let Some(v) = self.midnight_output_storage_timeout_secs {
+            args.extend([
+                "--midnight-output-storage-timeout-secs".to_string(),
+                v.to_string(),
+            ]);
+        }
+        #[cfg(feature = "test-feature")]
+        if let Some(v) = self.midnight_output_storage_emulator_endpoint {
+            args.extend(["--midnight-output-storage-emulator-endpoint".to_string(), v]);
         }
         args
     }
@@ -118,8 +160,17 @@ impl MidnightArgs {
             proof_server_url,
             indexer_url,
             indexer_ws_url,
+            output_storage_bucket: self.midnight_output_storage_bucket,
+            #[cfg(feature = "test-feature")]
+            output_storage_emulator_endpoint: self.midnight_output_storage_emulator_endpoint,
             ..Default::default()
         };
+        if let Some(prefix) = self.midnight_output_storage_prefix {
+            publisher.output_storage_prefix = prefix;
+        }
+        if let Some(timeout_secs) = self.midnight_output_storage_timeout_secs {
+            publisher.output_storage_timeout = Duration::from_secs(timeout_secs);
+        }
         if let Some(command) = self.midnight_intent_gen_command {
             publisher.intent_gen_command = serde_json::from_str(&command).with_context(|| {
                 format!("midnight config: --midnight-intent-gen-command must be a JSON array of strings, got {command}")
@@ -135,14 +186,15 @@ impl MidnightArgs {
             indexer: Default::default(),
         };
         config.validate()?;
+        config.publisher.validate_output_storage()?;
         Ok(Some(config))
     }
 
     pub fn from_config(config: Option<MidnightConfig>) -> Self {
         match config {
             Some(c) => {
-                // No flags for the tuning fields. Destructured in full so a new
-                // field fails to compile here rather than silently miss the round trip.
+                // Cargo can enable the dependency's sandbox without this crate's
+                // test-feature, so its test-only fields may be present but not forwarded.
                 let MidnightConfig {
                     node_url,
                     central_address,
@@ -153,9 +205,15 @@ impl MidnightArgs {
                             proof_server_url,
                             indexer_url,
                             indexer_ws_url,
+                            output_storage_bucket,
+                            output_storage_prefix,
+                            output_storage_timeout,
+                            #[cfg(feature = "test-feature")]
+                            output_storage_emulator_endpoint,
                             request_timeout: _,
                             submit_timeout: _,
                             restart_backoff: _,
+                            ..
                         },
                     rpc: _,
                     indexer: _,
@@ -171,6 +229,11 @@ impl MidnightArgs {
                     midnight_proof_server_url: Some(proof_server_url),
                     midnight_indexer_url: Some(indexer_url),
                     midnight_indexer_ws_url: Some(indexer_ws_url),
+                    midnight_output_storage_bucket: output_storage_bucket,
+                    midnight_output_storage_prefix: Some(output_storage_prefix),
+                    midnight_output_storage_timeout_secs: Some(output_storage_timeout.as_secs()),
+                    #[cfg(feature = "test-feature")]
+                    midnight_output_storage_emulator_endpoint: output_storage_emulator_endpoint,
                 }
             }
             None => MidnightArgs {
@@ -181,6 +244,11 @@ impl MidnightArgs {
                 midnight_proof_server_url: None,
                 midnight_indexer_url: None,
                 midnight_indexer_ws_url: None,
+                midnight_output_storage_bucket: None,
+                midnight_output_storage_prefix: None,
+                midnight_output_storage_timeout_secs: None,
+                #[cfg(feature = "test-feature")]
+                midnight_output_storage_emulator_endpoint: None,
             },
         }
     }
@@ -191,7 +259,6 @@ mod tests {
     use super::*;
     use clap::Parser as _;
     use mpc_chain_midnight::IndexerConfig;
-    use std::time::Duration;
 
     /// Publisher fields all distinguishable from their defaults, so an
     /// assertion cannot pass on a dropped flag.
@@ -210,6 +277,9 @@ mod tests {
                 proof_server_url: "http://127.0.0.1:6300".into(),
                 indexer_url: "http://127.0.0.1:8088/api/v3/graphql".into(),
                 indexer_ws_url: "ws://127.0.0.1:8088/api/v3/graphql/ws".into(),
+                output_storage_bucket: Some("midnight-results".into()),
+                output_storage_prefix: "staging/testnet".into(),
+                output_storage_timeout: Duration::from_secs(47),
                 ..Default::default()
             },
             rpc: Default::default(),
@@ -235,8 +305,8 @@ mod tests {
 
     #[test]
     fn tuning_fields_do_not_survive_the_cli_round_trip() {
-        // Known limitation, pinned deliberately: no tuning traverses a process
-        // restart. Adding real flags flips this into a round-trip assert.
+        // Indexer and submission tuning have no CLI flags and do not traverse
+        // a process restart. Adding flags flips this into a round-trip assert.
         crate::cli::tests::assert_midnight_env_unset();
 
         let mut cfg = configured();
@@ -263,12 +333,12 @@ mod tests {
         assert_eq!(
             reparsed.indexer,
             IndexerConfig::default(),
-            "tuning does not traverse the CLI; if this fails, flags were added and this test should become a round-trip assert"
+            "indexer tuning does not traverse the CLI; if this fails, flags were added and this test should become a round-trip assert"
         );
         assert_eq!(
             reparsed.publisher.submit_timeout,
             PublisherConfig::default().submit_timeout,
-            "publisher tuning does not traverse the CLI either"
+            "publisher submission timeout does not traverse the CLI"
         );
     }
 
@@ -301,6 +371,39 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "test-feature")]
+    #[test]
+    fn storage_emulator_endpoint_survives_the_cli_round_trip() {
+        crate::cli::tests::assert_midnight_env_unset();
+        let mut args = MidnightArgs::from_config(Some(configured())).into_str_args();
+        args.extend([
+            "--midnight-output-storage-emulator-endpoint".into(),
+            "http://127.0.0.1:4443".into(),
+        ]);
+        let config = MidnightArgs::try_parse_from(std::iter::once("test".into()).chain(args))
+            .expect("test builds accept the Midnight storage emulator endpoint")
+            .into_config()
+            .unwrap();
+        let forwarded = MidnightArgs::from_config(config).into_str_args();
+        assert!(forwarded.windows(2).any(|args| args
+            == [
+                "--midnight-output-storage-emulator-endpoint",
+                "http://127.0.0.1:4443"
+            ]));
+    }
+
+    #[cfg(not(feature = "test-feature"))]
+    #[test]
+    fn production_cli_rejects_the_storage_emulator_endpoint() {
+        let error = MidnightArgs::try_parse_from([
+            "test",
+            "--midnight-output-storage-emulator-endpoint",
+            "http://127.0.0.1:4443",
+        ])
+        .expect_err("production nodes must not accept anonymous emulator configuration");
+        assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
+    }
+
     #[test]
     fn the_midnight_flags_are_all_or_nothing() {
         // A publisher flag accepted on its own would let a node carry a funding
@@ -313,8 +416,11 @@ mod tests {
             "--midnight-proof-server-url",
             "--midnight-indexer-url",
             "--midnight-indexer-ws-url",
+            "--midnight-output-storage-bucket",
+            "--midnight-output-storage-prefix",
+            "--midnight-output-storage-timeout-secs",
         ] {
-            let err = MidnightArgs::try_parse_from(["test", flag, "x"])
+            let err = MidnightArgs::try_parse_from(["test", flag, "1"])
                 .expect_err("clap must reject a publisher flag supplied on its own");
             assert!(
                 err.to_string().contains("midnight-node-url"),
@@ -342,6 +448,29 @@ mod tests {
                 "clap must name {flag} as missing: {err}"
             );
         }
+    }
+
+    #[test]
+    fn midnight_output_storage_bucket_is_optional() {
+        crate::cli::tests::assert_midnight_env_unset();
+        let mut args = MidnightArgs::from_config(Some(configured())).into_str_args();
+        let index = args
+            .iter()
+            .position(|arg| arg == "--midnight-output-storage-bucket")
+            .expect("configured Midnight args include the storage bucket");
+        args.drain(index..=index + 1);
+        let parsed = MidnightArgs::try_parse_from(std::iter::once("test".to_owned()).chain(args))
+            .expect("Midnight can run without GCS storage");
+        assert!(parsed.midnight_output_storage_bucket.is_none());
+        let config = parsed
+            .into_config()
+            .unwrap()
+            .expect("Midnight remains enabled");
+        assert_eq!(config.node_url, configured().node_url);
+        let forwarded = MidnightArgs::from_config(Some(config)).into_str_args();
+        assert!(!forwarded
+            .iter()
+            .any(|arg| arg == "--midnight-output-storage-bucket"));
     }
 
     #[test]

--- a/chain-signatures/node/src/cli/args/midnight.rs
+++ b/chain-signatures/node/src/cli/args/midnight.rs
@@ -1,5 +1,5 @@
 use anyhow::Context as _;
-use mpc_chain_midnight::{MidnightAddress, MidnightConfig, PublisherConfig};
+use mpc_chain_midnight::{MidnightAddress, MidnightConfig, OutputStorageConfig, PublisherConfig};
 use secrecy::{ExposeSecret as _, SecretString};
 use std::time::Duration;
 
@@ -160,16 +160,19 @@ impl MidnightArgs {
             proof_server_url,
             indexer_url,
             indexer_ws_url,
-            output_storage_bucket: self.midnight_output_storage_bucket,
-            #[cfg(feature = "test-feature")]
-            output_storage_emulator_endpoint: self.midnight_output_storage_emulator_endpoint,
+            output_storage: self.midnight_output_storage_bucket.map(|bucket| {
+                OutputStorageConfig::new(
+                    bucket,
+                    self.midnight_output_storage_prefix
+                        .unwrap_or_else(|| "v1".to_string()),
+                    Duration::from_secs(self.midnight_output_storage_timeout_secs.unwrap_or(30)),
+                )
+            }),
             ..Default::default()
         };
-        if let Some(prefix) = self.midnight_output_storage_prefix {
-            publisher.output_storage_prefix = prefix;
-        }
-        if let Some(timeout_secs) = self.midnight_output_storage_timeout_secs {
-            publisher.output_storage_timeout = Duration::from_secs(timeout_secs);
+        #[cfg(feature = "test-feature")]
+        if let Some(storage) = &mut publisher.output_storage {
+            storage.emulator_endpoint = self.midnight_output_storage_emulator_endpoint;
         }
         if let Some(command) = self.midnight_intent_gen_command {
             publisher.intent_gen_command = serde_json::from_str(&command).with_context(|| {
@@ -192,8 +195,6 @@ impl MidnightArgs {
     pub fn from_config(config: Option<MidnightConfig>) -> Self {
         match config {
             Some(c) => {
-                // Cargo can enable the dependency's sandbox without this crate's
-                // test-feature, so its test-only fields may be present but not forwarded.
                 let MidnightConfig {
                     node_url,
                     central_address,
@@ -204,17 +205,13 @@ impl MidnightArgs {
                             proof_server_url,
                             indexer_url,
                             indexer_ws_url,
-                            output_storage_bucket,
-                            output_storage_prefix,
-                            output_storage_timeout,
-                            #[cfg(feature = "test-feature")]
-                            output_storage_emulator_endpoint,
+                            output_storage,
                             ..
                         },
                     rpc: _,
                     indexer: _,
                 } = c;
-                MidnightArgs {
+                let mut args = MidnightArgs {
                     midnight_node_url: Some(node_url),
                     midnight_central_address: Some(central_address.to_hex()),
                     midnight_funding_seed: Some(funding_seed.into()),
@@ -225,12 +222,22 @@ impl MidnightArgs {
                     midnight_proof_server_url: Some(proof_server_url),
                     midnight_indexer_url: Some(indexer_url),
                     midnight_indexer_ws_url: Some(indexer_ws_url),
-                    midnight_output_storage_bucket: output_storage_bucket,
-                    midnight_output_storage_prefix: Some(output_storage_prefix),
-                    midnight_output_storage_timeout_secs: Some(output_storage_timeout.as_secs()),
+                    midnight_output_storage_bucket: None,
+                    midnight_output_storage_prefix: None,
+                    midnight_output_storage_timeout_secs: None,
                     #[cfg(feature = "test-feature")]
-                    midnight_output_storage_emulator_endpoint: output_storage_emulator_endpoint,
+                    midnight_output_storage_emulator_endpoint: None,
+                };
+                if let Some(storage) = output_storage {
+                    args.midnight_output_storage_bucket = Some(storage.bucket);
+                    args.midnight_output_storage_prefix = Some(storage.prefix);
+                    args.midnight_output_storage_timeout_secs = Some(storage.timeout.as_secs());
+                    #[cfg(feature = "test-feature")]
+                    {
+                        args.midnight_output_storage_emulator_endpoint = storage.emulator_endpoint;
+                    }
                 }
+                args
             }
             None => MidnightArgs {
                 midnight_node_url: None,
@@ -273,9 +280,11 @@ mod tests {
                 proof_server_url: "http://127.0.0.1:6300".into(),
                 indexer_url: "http://127.0.0.1:8088/api/v3/graphql".into(),
                 indexer_ws_url: "ws://127.0.0.1:8088/api/v3/graphql/ws".into(),
-                output_storage_bucket: Some("midnight-results".into()),
-                output_storage_prefix: "staging/testnet".into(),
-                output_storage_timeout: Duration::from_secs(47),
+                output_storage: Some(OutputStorageConfig::new(
+                    "midnight-results".into(),
+                    "staging/testnet".into(),
+                    Duration::from_secs(47),
+                )),
                 ..Default::default()
             },
             rpc: Default::default(),
@@ -463,10 +472,29 @@ mod tests {
             .unwrap()
             .expect("Midnight remains enabled");
         assert_eq!(config.node_url, configured().node_url);
+        assert!(config.publisher.output_storage.is_none());
         let forwarded = MidnightArgs::from_config(Some(config)).into_str_args();
         assert!(!forwarded
             .iter()
-            .any(|arg| arg == "--midnight-output-storage-bucket"));
+            .any(|arg| arg.starts_with("--midnight-output-storage-")));
+    }
+
+    #[test]
+    fn output_storage_defaults_are_resolved_at_the_cli_boundary() {
+        crate::cli::tests::assert_midnight_env_unset();
+        let mut args = MidnightArgs::from_config(Some(configured()));
+        args.midnight_output_storage_prefix = None;
+        args.midnight_output_storage_timeout_secs = None;
+
+        let config = args.into_config().unwrap().unwrap();
+        assert_eq!(
+            config.publisher.output_storage,
+            Some(OutputStorageConfig::new(
+                "midnight-results".into(),
+                "v1".into(),
+                Duration::from_secs(30),
+            ))
+        );
     }
 
     #[test]

--- a/chain-signatures/node/src/cli/args/midnight.rs
+++ b/chain-signatures/node/src/cli/args/midnight.rs
@@ -186,7 +186,6 @@ impl MidnightArgs {
             indexer: Default::default(),
         };
         config.validate()?;
-        config.publisher.validate_output_storage()?;
         Ok(Some(config))
     }
 

--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -1175,6 +1175,9 @@ mod tests {
             "MPC_MIDNIGHT_PROOF_SERVER_URL",
             "MPC_MIDNIGHT_INDEXER_URL",
             "MPC_MIDNIGHT_INDEXER_WS_URL",
+            "MPC_MIDNIGHT_OUTPUT_STORAGE_BUCKET",
+            "MPC_MIDNIGHT_OUTPUT_STORAGE_PREFIX",
+            "MPC_MIDNIGHT_OUTPUT_STORAGE_TIMEOUT_SECS",
         ] {
             assert!(
                 std::env::var_os(var).is_none(),
@@ -1225,6 +1228,12 @@ mod tests {
             "http://127.0.0.1:8088/api/v3/graphql",
             "--midnight-indexer-ws-url",
             "ws://127.0.0.1:8088/api/v3/graphql/ws",
+            "--midnight-output-storage-bucket",
+            "midnight-results",
+            "--midnight-output-storage-prefix",
+            "staging/testnet",
+            "--midnight-output-storage-timeout-secs",
+            "47",
         ];
         let out = Cli::try_parse_from(argv).unwrap().into_str_args();
 
@@ -1243,6 +1252,12 @@ mod tests {
             "http://127.0.0.1:8088/api/v3/graphql",
             "--midnight-indexer-ws-url",
             "ws://127.0.0.1:8088/api/v3/graphql/ws",
+            "--midnight-output-storage-bucket",
+            "midnight-results",
+            "--midnight-output-storage-prefix",
+            "staging/testnet",
+            "--midnight-output-storage-timeout-secs",
+            "47",
         ] {
             assert!(
                 out.contains(&expected.to_string()),

--- a/integration-tests/src/gcs.rs
+++ b/integration-tests/src/gcs.rs
@@ -1,0 +1,91 @@
+use std::time::Duration;
+
+use anyhow::Context as _;
+use reqwest::Client;
+use testcontainers::core::{IntoContainerPort as _, WaitFor};
+use testcontainers::runners::AsyncRunner as _;
+use testcontainers::{ContainerAsync, GenericImage, ImageExt as _};
+
+const PORT: u16 = 4443;
+
+pub struct GcsEmulator {
+    pub endpoint: String,
+    pub bucket: String,
+    container: ContainerAsync<GenericImage>,
+    client: Client,
+}
+
+impl GcsEmulator {
+    pub async fn run() -> anyhow::Result<Self> {
+        let container = GenericImage::new("fsouza/fake-gcs-server", "1.56.1")
+            .with_exposed_port(PORT.tcp())
+            .with_wait_for(WaitFor::message_on_stderr("server started at"))
+            .with_cmd(["-scheme", "http", "-backend", "memory", "-port", "4443"])
+            .start()
+            .await
+            .context("starting the GCS emulator")?;
+        let mut emulator = Self {
+            endpoint: String::new(),
+            bucket: format!("mpc-test-{}", uuid::Uuid::new_v4()),
+            container,
+            client: Client::builder().timeout(Duration::from_secs(5)).build()?,
+        };
+        emulator.refresh_endpoint().await?;
+        emulator.create_bucket().await?;
+        Ok(emulator)
+    }
+
+    async fn refresh_endpoint(&mut self) -> anyhow::Result<()> {
+        self.endpoint = format!(
+            "http://{}:{}",
+            self.container.get_host().await?,
+            self.container.get_host_port_ipv4(PORT).await?
+        );
+        Ok(())
+    }
+
+    async fn create_bucket(&self) -> anyhow::Result<()> {
+        tokio::time::timeout(Duration::from_secs(15), async {
+            loop {
+                match self
+                    .client
+                    .post(format!("{}/storage/v1/b", self.endpoint))
+                    .query(&[("project", "local-test")])
+                    .json(&serde_json::json!({ "name": self.bucket }))
+                    .send()
+                    .await
+                {
+                    Ok(response) => {
+                        response
+                            .error_for_status()
+                            .context("creating the GCS test bucket")?;
+                        return Ok::<_, anyhow::Error>(());
+                    }
+                    Err(error) if error.is_connect() => {
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                    }
+                    Err(error) => return Err(error.into()),
+                }
+            }
+        })
+        .await
+        .context("waiting for the GCS emulator to accept bucket creation")?
+    }
+
+    pub async fn read_object(&self, object: &str) -> anyhow::Result<Vec<u8>> {
+        let mut url = url::Url::parse(&self.endpoint)?;
+        url.path_segments_mut()
+            .map_err(|()| anyhow::anyhow!("GCS emulator endpoint cannot hold a path"))?
+            .extend(["storage", "v1", "b", &self.bucket, "o", object]);
+        Ok(self
+            .client
+            .get(url)
+            .query(&[("alt", "media")])
+            .send()
+            .await?
+            .error_for_status()?
+            .bytes()
+            .await?
+            .to_vec())
+    }
+}

--- a/integration-tests/src/gcs.rs
+++ b/integration-tests/src/gcs.rs
@@ -11,7 +11,7 @@ const PORT: u16 = 4443;
 pub struct GcsEmulator {
     pub endpoint: String,
     pub bucket: String,
-    container: ContainerAsync<GenericImage>,
+    _container: ContainerAsync<GenericImage>,
     client: Client,
 }
 
@@ -24,24 +24,17 @@ impl GcsEmulator {
             .start()
             .await
             .context("starting the GCS emulator")?;
-        let mut emulator = Self {
-            endpoint: String::new(),
+        let host = container.get_host().await?;
+        let host_port = container.get_host_port_ipv4(PORT).await?;
+        let endpoint = format!("http://{host}:{host_port}");
+        let emulator = Self {
+            endpoint,
             bucket: format!("mpc-test-{}", uuid::Uuid::new_v4()),
-            container,
+            _container: container,
             client: Client::builder().timeout(Duration::from_secs(5)).build()?,
         };
-        emulator.refresh_endpoint().await?;
         emulator.create_bucket().await?;
         Ok(emulator)
-    }
-
-    async fn refresh_endpoint(&mut self) -> anyhow::Result<()> {
-        self.endpoint = format!(
-            "http://{}:{}",
-            self.container.get_host().await?,
-            self.container.get_host_port_ipv4(PORT).await?
-        );
-        Ok(())
     }
 
     async fn create_bucket(&self) -> anyhow::Result<()> {

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -5,6 +5,7 @@ pub mod cluster;
 pub mod containers;
 pub mod eth;
 pub mod execute;
+pub mod gcs;
 pub mod local;
 pub mod midnight;
 pub mod mpc_fixture;

--- a/integration-tests/src/midnight.rs
+++ b/integration-tests/src/midnight.rs
@@ -72,6 +72,7 @@ pub struct SignedEvmTransaction {
 
 pub struct MidnightContext {
     _stack: MidnightStack,
+    pub output_storage: crate::gcs::GcsEmulator,
     pub config: MidnightConfig,
     driver: Mutex<MidnightDriver>,
 }
@@ -81,6 +82,7 @@ impl MidnightContext {
         spawner: &ClusterSpawner,
         root_public_key: mpc_crypto::PublicKey,
     ) -> anyhow::Result<Self> {
+        let output_storage = crate::gcs::GcsEmulator::run().await?;
         let stack = MidnightStack::run(spawner).await?;
         let mut driver = MidnightDriver::spawn(&stack.artifact_dir).await?;
         let bootstrap = driver
@@ -122,15 +124,18 @@ impl MidnightContext {
             publisher_entrypoint.display(),
             publisher_package_dir()?.display()
         );
-        let config = responder_config(
+        let mut config = responder_config(
             &stack.endpoints,
             &bootstrap,
             node_executable()?,
             publisher_entrypoint,
+            Some(output_storage.bucket.clone()),
         )?;
+        config.publisher.output_storage_emulator_endpoint = Some(output_storage.endpoint.clone());
         config.validate()?;
         Ok(Self {
             _stack: stack,
+            output_storage,
             config,
             driver: Mutex::new(driver),
         })
@@ -169,11 +174,27 @@ impl MidnightContext {
             .await
     }
 
-    pub async fn settle_response(&self, request_id: [u8; 32]) -> anyhow::Result<()> {
+    pub async fn stored_output(&self, request_id: [u8; 32]) -> anyhow::Result<Vec<u8>> {
+        let object = format!(
+            "{}/{}/{}/{}.bin",
+            self.config.publisher.output_storage_prefix,
+            self._stack.network_id,
+            self.config.central_address.to_hex(),
+            hex::encode(request_id),
+        );
+        self.output_storage.read_object(&object).await
+    }
+
+    pub async fn settle_response(
+        &self,
+        request_id: [u8; 32],
+        serialized_output: &[u8],
+    ) -> anyhow::Result<()> {
         let mut driver = self.driver.lock().await;
         let _: serde_json::Value = driver
             .request(&serde_json::json!({
                 "op": "settleResponse",
+                "serializedOutput": hex::encode(serialized_output),
                 "requestId": format!("0x{}", hex::encode(request_id)),
             }))
             .await?;
@@ -216,12 +237,15 @@ fn responder_config(
     bootstrap: &BootstrapResult,
     node_executable: String,
     publisher_entrypoint: PathBuf,
+    output_storage_bucket: Option<String>,
 ) -> anyhow::Result<MidnightConfig> {
     Ok(MidnightConfig {
         node_url: endpoints.node_http_url.clone(),
         central_address: MidnightAddress::from_hex(&bootstrap.central_address)
             .context("decoding Midnight central address")?,
         publisher: PublisherConfig {
+            output_storage_bucket,
+            output_storage_prefix: format!("integration-tests/{}", uuid::Uuid::new_v4()),
             intent_gen_command: vec![
                 node_executable,
                 publisher_entrypoint.to_string_lossy().into_owned(),

--- a/integration-tests/src/midnight.rs
+++ b/integration-tests/src/midnight.rs
@@ -7,7 +7,9 @@ use std::time::Duration;
 
 use anyhow::Context as _;
 use k256::elliptic_curve::sec1::ToEncodedPoint as _;
-use mpc_chain_midnight::{probe_network_id, MidnightAddress, MidnightConfig, PublisherConfig};
+use mpc_chain_midnight::{
+    probe_network_id, MidnightAddress, MidnightConfig, OutputStorageConfig, PublisherConfig,
+};
 use reqwest::Client;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -124,14 +126,18 @@ impl MidnightContext {
             publisher_entrypoint.display(),
             publisher_package_dir()?.display()
         );
-        let mut config = responder_config(
+        let config = responder_config(
             &stack.endpoints,
             &bootstrap,
             node_executable()?,
             publisher_entrypoint,
-            Some(output_storage.bucket.clone()),
+            Some(OutputStorageConfig {
+                bucket: output_storage.bucket.clone(),
+                prefix: format!("integration-tests/{}", uuid::Uuid::new_v4()),
+                timeout: Duration::from_secs(30),
+                emulator_endpoint: Some(output_storage.endpoint.clone()),
+            }),
         )?;
-        config.publisher.output_storage_emulator_endpoint = Some(output_storage.endpoint.clone());
         config.validate()?;
         Ok(Self {
             _stack: stack,
@@ -177,7 +183,12 @@ impl MidnightContext {
     pub async fn stored_output(&self, request_id: [u8; 32]) -> anyhow::Result<Vec<u8>> {
         let object = format!(
             "{}/{}/{}/{}.bin",
-            self.config.publisher.output_storage_prefix,
+            self.config
+                .publisher
+                .output_storage
+                .as_ref()
+                .context("Midnight output storage is disabled")?
+                .prefix,
             self._stack.network_id,
             self.config.central_address.to_hex(),
             hex::encode(request_id),
@@ -237,15 +248,14 @@ fn responder_config(
     bootstrap: &BootstrapResult,
     node_executable: String,
     publisher_entrypoint: PathBuf,
-    output_storage_bucket: Option<String>,
+    output_storage: Option<OutputStorageConfig>,
 ) -> anyhow::Result<MidnightConfig> {
     Ok(MidnightConfig {
         node_url: endpoints.node_http_url.clone(),
         central_address: MidnightAddress::from_hex(&bootstrap.central_address)
             .context("decoding Midnight central address")?,
         publisher: PublisherConfig {
-            output_storage_bucket,
-            output_storage_prefix: format!("integration-tests/{}", uuid::Uuid::new_v4()),
+            output_storage,
             intent_gen_command: vec![
                 node_executable,
                 publisher_entrypoint.to_string_lossy().into_owned(),

--- a/integration-tests/tests/cases/midnight_stream.rs
+++ b/integration-tests/tests/cases/midnight_stream.rs
@@ -156,7 +156,12 @@ async fn midnight_to_ethereum_to_midnight_consumes_caller_response() -> anyhow::
         )
         .await
         .context("waiting for the finalized respondBidirectional entry")?;
-    midnight.settle_response(request_id).await?;
+    let output = midnight.stored_output(request_id).await?;
+    anyhow::ensure!(
+        !output.is_empty(),
+        "the executed bool result must have stored bytes"
+    );
+    midnight.settle_response(request_id, &output).await?;
     let ChainEvent::Block(final_block) = events
         .wait_for(|event| matches!(event, ChainEvent::Block(_)), EVENT_TIMEOUT)
         .await


### PR DESCRIPTION
Midnight's Compact circuits require byte-payload sizes at compile time. Serialized execution outcomes vary in size across requests, so the shared response contract cannot know their size when compiled. Add optional GCS storage for the exact attested bytes off-chain before publishing the execution signature on-chain.

- Keep storage configuration scoped to Midnight and verify the full flow with a local Docker emulator.
- The bucket name and output-serving URL should include `cache`.

Validated: full local Midnight → Ethereum → Midnight flow, 581 Rust library tests, 41 TypeScript tests, build, type checks, lint, and formatting.
