### PR TITLE
refactor(posit): one round gate for sign posits

### DIFF
--- a/chain-signatures/node/src/protocol/request/mailbox.rs
+++ b/chain-signatures/node/src/protocol/request/mailbox.rs
@@ -3,6 +3,7 @@ use crate::protocol::presignature::PresignatureId;
 
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use cait_sith::protocol::Participant;
@@ -27,9 +28,17 @@ pub(crate) struct SignPositMessage {
 ///   here. But we can't get a `Start` message for a round that we haven't already
 ///   responded to a `Propose` message. Therefore, one message per round is all we
 ///   need to buffer.
+///
+/// Messages for a round the task has not reached stay here until it gets there
+/// ([`recv_up_to`](Self::recv_up_to)). The mailbox also remembers the highest
+/// round peers have shown us, so the task's next round bump can jump straight
+/// to it.
 pub(crate) struct PositMailbox {
     // using std Mutex here, do not hold across .await
     messages: std::sync::Mutex<HashMap<Participant, SignPositMessage>>,
+    /// Highest round carried by a message pushed here, or named by a peer in a
+    /// `StaleRound` reject (see [`record_round`](Self::record_round)).
+    highest_round: AtomicUsize,
     notify: Notify,
 }
 
@@ -37,8 +46,20 @@ impl PositMailbox {
     pub(crate) fn new() -> Arc<Self> {
         Arc::new(Self {
             messages: std::sync::Mutex::new(HashMap::new()),
+            highest_round: AtomicUsize::new(0),
             notify: Notify::new(),
         })
+    }
+
+    /// Highest round any peer has shown us so far.
+    pub(crate) fn highest_round(&self) -> usize {
+        self.highest_round.load(Ordering::Relaxed)
+    }
+
+    /// Note a round a peer is at, from a message or from the payload of a
+    /// `StaleRound` reject. Never goes down.
+    pub(crate) fn record_round(&self, round: usize) {
+        self.highest_round.fetch_max(round, Ordering::Relaxed);
     }
 
     /// Buffer `msg` in its sender's slot, overwriting when its round is `>=` the
@@ -49,6 +70,7 @@ impl PositMailbox {
             round: new_round,
             ..
         } = msg;
+        self.record_round(new_round);
         let mut guard = self.messages.lock().unwrap();
         let mut inserted = false;
         match guard.entry(from) {
@@ -74,18 +96,28 @@ impl PositMailbox {
         }
     }
 
-    fn try_recv(&self) -> Option<SignPositMessage> {
+    /// Take one message whose round is at most `round`, if any.
+    fn try_recv_up_to(&self, round: usize) -> Option<SignPositMessage> {
         let mut guard = self.messages.lock().unwrap();
-        let key = guard.keys().next().copied()?;
+        let key = guard
+            .iter()
+            .find(|(_, msg)| msg.round <= round)
+            .map(|(from, _)| *from)?;
         guard.remove(&key)
     }
 
-    /// Wait for the next available posit message.
+    /// Wait for the next available posit message, whatever its round.
     pub(crate) async fn recv(&self) -> SignPositMessage {
+        self.recv_up_to(usize::MAX).await
+    }
+
+    /// Wait for the next posit message from round `round` or earlier. Messages
+    /// for later rounds stay put until a call names a round that includes them.
+    pub(crate) async fn recv_up_to(&self, round: usize) -> SignPositMessage {
         loop {
             // Register for wakeup BEFORE checking to avoid races with a push.
             let notified = self.notify.notified();
-            if let Some(msg) = self.try_recv() {
+            if let Some(msg) = self.try_recv_up_to(round) {
                 return msg;
             }
             notified.await;
@@ -118,13 +150,51 @@ mod tests {
         mailbox.push(posit(2, 3, PositAction::Accept));
 
         let mut got = [
-            mailbox.try_recv().expect("first message"),
-            mailbox.try_recv().expect("second message"),
+            mailbox.try_recv_up_to(usize::MAX).expect("first message"),
+            mailbox.try_recv_up_to(usize::MAX).expect("second message"),
         ];
         got.sort_by_key(|msg| u32::from(msg.from));
         assert!(matches!(got[0].action, PositAction::Accept));
         assert_eq!(got[0].round, 5, "the round-2 straggler must not win");
         assert_eq!(got[1].round, 3);
-        assert!(mailbox.try_recv().is_none());
+        assert!(mailbox.try_recv_up_to(usize::MAX).is_none());
+    }
+
+    /// A message for a round the task has not reached is not handed out; it
+    /// waits, and is delivered once the task's round catches up.
+    #[tokio::test]
+    async fn future_rounds_wait_for_the_task() {
+        let mailbox = PositMailbox::new();
+        mailbox.push(posit(1, 5, PositAction::Propose));
+        mailbox.push(posit(2, 3, PositAction::Propose));
+
+        let current = mailbox.recv_up_to(3).await;
+        assert_eq!(current.round, 3);
+        assert!(
+            mailbox.try_recv_up_to(3).is_none(),
+            "the round-5 message must stay in the mailbox"
+        );
+
+        let later = mailbox.recv_up_to(5).await;
+        assert_eq!(later.round, 5);
+        assert!(mailbox.try_recv_up_to(usize::MAX).is_none());
+    }
+
+    /// The highest round moves with what peers show us, from pushed messages
+    /// and from rounds recorded out of StaleRound rejects, and never down.
+    #[test]
+    fn highest_round_follows_peers() {
+        let mailbox = PositMailbox::new();
+        assert_eq!(mailbox.highest_round(), 0);
+
+        mailbox.push(posit(1, 4, PositAction::Propose));
+        assert_eq!(mailbox.highest_round(), 4);
+
+        mailbox.record_round(9);
+        assert_eq!(mailbox.highest_round(), 9);
+
+        mailbox.push(posit(2, 2, PositAction::Accept));
+        mailbox.record_round(1);
+        assert_eq!(mailbox.highest_round(), 9);
     }
 }

--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -102,7 +102,7 @@ fn round_timeout(round: usize) -> Duration {
         return ORGANIZE_POSIT_TIMEOUT;
     }
     // Saturates at the ceiling within ~16 iterations, which bounds the loop:
-    // `round` derives from `highest_seen_round`, so a peer can make it huge.
+    // `round` derives from the highest round a peer has shown us, so a peer can make it huge.
     let mut timeout = ROUND_TIMEOUT_FLOOR;
     for _ in 1..round {
         if timeout >= ROUND_TIMEOUT_CEILING {

--- a/chain-signatures/node/src/protocol/request/organize.rs
+++ b/chain-signatures/node/src/protocol/request/organize.rs
@@ -11,7 +11,7 @@ impl OrganizingPhase {
     /// Seeded by request entropy so all nodes pick the same proposer.
     ///
     /// Both operands are reduced before adding: `round` comes from
-    /// `highest_seen_round`, which a peer sets, so it can be arbitrarily large.
+    /// the highest round a peer has shown us, so it can be arbitrarily large.
     fn proposer_per_round(
         round: usize,
         participants: &[Participant],

--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -1,4 +1,3 @@
-use super::mailbox::PositMailbox;
 use super::state::SignState;
 use super::task::{GeneratingPhase, SignPhase};
 use super::*;
@@ -17,162 +16,76 @@ impl PositPhase {
     async fn wait_for_propose(
         ctx: &mut SignTask,
         state: &mut SignState,
-        mailbox: &PositMailbox,
         proposer: Participant,
     ) -> Result<PresignatureId, Box<SignPhase>> {
         let sign_id = ctx.sign_id;
         let remaining = state.budget.remaining();
         let outcome = tokio::time::timeout(remaining, async {
             loop {
-                // Prioritize buffered messages for the current round.
-                let task_msg = match state.take_buffered_posit_message() {
-                    Some(buffered) => buffered,
-                    None => mailbox.recv().await,
-                };
-
                 let SignPositMessage {
                     presignature_id,
                     from,
                     action,
-                    round: peer_round,
-                } = &task_msg;
+                    ..
+                } = state.recv_current(ctx).await;
 
-                // A StaleRound reject carries the rejector's current round;
-                // remember it so our next bump catches up in one step.
-                if let PositAction::RejectWithReason(PositRejectReason::StaleRound(peer_current)) =
-                    action
-                {
-                    state.record_peer_round(*peer_current);
-                }
-
-                // Nothing else to do with a Reject: a deliberator has sent
-                // nothing that could be rejected, and answering one would
-                // ping-pong rejects between two nodes.
+                // Nothing to do with a Reject: a deliberator has sent nothing
+                // that could be rejected.
                 if matches!(action, PositAction::RejectWithReason(_)) {
-                    continue;
-                }
-
-                // reject any messages with a different round than ours
-                //
-                // note: Rejecting messages of older rounds is always the right
-                // choice. But for newer messages, we could buffer them and try
-                // that round later. What we must not do is immediately jump to
-                // that higher round, or else any peer could force themselves to
-                // be the proposer every time.
-                if state.round() > *peer_round {
-                    tracing::info!(
-                        ?from,
-                        peer_round,
-                        my_round = state.round(),
-                        "Rejecting message from older round, as deliberator",
-                    );
-                    ctx.msg
-                        .send(
-                            ctx.governance.me,
-                            *from,
-                            PositMessage {
-                                // The id echoes the rejected message so the
-                                // sender knows which attempt we are answering.
-                                id: PositProtocolId::Signature(
-                                    sign_id,
-                                    *presignature_id,
-                                    *peer_round,
-                                ),
-                                from: ctx.governance.me,
-                                action: PositAction::RejectWithReason(
-                                    PositRejectReason::StaleRound(state.round()),
-                                ),
-                            },
-                        )
-                        .await;
-                    continue;
-                }
-
-                // Message can't be processed now but is crucial to make progress later.
-                // Note that we must first try and finish the current round and
-                // not immediately jump to that higher round. Otherwise, any peer
-                // could force themselves to be the proposer every time.
-                if state.round() < *peer_round {
-                    tracing::info!(
-                        peer_round,
-                        my_round = state.round(),
-                        "Storing message for future round, as deliberator",
-                    );
-                    state.buffer_future_posit_message(task_msg);
                     continue;
                 }
 
                 if !matches!(action, PositAction::Propose) {
                     tracing::warn!(
-                        round = peer_round,
+                        round = state.round(),
                         ?action,
                         "Got unexpected posit message while waiting for propose"
                     );
                     continue;
                 }
 
-                if from == &proposer {
-                    tracing::info!(
-                        ?sign_id,
-                        ?presignature_id,
-                        ?from,
-                        "deliberator received Propose"
-                    );
-
-                    // Check if we have access to this presignature (in storage or generating)
-                    if !ctx.presignatures.contains(*presignature_id).await {
-                        tracing::warn!(
-                            ?sign_id,
-                            presignature_id,
-                            "deliberator does not have access to proposed presignature, rejecting"
-                        );
-                        ctx.msg
-                            .send(
-                                ctx.governance.me,
-                                proposer,
-                                PositMessage {
-                                    id: PositProtocolId::Signature(
-                                        sign_id,
-                                        *presignature_id,
-                                        state.round(),
-                                    ),
-                                    from: ctx.governance.me,
-                                    action: PositAction::RejectWithReason(
-                                        PositRejectReason::MissingArtifact,
-                                    ),
-                                },
-                            )
-                            .await;
-                        continue;
-                    }
-
-                    break *presignature_id;
-                } else {
+                if from != proposer {
                     tracing::warn!(
                         ?sign_id,
                         ?from,
                         ?proposer,
                         "received Propose from non-proposer, rejecting"
                     );
-
-                    ctx.msg
-                        .send(
-                            ctx.governance.me,
-                            *from,
-                            PositMessage {
-                                id: PositProtocolId::Signature(
-                                    sign_id,
-                                    *presignature_id,
-                                    state.round(),
-                                ),
-                                from: ctx.governance.me,
-                                action: PositAction::RejectWithReason(
-                                    PositRejectReason::InvalidRequest,
-                                ),
-                            },
-                        )
-                        .await;
+                    ctx.reject(
+                        from,
+                        presignature_id,
+                        state.round(),
+                        PositRejectReason::InvalidRequest,
+                    )
+                    .await;
+                    continue;
                 }
+
+                tracing::info!(
+                    ?sign_id,
+                    ?presignature_id,
+                    ?from,
+                    "deliberator received Propose"
+                );
+
+                // Check if we have access to this presignature (in storage or generating)
+                if !ctx.presignatures.contains(presignature_id).await {
+                    tracing::warn!(
+                        ?sign_id,
+                        presignature_id,
+                        "deliberator does not have access to proposed presignature, rejecting"
+                    );
+                    ctx.reject(
+                        proposer,
+                        presignature_id,
+                        state.round(),
+                        PositRejectReason::MissingArtifact,
+                    )
+                    .await;
+                    continue;
+                }
+
+                break presignature_id;
             }
         })
         .await;
@@ -201,12 +114,7 @@ impl PositPhase {
 
     /// Run the posit round. Returns `Generating` with the accepted participants,
     /// or `Organizing` on rejection/timeout.
-    pub async fn advance(
-        &mut self,
-        ctx: &mut SignTask,
-        state: &mut SignState,
-        mailbox: &PositMailbox,
-    ) -> SignPhase {
+    pub async fn advance(&mut self, ctx: &mut SignTask, state: &mut SignState) -> SignPhase {
         let proposer = self.proposer;
         let active = self.active.clone();
         let mut presignature_id = self.presignature_id;
@@ -233,7 +141,7 @@ impl PositPhase {
                 "deliberator waiting for Propose"
             );
 
-            presignature_id = match Self::wait_for_propose(ctx, state, mailbox, proposer).await {
+            presignature_id = match Self::wait_for_propose(ctx, state, proposer).await {
                 Ok(id) => id,
                 Err(phase) => return *phase,
             };
@@ -262,59 +170,7 @@ impl PositPhase {
 
         let accepted_participants = loop {
             tokio::select! {
-                task_msg = mailbox.recv() => {
-                    let SignPositMessage { round: peer_round , ..} = task_msg;
-
-                    // A StaleRound reject carries the rejector's current round;
-                    // remember it so our next bump catches up in one step.
-                    if let PositAction::RejectWithReason(PositRejectReason::StaleRound(peer_current)) = task_msg.action {
-                        state.record_peer_round(peer_current);
-                    }
-
-                    // Answer older rounds with StaleRound (as `wait_for_propose`
-                    // does) so a behind peer learns our round instead of
-                    // burning its full timeout in silence. Rejects are never
-                    // answered: replying would ping-pong rejects between nodes.
-                    if state.round() > peer_round {
-                        if matches!(task_msg.action, PositAction::RejectWithReason(_)) {
-                            continue;
-                        }
-                        ctx.msg
-                            .send(
-                                ctx.governance.me,
-                                task_msg.from,
-                                PositMessage {
-                                    // The id echoes the rejected message so the
-                                    // sender knows which attempt we are answering.
-                                    id: PositProtocolId::Signature(
-                                        sign_id,
-                                        task_msg.presignature_id,
-                                        peer_round,
-                                    ),
-                                    from: ctx.governance.me,
-                                    action: PositAction::RejectWithReason(
-                                        PositRejectReason::StaleRound(state.round()),
-                                    ),
-                                },
-                            )
-                            .await;
-                        continue;
-                    }
-
-                    // Message can't be processed now but is crucial to make progress later.
-                    // Note that we must first try and finish the current round and
-                    // not immediately jump to that higher round. Otherwise, any peer
-                    // could force themselves to be the proposer every time.
-                    if state.round() < peer_round {
-                        tracing::info!(
-                            peer_round,
-                            my_round = state.round(),
-                            "Storing message for future round",
-                        );
-                        state.buffer_future_posit_message(task_msg);
-                        continue;
-                    }
-
+                task_msg = state.recv_current(ctx) => {
                     let SignPositMessage { presignature_id: _, round: _peer_round, from, action } = task_msg;
 
                     if is_deliberator {
@@ -527,7 +383,12 @@ pub(crate) mod tests {
             SignKind::Sign,
         );
         let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
-        let state = SignState::new(Arc::new(request), mesh_rx, Arc::clone(&ctx.round));
+        let state = SignState::new(
+            Arc::new(request),
+            mesh_rx,
+            Arc::clone(&ctx.round),
+            PositMailbox::new(),
+        );
 
         TestSetup {
             ctx,
@@ -581,8 +442,7 @@ pub(crate) mod tests {
         t.state.set_round(our_round);
         t.state.budget.reset(Duration::from_millis(200));
 
-        let mailbox = PositMailbox::new();
-        mailbox.push(SignPositMessage {
+        t.state.mailbox.push(SignPositMessage {
             presignature_id: 42,
             round: propose_round,
             from: proposer,
@@ -591,8 +451,7 @@ pub(crate) mod tests {
 
         // Behind-proposer Propose is rejected; the call then times out waiting
         // for a valid one and reorganizes.
-        let phase =
-            PositPhase::wait_for_propose(&mut t.ctx, &mut t.state, &mailbox, proposer).await;
+        let phase = PositPhase::wait_for_propose(&mut t.ctx, &mut t.state, proposer).await;
         assert!(matches!(phase, Err(p) if matches!(*p, SignPhase::Organizing(_))));
 
         let (round, action) = sent_posit(&mut t.outbox, me, proposer);
@@ -620,8 +479,7 @@ pub(crate) mod tests {
         t.state.set_round(2);
         t.state.budget.reset(Duration::from_millis(200));
 
-        let mailbox = PositMailbox::new();
-        mailbox.push(SignPositMessage {
+        t.state.mailbox.push(SignPositMessage {
             presignature_id: 42,
             round: 2,
             from: peer,
@@ -630,7 +488,7 @@ pub(crate) mod tests {
 
         // No Propose ever arrives, so the wait times out and reorganizes,
         // bumping the round with the recorded rejector's round.
-        let phase = PositPhase::wait_for_propose(&mut t.ctx, &mut t.state, &mailbox, peer).await;
+        let phase = PositPhase::wait_for_propose(&mut t.ctx, &mut t.state, peer).await;
         assert!(matches!(phase, Err(p) if matches!(*p, SignPhase::Organizing(_))));
 
         // Caught up in one bump: max(2 + 1, 5) = 5.
@@ -654,8 +512,7 @@ pub(crate) mod tests {
         t.state.set_round(5);
         t.state.budget.reset(Duration::from_millis(200));
 
-        let mailbox = PositMailbox::new();
-        mailbox.push(SignPositMessage {
+        t.state.mailbox.push(SignPositMessage {
             presignature_id: 42,
             round: 2,
             from: behind,
@@ -668,7 +525,7 @@ pub(crate) mod tests {
             presignature_id: 42,
             presignature: None,
         };
-        let next = phase.advance(&mut t.ctx, &mut t.state, &mailbox).await;
+        let next = phase.advance(&mut t.ctx, &mut t.state).await;
         assert!(matches!(next, SignPhase::Organizing(_)));
 
         let (round, action) = sent_posit(&mut t.outbox, proposer, behind);
@@ -697,8 +554,7 @@ pub(crate) mod tests {
         t.state.set_round(3);
         t.state.budget.reset(Duration::from_millis(200));
 
-        let mailbox = PositMailbox::new();
-        mailbox.push(SignPositMessage {
+        t.state.mailbox.push(SignPositMessage {
             presignature_id: 42,
             round: 2,
             from: rejector,
@@ -711,7 +567,7 @@ pub(crate) mod tests {
             presignature_id: 42,
             presignature: None,
         };
-        let next = phase.advance(&mut t.ctx, &mut t.state, &mailbox).await;
+        let next = phase.advance(&mut t.ctx, &mut t.state).await;
         assert!(matches!(next, SignPhase::Organizing(_)));
 
         assert_eq!(t.state.round(), 5, "must catch up in one bump");
@@ -732,9 +588,8 @@ pub(crate) mod tests {
         let mut t = setup(proposer, first, 2);
         t.state.budget.reset(Duration::from_millis(200));
 
-        let mailbox = PositMailbox::new();
         for from in [first, second] {
-            mailbox.push(SignPositMessage {
+            t.state.mailbox.push(SignPositMessage {
                 presignature_id: 42,
                 round: 0,
                 from,
@@ -748,7 +603,7 @@ pub(crate) mod tests {
             presignature_id: 42,
             presignature: None,
         };
-        let next = phase.advance(&mut t.ctx, &mut t.state, &mailbox).await;
+        let next = phase.advance(&mut t.ctx, &mut t.state).await;
         assert!(matches!(next, SignPhase::Organizing(_)));
 
         // `rejects` is a BTreeMap, so reports come out in participant order.
@@ -771,14 +626,13 @@ pub(crate) mod tests {
         let mut t = setup(proposer, missing, 2);
         t.state.budget.reset(Duration::from_millis(200));
 
-        let mailbox = PositMailbox::new();
-        mailbox.push(SignPositMessage {
+        t.state.mailbox.push(SignPositMessage {
             presignature_id: 42,
             round: 0,
             from: missing,
             action: PositAction::RejectWithReason(PositRejectReason::MissingArtifact),
         });
-        mailbox.push(SignPositMessage {
+        t.state.mailbox.push(SignPositMessage {
             presignature_id: 42,
             round: 0,
             from: invalid,
@@ -791,7 +645,7 @@ pub(crate) mod tests {
             presignature_id: 42,
             presignature: None,
         };
-        let next = phase.advance(&mut t.ctx, &mut t.state, &mailbox).await;
+        let next = phase.advance(&mut t.ctx, &mut t.state).await;
         assert!(matches!(next, SignPhase::Organizing(_)));
 
         assert_eq!(

--- a/chain-signatures/node/src/protocol/request/state.rs
+++ b/chain-signatures/node/src/protocol/request/state.rs
@@ -1,6 +1,7 @@
 use super::limiter::SignPermit;
+use super::mailbox::PositMailbox;
 use super::organize::OrganizingPhase;
-use super::task::SignPhase;
+use super::task::{SignPhase, SignTask};
 use super::*;
 
 pub struct SignState {
@@ -10,20 +11,22 @@ pub struct SignState {
     /// Budget for the current organizing+posit attempt.
     pub budget: TimeoutBudget,
     pub permit: Option<SignPermit>,
-    /// The highest round sent by a peer
-    pub highest_seen_round: usize,
-    /// Posit message for `highest_seen_round` round.
-    ///
-    /// These are later processed, if the task reaches the `highest_seen_round`
-    /// as a deliberator. Proposers do not reprocess old messages. A valid peer
-    /// would not have sent a posit message before the proposer proposes.
-    ///
-    /// INVARIANT: All messages stored here are for `highest_seen_round`. Must
-    /// be cleared when `highest_seen_round` changes. One slot per sender.
-    pub buffered_messages: HashMap<Participant, SignPositMessage>,
+    /// Posits for this request. Shared with the spawner, which buffers messages
+    /// that arrive before the task, and kept across respawns. Messages for
+    /// rounds we have not reached wait in it, and it remembers the highest
+    /// round peers have shown us.
+    pub mailbox: Arc<PositMailbox>,
     /// Shared with `SignEntry` so a respawn resumes at the round it left off;
     /// peers rely on our rounds never going down.
     carried_round: Arc<AtomicUsize>,
+}
+
+/// Where a posit stands against our round; see [`SignState::gate`].
+pub enum Gate {
+    /// Our round, or one we have not reached: for the caller to handle.
+    Live(SignPositMessage),
+    /// From a round we have left: the sender should learn our round.
+    Stale(SignPositMessage),
 }
 
 impl SignState {
@@ -31,6 +34,7 @@ impl SignState {
         request: Arc<IndexedSignRequest>,
         mesh_state: watch::Receiver<MeshState>,
         carried_round: Arc<AtomicUsize>,
+        mailbox: Arc<PositMailbox>,
     ) -> Self {
         Self {
             round: carried_round.load(Ordering::Relaxed),
@@ -38,8 +42,7 @@ impl SignState {
             mesh_state,
             budget: TimeoutBudget::new(round_timeout(0)),
             permit: None,
-            highest_seen_round: 0,
-            buffered_messages: HashMap::new(),
+            mailbox,
             carried_round,
         }
     }
@@ -73,11 +76,14 @@ impl SignState {
         SignPhase::Organizing(OrganizingPhase)
     }
 
+    /// Next round: one past ours, or straight to the highest round peers have
+    /// shown us, whichever is further. We never jump on sight: if we did, any
+    /// peer could name a round that makes itself proposer, every time.
     fn bump_round(&mut self) {
         let prev_round = self.round;
         self.set_round(std::cmp::max(
             self.round.saturating_add(1),
-            self.highest_seen_round,
+            self.mailbox.highest_round(),
         ));
         self.budget.reset(round_timeout(self.round));
         self.permit = None;
@@ -86,39 +92,58 @@ impl SignState {
 
     /// Record a peer's round learned from a `StaleRound` reject so the next
     /// bump catches up in one step.
-    pub fn record_peer_round(&mut self, peer_round: usize) {
-        if peer_round > self.highest_seen_round {
-            self.highest_seen_round = peer_round;
-            self.buffered_messages.clear();
-        }
+    pub fn record_peer_round(&self, peer_round: usize) {
+        self.mailbox.record_round(peer_round);
     }
 
-    /// Buffer a posit message for a future round until that round is reached.
-    pub fn buffer_future_posit_message(&mut self, msg: SignPositMessage) {
-        let SignPositMessage {
-            round: peer_round,
-            from,
-            ..
-        } = msg;
+    /// Place a posit against our round, recording whatever it tells us about
+    /// the sender's round on the way. `None` is a reject from a round we have
+    /// left: there is nothing to answer (a reject is never answered with a
+    /// reject, or two nodes ping-pong) and any `StaleRound` payload has been
+    /// recorded.
+    pub fn gate(&self, msg: SignPositMessage) -> Option<Gate> {
+        self.mailbox.record_round(msg.round);
+        if let PositAction::RejectWithReason(PositRejectReason::StaleRound(peer_round)) = msg.action
+        {
+            self.record_peer_round(peer_round);
+        }
 
-        if peer_round < self.highest_seen_round {
-            return;
+        if msg.round >= self.round {
+            return Some(Gate::Live(msg));
         }
-        if peer_round > self.highest_seen_round {
-            self.highest_seen_round = peer_round;
-            self.buffered_messages.clear();
+        if matches!(msg.action, PositAction::RejectWithReason(_)) {
+            return None;
         }
-        // One slot per sender, keep only the latest round.
-        self.buffered_messages.insert(from, msg);
+        Some(Gate::Stale(msg))
     }
 
-    /// Take a buffered message to process, if one exists for the current round.
-    pub fn take_buffered_posit_message(&mut self) -> Option<SignPositMessage> {
-        if self.highest_seen_round == self.round {
-            let key = self.buffered_messages.keys().next().copied()?;
-            self.buffered_messages.remove(&key)
-        } else {
-            None
+    /// Next posit for the current round. A message from a round we have left
+    /// is answered with `StaleRound`, carrying our round so the sender catches
+    /// up in one bump. Messages for rounds we have not reached wait in the
+    /// mailbox until we get there.
+    pub async fn recv_current(&self, ctx: &SignTask) -> SignPositMessage {
+        loop {
+            let msg = self.mailbox.recv_up_to(self.round).await;
+            match self.gate(msg) {
+                Some(Gate::Live(msg)) => return msg,
+                Some(Gate::Stale(msg)) => {
+                    tracing::info!(
+                        sign_id = ?ctx.sign_id,
+                        from = ?msg.from,
+                        peer_round = msg.round,
+                        my_round = self.round,
+                        "rejecting posit from an older round"
+                    );
+                    ctx.reject(
+                        msg.from,
+                        msg.presignature_id,
+                        msg.round,
+                        PositRejectReason::StaleRound(self.round),
+                    )
+                    .await;
+                }
+                None => {}
+            }
         }
     }
 }
@@ -142,22 +167,97 @@ mod tests {
         )
     }
 
+    fn posit(from: u32, round: usize, action: PositAction) -> SignPositMessage {
+        SignPositMessage {
+            presignature_id: 0,
+            round,
+            from: Participant::from(from),
+            action,
+        }
+    }
+
+    fn state(round: usize) -> SignState {
+        let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
+        let mut state = SignState::new(
+            Arc::new(request()),
+            mesh_rx,
+            Arc::new(AtomicUsize::new(0)),
+            PositMailbox::new(),
+        );
+        state.set_round(round);
+        state
+    }
+
     /// A respawn rebuilds `SignState`; the round must resume from the carried
     /// value, not restart at 0 — peers read a round reset as time travel.
     #[test]
     fn round_survives_a_respawn() {
         let carried = Arc::new(AtomicUsize::new(0));
+        let mailbox = PositMailbox::new();
         let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
 
-        let mut state = SignState::new(Arc::new(request()), mesh_rx.clone(), Arc::clone(&carried));
+        let mut state = SignState::new(
+            Arc::new(request()),
+            mesh_rx.clone(),
+            Arc::clone(&carried),
+            Arc::clone(&mailbox),
+        );
         state.reorganize("test");
-        state.highest_seen_round = 9;
+        state.record_peer_round(9);
         state.reorganize("test");
         assert_eq!(state.round(), 9);
 
         // The task is aborted and a new incarnation takes over.
         drop(state);
-        let respawned = SignState::new(Arc::new(request()), mesh_rx, carried);
+        let respawned = SignState::new(Arc::new(request()), mesh_rx, carried, mailbox);
         assert_eq!(respawned.round(), 9);
+    }
+
+    /// The gate sorts messages by round: ours or later pass through, older
+    /// ones come back as stale unless they are rejects, which have nothing to
+    /// answer. Every message leaves its round behind for the next bump.
+    #[test]
+    fn gate_sorts_by_round_and_drops_stale_rejects() {
+        let state = state(5);
+
+        assert!(matches!(
+            state.gate(posit(1, 5, PositAction::Accept)),
+            Some(Gate::Live(_))
+        ));
+        assert!(matches!(
+            state.gate(posit(1, 7, PositAction::Propose)),
+            Some(Gate::Live(_))
+        ));
+        assert!(matches!(
+            state.gate(posit(1, 2, PositAction::Propose)),
+            Some(Gate::Stale(_))
+        ));
+        assert!(state
+            .gate(posit(
+                1,
+                2,
+                PositAction::RejectWithReason(PositRejectReason::InvalidRequest)
+            ))
+            .is_none());
+
+        // The round-7 Propose was recorded on the way through.
+        assert_eq!(state.mailbox.highest_round(), 7);
+    }
+
+    /// A StaleRound reject names the rejector's round; that is recorded even
+    /// when the reject itself is dropped as stale.
+    #[test]
+    fn gate_records_the_round_inside_a_stale_round_reject() {
+        let mut state = state(3);
+
+        let gated = state.gate(posit(
+            1,
+            2,
+            PositAction::RejectWithReason(PositRejectReason::StaleRound(12)),
+        ));
+        assert!(gated.is_none());
+
+        state.reorganize("test");
+        assert_eq!(state.round(), 12, "must catch up in one bump");
     }
 }

--- a/chain-signatures/node/src/protocol/request/task.rs
+++ b/chain-signatures/node/src/protocol/request/task.rs
@@ -4,7 +4,7 @@ use super::mailbox::PositMailbox;
 use super::metrics::PhaseDurations;
 use super::organize::OrganizingPhase;
 use super::posit::PositPhase;
-use super::state::SignState;
+use super::state::{Gate, SignState};
 use super::*;
 
 /// Generating phase — see [`SignPhase::Generating`].
@@ -31,28 +31,18 @@ pub enum SignPhase {
 }
 
 impl SignPhase {
-    async fn advance(
-        &mut self,
-        ctx: &mut SignTask,
-        state: &mut SignState,
-        mailbox: &PositMailbox,
-    ) -> SignPhase {
+    async fn advance(&mut self, ctx: &mut SignTask, state: &mut SignState) -> SignPhase {
         match self {
             SignPhase::Organizing(phase) => phase.advance(ctx, state).await,
-            SignPhase::Posit(phase) => phase.advance(ctx, state, mailbox).await,
-            SignPhase::Generating(phase) => phase.advance(ctx, state, mailbox).await,
+            SignPhase::Posit(phase) => phase.advance(ctx, state).await,
+            SignPhase::Generating(phase) => phase.advance(ctx, state).await,
             SignPhase::Complete(result) => SignPhase::Complete(*result),
         }
     }
 }
 
 impl GeneratingPhase {
-    async fn advance(
-        &mut self,
-        ctx: &SignTask,
-        state: &mut SignState,
-        mailbox: &PositMailbox,
-    ) -> SignPhase {
+    async fn advance(&mut self, ctx: &SignTask, state: &mut SignState) -> SignPhase {
         let sign_id = ctx.sign_id;
 
         tracing::info!(
@@ -99,7 +89,10 @@ impl GeneratingPhase {
 
         // Drive generation while answering posit traffic: peers proposing this
         // signature get a Reject so they don't wait for us. The generator itself
-        // knows nothing about posits.
+        // knows nothing about posits. Every round is read here, including ones
+        // we have not reached: a proposer for a later round should hear that we
+        // are busy rather than wait for our Accept.
+        let mailbox = Arc::clone(&state.mailbox);
         let generation = generator.run(&gen_ctx);
         tokio::pin!(generation);
         let result = loop {
@@ -119,46 +112,24 @@ impl GeneratingPhase {
 
     /// Reject a `Propose` that arrives while we are already generating; drop
     /// stale Accept/Reject/Start messages.
-    async fn reject_late_propose(
-        ctx: &SignTask,
-        state: &mut SignState,
-        task_msg: SignPositMessage,
-    ) {
-        let SignPositMessage {
-            presignature_id,
-            round,
-            from,
-            action,
-            ..
-        } = task_msg;
-        if !matches!(action, PositAction::Propose) {
+    async fn reject_late_propose(ctx: &SignTask, state: &SignState, task_msg: SignPositMessage) {
+        let (msg, reason) = match state.gate(task_msg) {
+            Some(Gate::Stale(msg)) => (msg, PositRejectReason::StaleRound(state.round())),
+            Some(Gate::Live(msg)) => (msg, PositRejectReason::AlreadyGenerating),
+            None => return,
+        };
+        if !matches!(msg.action, PositAction::Propose) {
             return;
         }
-        let me = ctx.governance.me;
-        let reason = if state.round() > round {
-            PositRejectReason::StaleRound(state.round())
-        } else {
-            state.record_peer_round(round);
-            PositRejectReason::AlreadyGenerating
-        };
         tracing::info!(
             sign_id = ?ctx.sign_id,
-            ?from,
-            round,
+            from = ?msg.from,
+            round = msg.round,
             my_round = state.round(),
             ?reason,
             "received Propose while already generating, rejecting"
         );
-        ctx.msg
-            .send(
-                me,
-                from,
-                PositMessage {
-                    id: PositProtocolId::Signature(ctx.sign_id, presignature_id, round),
-                    from: me,
-                    action: PositAction::RejectWithReason(reason),
-                },
-            )
+        ctx.reject(msg.from, msg.presignature_id, msg.round, reason)
             .await;
     }
 }
@@ -194,7 +165,7 @@ impl SignTask {
         let sign_id = self.sign_id;
         tracing::info!(?sign_id, governance = ?self.governance, "signature task starting...");
 
-        let mut state = SignState::new(request, mesh_state, Arc::clone(&self.round));
+        let mut state = SignState::new(request, mesh_state, Arc::clone(&self.round), mailbox);
         let mut phase = SignPhase::Organizing(OrganizingPhase);
 
         // Sum per-phase time across loop attempts; emit on Complete(Ok) only.
@@ -209,7 +180,7 @@ impl SignTask {
                 SignPhase::Complete(_) => None,
             };
 
-            let new_phase = phase.advance(&mut self, &mut state, &mailbox).await;
+            let new_phase = phase.advance(&mut self, &mut state).await;
             if let Some(step) = current_phase_step {
                 durations.add(step, phase_start.elapsed());
                 if matches!(&new_phase, SignPhase::Organizing(_)) {
@@ -229,6 +200,30 @@ impl SignTask {
                 new_phase => phase = new_phase,
             }
         }
+    }
+
+    /// Answer a posit with a reject. The id echoes the round being answered, so
+    /// the sender knows which of its attempts this is about; a `StaleRound`
+    /// carries our own round inside.
+    pub(super) async fn reject(
+        &self,
+        to: Participant,
+        presignature_id: PresignatureId,
+        round: usize,
+        reason: PositRejectReason,
+    ) {
+        let me = self.governance.me;
+        self.msg
+            .send(
+                me,
+                to,
+                PositMessage {
+                    id: PositProtocolId::Signature(self.sign_id, presignature_id, round),
+                    from: me,
+                    action: PositAction::RejectWithReason(reason),
+                },
+            )
+            .await;
     }
 
     /// Snapshot the fields the generation protocol needs.
@@ -267,7 +262,7 @@ mod tests {
         let mut t = setup(me, behind, 2);
         t.state.set_round(5);
 
-        GeneratingPhase::reject_late_propose(&t.ctx, &mut t.state, propose(behind, 2)).await;
+        GeneratingPhase::reject_late_propose(&t.ctx, &t.state, propose(behind, 2)).await;
 
         let (round, action) = sent_posit(&mut t.outbox, me, behind);
         // The id echoes the rejected round; ours rides in the reject.
@@ -288,7 +283,7 @@ mod tests {
         let mut t = setup(me, ahead, 2);
         t.state.set_round(3);
 
-        GeneratingPhase::reject_late_propose(&t.ctx, &mut t.state, propose(ahead, 12)).await;
+        GeneratingPhase::reject_late_propose(&t.ctx, &t.state, propose(ahead, 12)).await;
 
         let (_, action) = sent_posit(&mut t.outbox, me, ahead);
         assert!(matches!(


### PR DESCRIPTION
Do not review yet

Future-round messages wait in PositMailbox (recv_up_to) instead of a
second buffer on SignState, and the mailbox tracks the highest round
peers have shown us. SignState::gate classifies a message against our
round; recv_current answers stale ones with StaleRound. SignTask::reject
builds every posit reject. Removes the three copies of this logic from
wait_for_propose, the posit loop and reject_late_propose.