### PR TITLE
ci: drop develop push

### DIFF
--- a/.github/workflows/_ci-changes.yml
+++ b/.github/workflows/_ci-changes.yml
@@ -11,9 +11,11 @@
 #   cluster-test: core|near|eth|solana|hydration|contract_eth
 #   anvil-test: eth|core|contract_eth    unit-test: unit   audit: audit
 #
-# Skipped jobs satisfy required checks; non-PR events (push, merge queue,
-# dispatch) set every flag to true — the merge queue is the full-suite safety
-# net. Globs use minimatch: `**` must be a full segment (`**/*canton*`, never
+# Skipped jobs satisfy required checks; non-PR events (merge queue, dispatch)
+# set every flag to true — the merge queue is the full-suite safety net. Test
+# workflows have no push trigger: develop only advances through the queue, so
+# the tree was already tested. Caches are saved from merge_group runs.
+# Globs use minimatch: `**` must be a full segment (`**/*canton*`, never
 # `**canton**`).
 name: CI Changes
 

--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -93,7 +93,7 @@ jobs:
           cache-targets: true
           cache-on-failure: false
           # Prevent every PR from uploading multi-GB caches
-          save-if: ${{ github.ref == 'refs/heads/develop' }}
+          save-if: ${{ github.event_name == 'merge_group' }}
 
       - name: Build eth contract
         run: just build eth

--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -1,12 +1,6 @@
 name: Canton Integration Tests
 
 on:
-  push:
-    branches:
-      - develop
-    paths:
-      - integration-tests/**
-      - chain-signatures/**
   pull_request:
   merge_group:
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,12 +1,6 @@
 name: Integration
 
 on:
-  push:
-    branches:
-      - develop
-    paths:
-      - integration-tests/**
-      - chain-signatures/**
   pull_request:
   merge_group:
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -71,7 +71,7 @@ jobs:
           cache-targets: true
           cache-on-failure: false
           # Prevent every PR from uploading multi-GB caches
-          save-if: ${{ github.ref == 'refs/heads/develop' }}
+          save-if: ${{ github.event_name == 'merge_group' }}
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
@@ -170,7 +170,7 @@ jobs:
           cache-targets: true
           cache-on-failure: false
           # Prevent every PR from uploading multi-GB caches
-          save-if: ${{ github.ref == 'refs/heads/develop' }}
+          save-if: ${{ github.event_name == 'merge_group' }}
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
@@ -231,7 +231,7 @@ jobs:
         with:
           shared-key: anvil-integration-test
           cache-targets: true
-          save-if: ${{ github.ref == 'refs/heads/develop' }}
+          save-if: ${{ github.event_name == 'merge_group' }}
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/midnight-publisher-ts.yml
+++ b/.github/workflows/midnight-publisher-ts.yml
@@ -75,7 +75,7 @@ jobs:
           cache-targets: true
           cache-on-failure: false
           # Prevent every PR from uploading multi-GB caches
-          save-if: ${{ github.ref == 'refs/heads/develop' }}
+          save-if: ${{ github.event_name == 'merge_group' }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
       # The filter names the test binary: the seam tests live in

--- a/.github/workflows/midnight-publisher-ts.yml
+++ b/.github/workflows/midnight-publisher-ts.yml
@@ -12,14 +12,6 @@
 name: Midnight Publisher TS
 
 on:
-  push:
-    branches:
-      - develop
-    paths:
-      - ".github/workflows/midnight-publisher-ts.yml"
-      - "Dockerfile"
-      - "chain-signatures/midnight-publisher-ts/**"
-      - "chain-signatures/chain-midnight/**"
   pull_request:
   merge_group:
 

--- a/.github/workflows/midnight.yml
+++ b/.github/workflows/midnight.yml
@@ -94,7 +94,7 @@ jobs:
           shared-key: midnight-real-stack
           cache-targets: true
           cache-on-failure: false
-          save-if: ${{ github.ref == 'refs/heads/develop' }}
+          save-if: ${{ github.event_name == 'merge_group' }}
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest

--- a/.github/workflows/midnight.yml
+++ b/.github/workflows/midnight.yml
@@ -1,12 +1,6 @@
 name: Midnight Integration Tests
 
 on:
-  push:
-    branches:
-      - develop
-    paths:
-      - integration-tests/**
-      - chain-signatures/**
   pull_request:
   merge_group:
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,20 +1,5 @@
 name: Unit
 on:
-  push:
-    branches:
-      - main
-      - develop
-    paths:
-      - ".github/workflows/unit.yml"
-      - "chain-signatures/**/*.rs"
-      - "chain-signatures/Cargo.*"
-      - "integration-tests/**/*.rs"
-      - "chain-signatures/contract-eth/**/*.sol"
-      - "chain-signatures/contract-eth/**/*.js"
-      - "signet-crypto/**"
-      - "signet-primitives/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
   pull_request:
   merge_group:
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -43,7 +43,7 @@ jobs:
           cache-targets: true
           cache-on-failure: false
           # Prevent every PR from uploading multi-GB caches
-          save-if: ${{ github.ref == 'refs/heads/develop' }}
+          save-if: ${{ github.event_name == 'merge_group' }}
       
       # Install system OpenSSL explicitly here so the build uses system OpenSSL instead of building OpenSSL from source
       - name: Install system OpenSSL


### PR DESCRIPTION
Test workflows ran three times per change: on the PR, in the merge queue, and again on push to develop. The third run is redundant: develop only advances through the queue (rulesets block direct pushes), and the queue fast-forwards develop to the exact commit it tested, so its checks are already attached to every develop commit. The push run only duplicated them and produced flaky reds (8 of the last 60 Integration runs on develop).

What was changed:
1. Drop the push-to-develop trigger from Unit, Integration, Canton, Midnight and Midnight Publisher TS. Deploy and load-test workflows keep theirs.
2. Save Rust caches from `merge_group` runs instead of develop pushes, so caches don't go stale. `nightly.yml` keeps its develop condition.
3. Document the policy in the `_ci-changes.yml` comment.