### PR TITLE
feat(ci): add GitHub Action to lint PR titles for conventional format

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -17,6 +17,11 @@ jobs:
     name: Conventional PR title
     runs-on: ubuntu-latest
     steps:
+      # Using default settings (let me know if we need to adjust anything):
+      # types: feat, fix, chore, docs, style, refactor, perf, test, build, ci, revert
+      # requireScope: false, disallowScopes: none, subjectPattern: none
+      # wip: false (draft PRs are VALIDATED)
+      # More configuration options - https://github.com/amannn/action-semantic-pull-request#configuration
       - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -17,7 +17,7 @@ jobs:
     name: Conventional PR title
     runs-on: ubuntu-latest
     steps:
-      # Using default settings (let me know if we need to adjust anything):
+      # Using default settings:
       # types: feat, fix, chore, docs, style, refactor, perf, test, build, ci, revert
       # requireScope: false, disallowScopes: none, subjectPattern: none
       # wip: false (draft PRs are VALIDATED)

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,22 @@
+name: Lint PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Conventional PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #443 

Add `.github/workflows/pr-title.yml` workflow. 

Using default settings (let me know if we need to adjust anything):

- types: feat, fix, chore, docs, style, refactor, perf, test, build, ci, revert
- `requireScope`: false, `disallowScopes`: none, `subjectPattern`: none
- `wip`: false (draft PRs are VALIDATED)

@volovyks we probably should add `Conventional PR title` to branch protection's required status checks