### PR TITLE
refactor: resolve the presignature in GeneratingPhase

### DIFF
--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -1,4 +1,4 @@
-use crate::protocol::signature::{GenerateCtx, PendingPresignature, SignError, SignGenerator};
+use crate::protocol::signature::{GenerateCtx, SignError, SignGenerator};
 
 use crate::backlog::Backlog;
 use crate::config::Config;

--- a/chain-signatures/node/src/protocol/request/task.rs
+++ b/chain-signatures/node/src/protocol/request/task.rs
@@ -7,10 +7,14 @@ use super::posit::PositPhase;
 use super::state::SignState;
 use super::*;
 
+use crate::storage::presignature_storage::PresignatureTaken;
+
 /// Generating phase — see [`SignPhase::Generating`].
 pub struct GeneratingPhase {
     pub proposer: Participant,
     pub presignature_id: PresignatureId,
+    /// Our reservation when we are the proposer; `None` for a deliberator,
+    /// whose copy is taken from storage when generation starts.
     pub presignature: Option<PresignatureReservation>,
     pub accepted_participants: Vec<Participant>,
 }
@@ -24,7 +28,8 @@ pub enum SignPhase {
     /// Agree on the presignature and participant set: the proposer collects
     /// Accepts and broadcasts Start; each deliberator does Propose -> Accept -> Start.
     Posit(PositPhase),
-    /// Commit the reserved presignature and run the signing protocol to completion.
+    /// Take the agreed presignature (commit our reservation, or wait for our
+    /// copy in storage) and run the signing protocol to completion.
     Generating(GeneratingPhase),
     /// Terminal: the request finished (`Ok`) or aborted (`Err`).
     Complete(Result<(), SignError>),
@@ -62,20 +67,9 @@ impl GeneratingPhase {
             "posit complete, starting generation"
         );
 
-        let presignature_pending = if let Some(reservation) = self.presignature.take() {
-            // Commit: actually remove from Redis now that posit succeeded and generation starts
-            match reservation.commit().await {
-                Some(taken) => PendingPresignature::Available(Box::new(taken)),
-                None => {
-                    return state.reorganize("failed to commit presignature reservation");
-                }
-            }
-        } else {
-            PendingPresignature::InStorage(
-                self.presignature_id,
-                self.proposer,
-                ctx.presignatures.clone(),
-            )
+        let taken = match self.take_presignature(ctx).await {
+            Ok(taken) => taken,
+            Err(reason) => return state.reorganize(&reason),
         };
 
         // Create and run signature generator, which will drive the protocol to completion.
@@ -84,7 +78,7 @@ impl GeneratingPhase {
             &gen_ctx,
             self.proposer,
             Arc::clone(&state.request),
-            presignature_pending,
+            taken,
             self.accepted_participants.clone(),
         )
         .await
@@ -115,6 +109,35 @@ impl GeneratingPhase {
             Ok(()) => SignPhase::Complete(Ok(())),
             Err(err) => state.reorganize(&format!("signature generation failed: {err:?}")),
         }
+    }
+
+    /// Resolve the agreed presignature to one we hold. The proposer commits its
+    /// reservation, which removes the presignature from Redis now that posit
+    /// succeeded. A deliberator takes its copy from storage, waiting for it up
+    /// to the generation timeout: we accepted the Propose knowing only that the
+    /// presignature exists or is still being generated.
+    async fn take_presignature(&mut self, ctx: &SignTask) -> Result<PresignatureTaken, String> {
+        if let Some(reservation) = self.presignature.take() {
+            return reservation
+                .commit()
+                .await
+                .ok_or_else(|| "failed to commit presignature reservation".to_string());
+        }
+
+        let id = self.presignature_id;
+        let timeout = Duration::from_millis(ctx.cfg.signature.generation_timeout);
+        // TODO: we can make storage wait for presignature to be available instead of here
+        tokio::time::timeout(timeout, async {
+            let mut interval = tokio::time::interval(Duration::from_millis(250));
+            loop {
+                interval.tick().await;
+                if let Some(taken) = ctx.presignatures.take(id, self.proposer).await {
+                    break taken;
+                }
+            }
+        })
+        .await
+        .map_err(|_| format!("timeout ({timeout:?}) waiting for presignature {id} to be available"))
     }
 
     /// Reject a `Propose` that arrives while we are already generating; drop

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -2,11 +2,9 @@
 
 use crate::backlog::Backlog;
 use crate::protocol::message::{MessageChannel, SignatureMessage};
-use crate::protocol::presignature::PresignatureId;
 use crate::rpc::{GovernanceInfo, RpcChannel};
 use crate::sign_bidirectional::PublishState;
 use crate::storage::presignature_storage::{PresignatureTaken, PresignatureTakenDropper};
-use crate::storage::PresignatureStorage;
 use crate::types::SignatureProtocol;
 use mpc_chain_near::AffinePointExt as _;
 
@@ -63,24 +61,16 @@ pub(crate) struct SignGenerator {
 }
 
 impl SignGenerator {
-    /// Fetch the committed presignature, apply the delta, and build the cait-sith signing protocol.
+    /// Apply the request's delta to the taken presignature and build the
+    /// cait-sith signing protocol.
     pub(crate) async fn new(
         ctx: &GenerateCtx,
         proposer: Participant,
         request: Arc<IndexedSignRequest>,
-        presignature: PendingPresignature,
+        taken: PresignatureTaken,
         participants: Vec<Participant>,
     ) -> Result<Self, InitializationError> {
-        let presignature_id = presignature.id();
-        let taken = presignature
-            .fetch(Duration::from_millis(ctx.cfg.signature.generation_timeout))
-            .await
-            .ok_or_else(|| {
-                InitializationError::BadParameters(format!(
-                    "presignature {presignature_id} not found or timeout",
-                ))
-            })?;
-
+        let presignature_id = taken.artifact.id;
         let sign_id = request.id;
         tracing::info!(
             me = ?ctx.governance.me,
@@ -368,53 +358,6 @@ impl Drop for SignGenerator {
             msg.unsubscribe_signature(sign_id, presignature_id).await;
             msg.filter_sign(sign_id, presignature_id).await;
         });
-    }
-}
-
-/// A presignature the generator will consume: already taken in memory, or still in storage (fetched with a timeout once generation starts).
-pub(crate) enum PendingPresignature {
-    Available(Box<PresignatureTaken>),
-    InStorage(PresignatureId, Participant, PresignatureStorage),
-}
-
-impl PendingPresignature {
-    pub fn id(&self) -> PresignatureId {
-        match self {
-            PendingPresignature::Available(taken) => taken.artifact.id,
-            PendingPresignature::InStorage(id, _, _) => *id,
-        }
-    }
-
-    /// Resolve to the taken presignature, polling storage up to `timeout` if not already in memory.
-    pub async fn fetch(self, timeout: Duration) -> Option<PresignatureTaken> {
-        let (id, storage, owner) = match self {
-            PendingPresignature::Available(taken) => return Some(*taken),
-            PendingPresignature::InStorage(id, owner, storage) => (id, storage, owner),
-        };
-
-        let presignature = tokio::time::timeout(timeout, async {
-            // TODO: we can make storage wait for presignature to be available instead of here
-            let mut interval = tokio::time::interval(Duration::from_millis(250));
-            loop {
-                interval.tick().await;
-                if let Some(presignature) = storage.take(id, owner).await {
-                    break presignature;
-                };
-            }
-        })
-        .await;
-
-        match presignature {
-            Ok(presignature) => Some(presignature),
-            Err(_) => {
-                tracing::warn!(
-                    id,
-                    ?timeout,
-                    "timeout waiting for presignature to be available"
-                );
-                None
-            }
-        }
     }
 }
 


### PR DESCRIPTION
SignGenerator::new takes a PresignatureTaken. The proposer/deliberator
split (commit our reservation, or wait for our copy in storage) lives in
GeneratingPhase::take_presignature; PendingPresignature is removed.