### PR TITLE
chore: tidy start flags

### DIFF
--- a/chain-signatures/node/src/cli/args/canton.rs
+++ b/chain-signatures/node/src/cli/args/canton.rs
@@ -4,6 +4,7 @@ use mpc_chain_canton::{CantonAuthConfig, CantonConfig};
 #[derive(Debug, Clone, clap::Parser)]
 #[group(id = "indexer_canton_options")]
 pub struct CantonArgs {
+    /// Canton JSON Ledger API HTTP URL.
     #[arg(
         long,
         env("MPC_CANTON_JSON_API_URL"),
@@ -20,44 +21,52 @@ pub struct CantonArgs {
         ]
     )]
     pub canton_json_api_url: Option<String>,
+    /// Canton JSON Ledger API websocket URL.
     #[arg(
         long,
         env("MPC_CANTON_JSON_API_WS_URL"),
         requires = "canton_json_api_url"
     )]
     pub canton_json_api_ws_url: Option<String>,
+    /// Ledger API user the node acts as.
     #[arg(
         long,
         env("MPC_CANTON_LEDGER_API_USER"),
         requires = "canton_json_api_url"
     )]
     pub canton_ledger_api_user: Option<String>,
+    /// OIDC token endpoint.
     #[arg(
         long,
         env("MPC_CANTON_OIDC_TOKEN_URL"),
         requires = "canton_json_api_url"
     )]
     pub canton_oidc_token_url: Option<String>,
+    /// OIDC client id.
     #[arg(
         long,
         env("MPC_CANTON_OIDC_CLIENT_ID"),
         requires = "canton_json_api_url"
     )]
     pub canton_oidc_client_id: Option<String>,
+    /// OIDC client secret.
     #[arg(
         long,
         env("MPC_CANTON_OIDC_CLIENT_SECRET"),
         requires = "canton_json_api_url"
     )]
     pub canton_oidc_client_secret: Option<String>,
+    /// OIDC audience.
     #[arg(
         long,
         env("MPC_CANTON_OIDC_AUDIENCE"),
         requires = "canton_json_api_url"
     )]
     pub canton_oidc_audience: Option<String>,
+    /// Optional OIDC scope.
     #[arg(long, env("MPC_CANTON_OIDC_SCOPE"), requires = "canton_json_api_url")]
     pub canton_oidc_scope: Option<String>,
+    /// Canton party id the node submits commands as.
     #[arg(long, env("MPC_CANTON_PARTY_ID"), requires = "canton_json_api_url")]
     pub canton_party_id: Option<String>,
     /// The Signer contract ID on the Canton ledger. Must be updated if the contract is re-deployed.

--- a/chain-signatures/node/src/cli/args/ethereum.rs
+++ b/chain-signatures/node/src/cli/args/ethereum.rs
@@ -2,6 +2,8 @@ use anyhow::Context as _;
 use mpc_chain_ethereum::EthConfig;
 use secrecy::{ExposeSecret, SecretString};
 
+const DEFAULT_REFRESH_FINALIZED_INTERVAL_MS: u64 = 10_000;
+
 // Configures Ethereum indexer.
 #[derive(Debug, Clone, clap::Parser)]
 #[group(id = "indexer_eth_options")]
@@ -68,7 +70,7 @@ pub struct EthArgs {
     #[clap(
         long,
         env("MPC_ETH_REFRESH_FINALIZED_INTERVAL"),
-        default_value = "10000"
+        default_value_t = DEFAULT_REFRESH_FINALIZED_INTERVAL_MS
     )]
     pub eth_refresh_finalized_interval: u64,
     /// Emit requests without waiting for block finality. FOR DEV/DEMO USE ONLY:
@@ -78,14 +80,15 @@ pub struct EthArgs {
 }
 
 impl EthArgs {
+    /// Empty when Ethereum is not configured.
     pub fn into_str_args(self) -> Vec<String> {
-        let mut args = Vec::with_capacity(10);
-        if let Some(eth_account_sk) = self.eth_account_sk {
-            args.extend([
-                "--eth-account-sk".to_string(),
-                eth_account_sk.expose_secret().to_string(),
-            ]);
-        }
+        let Some(eth_account_sk) = self.eth_account_sk else {
+            return Vec::new();
+        };
+        let mut args = vec![
+            "--eth-account-sk".to_string(),
+            eth_account_sk.expose_secret().to_string(),
+        ];
         if let Some(eth_consensus_rpc_http_url) = self.eth_consensus_rpc_http_url {
             args.extend([
                 "--eth-consensus-rpc-http-url".to_string(),
@@ -196,7 +199,7 @@ impl EthArgs {
                 eth_contract_address: None,
                 eth_network: None,
                 eth_helios_data_path: None,
-                eth_refresh_finalized_interval: 0,
+                eth_refresh_finalized_interval: DEFAULT_REFRESH_FINALIZED_INTERVAL_MS,
                 eth_optimistic_requests: false,
                 eth_light_client: false,
             },

--- a/chain-signatures/node/src/cli/args/solana.rs
+++ b/chain-signatures/node/src/cli/args/solana.rs
@@ -20,11 +20,12 @@ pub struct SolArgs {
 }
 
 impl SolArgs {
+    /// Empty when Solana is not configured.
     pub fn into_str_args(self) -> Vec<String> {
-        let mut args = Vec::with_capacity(6);
-        if let Some(sol_account_sk) = self.sol_account_sk {
-            args.extend(["--sol-account-sk".to_string(), sol_account_sk]);
-        }
+        let Some(sol_account_sk) = self.sol_account_sk else {
+            return Vec::new();
+        };
+        let mut args = vec!["--sol-account-sk".to_string(), sol_account_sk];
         if let Some(sol_rpc_http_url) = self.sol_rpc_http_url {
             args.extend(["--sol-rpc-http-url".to_string(), sol_rpc_http_url]);
         }

--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -53,6 +53,7 @@ const MAX_SIGN_COMMANDS: usize = 16384;
 
 #[derive(Parser, Debug)]
 pub enum Cli {
+    /// Start the MPC node
     Start {
         /// NEAR RPC address
         #[arg(

--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -155,8 +155,6 @@ impl Cli {
                     account_sk.to_string(),
                     "--cipher-sk".to_string(),
                     cipher_sk,
-                    "--redis-url".to_string(),
-                    storage_options.redis_url.to_string(),
                 ];
                 if let Some(sign_sk) = sign_sk {
                     args.extend(["--sign-sk".to_string(), sign_sk.to_string()]);

--- a/chain-signatures/node/src/cli/mod.rs
+++ b/chain-signatures/node/src/cli/mod.rs
@@ -55,6 +55,7 @@ const MAX_SIGN_COMMANDS: usize = 16384;
 pub enum Cli {
     /// Start the MPC node
     Start {
+        // -- NEAR identity and governance contract --
         /// NEAR RPC address
         #[arg(
             long,
@@ -71,17 +72,37 @@ pub enum Cli {
         /// This node's account ed25519 secret key
         #[arg(long, env("MPC_ACCOUNT_SK"))]
         account_sk: SecretKey,
+
+        // -- Node-to-node networking --
         /// The web port for this server
         /// this is default to 3000 for all nodes now.
         /// Partners can choose to change the port, but then they also need to make sure they change their load balancer config to match this
         #[arg(long, env("MPC_WEB_PORT"), default_value = "3000")]
         web_port: u16,
+        /// Local address that other peers can use to message this node.
+        /// mainnet nodes: this should be set to their domain name
+        /// testnet nodes: this should be set to their http://ip:web_port
+        /// dev nodes: this should be set to their local network domain name
+        /// integration test nodes: this should be set to None
+        #[arg(long, env("MPC_LOCAL_ADDRESS"))]
+        my_address: Option<Url>,
         /// The cipher secret key used to decrypt messages between nodes.
         #[arg(long, env("MPC_CIPHER_SK"))]
         cipher_sk: String,
         /// The secret key used to sign messages to be sent between nodes.
         #[arg(long, env("MPC_SIGN_SK"))]
         sign_sk: Option<SecretKey>,
+        #[clap(flatten)]
+        mesh_options: mesh::Options,
+        #[clap(flatten)]
+        message_options: node_client::Options,
+
+        // -- Protocol --
+        /// The set of configurations that we will use to override contract configurations.
+        #[arg(long, env("MPC_OVERRIDE_CONFIG"), value_parser = clap::value_parser!(OverrideConfig))]
+        override_config: Option<OverrideConfig>,
+
+        // -- Chains --
         /// Ethereum Indexer options
         #[clap(flatten)]
         eth: EthArgs,
@@ -97,26 +118,14 @@ pub enum Cli {
         /// Midnight Indexer options
         #[clap(flatten)]
         midnight: MidnightArgs,
-        /// Local address that other peers can use to message this node.
-        /// mainnet nodes: this should be set to their domain name
-        /// testnet nodes: this should be set to their http://ip:web_port
-        /// dev nodes: this should be set to their local network domain name
-        /// integration test nodes: this should be set to None
-        #[arg(long, env("MPC_LOCAL_ADDRESS"))]
-        my_address: Option<Url>,
+
+        // -- Infrastructure --
         /// Storage options
         #[clap(flatten)]
         storage_options: storage::Options,
         /// Logging options
         #[clap(flatten)]
         log_options: logs::Options,
-        /// The set of configurations that we will use to override contract configurations.
-        #[arg(long, env("MPC_OVERRIDE_CONFIG"), value_parser = clap::value_parser!(OverrideConfig))]
-        override_config: Option<OverrideConfig>,
-        #[clap(flatten)]
-        mesh_options: mesh::Options,
-        #[clap(flatten)]
-        message_options: node_client::Options,
     },
 }
 
@@ -125,23 +134,23 @@ impl Cli {
         match self {
             Cli::Start {
                 near_rpc,
-                account_id,
                 mpc_contract_id,
+                account_id,
                 account_sk,
                 web_port,
+                my_address,
                 cipher_sk,
                 sign_sk,
+                mesh_options,
+                message_options,
+                override_config,
                 eth,
                 sol,
                 hydration,
                 canton,
                 midnight,
-                my_address,
                 storage_options,
                 log_options,
-                override_config,
-                mesh_options,
-                message_options,
             } => {
                 let mut args = vec![
                     "start".to_string(),
@@ -153,24 +162,25 @@ impl Cli {
                     account_id.to_string(),
                     "--account-sk".to_string(),
                     account_sk.to_string(),
+                    "--web-port".to_string(),
+                    web_port.to_string(),
                     "--cipher-sk".to_string(),
                     cipher_sk,
                 ];
-                if let Some(sign_sk) = sign_sk {
-                    args.extend(["--sign-sk".to_string(), sign_sk.to_string()]);
-                }
                 if let Some(my_address) = my_address {
                     args.extend(["--my-address".to_string(), my_address.to_string()]);
                 }
+                if let Some(sign_sk) = sign_sk {
+                    args.extend(["--sign-sk".to_string(), sign_sk.to_string()]);
+                }
+                args.extend(mesh_options.into_str_args());
+                args.extend(message_options.into_str_args());
                 if let Some(override_config) = override_config {
                     args.extend([
                         "--override-config".to_string(),
                         serde_json::to_string(&override_config).unwrap(),
                     ]);
                 }
-
-                args.extend(["--web-port".to_string(), web_port.to_string()]);
-
                 args.extend(eth.into_str_args());
                 args.extend(sol.into_str_args());
                 args.extend(hydration.into_str_args());
@@ -178,8 +188,6 @@ impl Cli {
                 args.extend(midnight.into_str_args());
                 args.extend(storage_options.into_str_args());
                 args.extend(log_options.into_str_args());
-                args.extend(mesh_options.into_str_args());
-                args.extend(message_options.into_str_args());
                 args
             }
         }

--- a/chain-signatures/node/src/logs.rs
+++ b/chain-signatures/node/src/logs.rs
@@ -20,7 +20,9 @@ use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
+/// Configures logging and tracing export.
 #[derive(Debug, Clone, clap::Parser)]
+#[group(id = "log_options")]
 pub struct Options {
     #[clap(
         long,

--- a/chain-signatures/node/src/storage/mod.rs
+++ b/chain-signatures/node/src/storage/mod.rs
@@ -29,6 +29,7 @@ pub struct Options {
     /// Mostly for integration tests.
     #[arg(long, env("MPC_SK_SHARE_LOCAL_PATH"))]
     pub sk_share_local_path: Option<String>,
+    /// Redis URL for triples, presignatures, checkpoints and the backlog.
     #[arg(long, env("MPC_REDIS_URL"))]
     pub redis_url: String,
 }

--- a/chain-signatures/node/src/storage/mod.rs
+++ b/chain-signatures/node/src/storage/mod.rs
@@ -41,6 +41,8 @@ impl Options {
             self.env,
             "--gcp-project-id".to_string(),
             self.gcp_project_id,
+            "--redis-url".to_string(),
+            self.redis_url,
         ];
         if let Some(sk_share_secret_id) = self.sk_share_secret_id {
             opts.extend(vec!["--sk-share-secret-id".to_string(), sk_share_secret_id]);


### PR DESCRIPTION
d2655475 refactor(cli): group Cli::Start fields by concern
9160e13b refactor(cli): emit no chain flags for an unconfigured chain
5f2d8756 refactor(cli): emit --redis-url from storage options
d93b995d docs(cli): document the Canton and Redis flags
12b943b6 fix(cli): describe the start subcommand in --help