### PR TITLE
refactor(node): invert the signing delta once, and don't panic on zero

### DIFF
--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -94,10 +94,17 @@ impl SignGenerator {
         let delta =
             mpc_crypto::kdf::derive_delta(request.id.request_id, request.args.entropy, big_r);
         // TODO: Check whether it is okay to use invert_vartime instead
+        // `delta` is HKDF output, so a zero is only reachable by breaking the hash;
+        // reject it rather than panicking mid-signing.
+        let Some(delta_inv) = Option::<k256::Scalar>::from(delta.invert()) else {
+            return Err(InitializationError::BadParameters(format!(
+                "derived delta for {sign_id:?} is zero and cannot be inverted",
+            )));
+        };
         let output: PresignOutput<Secp256k1> = PresignOutput {
             big_r: (big_r * delta).to_affine(),
-            k: k * delta.invert().unwrap(),
-            sigma: (sigma + request.args.epsilon * k) * delta.invert().unwrap(),
+            k: k * delta_inv,
+            sigma: (sigma + request.args.epsilon * k) * delta_inv,
         };
         let protocol = Box::new(cait_sith::sign(
             &participants,


### PR DESCRIPTION
Computes the signing delta's inverse once instead of twice per signature, and rejects a zero delta as an InitializationError rather than unwrapping mid-signing.