### PR TITLE
refactor(ethereum): remove the unused max_finalized_failures knob

### DIFF
--- a/chain-signatures/chain-ethereum/src/config.rs
+++ b/chain-signatures/chain-ethereum/src/config.rs
@@ -154,9 +154,6 @@ impl Default for PublisherConfig {
 /// Tuning for the indexing pipeline (catchup, live stream, finality waits).
 #[derive(Clone, Debug)]
 pub struct IndexerConfig {
-    /// Consecutive `get_block(Finalized)` failures after which the finalized-head
-    /// watcher escalates its retry warning (it never gives up)
-    pub max_finalized_failures: u32,
     /// Re-warn interval (seconds) while the finalized head is stalled
     pub stall_rewarn_secs: u64,
     /// Max concurrent JSON-RPC calls when resolving watcher receipts/nonces.
@@ -169,7 +166,6 @@ pub struct IndexerConfig {
 impl Default for IndexerConfig {
     fn default() -> Self {
         Self {
-            max_finalized_failures: 20,
             stall_rewarn_secs: 300,
             max_concurrent_watcher_rpcs: 8,
             watcher_slow_sweep_interval: 10,

--- a/chain-signatures/chain-ethereum/src/finalized_head.rs
+++ b/chain-signatures/chain-ethereum/src/finalized_head.rs
@@ -79,7 +79,6 @@ pub struct FinalizedHeadTracker {
     head: watch::Sender<Option<u64>>,
     optimistic: bool,
     refresh_interval: Duration,
-    max_failures: u32,
     stall_rewarn_secs: u64,
 }
 
@@ -138,7 +137,6 @@ impl FinalizedHeadTracker {
             head: watch::channel(None).0,
             optimistic: eth.optimistic_requests,
             refresh_interval: Duration::from_millis(eth.refresh_finalized_interval),
-            max_failures: eth.indexer.max_finalized_failures,
             stall_rewarn_secs: eth.indexer.stall_rewarn_secs,
         }
     }
@@ -151,7 +149,6 @@ impl FinalizedHeadTracker {
             head: watch::channel(None).0,
             optimistic: false, // existing unit tests assume finalized mode
             refresh_interval: Duration::from_millis(100),
-            max_failures: indexer.max_finalized_failures,
             stall_rewarn_secs: indexer.stall_rewarn_secs,
         }
     }
@@ -191,7 +188,6 @@ impl FinalizedHeadTracker {
             client,
             self.head.clone(),
             self.refresh_interval,
-            self.max_failures,
             self.stall_rewarn_secs,
             self.optimistic,
             cancel,
@@ -213,7 +209,6 @@ impl FinalizedHeadTracker {
         client: Arc<EthereumClient>,
         head: watch::Sender<Option<u64>>,
         refresh_interval: Duration,
-        max_failures: u32,
         stall_rewarn_secs: u64,
         optimistic: bool,
         cancel: CancellationToken,
@@ -256,7 +251,6 @@ impl FinalizedHeadTracker {
                     tracing::warn!(
                         ?err,
                         failures,
-                        max_failures,
                         "ethereum get_block(head) failed; watcher keeps retrying"
                     );
                 }


### PR DESCRIPTION
Removes `max_finalized_failures`: a hardcoded 20 (`IndexerConfig` isn't configurable) used only as a tracing field, documenting an escalation that was never implemented.

**Question before merging:** do we want this behaviour at all? If the escalation is worth having, I can implement it instead — reset-on-success is already there, so it would just need an error-level log once N consecutive failures are exceeded, plus making the threshold actually configurable. Deleting seemed right since the watcher retries forever by design and the stream supervisor watchdog is the documented escape hatch.