### PR TITLE
fix(node): require cumulative_digest when decoding a checkpoint

### DIFF
--- a/chain-signatures/node/src/backlog/checkpoints.rs
+++ b/chain-signatures/node/src/backlog/checkpoints.rs
@@ -15,7 +15,11 @@ pub struct Checkpoint {
     pub block_height: u64,
     pub pending_requests: Vec<BacklogEntry>,
     /// Commitment to each pending request's checkpoint-consensus phase.
-    #[serde(default, with = "serde_bytes")]
+    ///
+    /// Deliberately not `#[serde(default)]`: a missing digest must fail to
+    /// decode rather than deserialize as all-zeros, which consensus would
+    /// otherwise compare against as if it were a real commitment.
+    #[serde(with = "serde_bytes")]
     pub cumulative_digest: [u8; 32],
 }
 


### PR DESCRIPTION
Drops `serde(default)` from `Checkpoint::cumulative_digest` so a peer that omits it fails to decode instead of yielding an all-zeros digest that checkpoint consensus would compare against as a real commitment.