### PR TITLE
revert: enhance PR path filters for Canton and Midnight workflows (#1225)

### DIFF
--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -7,32 +7,7 @@ on:
     paths:
       - integration-tests/**
       - chain-signatures/**
-  # PRs run only on Canton or shared-core changes; merge_group stays
-  # unfiltered as the safety net. Keep core in sync with other chain workflows.
   pull_request:
-    paths:
-      - ".github/workflows/canton.yml"
-      # Shared core: changes here trigger every chain workflow.
-      - "chain-signatures/chain-integration-core/**"
-      - "chain-signatures/primitives/**"
-      - "chain-signatures/crypto/**"
-      - "chain-signatures/keys/**"
-      - "chain-signatures/utils/**"
-      - "chain-signatures/compact-hashing/**"
-      - "chain-signatures/node/**"
-      - "signet-crypto/**"
-      - "signet-primitives/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "justfile"
-      - ".config/nextest.toml"
-      # Canton crate, tests, and fixtures (matches any *canton* file at any depth).
-      - "chain-signatures/chain-canton/**"
-      - "integration-tests/{src,fixtures,tests}/**canton**"
-      # Shared integration-test harness.
-      - "integration-tests/{Cargo.toml,src/lib.rs,src/cluster/**,src/mpc_fixture/**,tests/lib.rs,tests/cases/mod.rs}"
-      # Canton tests cross-sign over Ethereum via anvil + the eth contract.
-      - "chain-signatures/contract-eth/**"
   merge_group:
 
 env:

--- a/.github/workflows/midnight-publisher-ts.yml
+++ b/.github/workflows/midnight-publisher-ts.yml
@@ -20,29 +20,7 @@ on:
       - "Dockerfile"
       - "chain-signatures/midnight-publisher-ts/**"
       - "chain-signatures/chain-midnight/**"
-  # Push paths plus the shared core, since the seam differential compiles
-  # mpc-chain-midnight. merge_group stays unfiltered as the safety net.
-  # Keep core in sync with the other chain workflows.
   pull_request:
-    paths:
-      - ".github/workflows/midnight-publisher-ts.yml"
-      - "Dockerfile"
-      - "chain-signatures/midnight-publisher-ts/**"
-      - "chain-signatures/chain-midnight/**"
-      # Shared core: compiled into mpc-chain-midnight and the seam tests.
-      - "chain-signatures/chain-integration-core/**"
-      - "chain-signatures/primitives/**"
-      - "chain-signatures/crypto/**"
-      - "chain-signatures/keys/**"
-      - "chain-signatures/utils/**"
-      - "chain-signatures/compact-hashing/**"
-      - "chain-signatures/node/**"
-      - "signet-crypto/**"
-      - "signet-primitives/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "justfile"
-      - ".config/nextest.toml"
   merge_group:
 
 jobs:

--- a/.github/workflows/midnight.yml
+++ b/.github/workflows/midnight.yml
@@ -7,33 +7,8 @@ on:
     paths:
       - integration-tests/**
       - chain-signatures/**
-  # PRs run only on Midnight or shared-core changes; merge_group stays
-  # unfiltered as the safety net. Keep core in sync with other chain workflows.
+  # TODO(#1165): Add pull_request path filters to skip redundant runs.
   pull_request:
-    paths:
-      - ".github/workflows/midnight.yml"
-      # Shared core: changes here trigger every chain workflow.
-      - "chain-signatures/chain-integration-core/**"
-      - "chain-signatures/primitives/**"
-      - "chain-signatures/crypto/**"
-      - "chain-signatures/keys/**"
-      - "chain-signatures/utils/**"
-      - "chain-signatures/compact-hashing/**"
-      - "chain-signatures/node/**"
-      - "signet-crypto/**"
-      - "signet-primitives/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "justfile"
-      - ".config/nextest.toml"
-      # Midnight crate, TS publisher fixtures, and tests.
-      - "chain-signatures/chain-midnight/**"
-      - "chain-signatures/midnight-publisher-ts/**"
-      - "integration-tests/{src,tests}/**midnight**"
-      # Shared integration-test harness.
-      - "integration-tests/{Cargo.toml,src/lib.rs,src/cluster/**,src/mpc_fixture/**,tests/lib.rs,tests/cases/mod.rs}"
-      # The e2e test cross-signs over Ethereum via anvil + the eth contract.
-      - "chain-signatures/contract-eth/**"
   merge_group:
 
 env:


### PR DESCRIPTION
Reverts #1225.

Canton checks (`Canton E2E Tests`, `Canton Stream Tests`) are still required in the `merge-queue` ruleset. With PR-level path filters, the Canton workflow never reports on PRs that skip it, so those checks hang at *Expected — Waiting for status* and block merging.