### PR TITLE
refactor(stream): simplify execution watching and ops with typestate

### DIFF
--- a/chain-signatures/chain-ethereum/src/execution_watcher.rs
+++ b/chain-signatures/chain-ethereum/src/execution_watcher.rs
@@ -655,6 +655,32 @@ mod tests {
     use serde_json::json;
     use std::sync::Arc;
 
+    fn test_watcher_tx(
+        tx_hash: alloy::primitives::B256,
+        from_address: alloy::primitives::Address,
+        nonce: u64,
+    ) -> Arc<BidirectionalTx> {
+        Arc::new(BidirectionalTx {
+            id: BidirectionalTxId(tx_hash.0),
+            sender: [0u8; 32],
+            serialized_transaction: vec![],
+            source_chain: Chain::Solana,
+            target_chain: Chain::Ethereum,
+            caip2_id: "eip155:31337".to_string(),
+            key_version: LATEST_MPC_KEY_VERSION,
+            deposit: 0,
+            path: "m/44'/60'/0'/0/0".to_string(),
+            algo: "secp256k1".to_string(),
+            dest: Chain::Ethereum.to_string(),
+            params: "{}".to_string(),
+            output_deserialization_schema: vec![],
+            respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
+            request_id: tx_hash.0,
+            from_address: **from_address,
+            nonce,
+        })
+    }
+
     #[tokio::test]
     async fn late_watcher_backfill_uses_tx_hash_and_mined_block() {
         let mut server = Server::new_async().await;
@@ -715,30 +741,12 @@ mod tests {
             .await;
 
         let sign_id = SignId::new([0x55; 32]);
-        let tx = BidirectionalTx {
-            id: BidirectionalTxId(tx_hash.0),
-            sender: [0u8; 32],
-            serialized_transaction: vec![],
-            source_chain: Chain::Solana,
-            target_chain: Chain::Ethereum,
-            caip2_id: "eip155:31337".to_string(),
-            key_version: LATEST_MPC_KEY_VERSION,
-            deposit: 0,
-            path: "m/44'/60'/0'/0/0".to_string(),
-            algo: "secp256k1".to_string(),
-            dest: Chain::Ethereum.to_string(),
-            params: "{}".to_string(),
-            output_deserialization_schema: vec![],
-            respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
-            request_id: sign_id.request_id,
-            from_address: **from_address,
-            nonce: 0,
-        };
+        let tx = test_watcher_tx(tx_hash, from_address, 0);
 
         let harness = test_utils::WatcherHarness::new(&server.url()).await;
         harness
             .state_manager
-            .watch_execution(Chain::Ethereum, sign_id, Arc::new(tx))
+            .watch_execution(Chain::Ethereum, sign_id, tx)
             .await;
 
         // Construct mock block at height 10 (triggers modulo 10 check)
@@ -822,34 +830,12 @@ mod tests {
         // Setup Indexer & Watchers
         let harness = test_utils::WatcherHarness::new(&server.url()).await;
 
-        let create_tx = |hash: alloy::primitives::B256, nonce: u64| {
-            Arc::new(BidirectionalTx {
-                id: BidirectionalTxId(hash.0),
-                sender: [0u8; 32],
-                serialized_transaction: vec![],
-                source_chain: Chain::Solana,
-                target_chain: Chain::Ethereum,
-                caip2_id: "eip155:31337".to_string(),
-                key_version: LATEST_MPC_KEY_VERSION,
-                deposit: 0,
-                path: "m/44'/60'/0'/0/0".to_string(),
-                algo: "secp256k1".to_string(),
-                dest: Chain::Ethereum.to_string(),
-                params: "{}".to_string(),
-                output_deserialization_schema: vec![],
-                respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
-                request_id: hash.0,
-                from_address: **from_address,
-                nonce,
-            })
-        };
-
         harness
             .state_manager
             .watch_execution(
                 Chain::Ethereum,
                 SignId::new([0; 32]),
-                create_tx(tx_hash_0, 0),
+                test_watcher_tx(tx_hash_0, from_address, 0),
             )
             .await;
         harness
@@ -857,7 +843,7 @@ mod tests {
             .watch_execution(
                 Chain::Ethereum,
                 SignId::new([1; 32]),
-                create_tx(tx_hash_1, 1),
+                test_watcher_tx(tx_hash_1, from_address, 1),
             )
             .await;
         harness
@@ -865,7 +851,7 @@ mod tests {
             .watch_execution(
                 Chain::Ethereum,
                 SignId::new([2; 32]),
-                create_tx(tx_hash_2, 2),
+                test_watcher_tx(tx_hash_2, from_address, 2),
             )
             .await;
 
@@ -940,30 +926,12 @@ mod tests {
             .await;
 
         let sign_id = SignId::new([0x55; 32]);
-        let tx = BidirectionalTx {
-            id: BidirectionalTxId(tx_hash.0),
-            sender: [0u8; 32],
-            serialized_transaction: vec![],
-            source_chain: Chain::Solana,
-            target_chain: Chain::Ethereum,
-            caip2_id: "eip155:31337".to_string(),
-            key_version: LATEST_MPC_KEY_VERSION,
-            deposit: 0,
-            path: "m/44'/60'/0'/0/0".to_string(),
-            algo: "secp256k1".to_string(),
-            dest: Chain::Ethereum.to_string(),
-            params: "{}".to_string(),
-            output_deserialization_schema: vec![],
-            respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
-            request_id: sign_id.request_id,
-            from_address: **from_address,
-            nonce: 0,
-        };
+        let tx = test_watcher_tx(tx_hash, from_address, 0);
 
         let harness = test_utils::WatcherHarness::new(&server.url()).await;
         harness
             .state_manager
-            .watch_execution(Chain::Ethereum, sign_id, Arc::new(tx))
+            .watch_execution(Chain::Ethereum, sign_id, tx)
             .await;
 
         // Block height 5 (NOT a modulo 10 block), but contains tx_hash in block.transactions
@@ -1035,38 +1003,20 @@ mod tests {
 
         let harness = test_utils::WatcherHarness::new(&server.url()).await;
 
-        let create_tx = |hash: alloy::primitives::B256| {
-            Arc::new(BidirectionalTx {
-                id: BidirectionalTxId(hash.0),
-                sender: [0u8; 32],
-                serialized_transaction: vec![],
-                source_chain: Chain::Solana,
-                target_chain: Chain::Ethereum,
-                caip2_id: "eip155:31337".to_string(),
-                key_version: LATEST_MPC_KEY_VERSION,
-                deposit: 0,
-                path: "m/44'/60'/0'/0/0".to_string(),
-                algo: "secp256k1".to_string(),
-                dest: Chain::Ethereum.to_string(),
-                params: "{}".to_string(),
-                output_deserialization_schema: vec![],
-                respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
-                request_id: hash.0,
-                from_address: **from_address,
-                nonce: 0,
-            })
-        };
-
         harness
             .state_manager
-            .watch_execution(Chain::Ethereum, SignId::new([1; 32]), create_tx(tx_hash_ok))
+            .watch_execution(
+                Chain::Ethereum,
+                SignId::new([1; 32]),
+                test_watcher_tx(tx_hash_ok, from_address, 0),
+            )
             .await;
         harness
             .state_manager
             .watch_execution(
                 Chain::Ethereum,
                 SignId::new([2; 32]),
-                create_tx(tx_hash_err),
+                test_watcher_tx(tx_hash_err, from_address, 0),
             )
             .await;
 
@@ -1133,30 +1083,12 @@ mod tests {
             .create_async()
             .await;
 
-        let tx = BidirectionalTx {
-            id: BidirectionalTxId(tx_hash.0),
-            sender: [0u8; 32],
-            serialized_transaction: vec![],
-            source_chain: Chain::Solana,
-            target_chain: Chain::Ethereum,
-            caip2_id: "eip155:31337".to_string(),
-            key_version: LATEST_MPC_KEY_VERSION,
-            deposit: 0,
-            path: "m/44'/60'/0'/0/0".to_string(),
-            algo: "secp256k1".to_string(),
-            dest: Chain::Ethereum.to_string(),
-            params: "{}".to_string(),
-            output_deserialization_schema: vec![],
-            respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
-            request_id: tx_hash.0,
-            from_address: **from_address,
-            nonce: 0,
-        };
+        let tx = test_watcher_tx(tx_hash, from_address, 0);
 
         let harness = test_utils::WatcherHarness::new(&server.url()).await;
         harness
             .state_manager
-            .watch_execution(Chain::Ethereum, SignId::new([3; 32]), Arc::new(tx))
+            .watch_execution(Chain::Ethereum, SignId::new([3; 32]), tx)
             .await;
 
         // Block height 10 triggers the throttled nonce check

--- a/chain-signatures/node/src/backlog/mod.rs
+++ b/chain-signatures/node/src/backlog/mod.rs
@@ -116,34 +116,24 @@ impl PendingRequests {
     }
 }
 
-#[derive(Debug, Clone)]
-struct ExecutionWatcher {
-    sign_id: SignId,
-    tx: Arc<BidirectionalTx>,
-}
-
 #[derive(Debug, Clone, Default)]
 struct ExecutionWatchers {
-    watchers: HashMap<BidirectionalTxId, ExecutionWatcher>,
+    watchers: HashMap<BidirectionalTxId, Arc<BidirectionalTx>>,
 }
 
 impl ExecutionWatchers {
-    fn insert(
-        &mut self,
-        tx_id: BidirectionalTxId,
-        watcher: ExecutionWatcher,
-    ) -> Option<ExecutionWatcher> {
-        self.watchers.insert(tx_id, watcher)
+    fn insert(&mut self, tx: Arc<BidirectionalTx>) -> Option<Arc<BidirectionalTx>> {
+        self.watchers.insert(tx.id, tx)
     }
 
-    fn remove(&mut self, tx_id: &BidirectionalTxId) -> Option<ExecutionWatcher> {
+    fn remove(&mut self, tx_id: &BidirectionalTxId) -> Option<Arc<BidirectionalTx>> {
         self.watchers.remove(tx_id)
     }
 
     fn all(&self) -> HashMap<BidirectionalTxId, (SignId, Arc<BidirectionalTx>)> {
         self.watchers
             .iter()
-            .map(|(id, watcher)| (*id, (watcher.sign_id, Arc::clone(&watcher.tx))))
+            .map(|(id, tx)| (*id, (tx.sign_id(), Arc::clone(tx))))
             .collect()
     }
 }
@@ -337,52 +327,29 @@ impl Backlog {
         self.pending(&chain).read().await.len()
     }
 
-    /// Record that this node dispatched a publish for `id`'s current
-    /// pending-publish episode, returning `false` if one was already dispatched or
-    /// the entry is gone.
-    pub async fn mark_publish_dispatched(&self, chain: Chain, id: &SignId) -> bool {
-        let pending = self.pending(&chain).read().await;
-
-        pending
-            .requests
-            .get(id)
-            .and_then(|entry| entry.status.publishing())
-            .map(|publishing| publishing.mark_publish_dispatched())
-            .unwrap_or(false)
-    }
-
     /// Begin watching for execution of a bidirectional transaction on the destination chain.
-    pub async fn watch_execution(
-        &self,
-        entry: &SignEntry<Bidirectional<Executing>>,
-    ) -> Option<(SignId, Arc<BidirectionalTx>)> {
+    pub async fn watch_execution(&self, entry: &SignEntry<Bidirectional<Executing>>) {
         let tx = entry.execution_tx();
         let target_chain = tx.target_chain;
-        let sign_id = entry.sign_id();
         let mut watchers = self.watchers(&target_chain).write().await;
 
-        watchers
-            .insert(
-                tx.id,
-                ExecutionWatcher {
-                    sign_id,
-                    tx: Arc::clone(tx),
-                },
-            )
-            .map(|previous| (previous.sign_id, previous.tx))
+        watchers.insert(Arc::clone(tx));
     }
 
-    /// Stop watching for execution of a bidirectional transaction on the destination chain.
+    /// Stop watching for execution of a bidirectional transaction on the destination chain
+    /// and retrieve the executing backlog entry from its source chain.
     pub async fn unwatch_execution(
         &self,
         chain: Chain,
         tx_id: &BidirectionalTxId,
-    ) -> Option<(SignId, Arc<BidirectionalTx>)> {
-        let mut entry = self.watchers(&chain).write().await;
+    ) -> Option<SignEntry<Bidirectional<Executing>>> {
+        let tx = {
+            let mut watchers = self.watchers(&chain).write().await;
+            watchers.remove(tx_id)?
+        };
 
-        entry
-            .remove(tx_id)
-            .map(|watcher| (watcher.sign_id, watcher.tx))
+        self.get_by::<Bidirectional<Executing>>(tx.source_chain, &tx.sign_id())
+            .await
     }
 
     /// Set the processed block height for a specific chain.
@@ -543,9 +510,7 @@ impl Backlog {
         // Clear execution watchers whose source chain is the recovered chain
         for destination_chain in Chain::iter() {
             let mut watchers = self.watchers(&destination_chain).write().await;
-            watchers
-                .watchers
-                .retain(|_, watcher| watcher.tx.source_chain != chain);
+            watchers.watchers.retain(|_, tx| tx.source_chain != chain);
         }
 
         // now repopulate our execution watchers

--- a/chain-signatures/node/src/backlog/request.rs
+++ b/chain-signatures/node/src/backlog/request.rs
@@ -7,8 +7,8 @@ use cait_sith::FullSignature;
 use k256::Secp256k1;
 use mpc_crypto::{derive_key, reconstruct_signature};
 use mpc_primitives::{
-    BidirectionalTx, Chain, ExecutionOutcome, IndexedSignRequest, PublicKey, SignId, SignKind,
-    Signature,
+    BidirectionalTx, Chain, ExecutionOutcome, IndexedSignRequest, PublicKey,
+    SignBidirectionalEvent, SignId, SignKind, Signature,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -486,14 +486,24 @@ impl SignEntry<Bidirectional<Initial<AnyProgress>>> {
     }
 }
 
+impl<P> SignEntry<Bidirectional<Initial<P>>> {
+    /// Return the underlying [`SignBidirectionalEvent`] for this initial bidirectional entry.
+    pub fn sign_bidirectional_event(&self) -> &SignBidirectionalEvent {
+        match &self.request.kind {
+            SignKind::SignBidirectional(event) => event,
+            _ => unreachable!("guaranteed by Bidirectional typestate invariant"),
+        }
+    }
+}
+
 impl SignEntry<Bidirectional<Executing>> {
     pub fn execution_tx(&self) -> &Arc<BidirectionalTx> {
         &self.state.0 .0
     }
 
     /// Watch execution of this bidirectional transaction on its target chain.
-    pub async fn watch_execution(&self) -> Option<(SignId, Arc<BidirectionalTx>)> {
-        self.backlog.watch_execution(self).await
+    pub async fn watch_execution(&self) {
+        self.backlog.watch_execution(self).await;
     }
 
     /// Advance destination-chain `Executing` into Phase 2 response signing based on

--- a/chain-signatures/node/src/backlog/tests.rs
+++ b/chain-signatures/node/src/backlog/tests.rs
@@ -533,8 +533,7 @@ async fn test_plain_sign_typestate_lifecycle() {
 
     // 6. Invalid signature rejection
     let sign_id3 = SignId::from_u8(99);
-    let req3 = mock_sign_request(sign_id3, Chain::Ethereum);
-    let entry3 = backlog.insert_sign(req3).await;
+    let entry3 = backlog.insert_mock_sign(sign_id3, Chain::Ethereum).await;
     let wrong_root_sk = k256::SecretKey::random(&mut rand::thread_rng());
     let wrong_pk = wrong_root_sk.public_key().into();
     let dummy_output = cait_sith::FullSignature {
@@ -700,35 +699,31 @@ async fn test_watch_unwatch_and_respond() {
     let tx = mock_tx(7);
     let sign_id = tx.sign_id();
 
-    let entry = backlog.insert_mock_executing(&tx).await;
+    backlog.insert_mock_executing(&tx).await;
 
-    // Unwatch returns the watcher (automatically registered on advance to executing)
-    let (watched_id, watched_tx) = backlog
+    // Unwatch returns the executing SignEntry (automatically registered on advance to executing)
+    let executing_entry = backlog
         .unwatch_execution(tx.target_chain, &tx.id)
         .await
         .expect("watcher present");
-    assert_eq!(watched_id, sign_id);
-    assert_eq!(watched_tx.id, tx.id);
+    assert_eq!(executing_entry.sign_id(), sign_id);
+    assert_eq!(executing_entry.execution_tx().id, tx.id);
 
     // Watch execution on target chain using typed SignEntry
-    backlog.watch_execution(&entry).await;
+    backlog.watch_execution(&executing_entry).await;
 
     // Also verify entry.watch_execution() method
-    entry.watch_execution().await;
+    executing_entry.watch_execution().await;
 
-    let (watched_id2, watched_tx2) = backlog
+    let executing_entry = backlog
         .unwatch_execution(tx.target_chain, &tx.id)
         .await
         .expect("watcher present");
-    assert_eq!(watched_id2, sign_id);
-    assert_eq!(watched_tx2.id, tx.id);
+    assert_eq!(executing_entry.sign_id(), sign_id);
+    assert_eq!(executing_entry.execution_tx().id, tx.id);
 
     // Advance executing entry to final response signing
-    let entry = backlog
-        .get_by::<Bidirectional<Executing>>(tx.source_chain, &sign_id)
-        .await
-        .expect("executing entry exists");
-    entry
+    executing_entry
         .advance(ExecutionOutcome::Success { output: vec![] })
         .await
         .expect("respond should transition to final generating");
@@ -868,7 +863,7 @@ async fn test_publishable_requests() {
     // 1. Plain sign request advanced to publishing
     let req1 = mock_sign_request(SignId::from_u8(1), chain);
     let (pk1, out1) = mock_signature_output(&req1.args);
-    let _ = backlog
+    backlog
         .insert_sign(req1)
         .await
         .advance(pk1, &out1, mock_participants(), true)
@@ -876,13 +871,12 @@ async fn test_publishable_requests() {
         .unwrap();
 
     // 2. Plain sign request still generating (not publishable)
-    let req2 = mock_sign_request(SignId::from_u8(2), chain);
-    let _ = backlog.insert_sign(req2).await;
+    backlog.insert_mock_sign(SignId::from_u8(2), chain).await;
 
     // 3. Bidirectional request advanced to Phase 1 publishing
     let req3 = mock_bidi_request(SignId::from_u8(3), chain);
     let (pk3, out3) = mock_signature_output(&req3.args);
-    let _ = backlog
+    backlog
         .insert_bidirectional(req3)
         .await
         .advance(pk3, &out3, mock_participants(), false)
@@ -914,7 +908,7 @@ async fn test_insert_and_accessors() {
     assert_eq!(entry.into_request().id, sign_id);
 
     // Duplicate insert should report is_new == false
-    let (_entry2, is_new2) = backlog.insert(req).await;
+    let (_, is_new2) = backlog.insert(req).await;
     assert!(!is_new2);
 }
 
@@ -926,7 +920,7 @@ async fn test_dynamic_entry_cast_and_is() {
     let req = mock_sign_request(sign_id, chain);
 
     let (pk, out) = mock_signature_output(&req.args);
-    let _ = backlog
+    backlog
         .insert_sign(req)
         .await
         .advance(pk, &out, mock_participants(), true)
@@ -955,10 +949,11 @@ async fn test_dynamic_entry_cast_and_is() {
 async fn test_initial_any_progress_advance() {
     let backlog = Backlog::new();
     let sign_id = SignId::from_u8(7);
-    let req = mock_bidi_request(sign_id, Chain::Solana);
     let tx = Arc::new(mock_bidirectional_tx(sign_id, Chain::Solana));
 
-    let _ = backlog.insert_bidirectional(req).await;
+    backlog
+        .insert_mock_bidirectional(sign_id, Chain::Solana)
+        .await;
 
     // Retrieve via wildcard AnyProgress
     let entry = backlog
@@ -988,12 +983,13 @@ async fn test_pending_executions_typestate() {
     tx2_sol.source_chain = Chain::Solana;
     tx2_sol.target_chain = Chain::Ethereum;
 
-    let _ = backlog.insert_mock_executing(&tx1).await;
-    let _ = backlog.insert_mock_executing(&tx2_sol).await;
+    backlog.insert_mock_executing(&tx1).await;
+    backlog.insert_mock_executing(&tx2_sol).await;
 
     // Plain sign on Ethereum (should not appear in pending executions)
-    let plain_req = mock_sign_request(SignId::from_u8(99), Chain::Ethereum);
-    let _ = backlog.insert_sign(plain_req).await;
+    backlog
+        .insert_mock_sign(SignId::from_u8(99), Chain::Ethereum)
+        .await;
 
     let eth_execs = backlog.pending_executions(Chain::Ethereum).await;
     assert_eq!(eth_execs.len(), 1);

--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -596,22 +596,10 @@ mod tests {
 
         let cfg = ProtocolConfig::default();
         let sign_id = SignId::new([42u8; 32]);
-        let args = mpc_primitives::SignArgs {
-            entropy: [1u8; 32],
-            epsilon: k256::Scalar::from(1u64),
-            payload: k256::Scalar::from(2u64),
-            path: "test".to_string(),
-            key_version: 1,
-        };
-        let request = Arc::new(IndexedSignRequest::sign(sign_id, args, Chain::Solana, 0));
+        let request = crate::backlog::mock::mock_sign_request(sign_id, Chain::Solana);
 
         let probe_id = SignId::new([43u8; 32]);
-        let probe_request = IndexedSignRequest::sign(
-            probe_id,
-            request.args.clone(),
-            Chain::Solana,
-            request.unix_timestamp_indexed,
-        );
+        let probe_request = crate::backlog::mock::mock_sign_request(probe_id, Chain::Solana);
         let dropped = Arc::new(Notify::new());
         struct DropProbe(Arc<Notify>);
         impl Drop for DropProbe {
@@ -620,8 +608,7 @@ mod tests {
             }
         }
         let probe = DropProbe(Arc::clone(&dropped));
-        let probe_req_arc = Arc::new(probe_request);
-        let entry = backlog::SignEntry::generating(probe_req_arc, &backlog);
+        let entry = backlog::SignEntry::generating(probe_request, &backlog);
         spawner.requests.insert(
             probe_id,
             SignEntry {

--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -465,7 +465,6 @@ pub(crate) mod tests {
     use crate::protocol::sync::SyncReportReceiver;
     use crate::rpc::RpcAction;
     use deadpool_redis::Runtime;
-    use mpc_primitives::SignKind;
 
     /// A posit-phase harness; the unused channel ends are held alive so sends
     /// keep working. The redis pool is lazy and never actually connected.
@@ -513,21 +512,11 @@ pub(crate) mod tests {
             sync_report_tx,
         };
 
-        let request = IndexedSignRequest::new(
-            ctx.sign_id,
-            mpc_primitives::SignArgs {
-                entropy: [0u8; 32],
-                epsilon: k256::Scalar::from(1u64),
-                payload: k256::Scalar::from(2u64),
-                path: "test".to_string(),
-                key_version: 0,
-            },
-            Chain::Ethereum,
-            0,
-            SignKind::Sign,
-        );
         let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
-        let entry = backlog::SignEntry::generating(Arc::new(request), &Backlog::new());
+        let entry = backlog::SignEntry::generating(
+            crate::backlog::mock::mock_sign_request(ctx.sign_id, Chain::Ethereum),
+            &Backlog::new(),
+        );
         let state = SignState::new(entry, mesh_rx, Arc::clone(&ctx.round));
 
         TestSetup {

--- a/chain-signatures/node/src/protocol/request/state.rs
+++ b/chain-signatures/node/src/protocol/request/state.rs
@@ -127,22 +127,8 @@ impl SignState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backlog::mock::mock_sign_request;
     use crate::backlog::Backlog;
-
-    fn request() -> IndexedSignRequest {
-        IndexedSignRequest::sign(
-            SignId::new([0u8; 32]),
-            mpc_primitives::SignArgs {
-                entropy: [0u8; 32],
-                epsilon: k256::Scalar::from(1u64),
-                payload: k256::Scalar::from(2u64),
-                path: "test".to_string(),
-                key_version: 0,
-            },
-            Chain::Ethereum,
-            0,
-        )
-    }
 
     /// A respawn rebuilds `SignState`; the round must resume from the carried
     /// value, not restart at 0 — peers read a round reset as time travel.
@@ -151,7 +137,10 @@ mod tests {
         let carried = Arc::new(AtomicUsize::new(0));
         let (_mesh_tx, mesh_rx) = watch::channel(MeshState::default());
         let backlog = Backlog::new();
-        let entry = SignEntry::generating(Arc::new(request()), &backlog);
+        let entry = SignEntry::generating(
+            mock_sign_request(SignId::new([0u8; 32]), Chain::Ethereum),
+            &backlog,
+        );
 
         let mut state = SignState::new(entry.clone(), mesh_rx.clone(), Arc::clone(&carried));
         state.reorganize("test");

--- a/chain-signatures/node/src/sign_bidirectional.rs
+++ b/chain-signatures/node/src/sign_bidirectional.rs
@@ -5,7 +5,9 @@ use k256::elliptic_curve::point::AffineCoordinates;
 use k256::elliptic_curve::sec1::ToEncodedPoint as _;
 use k256::{AffinePoint, Scalar};
 use mpc_crypto::derive_key;
-pub use mpc_primitives::{BidirectionalTx, ChainFromError, SignBidirectionalEvent, Signature};
+pub use mpc_primitives::{
+    BidirectionalTx, BidirectionalTxId, ChainFromError, SignBidirectionalEvent, Signature,
+};
 use rlp::{Rlp, RlpStream};
 use serde::{Deserialize, Serialize};
 
@@ -120,6 +122,14 @@ pub trait SignBidirectionalEventExt {
     /// path's failure handling (quarantine): both must agree on what "can never
     /// advance" means.
     fn validate(&self) -> anyhow::Result<()>;
+
+    /// Construct a [`BidirectionalTx`] from this event, the response signature, and the MPC root key.
+    fn to_bidirectional_tx(
+        &self,
+        request_id: [u8; 32],
+        mpc_sig: Signature,
+        root_pk: mpc_primitives::PublicKey,
+    ) -> anyhow::Result<BidirectionalTx>;
 }
 
 impl SignBidirectionalEventExt for SignBidirectionalEvent {
@@ -171,6 +181,41 @@ impl SignBidirectionalEventExt for SignBidirectionalEvent {
         validate_unsigned_transaction(&self.serialized_transaction)
             .context("undecodable serialized_transaction")?;
         Ok(())
+    }
+
+    fn to_bidirectional_tx(
+        &self,
+        request_id: [u8; 32],
+        mpc_sig: Signature,
+        root_pk: mpc_primitives::PublicKey,
+    ) -> anyhow::Result<BidirectionalTx> {
+        let target_chain = self.target_chain().with_context(|| {
+            format!("failed to determine target chain for request: {request_id:?}")
+        })?;
+        let epsilon = self.epsilon()?;
+        let from_address = derive_user_address(root_pk, epsilon);
+        let (signed_tx_hash, nonce) =
+            sign_and_hash_transaction(&self.serialized_transaction, mpc_sig)?;
+
+        Ok(BidirectionalTx {
+            id: BidirectionalTxId(signed_tx_hash),
+            sender: self.sender,
+            serialized_transaction: self.serialized_transaction.clone(),
+            source_chain: self.chain,
+            target_chain,
+            caip2_id: self.caip2_id.clone(),
+            key_version: self.key_version,
+            deposit: self.deposit,
+            path: self.path.clone(),
+            algo: self.algo.clone(),
+            dest: self.dest.clone(),
+            params: self.params.clone(),
+            output_deserialization_schema: self.output_deserialization_schema.clone(),
+            respond_serialization_schema: self.respond_serialization_schema.clone(),
+            request_id,
+            from_address: **from_address,
+            nonce,
+        })
     }
 }
 
@@ -488,58 +533,14 @@ mod tests {
     #[test]
     fn test_checkpoint_consensus_bytes_deterministic_across_publish_states() {
         use super::{BidirectionalProgress, SignProgress, SignStatus};
-        use crate::backlog::Publishing;
-        use k256::Scalar;
-        use mpc_primitives::{
-            BidirectionalTx, BidirectionalTxId, Chain, IndexedSignRequest, RespondBidirectionalTx,
-            SignArgs, SignId, SignKind, Signature,
-        };
+        use crate::backlog::mock::{mock_bidi_response, mock_publishing, mock_tx};
 
-        let dummy_sig = Signature {
-            big_r: k256::ProjectivePoint::GENERATOR.to_affine(),
-            s: k256::Scalar::ONE,
-            recovery_id: 0,
-        };
-        let dummy_tx = Arc::new(BidirectionalTx {
-            id: BidirectionalTxId([1u8; 32]),
-            sender: [0u8; 32],
-            serialized_transaction: vec![],
-            source_chain: Chain::Solana,
-            target_chain: Chain::Ethereum,
-            caip2_id: String::new(),
-            key_version: 0,
-            deposit: 0,
-            path: String::new(),
-            algo: String::new(),
-            dest: String::new(),
-            params: String::new(),
-            output_deserialization_schema: vec![],
-            respond_serialization_schema: vec![],
-            request_id: [1u8; 32],
-            from_address: [0u8; 20],
-            nonce: 0,
-        });
-        let publish = || Publishing::new(dummy_sig, vec![], true);
-        let dummy_respond_req = Arc::new(IndexedSignRequest::new(
-            SignId::new([1u8; 32]),
-            SignArgs {
-                entropy: [0u8; 32],
-                epsilon: Scalar::ONE,
-                payload: Scalar::ONE,
-                path: String::new(),
-                key_version: 0,
-            },
-            Chain::Solana,
-            0,
-            SignKind::RespondBidirectional(RespondBidirectionalTx {
-                tx_id: dummy_tx.id,
-                output: vec![],
-                chain_ctx: None,
-            }),
-        ));
+        let dummy_tx = Arc::new(mock_tx(1));
+        let dummy_respond_req = mock_bidi_response(&dummy_tx);
 
         let generation_tag = SignStatus::Sign(SignProgress::Generating).consensus_tag();
-        let publish_tag = SignStatus::Sign(SignProgress::Publishing(publish())).consensus_tag();
+        let publish_tag =
+            SignStatus::Sign(SignProgress::Publishing(mock_publishing())).consensus_tag();
         assert_eq!(
             generation_tag, publish_tag,
             "Generating and Publishing must produce identical consensus tags"
@@ -562,7 +563,7 @@ mod tests {
         .consensus_tag();
         let pub_bidi_tag = SignStatus::Bidirectional(BidirectionalProgress::Final {
             respond_request: dummy_respond_req,
-            progress: SignProgress::Publishing(publish()),
+            progress: SignProgress::Publishing(mock_publishing()),
         })
         .consensus_tag();
         assert_eq!(

--- a/chain-signatures/node/src/stream/mod.rs
+++ b/chain-signatures/node/src/stream/mod.rs
@@ -139,22 +139,13 @@ pub(crate) async fn handle_chain_event<T: ChainTelemetry>(
         }
         ChainEvent::ExecutionConfirmed {
             tx_id,
-            sign_id,
-            source_chain,
             block_height,
             result,
+            ..
         } => {
-            process_execution_confirmed(
-                tx_id,
-                sign_id,
-                source_chain,
-                block_height,
-                result,
-                ctx,
-                chain,
-            )
-            .await
-            .context("failed to process execution confirmation")?;
+            process_execution_confirmed(tx_id, block_height, result, ctx, chain)
+                .await
+                .context("failed to process execution confirmation")?;
         }
     }
 

--- a/chain-signatures/node/src/stream/ops.rs
+++ b/chain-signatures/node/src/stream/ops.rs
@@ -10,27 +10,25 @@ use crate::types::SignCommand;
 use mpc_chain_integration_core::ChainTelemetry;
 use mpc_chain_solana::Pubkey;
 use mpc_primitives::{
-    BidirectionalTx, BidirectionalTxId, Chain, ExecutionOutcome, IndexedSignRequest,
-    RespondBidirectionalEvent, SignBidirectionalEvent, SignId, SignKind, SignatureRespondedEvent,
+    Chain, ExecutionOutcome, IndexedSignRequest, RespondBidirectionalEvent, SignId, SignKind,
+    SignatureRespondedEvent,
 };
 
 pub(crate) async fn process_sign_request(
     sign_request: Arc<IndexedSignRequest>,
     ctx: &StreamContext,
 ) -> anyhow::Result<bool> {
-    if matches!(sign_request.kind, SignKind::RespondBidirectional(_)) {
-        anyhow::bail!("Unexpected sign request kind");
-    }
-
-    // Reject malformed bidirectional requests at ingestion, running the same
-    // deterministic derivations the respond event will need later. A request
-    // admitted here but failing there can never advance: its entry sticks in
-    // pending-publish forever, and every node publishes a leg-1 response
-    // whose second leg will never come.
-    if let SignKind::SignBidirectional(event) = &sign_request.kind {
-        event.validate().with_context(|| {
+    match &sign_request.kind {
+        SignKind::RespondBidirectional(_) => anyhow::bail!("Unexpected sign request kind"),
+        // Reject malformed bidirectional requests at ingestion, running the same
+        // deterministic derivations the respond event will need later. A request
+        // admitted here but failing there can never advance: its entry sticks in
+        // pending-publish forever, and every node publishes a leg-1 response
+        // whose second leg will never come.
+        SignKind::SignBidirectional(event) => event.validate().with_context(|| {
             format!("rejecting bidirectional sign request {:?}", sign_request.id)
-        })?;
+        })?,
+        SignKind::Sign => {}
     }
 
     let (entry, is_new) = ctx.backlog.insert(sign_request).await;
@@ -138,12 +136,7 @@ pub(crate) async fn process_respond_event(
 
     if let Some(entry) = entry.cast::<Bidirectional<Initial<AnyProgress>>>() {
         entry.verify_signature(root_pk, &respond_event.signature)?;
-        let event = match &entry.request().kind {
-            SignKind::SignBidirectional(event) => event.clone(),
-            _ => anyhow::bail!("unexpected sign kind for bidirectional initial entry"),
-        };
-        return advance_bidirectional_to_execution(entry, &event, respond_event, sign_id, root_pk)
-            .await;
+        return advance_bidirectional_to_execution(entry, respond_event, root_pk).await;
     }
 
     if entry.is::<Bidirectional<Executing>>() {
@@ -167,12 +160,12 @@ pub(crate) async fn process_respond_event(
 /// "pending execution".
 async fn advance_bidirectional_to_execution(
     entry: SignEntry<Bidirectional<Initial<AnyProgress>>>,
-    event: &SignBidirectionalEvent,
     respond_event: SignatureRespondedEvent,
-    sign_id: SignId,
     root_pk: mpc_primitives::PublicKey,
 ) -> anyhow::Result<()> {
-    let source_chain = respond_event.chain;
+    let sign_id = entry.sign_id();
+    let source_chain = entry.chain();
+    let event = entry.sign_bidirectional_event();
 
     // Admission validates the same derivations, but entries can enter the backlog
     // without passing admission (checkpoint recovery restores them wholesale). One
@@ -191,68 +184,17 @@ async fn advance_bidirectional_to_execution(
         return Ok(());
     }
 
-    tracing::info!(?sign_id, "bidirectional processing initial respond event");
-    let target_chain = event
-        .target_chain()
-        .with_context(|| format!("failed to process respond event for sign id: {sign_id:?}"))?;
+    let tx = Arc::new(event.to_bidirectional_tx(
+        respond_event.request_id,
+        respond_event.signature,
+        root_pk,
+    )?);
 
-    // Get the MPC public key and derive the from_address.
-    let epsilon = event.epsilon()?;
-    let from_address = crate::sign_bidirectional::derive_user_address(root_pk, epsilon);
+    entry.advance(tx).await.with_context(|| {
+        format!("advance bidirectional tx to execution failed for sign id {sign_id:?}")
+    })?;
 
-    let mpc_sig = respond_event.signature;
-
-    // Sign and hash the transaction to get the correct tx_id and nonce
-    let (signed_tx_hash, nonce) = crate::sign_bidirectional::sign_and_hash_transaction(
-        &event.serialized_transaction,
-        mpc_sig,
-    )?;
-
-    let tx_id = BidirectionalTxId(signed_tx_hash);
-
-    let bidirectional_tx = Arc::new(BidirectionalTx {
-        id: tx_id,
-        sender: event.sender,
-        serialized_transaction: event.serialized_transaction.clone(),
-        source_chain,
-        target_chain,
-        caip2_id: event.caip2_id.clone(),
-        key_version: event.key_version,
-        deposit: event.deposit,
-        path: event.path.clone(),
-        algo: event.algo.clone(),
-        dest: event.dest.clone(),
-        params: event.params.clone(),
-        output_deserialization_schema: event.output_deserialization_schema.clone(),
-        respond_serialization_schema: event.respond_serialization_schema.clone(),
-        request_id: respond_event.request_id,
-        from_address: **from_address,
-        nonce,
-    });
-
-    tracing::info!(
-        ?sign_id,
-        ?tx_id,
-        nonce = ?bidirectional_tx.nonce,
-        from_address = ?bidirectional_tx.from_address,
-        "bidirectional tx details before advancement",
-    );
-
-    entry
-        .advance(bidirectional_tx)
-        .await
-        .with_context(|| {
-            format!(
-                "advance bidirectional tx to execution failed for sign id {sign_id:?}, tx_id {tx_id:?}, target_chain {target_chain:?}"
-            )
-        })?;
-    tracing::info!(
-        ?sign_id,
-        ?tx_id,
-        ?target_chain,
-        "advance bidirectional tx to execution successful"
-    );
-
+    tracing::info!(?sign_id, "advance bidirectional tx to execution successful");
     Ok(())
 }
 
@@ -275,14 +217,8 @@ pub(crate) async fn process_respond_bidirectional_event(
     };
 
     entry.verify_signature(root_pk, &event.signature)?;
-
-    if entry.complete().await {
-        tracing::info!(?sign_id, "bidirectional tx completed");
-    } else {
-        tracing::warn!(?sign_id, "bidirectional tx not found on completion");
-        return Ok(());
-    }
-
+    entry.complete().await;
+    tracing::info!(?sign_id, "bidirectional tx completed");
     ctx.try_enqueue(SignCommand::Completion(sign_id)).await?;
 
     Ok(())
@@ -292,13 +228,28 @@ pub(crate) async fn process_respond_bidirectional_event(
 /// The target chain is the chain where the execution was observed.
 pub async fn process_execution_confirmed(
     tx_id: mpc_primitives::BidirectionalTxId,
-    sign_id: SignId,
-    source_chain: Chain,
     block_height: u64,
     result: ExecutionOutcome,
     ctx: &StreamContext,
     target_chain: Chain,
 ) -> anyhow::Result<()> {
+    tracing::debug!(
+        ?tx_id,
+        ?target_chain,
+        block_height,
+        "received execution confirmation event"
+    );
+
+    let Some(entry) = ctx.backlog.unwatch_execution(target_chain, &tx_id).await else {
+        tracing::warn!(
+            ?tx_id,
+            "executing bidirectional entry not found (maybe already processed)"
+        );
+        return Ok(());
+    };
+
+    let sign_id = entry.sign_id();
+    let source_chain = entry.chain;
     tracing::info!(
         ?tx_id,
         ?sign_id,
@@ -308,57 +259,18 @@ pub async fn process_execution_confirmed(
         "handling execution confirmation"
     );
 
-    // Remove the watcher; if it's not found, it might have been processed already
-    let Some((unwatched_sign_id, pending_tx)) =
-        ctx.backlog.unwatch_execution(target_chain, &tx_id).await
-    else {
-        tracing::warn!(
-            ?tx_id,
-            "execution watcher not found (maybe already processed)"
-        );
-        return Ok(());
-    };
-    if unwatched_sign_id != sign_id {
-        tracing::warn!(?tx_id, expected = ?unwatched_sign_id, actual = ?sign_id, "sign_id mismatch between event and watcher");
-    }
-    // The watched transaction is the source of truth for the source chain. The
-    // follow-up request's chain decides which backlog bucket, publish key, and
-    // cancellation key it lives under, and all of them must agree; an execution
-    // watcher filling the event's field differently must not split them.
-    if source_chain != pending_tx.source_chain {
-        tracing::warn!(
-            ?tx_id,
-            event = ?source_chain,
-            watcher = ?pending_tx.source_chain,
-            "source_chain mismatch between event and watcher; using the watcher's"
-        );
-    }
-    let source_chain = pending_tx.source_chain;
-
-    let Some(entry) = ctx
-        .backlog
-        .get_by::<Bidirectional<Executing>>(source_chain, &unwatched_sign_id)
-        .await
-    else {
-        tracing::warn!(
-            ?tx_id,
-            ?unwatched_sign_id,
-            "executing bidirectional entry not found in backlog"
-        );
-        return Ok(());
-    };
-
     let entry = entry
         .advance(result)
         .await
         .with_context(|| {
             format!(
-                "failed to transition pending tx to final response for sign id {unwatched_sign_id:?}, tx_id {tx_id:?}, source_chain {source_chain}"
+                "failed to transition pending tx to final response for sign id {sign_id:?}, tx_id {tx_id:?}, source_chain {source_chain}"
             )
         })?;
     tracing::info!(
         ?tx_id,
-        ?unwatched_sign_id,
+        ?sign_id,
+        ?source_chain,
         "transitioned transaction to final response"
     );
     let chain = entry.chain;

--- a/chain-signatures/node/src/stream/ops_tests.rs
+++ b/chain-signatures/node/src/stream/ops_tests.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::backlog::mock::{mock_participants, mock_signature_output, mock_tx, BacklogTestExt};
+use crate::backlog::mock::{
+    mock_bidi_request, mock_bidi_response_request, mock_participants, mock_sign_request,
+    mock_signature_output, mock_tx, BacklogTestExt,
+};
 use crate::backlog::{Backlog, Bidirectional, Final, Generating};
 use crate::mesh::connection::NodeStatus;
 use crate::mesh::{wait_threshold_active, MeshState};
@@ -11,7 +14,7 @@ use crate::stream::ops::process_execution_confirmed;
 use crate::stream::test_utils::{
     make_test_stream_context, make_test_stream_context_with_generator_pk,
     make_test_stream_context_with_rpc, respond_event, test_bidirectional_tx,
-    test_canton_sign_bidirectional_request, test_indexed_request, test_sign_args,
+    test_canton_sign_bidirectional_request, test_sign_args,
 };
 use crate::types::SignCommand;
 use alloy::primitives::B256;
@@ -20,7 +23,8 @@ use k256::{ProjectivePoint, Scalar};
 use mpc_chain_canton::CantonChainCtx;
 use mpc_chain_integration_core::{NoopChainTelemetry, StateManager};
 use mpc_primitives::{
-    ChainConfig as _, RespondBidirectionalTx, SignArgs, SignBidirectionalEvent, SignKind, Signature,
+    BidirectionalTx, BidirectionalTxId, ChainConfig as _, IndexedSignRequest, SignArgs,
+    SignBidirectionalEvent, SignKind, Signature,
 };
 use mpc_utils::time::current_unix_timestamp;
 use near_primitives::types::AccountId;
@@ -55,25 +59,9 @@ async fn recover_backlog_requeues_pending_signs() {
     // should be marked for requeue during recovery.
     let backlog = Backlog::new();
     let sign_id = SignId::new([9u8; 32]);
-    let args = SignArgs {
-        entropy: [1u8; 32],
-        epsilon: Scalar::from(1u64),
-        payload: Scalar::from(2u64),
-        path: "test".to_string(),
-        key_version: 1,
-    };
-
-    // Add a request and persist a checkpoint so recover() can load it
-    let unix_timestamp_indexed = current_unix_timestamp();
-    backlog
-        .insert(test_indexed_request(
-            sign_id,
-            Chain::Solana,
-            args.clone(),
-            unix_timestamp_indexed,
-            SignKind::Sign,
-        ))
-        .await;
+    let entry = backlog.insert_mock_sign(sign_id, Chain::Solana).await;
+    let expected_args = entry.request().args.clone();
+    let expected_timestamp = entry.request().unix_timestamp_indexed;
     let checkpoint = backlog.checkpoint(Chain::Solana).await.unwrap();
 
     let threshold = 1;
@@ -98,11 +86,11 @@ async fn recover_backlog_requeues_pending_signs() {
     match msg.expect("sign_rx should contain a message") {
         SignCommand::Request(req) => {
             assert_eq!(req.sign_id(), sign_id);
-            assert_eq!(req.request().args, args);
+            assert_eq!(req.request().args, expected_args);
             assert_eq!(req.chain(), Chain::Solana);
             assert_eq!(req.request().kind, SignKind::Sign);
             // Verify that the unix_timestamp_indexed is preserved from the original entry
-            assert_eq!(req.request().unix_timestamp_indexed, unix_timestamp_indexed);
+            assert_eq!(req.request().unix_timestamp_indexed, expected_timestamp);
             assert!(req.request().unix_timestamp_indexed <= current_unix_timestamp());
         }
         other => panic!("unexpected message: {:?}", other),
@@ -131,24 +119,7 @@ async fn process_execution_confirmed_success_creates_respond_request() {
     let backlog = Backlog::new();
     let tx = test_bidirectional_tx(1, Chain::Solana, Chain::Ethereum);
     let sign_id = tx.sign_id();
-
-    // Insert a pending Sign request on the source chain
-    let args = SignArgs {
-        entropy: [1u8; 32],
-        epsilon: Scalar::from(1u64),
-        payload: Scalar::from(2u64),
-        path: "test".to_string(),
-        key_version: 1,
-    };
-    let unix_timestamp_indexed = current_unix_timestamp();
-    let request = test_indexed_request(
-        sign_id,
-        tx.source_chain,
-        args.clone(),
-        unix_timestamp_indexed,
-        SignKind::SignBidirectional(bidirectional_event(vec![])),
-    );
-    seed_executing_entry(&backlog, request, Arc::new(tx.clone())).await;
+    backlog.insert_mock_executing(&tx).await;
 
     let (sign_tx, mut sign_rx) = mpsc::channel(4);
 
@@ -160,8 +131,6 @@ async fn process_execution_confirmed_success_creates_respond_request() {
     let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
     process_execution_confirmed(
         tx_id,
-        sign_id,
-        tx.source_chain,
         123u64,
         ExecutionOutcome::Success { output: vec![] },
         &ctx,
@@ -210,30 +179,13 @@ async fn process_execution_confirmed_success_creates_respond_request() {
 async fn process_execution_confirmed_is_idempotent_after_first_processing() {
     let backlog = Backlog::new();
     let tx = test_bidirectional_tx(7, Chain::Solana, Chain::Ethereum);
-    let sign_id = tx.sign_id();
-    let args = SignArgs {
-        entropy: [7u8; 32],
-        epsilon: Scalar::from(1u64),
-        payload: Scalar::from(2u64),
-        path: "test".to_string(),
-        key_version: 1,
-    };
-    let request = test_indexed_request(
-        sign_id,
-        tx.source_chain,
-        args,
-        current_unix_timestamp(),
-        SignKind::SignBidirectional(bidirectional_event(vec![])),
-    );
-    seed_executing_entry(&backlog, request, Arc::new(tx.clone())).await;
+    backlog.insert_mock_executing(&tx).await;
 
     let (sign_tx, mut sign_rx) = mpsc::channel(4);
     let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
 
     process_execution_confirmed(
         tx.id,
-        sign_id,
-        tx.source_chain,
         123u64,
         ExecutionOutcome::Success { output: vec![] },
         &ctx,
@@ -244,8 +196,6 @@ async fn process_execution_confirmed_is_idempotent_after_first_processing() {
 
     process_execution_confirmed(
         tx.id,
-        sign_id,
-        tx.source_chain,
         124u64,
         ExecutionOutcome::Success { output: vec![] },
         &ctx,
@@ -276,88 +226,12 @@ async fn process_execution_confirmed_is_idempotent_after_first_processing() {
 }
 
 #[tokio::test]
-async fn process_execution_confirmed_warns_but_still_uses_watcher_sign_id() {
-    let backlog = Backlog::new();
-    let tx = test_bidirectional_tx(8, Chain::Solana, Chain::Ethereum);
-    let sign_id = tx.sign_id();
-    let mismatched_sign_id = SignId::new([88u8; 32]);
-    let args = SignArgs {
-        entropy: [8u8; 32],
-        epsilon: Scalar::from(1u64),
-        payload: Scalar::from(2u64),
-        path: "test".to_string(),
-        key_version: 1,
-    };
-    let request = test_indexed_request(
-        sign_id,
-        tx.source_chain,
-        args,
-        current_unix_timestamp(),
-        SignKind::SignBidirectional(bidirectional_event(vec![])),
-    );
-    seed_executing_entry(&backlog, request, Arc::new(tx.clone())).await;
-
-    let (sign_tx, mut sign_rx) = mpsc::channel(4);
-    let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
-
-    process_execution_confirmed(
-        tx.id,
-        mismatched_sign_id,
-        tx.source_chain,
-        321u64,
-        ExecutionOutcome::Failed,
-        &ctx,
-        tx.target_chain,
-    )
-    .await
-    .unwrap();
-
-    let tx_after = ctx.backlog.get(tx.source_chain, &sign_id).await.unwrap();
-    assert_matches!(
-        tx_after.status(),
-        SignStatus::Bidirectional(BidirectionalProgress::Final {
-            progress: SignProgress::Generating,
-            ..
-        })
-    );
-    assert_matches!(tx_after.request().kind, SignKind::RespondBidirectional(_));
-    assert!(ctx
-        .backlog
-        .get_execution_watchers(tx.target_chain)
-        .await
-        .is_empty());
-
-    let msg = timeout(Duration::from_secs(1), sign_rx.recv())
-        .await
-        .unwrap()
-        .unwrap();
-    match msg {
-        SignCommand::Request(req) => assert_eq!(req.sign_id(), sign_id),
-        other => panic!("expected sign request, got {other:?}"),
-    }
-}
-
-#[tokio::test]
 async fn process_execution_confirmed_recovery_requeues_final_respond_after_send_failure() {
     let storage = CheckpointStorage::in_memory();
     let backlog = Backlog::persisted(storage.clone());
     let tx = test_bidirectional_tx(9, Chain::Solana, Chain::Ethereum);
     let sign_id = tx.sign_id();
-    let args = SignArgs {
-        entropy: [9u8; 32],
-        epsilon: Scalar::from(1u64),
-        payload: Scalar::from(2u64),
-        path: "test".to_string(),
-        key_version: 1,
-    };
-    let request = test_indexed_request(
-        sign_id,
-        tx.source_chain,
-        args.clone(),
-        current_unix_timestamp(),
-        SignKind::SignBidirectional(bidirectional_event(vec![])),
-    );
-    seed_executing_entry(&backlog, request, Arc::new(tx.clone())).await;
+    backlog.insert_mock_executing(&tx).await;
 
     let (sign_tx, sign_rx) = mpsc::channel(4);
     drop(sign_rx);
@@ -365,8 +239,6 @@ async fn process_execution_confirmed_recovery_requeues_final_respond_after_send_
 
     process_execution_confirmed(
         tx.id,
-        sign_id,
-        tx.source_chain,
         444u64,
         ExecutionOutcome::Success { output: vec![] },
         &ctx,
@@ -502,29 +374,12 @@ async fn process_respond_event_quarantines_invalid_bidirectional_target_chain() 
 async fn process_sign_request_rejects_respond_bidirectional_kind() {
     let backlog = Backlog::new();
     let sign_id = SignId::new([12u8; 32]);
-    let args = SignArgs {
-        entropy: [12u8; 32],
-        epsilon: Scalar::from(1u64),
-        payload: Scalar::from(2u64),
-        path: "test".to_string(),
-        key_version: 1,
-    };
-
-    let request = IndexedSignRequest::respond_bidirectional(
-        sign_id,
-        args,
-        Chain::Solana,
-        current_unix_timestamp(),
-        RespondBidirectionalTx {
-            tx_id: BidirectionalTxId(B256::from([12u8; 32]).0),
-            output: vec![],
-            chain_ctx: None,
-        },
-    );
+    let tx_id = BidirectionalTxId(B256::from([12u8; 32]).0);
+    let request = mock_bidi_response_request(sign_id, tx_id, Chain::Solana);
 
     let (sign_tx, _sign_rx) = mpsc::channel(4);
     let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
-    let err = process_sign_request(Arc::new(request), &ctx)
+    let err = process_sign_request(request, &ctx)
         .await
         .expect_err("RespondBidirectional should be rejected from the sign queue path");
     assert!(err.to_string().contains("Unexpected sign request kind"));
@@ -538,21 +393,13 @@ async fn process_sign_request_rejects_respond_bidirectional_kind() {
 async fn process_respond_event_quarantines_a_bidirectional_entry_that_cannot_advance() {
     let backlog = Backlog::new();
     let sign_id = SignId::new([23u8; 32]);
-    let args = test_sign_args(23);
+    let req = mock_bidi_request(sign_id, Chain::Solana);
 
     // Inserted directly, as checkpoint recovery would: never passed admission.
-    backlog
-        .insert(test_indexed_request(
-            sign_id,
-            Chain::Solana,
-            args.clone(),
-            current_unix_timestamp(),
-            SignKind::SignBidirectional(bidirectional_event(vec![0xde, 0xad])),
-        ))
-        .await;
+    backlog.insert(req.clone()).await;
 
     let root_sk = k256::SecretKey::random(&mut rand::thread_rng());
-    let signature = mpc_crypto::generate_signature(&root_sk, &args);
+    let signature = mpc_crypto::generate_signature(&root_sk, &req.args);
     let event = SignatureRespondedEvent {
         request_id: sign_id.request_id,
         signature,
@@ -603,15 +450,7 @@ fn bidirectional_event(serialized_transaction: Vec<u8>) -> SignBidirectionalEven
 async fn process_sign_request_rejects_undecodable_bidirectional_transaction() {
     let backlog = Backlog::new();
     let sign_id = SignId::new([14u8; 32]);
-
-    let event = bidirectional_event(vec![0xde, 0xad, 0xbe, 0xef]);
-    let request = test_indexed_request(
-        sign_id,
-        Chain::Solana,
-        test_sign_args(14),
-        current_unix_timestamp(),
-        SignKind::SignBidirectional(event),
-    );
+    let request = mock_bidi_request(sign_id, Chain::Solana);
 
     let (sign_tx, _sign_rx) = mpsc::channel(4);
     let ctx = make_test_stream_context_with_generator_pk(backlog.clone(), sign_tx, true);
@@ -634,13 +473,13 @@ async fn process_sign_request_rejects_empty_bidirectional_serialized_transaction
     // it would sit in the backlog and later panic in `sign_and_hash_transaction`
     // (empty RLP) when the respond event advances it to execution.
     let event = bidirectional_event(vec![]);
-    let request = test_indexed_request(
+    let request = Arc::new(IndexedSignRequest::sign_bidirectional(
         sign_id,
-        Chain::Solana,
         test_sign_args(13),
+        Chain::Solana,
         current_unix_timestamp(),
-        SignKind::SignBidirectional(event),
-    );
+        event,
+    ));
 
     let (sign_tx, _sign_rx) = mpsc::channel(4);
     let ctx = make_test_stream_context_with_generator_pk(backlog.clone(), sign_tx, true);
@@ -660,13 +499,7 @@ async fn process_sign_request_rejects_empty_bidirectional_serialized_transaction
 async fn process_sign_request_duplicate_is_idempotent() {
     let backlog = Backlog::new();
     let sign_id = SignId::new([9u8; 32]);
-    let request = test_indexed_request(
-        sign_id,
-        Chain::Ethereum,
-        test_sign_args(9),
-        current_unix_timestamp(),
-        SignKind::Sign,
-    );
+    let request = mock_sign_request(sign_id, Chain::Ethereum);
 
     let (sign_tx, mut sign_rx) = mpsc::channel(4);
     let ctx = make_test_stream_context_with_generator_pk(backlog.clone(), sign_tx, false);
@@ -724,20 +557,10 @@ async fn process_sign_request_duplicate_is_idempotent() {
 async fn process_respond_event_rejects_invalid_signature() {
     let backlog = Backlog::new();
     let sign_id = SignId::new([15u8; 32]);
-    let args = test_sign_args(15);
-
-    backlog
-        .insert(test_indexed_request(
-            sign_id,
-            Chain::Ethereum,
-            args.clone(),
-            current_unix_timestamp(),
-            SignKind::Sign,
-        ))
-        .await;
+    let entry = backlog.insert_mock_sign(sign_id, Chain::Ethereum).await;
 
     let root_sk = k256::SecretKey::random(&mut rand::thread_rng());
-    let mut invalid_signature = mpc_crypto::generate_signature(&root_sk, &args);
+    let mut invalid_signature = mpc_crypto::generate_signature(&root_sk, &entry.request().args);
     invalid_signature.s += Scalar::ONE;
 
     let event = SignatureRespondedEvent {
@@ -764,25 +587,12 @@ async fn process_respond_event_rejects_invalid_signature() {
 #[tokio::test]
 async fn process_respond_bidirectional_event_duplicate_is_idempotent() {
     let backlog = Backlog::new();
-    let sign_id = SignId::new([13u8; 32]);
-    let args = test_sign_args(13);
-
-    backlog
-        .insert(Arc::new(IndexedSignRequest::respond_bidirectional(
-            sign_id,
-            args.clone(),
-            Chain::Solana,
-            current_unix_timestamp(),
-            RespondBidirectionalTx {
-                tx_id: BidirectionalTxId(B256::from([13u8; 32]).0),
-                output: vec![1, 2, 3],
-                chain_ctx: None,
-            },
-        )))
-        .await;
+    let tx = test_bidirectional_tx(13, Chain::Solana, Chain::Ethereum);
+    let sign_id = tx.sign_id();
+    let entry = backlog.insert_mock_final(&tx).await;
 
     let root_sk = k256::SecretKey::random(&mut rand::thread_rng());
-    let signature = mpc_crypto::generate_signature(&root_sk, &args);
+    let signature = mpc_crypto::generate_signature(&root_sk, &entry.request().args);
 
     let duplicate_event0 = respond_event(sign_id, signature);
     let duplicate_event1 = respond_event(sign_id, signature);
@@ -819,25 +629,12 @@ async fn process_respond_bidirectional_event_duplicate_is_idempotent() {
 #[tokio::test]
 async fn process_respond_bidirectional_event_rejects_invalid_signature() {
     let backlog = Backlog::new();
-    let sign_id = SignId::new([16u8; 32]);
-    let args = test_sign_args(16);
-
-    backlog
-        .insert(Arc::new(IndexedSignRequest::respond_bidirectional(
-            sign_id,
-            args.clone(),
-            Chain::Solana,
-            current_unix_timestamp(),
-            RespondBidirectionalTx {
-                tx_id: BidirectionalTxId(B256::from([16u8; 32]).0),
-                output: vec![1, 2, 3],
-                chain_ctx: None,
-            },
-        )))
-        .await;
+    let tx = test_bidirectional_tx(16, Chain::Solana, Chain::Ethereum);
+    let sign_id = tx.sign_id();
+    let entry = backlog.insert_mock_final(&tx).await;
 
     let root_sk = k256::SecretKey::random(&mut rand::thread_rng());
-    let mut invalid_signature = mpc_crypto::generate_signature(&root_sk, &args);
+    let mut invalid_signature = mpc_crypto::generate_signature(&root_sk, &entry.request().args);
     invalid_signature.s += Scalar::ONE;
 
     let event = respond_event(sign_id, invalid_signature);
@@ -861,22 +658,12 @@ async fn process_respond_bidirectional_event_rejects_invalid_signature() {
 async fn process_respond_event_duplicate_ethereum_is_idempotent() {
     let backlog = Backlog::new();
     let sign_id = SignId::new([3u8; 32]);
-    let args = test_sign_args(1);
-
-    backlog
-        .insert(test_indexed_request(
-            sign_id,
-            Chain::Ethereum,
-            args.clone(),
-            current_unix_timestamp(),
-            SignKind::Sign,
-        ))
-        .await;
+    let entry = backlog.insert_mock_sign(sign_id, Chain::Ethereum).await;
 
     let root_sk = k256::SecretKey::random(&mut rand::thread_rng());
     let event = SignatureRespondedEvent {
         request_id: sign_id.request_id,
-        signature: mpc_crypto::generate_signature(&root_sk, &args),
+        signature: mpc_crypto::generate_signature(&root_sk, &entry.request().args),
         chain: Chain::Ethereum,
     };
 
@@ -1010,32 +797,13 @@ async fn process_execution_confirmed_failed_creates_error_respond_request() {
 
     let tx = test_bidirectional_tx(2, Chain::Solana, Chain::Ethereum);
     let sign_id = tx.sign_id();
-
-    // Insert pending Sign request on source chain
-    let args = SignArgs {
-        entropy: [2u8; 32],
-        epsilon: Scalar::from(1u64),
-        payload: Scalar::from(3u64),
-        path: "test".to_string(),
-        key_version: 1,
-    };
-    let unix_timestamp_indexed = current_unix_timestamp();
-    let request = test_indexed_request(
-        sign_id,
-        tx.source_chain,
-        args.clone(),
-        unix_timestamp_indexed,
-        SignKind::SignBidirectional(bidirectional_event(vec![])),
-    );
-    seed_executing_entry(&backlog, request, Arc::new(tx.clone())).await;
+    backlog.insert_mock_executing(&tx).await;
 
     let (sign_tx, mut sign_rx) = mpsc::channel(4);
     let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, true);
 
     process_execution_confirmed(
         tx.id,
-        sign_id,
-        tx.source_chain,
         456u64,
         ExecutionOutcome::Failed,
         &ctx,
@@ -1081,56 +849,13 @@ async fn process_execution_confirmed_failed_creates_error_respond_request() {
 async fn process_execution_confirmed_cross_chain_emits_before_target_catchup() {
     let backlog = Backlog::new();
 
-    use alloy::primitives::{Address, B256};
-    let tx = BidirectionalTx {
-        id: BidirectionalTxId(B256::from([4u8; 32]).0),
-        sender: [0u8; 32],
-        serialized_transaction: vec![1, 2, 3],
-        source_chain: Chain::Solana,
-        target_chain: Chain::Ethereum,
-        caip2_id: "test_caip2_id".to_string(),
-        key_version: 1,
-        deposit: 1000,
-        path: "test_path".to_string(),
-        algo: "ECDSA".to_string(),
-        dest: "0x1234567890123456789012345678901234567890".to_string(),
-        params: "{}".to_string(),
-        output_deserialization_schema: vec![],
-        respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
-        request_id: [4u8; 32],
-        from_address: **Address::ZERO,
-        nonce: 0,
-    };
-    let sign_id = tx.sign_id();
-
-    let args = SignArgs {
-        entropy: [4u8; 32],
-        epsilon: Scalar::from(1u64),
-        payload: Scalar::from(2u64),
-        path: "test".to_string(),
-        key_version: 1,
-    };
-
-    let request = test_indexed_request(
-        sign_id,
-        tx.source_chain,
-        args,
-        current_unix_timestamp(),
-        SignKind::SignBidirectional(SignBidirectionalEvent {
-            chain: Chain::Solana,
-            dest: Chain::Canton.to_string(),
-            caip2_id: Chain::Canton.caip2_chain_id().to_string(),
-            ..bidirectional_event(vec![])
-        }),
-    );
-    seed_executing_entry(&backlog, request, Arc::new(tx.clone())).await;
+    let tx = test_bidirectional_tx(4, Chain::Solana, Chain::Ethereum);
+    backlog.insert_mock_executing(&tx).await;
 
     let (sign_tx, mut sign_rx) = mpsc::channel(4);
     let ctx = make_test_stream_context_with_generator_pk(backlog, sign_tx, false);
     process_execution_confirmed(
         tx.id,
-        sign_id,
-        tx.source_chain,
         789u64,
         ExecutionOutcome::Failed,
         &ctx,
@@ -1171,8 +896,6 @@ async fn process_execution_confirmed_carries_canton_chain_ctx_to_final_request()
 
     process_execution_confirmed(
         tx.id,
-        sign_id,
-        tx.source_chain,
         456u64,
         ExecutionOutcome::Success { output: vec![1] },
         &ctx,
@@ -1235,31 +958,12 @@ async fn requeue_pending_sign_requests_is_chain_scoped() {
     let backlog = Backlog::new();
     let solana_sign_id = SignId::new([7u8; 32]);
     let ethereum_sign_id = SignId::new([8u8; 32]);
-    let args = SignArgs {
-        entropy: [1u8; 32],
-        epsilon: Scalar::from(1u64),
-        payload: Scalar::from(2u64),
-        path: "test".to_string(),
-        key_version: 1,
-    };
 
     backlog
-        .insert(test_indexed_request(
-            solana_sign_id,
-            Chain::Solana,
-            args.clone(),
-            current_unix_timestamp(),
-            SignKind::Sign,
-        ))
+        .insert_mock_sign(solana_sign_id, Chain::Solana)
         .await;
     backlog
-        .insert(test_indexed_request(
-            ethereum_sign_id,
-            Chain::Ethereum,
-            args,
-            current_unix_timestamp(),
-            SignKind::Sign,
-        ))
+        .insert_mock_sign(ethereum_sign_id, Chain::Ethereum)
         .await;
 
     let (sign_tx, mut sign_rx) = mpsc::channel(4);

--- a/chain-signatures/node/src/stream/stream_tests.rs
+++ b/chain-signatures/node/src/stream/stream_tests.rs
@@ -1,5 +1,5 @@
 use super::supervisor::run_supervised;
-use crate::backlog::mock::mock_signature_output;
+use crate::backlog::mock::{mock_sign_request, mock_signature_output, BacklogTestExt};
 use crate::backlog::{Backlog, Bidirectional, Executing};
 use crate::mesh::MeshState;
 use crate::node_client::NodeClient;
@@ -72,27 +72,18 @@ impl_test_indexer!(EthereumTestIndexer, Chain::Ethereum);
 async fn test_stream_handles_sign_and_respond() {
     let backlog = Backlog::new();
     let sign_id = SignId::new([1u8; 32]);
-
-    // construct an IndexedSignRequest
-    let args = test_sign_args(0);
-
-    let request = IndexedSignRequest::sign(
-        sign_id,
-        args.clone(),
-        Chain::Solana,
-        current_unix_timestamp(),
-    );
+    let request = mock_sign_request(sign_id, Chain::Solana);
 
     let root_sk = k256::SecretKey::random(&mut rand::thread_rng());
     let root_pk = root_sk.public_key().to_projective().to_affine();
 
     // Prepare a respond event that matches the sign id
-    let mpc_sig = mpc_crypto::generate_signature(&root_sk, &args);
+    let mpc_sig = mpc_crypto::generate_signature(&root_sk, &request.args);
     let sig_responded = signature_responded_event(sign_id, mpc_sig, Chain::Solana);
     let indexer = SolanaTestIndexer::new(vec![
         Some(ChainEvent::CatchupCompleted),
         Some(ChainEvent::SignRequest {
-            request: Arc::new(request),
+            request: Arc::clone(&request),
             block_timestamp: None,
         }),
         Some(ChainEvent::Respond(sig_responded)),
@@ -380,8 +371,6 @@ async fn test_execution_confirmation_advances_to_respond_bidirectional() {
 
     crate::stream::ops::process_execution_confirmed(
         tx_id,
-        sign_id,
-        Chain::Solana,
         123u64,
         ExecutionOutcome::Success { output: vec![] },
         &ctx,
@@ -430,15 +419,8 @@ async fn test_stream_suppresses_pre_catchup_ethereum_completion() {
     let storage = CheckpointStorage::in_memory();
     let seeded_backlog = Backlog::persisted(storage.clone());
     let sign_id = SignId::new([99u8; 32]);
-    let args = test_sign_args(9);
-
-    seeded_backlog
-        .insert(Arc::new(IndexedSignRequest::sign(
-            sign_id,
-            args.clone(),
-            Chain::Ethereum,
-            current_unix_timestamp(),
-        )))
+    let entry = seeded_backlog
+        .insert_mock_sign(sign_id, Chain::Ethereum)
         .await;
     seeded_backlog
         .set_processed_block(Chain::Ethereum, 100)
@@ -448,7 +430,7 @@ async fn test_stream_suppresses_pre_catchup_ethereum_completion() {
 
     let root_sk = k256::SecretKey::random(&mut rand::thread_rng());
     let root_pk = root_sk.public_key().to_projective().to_affine();
-    let mpc_sig = mpc_crypto::generate_signature(&root_sk, &args);
+    let mpc_sig = mpc_crypto::generate_signature(&root_sk, &entry.request().args);
 
     let respond = signature_responded_event(sign_id, mpc_sig, Chain::Ethereum);
 
@@ -538,17 +520,10 @@ async fn test_stream_requeues_replaced_ethereum_recovery_entry_after_catchup() {
 async fn test_stream_resumes_pending_publish_after_catchup() {
     let backlog = Backlog::new();
     let sign_id = SignId::new([77u8; 32]);
-    let args = test_sign_args(9);
-    let (pk, output) = mock_signature_output(&args);
+    let entry = backlog.insert_mock_sign(sign_id, Chain::Solana).await;
+    let (pk, output) = mock_signature_output(&entry.request().args);
 
-    let pub_entry = backlog
-        .insert_sign(Arc::new(IndexedSignRequest::sign(
-            sign_id,
-            args,
-            Chain::Solana,
-            current_unix_timestamp(),
-        )))
-        .await
+    let pub_entry = entry
         .advance(pk, &output, vec![Participant::from(0u32)], true)
         .await
         .unwrap();
@@ -614,17 +589,10 @@ async fn test_stream_resumes_pending_publish_after_catchup() {
 async fn test_stream_does_not_resume_non_proposer_pending_publish_after_catchup() {
     let backlog = Backlog::new();
     let sign_id = SignId::new([88u8; 32]);
-    let args = test_sign_args(10);
-    let (pk, output) = mock_signature_output(&args);
+    let entry = backlog.insert_mock_sign(sign_id, Chain::Solana).await;
+    let (pk, output) = mock_signature_output(&entry.request().args);
 
-    backlog
-        .insert_sign(Arc::new(IndexedSignRequest::sign(
-            sign_id,
-            args,
-            Chain::Solana,
-            current_unix_timestamp(),
-        )))
-        .await
+    entry
         .advance(pk, &output, vec![Participant::from(0u32)], false)
         .await
         .unwrap();

--- a/chain-signatures/node/src/stream/test_utils.rs
+++ b/chain-signatures/node/src/stream/test_utils.rs
@@ -17,29 +17,13 @@ use mpc_chain_canton::CantonChainCtx;
 use mpc_chain_integration_core::{ChainIndexer, NoopChainTelemetry};
 use mpc_primitives::{
     BidirectionalTx, BidirectionalTxId, Chain, CheckpointDigest, IndexedSignRequest,
-    RespondBidirectionalEvent, SignArgs, SignBidirectionalEvent, SignId, SignKind, Signature,
+    RespondBidirectionalEvent, SignArgs, SignBidirectionalEvent, SignId, Signature,
     SignatureRespondedEvent,
 };
 use mpc_utils::time::current_unix_timestamp;
 use near_primitives::types::AccountId;
 use std::sync::Arc;
 use tokio::sync::{mpsc, watch};
-
-pub fn test_indexed_request(
-    sign_id: SignId,
-    chain: Chain,
-    args: SignArgs,
-    unix_timestamp_indexed: u64,
-    kind: SignKind,
-) -> Arc<IndexedSignRequest> {
-    Arc::new(IndexedSignRequest::new(
-        sign_id,
-        args,
-        chain,
-        unix_timestamp_indexed,
-        kind,
-    ))
-}
 
 pub fn test_bidirectional_tx(id: u8, source_chain: Chain, target_chain: Chain) -> BidirectionalTx {
     BidirectionalTx {

--- a/integration-tests/tests/cases/ethereum_stream.rs
+++ b/integration-tests/tests/cases/ethereum_stream.rs
@@ -45,6 +45,33 @@ fn test_rpc_channel(buffer: usize) -> (RpcChannel, mpsc::Receiver<mpc_node::rpc:
     (RpcChannel { tx }, rx)
 }
 
+fn test_eth_bidirectional_tx(
+    tx_id: mpc_primitives::BidirectionalTxId,
+    sign_id: SignId,
+    from_address: Address,
+    nonce: u64,
+) -> BidirectionalTx {
+    BidirectionalTx {
+        id: tx_id,
+        sender: [0u8; 32],
+        serialized_transaction: vec![],
+        source_chain: Chain::Solana,
+        target_chain: Chain::Ethereum,
+        caip2_id: "eip155:31337".to_string(),
+        key_version: LATEST_MPC_KEY_VERSION,
+        deposit: 0,
+        path: "m/44'/60'/0'/0/0".to_string(),
+        algo: "secp256k1".to_string(),
+        dest: Chain::Ethereum.to_string(),
+        params: "{}".to_string(),
+        output_deserialization_schema: vec![],
+        respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
+        request_id: sign_id.request_id,
+        from_address: **from_address,
+        nonce,
+    }
+}
+
 // Integration tests for the Ethereum indexer
 //
 // These tests spin up Anvil, deploy the ChainSignatures contract, and exercise the
@@ -491,25 +518,12 @@ async fn test_ethereum_stream_linear_catchup_from_checkpoint() -> Result<()> {
     let backlog = Backlog::persisted(storage.clone());
 
     let execution_sign_id = SignId::new([0x33; 32]);
-    let execution_tx = mpc_primitives::BidirectionalTx {
-        id: mpc_primitives::BidirectionalTxId(B256::from([0x44; 32]).0),
-        sender: [0u8; 32],
-        serialized_transaction: vec![],
-        source_chain: Chain::Solana,
-        target_chain: Chain::Ethereum,
-        caip2_id: "eip155:31337".to_string(),
-        key_version: LATEST_MPC_KEY_VERSION,
-        deposit: 1,
-        path: "bidirectional-test-path".to_string(),
-        algo: "secp256k1".to_string(),
-        dest: Chain::Ethereum.to_string(),
-        params: "{}".to_string(),
-        output_deserialization_schema: vec![],
-        respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
-        request_id: execution_sign_id.request_id,
-        from_address: **ctx.wallet,
-        nonce: checkpoint_nonce,
-    };
+    let execution_tx = test_eth_bidirectional_tx(
+        mpc_primitives::BidirectionalTxId(B256::from([0x44; 32]).0),
+        execution_sign_id,
+        ctx.wallet,
+        checkpoint_nonce,
+    );
     backlog.insert_mock_executing(&execution_tx).await;
 
     let responder_contract = ChainSignatures::new(ctx.contract_address, responder_signer.clone());
@@ -675,27 +689,14 @@ async fn test_ethereum_stream_execution_confirmation() -> Result<()> {
     let backlog = ctx.backlog();
 
     // Register an execution watcher with an intentionally stale nonce to trigger the staleness path.
-    let tx = mpc_primitives::BidirectionalTx {
-        id: mpc_primitives::BidirectionalTxId(B256::from([9u8; 32]).0),
-        sender: [0u8; 32],
-        serialized_transaction: vec![],
-        source_chain: Chain::Solana,
-        target_chain: Chain::Ethereum,
-        caip2_id: Chain::Ethereum.caip2_chain_id().to_string(),
-        key_version: LATEST_MPC_KEY_VERSION,
-        deposit: 0,
-        path: "m/44'/60'/0'/0/0".to_string(),
-        algo: "secp256k1".to_string(),
-        dest: "".to_string(),
-        params: "".to_string(),
-        output_deserialization_schema: vec![],
-        respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
-        request_id: [7u8; 32],
-        from_address: **ctx.wallet,
-        nonce: 0,
-    };
+    let tx = test_eth_bidirectional_tx(
+        mpc_primitives::BidirectionalTxId(B256::from([9u8; 32]).0),
+        SignId::new([7u8; 32]),
+        ctx.wallet,
+        0,
+    );
     let sign_id = tx.sign_id();
-    let _entry = backlog.insert_mock_executing(&tx).await;
+    backlog.insert_mock_executing(&tx).await;
 
     let mut stream = stream_ethereum(&ctx, backlog.clone()).await?;
 
@@ -806,25 +807,7 @@ async fn test_ethereum_stream_backfills_late_execution_watcher_after_catchup() -
     // transaction is already in the past relative to the stream.
     let sign_id = SignId::new([0x88; 32]);
     let tx_id = mpc_primitives::BidirectionalTxId(tx_hash.0);
-    let tx = mpc_primitives::BidirectionalTx {
-        id: tx_id,
-        sender: [0u8; 32],
-        serialized_transaction: vec![],
-        source_chain: Chain::Solana,
-        target_chain: Chain::Ethereum,
-        caip2_id: "eip155:31337".to_string(),
-        key_version: LATEST_MPC_KEY_VERSION,
-        deposit: 0,
-        path: "m/44'/60'/0'/0/1".to_string(),
-        algo: "secp256k1".to_string(),
-        dest: Chain::Ethereum.to_string(),
-        params: "{}".to_string(),
-        output_deserialization_schema: vec![],
-        respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
-        request_id: sign_id.request_id,
-        from_address: **ctx.wallet,
-        nonce: 0,
-    };
+    let tx = test_eth_bidirectional_tx(tx_id, sign_id, ctx.wallet, 0);
     backlog.insert_mock_executing(&tx).await;
 
     let msg = next_sign_message_within(&mut sign_rx, Duration::from_secs(20)).await?;
@@ -916,25 +899,7 @@ async fn test_ethereum_stream_respond_tx_replacement_resolves_watcher() -> Resul
     // Register the execution watcher
     let sign_id = SignId::new([0x71; 32]);
     let watched_tx_id = mpc_primitives::BidirectionalTxId(tx_a_hash.0);
-    let tx = mpc_primitives::BidirectionalTx {
-        id: watched_tx_id,
-        sender: [0u8; 32],
-        serialized_transaction: vec![],
-        source_chain: Chain::Solana,
-        target_chain: Chain::Ethereum,
-        caip2_id: "eip155:31337".to_string(),
-        key_version: LATEST_MPC_KEY_VERSION,
-        deposit: 0,
-        path: "m/44'/60'/0'/0/0".to_string(),
-        algo: "secp256k1".to_string(),
-        dest: Chain::Ethereum.to_string(),
-        params: "{}".to_string(),
-        output_deserialization_schema: vec![],
-        respond_serialization_schema: br#"[{"name":"output","type":"bool"}]"#.to_vec(),
-        request_id: sign_id.request_id,
-        from_address: **responder_address,
-        nonce,
-    };
+    let tx = test_eth_bidirectional_tx(watched_tx_id, sign_id, responder_address, nonce);
 
     backlog.insert_mock_executing(&tx).await;
 
@@ -962,11 +927,12 @@ async fn test_ethereum_stream_respond_tx_replacement_resolves_watcher() -> Resul
     let replacement_sign_id = SignId::new([0x72; 32]);
     let replacement_tx_id = mpc_primitives::BidirectionalTxId(receipt_b.transaction_hash.0);
 
-    let replacement_tx = BidirectionalTx {
-        id: replacement_tx_id,
-        request_id: replacement_sign_id.request_id,
-        ..tx.clone()
-    };
+    let replacement_tx = test_eth_bidirectional_tx(
+        replacement_tx_id,
+        replacement_sign_id,
+        responder_address,
+        nonce,
+    );
     backlog.insert_mock_executing(&replacement_tx).await;
 
     let mut stream = stream_ethereum(&ctx, backlog).await?;

--- a/integration-tests/tests/cases/solana_stream.rs
+++ b/integration-tests/tests/cases/solana_stream.rs
@@ -7,8 +7,7 @@ use mpc_chain_integration_core::{
     PublishAction, StateManager,
 };
 use mpc_chain_solana::{SolConfig, SolanaClient, SolanaIndexer};
-use mpc_crypto::ScalarExt;
-use mpc_node::backlog::mock::{mock_signature_output, BacklogTestExt};
+use mpc_node::backlog::mock::{mock_bidi_response_request, mock_signature_output, BacklogTestExt};
 use mpc_node::backlog::Backlog;
 use mpc_node::mesh::connection::NodeStatus;
 use mpc_node::mesh::MeshState;
@@ -20,8 +19,8 @@ use mpc_node::storage::checkpoint_storage::CheckpointStorage;
 use mpc_node::stream::{supervisor::run_supervised, StreamContext};
 use mpc_node::types::SignCommand;
 use mpc_primitives::{
-    BidirectionalTxId, Chain, ChainEvent, IndexedSignRequest, RespondBidirectionalTx, SignArgs,
-    SignId, Signature, LATEST_MPC_KEY_VERSION,
+    BidirectionalTxId, Chain, ChainEvent, IndexedSignRequest, ScalarExt, SignId, Signature,
+    LATEST_MPC_KEY_VERSION,
 };
 use near_primitives::types::AccountId;
 use solana_sdk::signer::Signer;
@@ -687,23 +686,7 @@ async fn test_solana_respond_bidirectional_round_trip() -> Result<()> {
     let mut indexer = run_solana_indexer(config.clone()).await?;
 
     let sign_id = SignId::new([9u8; 32]);
-    let request = Arc::new(IndexedSignRequest::respond_bidirectional(
-        sign_id,
-        SignArgs {
-            entropy: [7u8; 32],
-            epsilon: Scalar::from(1u64),
-            payload: Scalar::from(2u64),
-            path: "test".to_string(),
-            key_version: LATEST_MPC_KEY_VERSION,
-        },
-        Chain::Solana,
-        0,
-        RespondBidirectionalTx {
-            tx_id: BidirectionalTxId([1u8; 32]),
-            output: vec![0xde, 0xad, 0xbe, 0xef],
-            chain_ctx: None,
-        },
-    ));
+    let request = mock_bidi_response_request(sign_id, BidirectionalTxId([1u8; 32]), Chain::Solana);
 
     let publisher = SolanaClient::from_config(&config, Arc::new(NoopPublisherTelemetry));
     publisher


### PR DESCRIPTION
## Overview
Part 3 of the typestate refactoring stack (closes #779).

Leverages the `SignEntry` typestate introduced in PR 2 to streamline `stream/ops.rs`, clean up bidirectional execution watching, and eliminate obsolete defensive runtime checks and boilerplate test harnesses across stream integration tests (-623 net lines).

Stacked on top of `phuong/feat/typestate-core`.

## Key Changes

### 1. Stream Operations Simplification (`stream/ops.rs`)
- **`advance_bidirectional_to_execution`**: Replaced manual parameter extraction and transaction hashing with `event.to_bidirectional_tx(...)`, reducing the function to a linear ~25-line operation.
- **`unwatch_execution`**: Directly returns `Option<SignEntry<Bidirectional<Executing>>>` in a single operation, eliminating the secondary `backlog.get_by` lookup.
- **`process_execution_confirmed`**: Dropped redundant `sign_id` and `source_chain` arguments. Since the entry in the backlog is the authoritative source of truth, defensive mismatch checks (`unwatched_sign_id != sign_id` and `source_chain != pending_tx.source_chain`) have been completely removed.
- **`process_respond_bidirectional_event`**: Removed redundant completion warning check.

### 2. Execution Watcher Cleanup (`chain-ethereum/src/execution_watcher.rs`)
- Removed the private wrapper `struct ExecutionWatcher`; `ExecutionWatchers` now directly maps `BidirectionalTxId -> Arc<BidirectionalTx>`.

### 3. Test Suite Pruning (-942 lines removed)
- Deleted tests verifying runtime error handling for states and mismatches that are now strictly impossible at compile-time (e.g. `process_execution_confirmed_warns_but_still_uses_watcher_sign_id`).
- Converted `ops_tests.rs`, `stream_tests.rs`, `ethereum_stream.rs`, and `solana_stream.rs` to use `insert_mock_executing` and typed transitions.