### PR TITLE
feat(ci): gate CI jobs behind shared change detection

### DIFF
--- a/.github/workflows/_ci-changes.yml
+++ b/.github/workflows/_ci-changes.yml
@@ -97,7 +97,10 @@ jobs:
             canton:
               - .github/workflows/canton.yml
               - chain-signatures/chain-canton/**
-              - integration-tests/{src,fixtures,tests}/**/*canton*
+              # Files with "canton" in their name
+              - integration-tests/{src,tests}/**/*canton*
+              # Files in the canton fixture directory
+              - integration-tests/fixtures/canton/**
 
             midnight:
               - .github/workflows/midnight.yml

--- a/.github/workflows/_ci-changes.yml
+++ b/.github/workflows/_ci-changes.yml
@@ -1,0 +1,152 @@
+# Change-detection gate. Each test workflow calls it once and gates its jobs:
+#   changes:
+#     uses: ./.github/workflows/_ci-changes.yml
+#   test-job:
+#     needs: [changes]
+#     if: needs.changes.outputs.<flag> == 'true'
+#
+# Flag -> job gating:
+#   canton: canton|core|contract_eth     midnight: midnight|core
+#   midnight_ts: midnight_ts|core        fixture-test: core
+#   cluster-test: core|near|eth|solana|hydration|contract_eth
+#   anvil-test: eth|core|contract_eth    unit-test: unit   audit: audit
+#
+# Skipped jobs satisfy required checks; non-PR events (push, merge queue,
+# dispatch) set every flag to true — the merge queue is the full-suite safety
+# net. Globs use minimatch: `**` must be a full segment (`**/*canton*`, never
+# `**canton**`).
+name: CI Changes
+
+on:
+  workflow_call:
+    outputs:
+      core:
+        value: ${{ jobs.changes.outputs.core }}
+      canton:
+        value: ${{ jobs.changes.outputs.canton }}
+      midnight:
+        value: ${{ jobs.changes.outputs.midnight }}
+      midnight_ts:
+        value: ${{ jobs.changes.outputs.midnight_ts }}
+      eth:
+        value: ${{ jobs.changes.outputs.eth }}
+      contract_eth:
+        value: ${{ jobs.changes.outputs.contract_eth }}
+      solana:
+        value: ${{ jobs.changes.outputs.solana }}
+      near:
+        value: ${{ jobs.changes.outputs.near }}
+      hydration:
+        value: ${{ jobs.changes.outputs.hydration }}
+      unit:
+        value: ${{ jobs.changes.outputs.unit }}
+      audit:
+        value: ${{ jobs.changes.outputs.audit }}
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      core: ${{ steps.all.outputs.core || steps.filter.outputs.core }}
+      canton: ${{ steps.all.outputs.canton || steps.filter.outputs.canton }}
+      midnight: ${{ steps.all.outputs.midnight || steps.filter.outputs.midnight }}
+      midnight_ts: ${{ steps.all.outputs.midnight_ts || steps.filter.outputs.midnight_ts }}
+      eth: ${{ steps.all.outputs.eth || steps.filter.outputs.eth }}
+      contract_eth: ${{ steps.all.outputs.contract_eth || steps.filter.outputs.contract_eth }}
+      solana: ${{ steps.all.outputs.solana || steps.filter.outputs.solana }}
+      near: ${{ steps.all.outputs.near || steps.filter.outputs.near }}
+      hydration: ${{ steps.all.outputs.hydration || steps.filter.outputs.hydration }}
+      unit: ${{ steps.all.outputs.unit || steps.filter.outputs.unit }}
+      audit: ${{ steps.all.outputs.audit || steps.filter.outputs.audit }}
+    steps:
+      - name: Non-PR events run everything
+        id: all
+        if: github.event_name != 'pull_request'
+        run: |
+          for flag in core canton midnight midnight_ts eth contract_eth solana near hydration unit audit; do
+            echo "$flag=true" >> "$GITHUB_OUTPUT"
+          done
+      - name: Evaluate path filters
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            # Shared foundation: changes here trigger every chain workflow.
+            core:
+              - .github/workflows/_ci-changes.yml
+              - .github/workflows/integration.yml
+              - chain-signatures/chain-integration-core/**
+              - chain-signatures/primitives/**
+              - chain-signatures/crypto/**
+              - chain-signatures/keys/**
+              - chain-signatures/utils/**
+              - chain-signatures/compact-hashing/**
+              - chain-signatures/node/**
+              - signet-crypto/**
+              - signet-primitives/**
+              - Cargo.toml
+              - Cargo.lock
+              - justfile
+              - .config/nextest.toml
+              # Shared test harness; chain-specific test files are in the chain flags.
+              - integration-tests/{Cargo.toml,build.rs,benches/**}
+              - integration-tests/src/{lib.rs,actions/**,cluster/**,commands.rs,containers.rs,execute.rs,local.rs,main.rs,utils.rs,mpc_fixture/**}
+              - integration-tests/tests/{lib.rs,cases/{mod.rs,helpers.rs,chains.rs,checkpoint.rs,compat.rs,mpc.rs,mpc_with_stream.rs,state_sync.rs,store.rs,sync.rs,nightly.rs}}
+
+            canton:
+              - .github/workflows/canton.yml
+              - chain-signatures/chain-canton/**
+              - integration-tests/{src,fixtures,tests}/**/*canton*
+
+            midnight:
+              - .github/workflows/midnight.yml
+              - chain-signatures/chain-midnight/**
+              - chain-signatures/midnight-publisher-ts/**
+              - integration-tests/{src,tests}/**/*midnight*
+
+            # Midnight publisher TS package + the Rust seam differential.
+            midnight_ts:
+              - .github/workflows/midnight-publisher-ts.yml
+              - Dockerfile
+              - chain-signatures/midnight-publisher-ts/**
+              - chain-signatures/chain-midnight/**
+
+            eth:
+              - chain-signatures/chain-ethereum/**
+              - integration-tests/{src,tests}/**/*eth*
+
+            # EVM contract: built by eth jobs, cross-signing canton e2e tests.
+            contract_eth:
+              - chain-signatures/contract-eth/**
+
+            solana:
+              - chain-signatures/chain-solana/**
+              - chain-signatures/contract-sol/**
+              - integration-tests/{src,tests}/**/*solana*
+
+            near:
+              - chain-signatures/chain-near/**
+              - chain-signatures/contract/**
+
+            hydration:
+              - chain-signatures/chain-hydration/**
+
+            # fmt + clippy + unit tests across the whole workspace.
+            unit:
+              - .github/workflows/unit.yml
+              - rustfmt.toml
+              - Cargo.toml
+              - Cargo.lock
+              - justfile
+              - chain-signatures/**
+              - signet-crypto/**
+              - signet-primitives/**
+              - integration-tests/**
+
+            # Dependency scan, keyed on manifests and the lockfile.
+            audit:
+              - .github/workflows/unit.yml
+              - Cargo.toml
+              - Cargo.lock
+              - "**/Cargo.toml"

--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -7,39 +7,19 @@ on:
     paths:
       - integration-tests/**
       - chain-signatures/**
-  # PRs run only on Canton or shared-core changes; merge_group stays
-  # unfiltered as the safety net. Keep core in sync with other chain workflows.
   pull_request:
-    paths:
-      - ".github/workflows/canton.yml"
-      # Shared core: changes here trigger every chain workflow.
-      - "chain-signatures/chain-integration-core/**"
-      - "chain-signatures/primitives/**"
-      - "chain-signatures/crypto/**"
-      - "chain-signatures/keys/**"
-      - "chain-signatures/utils/**"
-      - "chain-signatures/compact-hashing/**"
-      - "chain-signatures/node/**"
-      - "signet-crypto/**"
-      - "signet-primitives/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "justfile"
-      - ".config/nextest.toml"
-      # Canton crate, tests, and fixtures (matches any *canton* file at any depth).
-      - "chain-signatures/chain-canton/**"
-      - "integration-tests/{src,fixtures,tests}/**canton**"
-      # Shared integration-test harness.
-      - "integration-tests/{Cargo.toml,src/lib.rs,src/cluster/**,src/mpc_fixture/**,tests/lib.rs,tests/cases/mod.rs}"
-      # Canton tests cross-sign over Ethereum via anvil + the eth contract.
-      - "chain-signatures/contract-eth/**"
   merge_group:
 
 env:
   RUSTFLAGS: -D warnings
 
 jobs:
+  changes:
+    uses: ./.github/workflows/_ci-changes.yml
+
   canton:
+    needs: [changes]
+    if: needs.changes.outputs.canton == 'true' || needs.changes.outputs.core == 'true' || needs.changes.outputs.contract_eth == 'true'
     name: Canton ${{ matrix.suite.name }} Tests
     runs-on: warp-ubuntu-latest-x64-4x
     strategy:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,9 +13,14 @@ on:
 env:
   RUSTFLAGS: -D warnings
 jobs:
+  changes:
+    uses: ./.github/workflows/_ci-changes.yml
+
   # Fixture tests: in-process MPC protocol tests, no Docker or external infra needed.
   # Runs the `fixture` nextest profile (see .config/nextest.toml).
   fixture-test:
+    needs: [changes]
+    if: needs.changes.outputs.core == 'true'
     name: Fixture Test
     runs-on: warp-ubuntu-latest-x64-4x
 
@@ -97,6 +102,8 @@ jobs:
   # Integration tests that need Docker (near-sandbox, anvil, solana validator) and
   # additional Solana/Anchor setup. Runs with num-cpus threads (see .config/nextest.toml).
   cluster-test:
+    needs: [changes]
+    if: needs.changes.outputs.core == 'true' || needs.changes.outputs.near == 'true' || needs.changes.outputs.eth == 'true' || needs.changes.outputs.solana == 'true' || needs.changes.outputs.hydration == 'true' || needs.changes.outputs.contract_eth == 'true'
     name: Integration Test
     strategy:
       matrix:
@@ -201,6 +208,8 @@ jobs:
 
   # Anvil-backed integration tests (no docker cluster): real EVM + real contract bytecode
   anvil-integration-test:
+    needs: [changes]
+    if: needs.changes.outputs.eth == 'true' || needs.changes.outputs.core == 'true' || needs.changes.outputs.contract_eth == 'true'
     name: Anvil Integration Tests
     runs-on: warp-ubuntu-latest-x64-4x
 

--- a/.github/workflows/midnight-publisher-ts.yml
+++ b/.github/workflows/midnight-publisher-ts.yml
@@ -20,33 +20,16 @@ on:
       - "Dockerfile"
       - "chain-signatures/midnight-publisher-ts/**"
       - "chain-signatures/chain-midnight/**"
-  # Push paths plus the shared core, since the seam differential compiles
-  # mpc-chain-midnight. merge_group stays unfiltered as the safety net.
-  # Keep core in sync with the other chain workflows.
   pull_request:
-    paths:
-      - ".github/workflows/midnight-publisher-ts.yml"
-      - "Dockerfile"
-      - "chain-signatures/midnight-publisher-ts/**"
-      - "chain-signatures/chain-midnight/**"
-      # Shared core: compiled into mpc-chain-midnight and the seam tests.
-      - "chain-signatures/chain-integration-core/**"
-      - "chain-signatures/primitives/**"
-      - "chain-signatures/crypto/**"
-      - "chain-signatures/keys/**"
-      - "chain-signatures/utils/**"
-      - "chain-signatures/compact-hashing/**"
-      - "chain-signatures/node/**"
-      - "signet-crypto/**"
-      - "signet-primitives/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "justfile"
-      - ".config/nextest.toml"
   merge_group:
 
 jobs:
+  changes:
+    uses: ./.github/workflows/_ci-changes.yml
+
   test:
+    needs: [changes]
+    if: needs.changes.outputs.midnight_ts == 'true' || needs.changes.outputs.core == 'true'
     name: Midnight Publisher TS Tests
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/midnight.yml
+++ b/.github/workflows/midnight.yml
@@ -7,40 +7,19 @@ on:
     paths:
       - integration-tests/**
       - chain-signatures/**
-  # PRs run only on Midnight or shared-core changes; merge_group stays
-  # unfiltered as the safety net. Keep core in sync with other chain workflows.
   pull_request:
-    paths:
-      - ".github/workflows/midnight.yml"
-      # Shared core: changes here trigger every chain workflow.
-      - "chain-signatures/chain-integration-core/**"
-      - "chain-signatures/primitives/**"
-      - "chain-signatures/crypto/**"
-      - "chain-signatures/keys/**"
-      - "chain-signatures/utils/**"
-      - "chain-signatures/compact-hashing/**"
-      - "chain-signatures/node/**"
-      - "signet-crypto/**"
-      - "signet-primitives/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "justfile"
-      - ".config/nextest.toml"
-      # Midnight crate, TS publisher fixtures, and tests.
-      - "chain-signatures/chain-midnight/**"
-      - "chain-signatures/midnight-publisher-ts/**"
-      - "integration-tests/{src,tests}/**midnight**"
-      # Shared integration-test harness.
-      - "integration-tests/{Cargo.toml,src/lib.rs,src/cluster/**,src/mpc_fixture/**,tests/lib.rs,tests/cases/mod.rs}"
-      # The e2e test cross-signs over Ethereum via anvil + the eth contract.
-      - "chain-signatures/contract-eth/**"
   merge_group:
 
 env:
   RUSTFLAGS: -D warnings
 
 jobs:
+  changes:
+    uses: ./.github/workflows/_ci-changes.yml
+
   midnight-real-stack:
+    needs: [changes]
+    if: needs.changes.outputs.midnight == 'true' || needs.changes.outputs.core == 'true'
     name: Midnight Real Stack
     runs-on: warp-ubuntu-latest-x64-4x
     timeout-minutes: 90

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,13 +11,22 @@ on:
       - "integration-tests/**/*.rs"
       - "chain-signatures/contract-eth/**/*.sol"
       - "chain-signatures/contract-eth/**/*.js"
+      - "signet-crypto/**"
+      - "signet-primitives/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
   pull_request:
   merge_group:
 
 env:
   RUSTFLAGS: -D warnings
 jobs:
+  changes:
+    uses: ./.github/workflows/_ci-changes.yml
+
   test:
+    needs: [changes]
+    if: needs.changes.outputs.unit == 'true'
     runs-on: warp-ubuntu-latest-x64-4x
     name: Check & Test
     steps:
@@ -81,6 +90,8 @@ jobs:
         run: just test-unit
 
   audit:
+    needs: [changes]
+    if: needs.changes.outputs.audit == 'true'
     name: Audit
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Introduce a reusable change-detection gate that lets jobs skip visibly (skipped = success = required checks satisfied). Merge queue and `develop` push still run the full suite (unchanged)

### Changes

- Add `.github/workflows/_ci-changes.yml`: Change-detection gate. Each test workflow calls it once and gates its jobs. Skipped jobs satisfy required checks
- Update existing workflows (`integration.yml`, `unit.yml`, `canton.yml` etc.) to utilize new gate (replaces trigger-level `pull_request.paths`)

### Benefits

- No more `Expected — Waiting for status` hangs
- Single place for path -> job mapping
- Canton required checks can be restored in the ruleset, new ones (Midnight) can be added
- Scaling: adding new chain only requires adding a flag in `_ci-changes.yml` and `if:` clause in chains workflow
  
  