### PR TITLE
fix(cli): fail fast on partial Solana or Hydration config

### DIFF
--- a/chain-signatures/node/src/cli/args/hydration.rs
+++ b/chain-signatures/node/src/cli/args/hydration.rs
@@ -5,10 +5,18 @@ use mpc_chain_hydration::HydrationConfig;
 #[group(id = "indexer_hydration_options")]
 pub struct HydrationArgs {
     /// Hydration RPC ws URL
-    #[clap(long = "hydration-rpc-ws-url", env("MPC_HYDRATION_RPC_WS_URL"))]
+    #[clap(
+        long = "hydration-rpc-ws-url",
+        env("MPC_HYDRATION_RPC_WS_URL"),
+        requires = "signer_uri"
+    )]
     pub rpc_ws_url: Option<String>,
     /// Hydration signer URI
-    #[clap(long = "hydration-signer-uri", env("MPC_HYDRATION_SIGNER_URI"))]
+    #[clap(
+        long = "hydration-signer-uri",
+        env("MPC_HYDRATION_SIGNER_URI"),
+        requires = "rpc_ws_url"
+    )]
     pub signer_uri: Option<String>,
 }
 

--- a/chain-signatures/node/src/cli/args/solana.rs
+++ b/chain-signatures/node/src/cli/args/solana.rs
@@ -6,7 +6,11 @@ use std::time::Duration;
 #[group(id = "indexer_sol_options")]
 pub struct SolArgs {
     /// The solana account secret key used to sign solana respond txn.
-    #[arg(long, env("MPC_SOL_ACCOUNT_SK"))]
+    #[arg(
+        long,
+        env("MPC_SOL_ACCOUNT_SK"),
+        requires_all = ["sol_rpc_http_url", "sol_program_address"]
+    )]
     pub sol_account_sk: Option<String>,
     /// Solana RPC HTTP URL
     #[clap(long, env("MPC_SOL_RPC_HTTP_URL"), requires = "sol_account_sk")]


### PR DESCRIPTION
`--sol-account-sk` now requires `--sol-rpc-http-url` and `--sol-program-address`; the two `--hydration-*` flags require each other. A partial config previously parsed and the node started with that chain silently disabled. Now clap rejects it and names the missing flags, as it already does for Ethereum, Canton and Midnight.

Nodes with a complete config are unaffected.
