### PR TITLE
feat(ci): enhance PR path filters for Canton and Midnight workflows

### DIFF
--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -7,7 +7,40 @@ on:
     paths:
       - integration-tests/**
       - chain-signatures/**
+  # PRs run only on Canton or shared-core changes; merge_group stays
+  # unfiltered as the safety net. Keep core in sync with other chain workflows.
   pull_request:
+    paths:
+      - ".github/workflows/canton.yml"
+      # Shared core: changes here trigger every chain workflow.
+      - "chain-signatures/chain-integration-core/**"
+      - "chain-signatures/primitives/**"
+      - "chain-signatures/crypto/**"
+      - "chain-signatures/keys/**"
+      - "chain-signatures/utils/**"
+      - "chain-signatures/compact-hashing/**"
+      - "chain-signatures/node/**"
+      - "signet-crypto/**"
+      - "signet-primitives/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "justfile"
+      - ".config/nextest.toml"
+      # Canton crate, tests, and fixtures.
+      - "chain-signatures/chain-canton/**"
+      - "integration-tests/src/canton.rs"
+      - "integration-tests/src/canton_auth.rs"
+      - "integration-tests/tests/cases/canton.rs"
+      - "integration-tests/tests/cases/canton_stream.rs"
+      - "integration-tests/fixtures/canton/**"
+      # Shared integration-test harness.
+      - "integration-tests/src/lib.rs"
+      - "integration-tests/src/cluster/**"
+      - "integration-tests/tests/lib.rs"
+      - "integration-tests/tests/cases/mod.rs"
+      - "integration-tests/Cargo.toml"
+      # Canton tests cross-sign over Ethereum via anvil + the eth contract.
+      - "chain-signatures/contract-eth/**"
   merge_group:
 
 env:

--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -26,19 +26,11 @@ on:
       - "Cargo.lock"
       - "justfile"
       - ".config/nextest.toml"
-      # Canton crate, tests, and fixtures.
+      # Canton crate, tests, and fixtures (matches any *canton* file at any depth).
       - "chain-signatures/chain-canton/**"
-      - "integration-tests/src/canton.rs"
-      - "integration-tests/src/canton_auth.rs"
-      - "integration-tests/tests/cases/canton.rs"
-      - "integration-tests/tests/cases/canton_stream.rs"
-      - "integration-tests/fixtures/canton/**"
+      - "integration-tests/{src,fixtures,tests}/**canton**"
       # Shared integration-test harness.
-      - "integration-tests/src/lib.rs"
-      - "integration-tests/src/cluster/**"
-      - "integration-tests/tests/lib.rs"
-      - "integration-tests/tests/cases/mod.rs"
-      - "integration-tests/Cargo.toml"
+      - "integration-tests/{Cargo.toml,src/lib.rs,src/cluster/**,src/mpc_fixture/**,tests/lib.rs,tests/cases/mod.rs}"
       # Canton tests cross-sign over Ethereum via anvil + the eth contract.
       - "chain-signatures/contract-eth/**"
   merge_group:

--- a/.github/workflows/midnight-publisher-ts.yml
+++ b/.github/workflows/midnight-publisher-ts.yml
@@ -20,7 +20,29 @@ on:
       - "Dockerfile"
       - "chain-signatures/midnight-publisher-ts/**"
       - "chain-signatures/chain-midnight/**"
+  # Push paths plus the shared core, since the seam differential compiles
+  # mpc-chain-midnight. merge_group stays unfiltered as the safety net.
+  # Keep core in sync with the other chain workflows.
   pull_request:
+    paths:
+      - ".github/workflows/midnight-publisher-ts.yml"
+      - "Dockerfile"
+      - "chain-signatures/midnight-publisher-ts/**"
+      - "chain-signatures/chain-midnight/**"
+      # Shared core: compiled into mpc-chain-midnight and the seam tests.
+      - "chain-signatures/chain-integration-core/**"
+      - "chain-signatures/primitives/**"
+      - "chain-signatures/crypto/**"
+      - "chain-signatures/keys/**"
+      - "chain-signatures/utils/**"
+      - "chain-signatures/compact-hashing/**"
+      - "chain-signatures/node/**"
+      - "signet-crypto/**"
+      - "signet-primitives/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "justfile"
+      - ".config/nextest.toml"
   merge_group:
 
 jobs:

--- a/.github/workflows/midnight.yml
+++ b/.github/workflows/midnight.yml
@@ -29,14 +29,9 @@ on:
       # Midnight crate, TS publisher fixtures, and tests.
       - "chain-signatures/chain-midnight/**"
       - "chain-signatures/midnight-publisher-ts/**"
-      - "integration-tests/src/midnight.rs"
-      - "integration-tests/tests/cases/midnight_stream.rs"
+      - "integration-tests/{src,tests}/**midnight**"
       # Shared integration-test harness.
-      - "integration-tests/src/lib.rs"
-      - "integration-tests/src/cluster/**"
-      - "integration-tests/tests/lib.rs"
-      - "integration-tests/tests/cases/mod.rs"
-      - "integration-tests/Cargo.toml"
+      - "integration-tests/{Cargo.toml,src/lib.rs,src/cluster/**,src/mpc_fixture/**,tests/lib.rs,tests/cases/mod.rs}"
       # The e2e test cross-signs over Ethereum via anvil + the eth contract.
       - "chain-signatures/contract-eth/**"
   merge_group:

--- a/.github/workflows/midnight.yml
+++ b/.github/workflows/midnight.yml
@@ -7,8 +7,38 @@ on:
     paths:
       - integration-tests/**
       - chain-signatures/**
-  # TODO(#1165): Add pull_request path filters to skip redundant runs.
+  # PRs run only on Midnight or shared-core changes; merge_group stays
+  # unfiltered as the safety net. Keep core in sync with other chain workflows.
   pull_request:
+    paths:
+      - ".github/workflows/midnight.yml"
+      # Shared core: changes here trigger every chain workflow.
+      - "chain-signatures/chain-integration-core/**"
+      - "chain-signatures/primitives/**"
+      - "chain-signatures/crypto/**"
+      - "chain-signatures/keys/**"
+      - "chain-signatures/utils/**"
+      - "chain-signatures/compact-hashing/**"
+      - "chain-signatures/node/**"
+      - "signet-crypto/**"
+      - "signet-primitives/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "justfile"
+      - ".config/nextest.toml"
+      # Midnight crate, TS publisher fixtures, and tests.
+      - "chain-signatures/chain-midnight/**"
+      - "chain-signatures/midnight-publisher-ts/**"
+      - "integration-tests/src/midnight.rs"
+      - "integration-tests/tests/cases/midnight_stream.rs"
+      # Shared integration-test harness.
+      - "integration-tests/src/lib.rs"
+      - "integration-tests/src/cluster/**"
+      - "integration-tests/tests/lib.rs"
+      - "integration-tests/tests/cases/mod.rs"
+      - "integration-tests/Cargo.toml"
+      # The e2e test cross-signs over Ethereum via anvil + the eth contract.
+      - "chain-signatures/contract-eth/**"
   merge_group:
 
 env:


### PR DESCRIPTION
Problem is described in #1165 

This PR targets Canton and Midnight, because their setup is expensive (might do the same for Solana and Ethereum next, need to split them between separate jobs).

### Changes

Added `pull_request.paths` filters to the three chain workflows:

- `canton.yml`
- `midnight.yml`
- `midnight-publisher-ts.yml`

Each one is now triggered if chain specific or shared core paths affected (previously run on every PR). Shared core includes:

- `chain-integration-core`
- `primitives`
- `crypto`
- `keys`
- `utils`
- `compact-hashing`
- `node`
- `signet-crypto`
- `signet-primitives`
- `Cargo.toml/Cargo.lock`
- `justfile`
- `.config/nextest.toml`

Note: `merge_group` does not support filtering, so it will always run everything (safety net)

