### PR TITLE
fix: lint all features and targets so gated dead code is caught

### DIFF
--- a/chain-signatures/chain-ethereum/src/indexer.rs
+++ b/chain-signatures/chain-ethereum/src/indexer.rs
@@ -149,7 +149,7 @@ impl<S: StateManager, T: ChainTelemetry> EthereumIndexer<S, T> {
         #[cfg(feature = "bench")]
         {
             crate::bench::add_process_time(start.elapsed());
-            if crate::bench::inc_block() % 100 == 0 {
+            if crate::bench::inc_block().is_multiple_of(100) {
                 crate::bench::report_metrics("catchup_progress");
             }
         }

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -42,7 +42,8 @@ struct AxumState {
     presignature_storage: PresignatureStorage,
     sync_channel: SyncChannel,
     msg_channel: MessageChannel,
-    #[allow(dead_code)] // used by debug-page
+    /// Only used to label the debug page.
+    #[cfg_attr(not(feature = "debug-page"), allow(dead_code))]
     my_account_id: AccountId,
     backlog: Backlog,
 }

--- a/justfile
+++ b/justfile
@@ -60,9 +60,10 @@ test-keep filter="" helios="": (setup helios)
     TESTCONTAINERS=keep cargo nextest run -p integration-tests {{ if filter != "" { "-E 'test(" + filter + ")'" } else { "" } }}
 alias tk := test-keep
 
-# Run clippy (mirrors CI: cargo clippy --tests -- -Dclippy::all)
+# Run clippy (mirrors CI). --all-features/--all-targets so dead code behind
+# feature gates (bench, test-feature, debug-page, helios, ...) is checked too.
 lint:
-    cargo clippy --tests -- -Dclippy::all
+    cargo clippy --workspace --all-targets --all-features -- -Dclippy::all
 
 # Check formatting without modifying files (mirrors CI)
 fmt-check:


### PR DESCRIPTION
Clippy ran with default features only, so anything behind bench, test-feature, debug-page or helios was never compiled and its dead code never reported. Also makes the debug-page allow(dead_code) self-correcting and fixes the one finding this exposed.