### PR TITLE
refactor: move publish from generation

### DIFF
--- a/chain-signatures/node/src/protocol/request/task.rs
+++ b/chain-signatures/node/src/protocol/request/task.rs
@@ -30,7 +30,10 @@ pub enum SignPhase {
     Posit(PositPhase),
     /// Commit the reserved presignature and run the signing protocol to completion.
     Generating(GeneratingPhase),
-    /// Terminal: the request finished (`Ok`) or aborted (`Err`).
+    /// Terminal. `Ok` means generation finished and the signature was handed
+    /// off to the backlog and the RPC queue; it does not mean a response is on
+    /// chain, which the backlog state and the chain streams track. `Err` means
+    /// the request aborted.
     Complete(Result<(), SignError>),
 }
 
@@ -117,41 +120,59 @@ impl GeneratingPhase {
 
         match result {
             Ok(output) => {
-                self.publish(ctx, state, output).await;
+                self.hand_off(ctx, state, output).await;
                 SignPhase::Complete(Ok(()))
             }
             Err(err) => state.reorganize(&format!("signature generation failed: {err:?}")),
         }
     }
 
-    /// Hand the finished signature on: every participant records it in the
-    /// backlog (so publish failover can pick it up), the proposer publishes it.
-    async fn publish(&self, ctx: &SignTask, state: &SignState, output: FullSignature<Secp256k1>) {
+    /// Hand the finished signature on. This is not the on-chain publish: every
+    /// participant moves the backlog entry to pending-publish, the record that
+    /// publish failover works from, and the proposer queues a publish for the
+    /// RPC worker, which submits and retries on its own. Neither outcome is
+    /// reported back here.
+    async fn hand_off(&self, ctx: &SignTask, state: &SignState, output: FullSignature<Secp256k1>) {
         let sign_id = ctx.sign_id;
-        let is_proposer = self.proposer == ctx.governance.me;
         let request = &state.request;
+        let is_proposer = self.proposer == ctx.governance.me;
 
-        if let Some(publish) = build_publish_state(
-            ctx.governance.public_key,
-            request,
-            &output,
-            &self.accepted_participants,
-            is_proposer,
+        let expected_public_key =
+            mpc_crypto::derive_key(ctx.governance.public_key, request.args.epsilon);
+        let signature = match mpc_crypto::reconstruct_signature(
+            &expected_public_key,
+            &output.big_r,
+            &output.s,
+            request.args.payload,
         ) {
-            if let Err(err) = ctx
-                .backlog
-                .mark_publishing(request.chain, &sign_id, publish)
-                .await
-            {
-                tracing::warn!(?sign_id, ?err, "failed to mark publishing for sign request");
+            Ok(signature) => signature,
+            Err(err) => {
+                tracing::error!(
+                    ?sign_id,
+                    ?err,
+                    "generated signature does not verify against the derived key; dropping it"
+                );
+                return;
             }
+        };
+
+        let publish = Arc::new(PublishState::new(
+            signature,
+            self.accepted_participants.clone(),
+            is_proposer,
+        ));
+        if let Err(err) = ctx
+            .backlog
+            .mark_publishing(request.chain, &sign_id, publish)
+            .await
+        {
+            tracing::warn!(?sign_id, ?err, "failed to mark publishing for sign request");
         }
 
         if is_proposer {
-            ctx.rpc.publish(
-                ctx.governance.public_key,
+            ctx.rpc.publish_signature(
                 Arc::clone(request),
-                output,
+                signature,
                 self.accepted_participants.clone(),
             );
         }
@@ -280,27 +301,6 @@ impl SignTask {
             node_account_id: self.node_account_id.clone(),
         }
     }
-}
-
-/// Reconstruct the full signature into a [`PublishState`], or `None` if reconstruction fails.
-fn build_publish_state(
-    public_key: mpc_crypto::PublicKey,
-    request: &IndexedSignRequest,
-    output: &FullSignature<Secp256k1>,
-    participants: &[Participant],
-    is_proposer: bool,
-) -> Option<Arc<PublishState>> {
-    let expected_public_key = mpc_crypto::derive_key(public_key, request.args.epsilon);
-    let signature = mpc_crypto::reconstruct_signature(
-        &expected_public_key,
-        &output.big_r,
-        &output.s,
-        request.args.payload,
-    )
-    .ok()?;
-    let publish = PublishState::new(signature, participants.to_vec(), is_proposer);
-
-    Some(Arc::new(publish))
 }
 
 #[cfg(test)]

--- a/chain-signatures/node/src/protocol/request/task.rs
+++ b/chain-signatures/node/src/protocol/request/task.rs
@@ -7,6 +7,10 @@ use super::posit::PositPhase;
 use super::state::SignState;
 use super::*;
 
+use crate::sign_bidirectional::PublishState;
+use cait_sith::FullSignature;
+use k256::Secp256k1;
+
 /// Generating phase — see [`SignPhase::Generating`].
 pub struct GeneratingPhase {
     pub proposer: Participant,
@@ -112,8 +116,44 @@ impl GeneratingPhase {
         };
 
         match result {
-            Ok(()) => SignPhase::Complete(Ok(())),
+            Ok(output) => {
+                self.publish(ctx, state, output).await;
+                SignPhase::Complete(Ok(()))
+            }
             Err(err) => state.reorganize(&format!("signature generation failed: {err:?}")),
+        }
+    }
+
+    /// Hand the finished signature on: every participant records it in the
+    /// backlog (so publish failover can pick it up), the proposer publishes it.
+    async fn publish(&self, ctx: &SignTask, state: &SignState, output: FullSignature<Secp256k1>) {
+        let sign_id = ctx.sign_id;
+        let is_proposer = self.proposer == ctx.governance.me;
+        let request = &state.request;
+
+        if let Some(publish) = build_publish_state(
+            ctx.governance.public_key,
+            request,
+            &output,
+            &self.accepted_participants,
+            is_proposer,
+        ) {
+            if let Err(err) = ctx
+                .backlog
+                .mark_publishing(request.chain, &sign_id, publish)
+                .await
+            {
+                tracing::warn!(?sign_id, ?err, "failed to mark publishing for sign request");
+            }
+        }
+
+        if is_proposer {
+            ctx.rpc.publish(
+                ctx.governance.public_key,
+                Arc::clone(request),
+                output,
+                self.accepted_participants.clone(),
+            );
         }
     }
 
@@ -236,12 +276,31 @@ impl SignTask {
         GenerateCtx {
             governance: self.governance.clone(),
             msg: self.msg.clone(),
-            rpc: self.rpc.clone(),
-            backlog: self.backlog.clone(),
             cfg: self.cfg.clone(),
             node_account_id: self.node_account_id.clone(),
         }
     }
+}
+
+/// Reconstruct the full signature into a [`PublishState`], or `None` if reconstruction fails.
+fn build_publish_state(
+    public_key: mpc_crypto::PublicKey,
+    request: &IndexedSignRequest,
+    output: &FullSignature<Secp256k1>,
+    participants: &[Participant],
+    is_proposer: bool,
+) -> Option<Arc<PublishState>> {
+    let expected_public_key = mpc_crypto::derive_key(public_key, request.args.epsilon);
+    let signature = mpc_crypto::reconstruct_signature(
+        &expected_public_key,
+        &output.big_r,
+        &output.s,
+        request.args.payload,
+    )
+    .ok()?;
+    let publish = PublishState::new(signature, participants.to_vec(), is_proposer);
+
+    Some(Arc::new(publish))
 }
 
 #[cfg(test)]

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -1,17 +1,15 @@
 //! Signature generation: runs the cait-sith signing protocol once a posit round agrees on a presignature and participant set.
 
-use crate::backlog::Backlog;
 use crate::protocol::message::{MessageChannel, SignatureMessage};
 use crate::protocol::presignature::PresignatureId;
-use crate::rpc::{GovernanceInfo, RpcChannel};
-use crate::sign_bidirectional::PublishState;
+use crate::rpc::GovernanceInfo;
 use crate::storage::presignature_storage::{PresignatureTaken, PresignatureTakenDropper};
 use crate::storage::PresignatureStorage;
 use crate::types::SignatureProtocol;
 use mpc_chain_near::AffinePointExt as _;
 
 use cait_sith::protocol::{Action, InitializationError, Participant};
-use cait_sith::PresignOutput;
+use cait_sith::{FullSignature, PresignOutput};
 use chrono::Utc;
 use k256::Secp256k1;
 use mpc_contract::config::ProtocolConfig;
@@ -28,13 +26,12 @@ pub(crate) enum SignError {
     Aborted,
 }
 
+/// What the signing protocol needs to run. Publishing the result is the
+/// caller's job: the generator returns the signature and knows nothing about
+/// the chain or the backlog.
 pub(crate) struct GenerateCtx {
     pub governance: GovernanceInfo,
     pub msg: MessageChannel,
-    /// Publishes the finished signature (proposer only).
-    pub rpc: RpcChannel,
-    /// Marks the request as publishing once a signature is produced.
-    pub backlog: Backlog,
     pub cfg: ProtocolConfig,
     /// Only used to label the debug page.
     #[cfg_attr(not(feature = "debug-page"), allow(dead_code))]
@@ -164,9 +161,12 @@ impl SignGenerator {
         }
     }
 
-    /// Poke-drive the protocol to completion: relay messages, and on `Return`
-    /// publish the signature (proposer) and mark the request publishing.
-    pub(crate) async fn run(mut self, ctx: &GenerateCtx) -> Result<(), SignError> {
+    /// Poke-drive the protocol to completion, relaying messages, and return the
+    /// finished signature. The caller publishes it.
+    pub(crate) async fn run(
+        mut self,
+        ctx: &GenerateCtx,
+    ) -> Result<FullSignature<Secp256k1>, SignError> {
         let me = ctx.governance.me;
         let epoch = ctx.governance.epoch;
 
@@ -280,39 +280,11 @@ impl SignGenerator {
                     crate::metrics::protocols::SIGN_GENERATION_LATENCY
                         .observe(self.created.elapsed().as_secs_f64());
                     crate::metrics::protocols::SIGNATURE_GENERATOR_SUCCESS.inc();
-
-                    let is_proposer = self.proposer == me;
-                    if let Some(publish) = build_publish_state(
-                        ctx.governance.public_key,
-                        &self.request,
-                        &output,
-                        &self.participants,
-                        is_proposer,
-                    ) {
-                        if let Err(err) = ctx
-                            .backlog
-                            .mark_publishing(self.request.chain, &sign_id, Arc::clone(&publish))
-                            .await
-                        {
-                            tracing::warn!(
-                                ?sign_id,
-                                ?err,
-                                "failed to mark publishing for sign request"
-                            );
-                        }
-                    }
-
-                    if is_proposer {
+                    if self.proposer == me {
                         crate::metrics::protocols::SIGNATURE_GENERATOR_MINE_SUCCESS.inc();
-                        ctx.rpc.publish(
-                            ctx.governance.public_key,
-                            Arc::clone(&self.request),
-                            output,
-                            self.participants.clone(),
-                        );
                     }
 
-                    break Ok(());
+                    break Ok(output);
                 }
             }
         }
@@ -335,27 +307,6 @@ fn awaited_peers(participants: &[Participant], seen: &[Participant]) -> Vec<Part
         .copied()
         .filter(|p| !seen.contains(p))
         .collect()
-}
-
-/// Reconstruct the full signature into a [`PublishState`], or `None` if reconstruction fails.
-fn build_publish_state(
-    public_key: mpc_crypto::PublicKey,
-    request: &IndexedSignRequest,
-    output: &cait_sith::FullSignature<Secp256k1>,
-    participants: &[Participant],
-    is_proposer: bool,
-) -> Option<Arc<PublishState>> {
-    let expected_public_key = mpc_crypto::derive_key(public_key, request.args.epsilon);
-    let signature = mpc_crypto::reconstruct_signature(
-        &expected_public_key,
-        &output.big_r,
-        &output.s,
-        request.args.payload,
-    )
-    .ok()?;
-    let publish = PublishState::new(signature, participants.to_vec(), is_proposer);
-
-    Some(Arc::new(publish))
 }
 
 impl Drop for SignGenerator {

--- a/chain-signatures/node/src/rpc/mod.rs
+++ b/chain-signatures/node/src/rpc/mod.rs
@@ -13,9 +13,8 @@ pub use mpc_chain_hydration::HydrationClient;
 pub use near_governance::{CheckpointVoteOutcome, NearGovernanceClient};
 
 use cait_sith::protocol::Participant;
-use cait_sith::FullSignature;
 use dashmap::DashSet;
-use k256::{AffinePoint, Secp256k1};
+use k256::AffinePoint;
 use mpc_chain_integration_core::{
     utils::retry::{retry_rpc, RetryConfig},
     ChainPublisher, PublishAction,
@@ -116,29 +115,6 @@ impl RpcChannel {
         if let Err(err) = self.tx.send(RpcAction::AbortCheckpoints(chain)).await {
             tracing::error!(%err, ?chain, "failed to send RPC chain abort");
         }
-    }
-
-    pub fn publish(
-        &self,
-        public_key: mpc_crypto::PublicKey,
-        request: Arc<IndexedSignRequest>,
-        output: FullSignature<Secp256k1>,
-        participants: Vec<Participant>,
-    ) {
-        let sign_id = request.id;
-        let Some(action) = PublishAction::new(public_key, request, output, participants) else {
-            tracing::error!(
-                ?sign_id,
-                "failed to validate signature; trashing publish request",
-            );
-            return;
-        };
-        let rpc = self.clone();
-        tokio::spawn(async move {
-            if let Err(err) = rpc.tx.send(RpcAction::Publish(action)).await {
-                tracing::error!(%err, "failed to send publish action");
-            }
-        });
     }
 
     pub fn publish_signature(


### PR DESCRIPTION
`SignGenerator::run` now returns the `FullSignature`; the backlog and RPC hand-off moves to `GeneratingPhase::hand_off` in `request/task.rs`. The generator no longer knows about `RpcChannel` or `Backlog`.

- `GenerateCtx` loses `rpc` and `backlog`.
- Signature is reconstructed once and passed to both the backlog and `rpc.publish_signature`; the duplicate check in `RpcChannel::publish` is gone with the method (no other callers).
- Docs on `SignPhase::Complete` and `hand_off` state that `Ok` means handed off, not on chain.

No behaviour change.