### PR TITLE
fix(ci): pair gated jobs with placeholder twins so required checks always report

### DIFF
--- a/.github/workflows/_ci-changes.yml
+++ b/.github/workflows/_ci-changes.yml
@@ -11,10 +11,12 @@
 #   cluster-test: core|near|eth|solana|hydration|contract_eth
 #   anvil-test: eth|core|contract_eth    unit-test: unit   audit: audit
 #
-# Skipped jobs satisfy required checks; non-PR events (merge queue, dispatch)
-# set every flag to true — the merge queue is the full-suite safety net. Test
-# workflows have no push trigger: develop only advances through the queue, so
-# the tree was already tested. Caches are saved from merge_group runs.
+# Gated jobs pair with a same-named *-skipped twin (inverse condition) so
+# required checks always report even when a skipped job's check run goes
+# missing. Non-PR events (merge queue, dispatch) set every flag to true —
+# the merge queue is the full-suite safety net. Test workflows have no push
+# trigger: develop only advances through the queue, so the tree was already
+# tested. Caches are saved from merge_group runs.
 # Globs use minimatch: `**` must be a full segment (`**/*canton*`, never
 # `**canton**`).
 name: CI Changes

--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -107,17 +107,19 @@ jobs:
           RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1
 
-  # Placeholder twin: keeps the check reporting when gated out.
-  canton-skipped:
+  # Placeholder twins: keep the checks reporting when gated out.
+  canton-e2e-skipped:
     needs: [changes]
     if: needs.changes.outputs.canton != 'true' && needs.changes.outputs.core != 'true' && needs.changes.outputs.contract_eth != 'true'
-    name: Canton ${{ matrix.suite.name }} Tests
+    name: Canton E2E Tests
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        suite:
-          - name: Stream
-          - name: E2E
+    steps:
+      - run: echo "no relevant changes"
+
+  canton-stream-skipped:
+    needs: [changes]
+    if: needs.changes.outputs.canton != 'true' && needs.changes.outputs.core != 'true' && needs.changes.outputs.contract_eth != 'true'
+    name: Canton Stream Tests
+    runs-on: ubuntu-latest
     steps:
       - run: echo "no relevant changes"

--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -106,3 +106,18 @@ jobs:
         env:
           RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1
+
+  # Placeholder twin: keeps the check reporting when gated out.
+  canton-skipped:
+    needs: [changes]
+    if: needs.changes.outputs.canton != 'true' && needs.changes.outputs.core != 'true' && needs.changes.outputs.contract_eth != 'true'
+    name: Canton ${{ matrix.suite.name }} Tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - name: Stream
+          - name: E2E
+    steps:
+      - run: echo "no relevant changes"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -93,6 +93,15 @@ jobs:
           RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1
 
+  # Placeholder twin: keeps the check reporting when gated out.
+  fixture-test-skipped:
+    needs: [changes]
+    if: needs.changes.outputs.core != 'true'
+    name: Fixture Test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "no relevant changes"
+
   # Integration tests that need Docker (near-sandbox, anvil, solana validator) and
   # additional Solana/Anchor setup. Runs with num-cpus threads (see .config/nextest.toml).
   cluster-test:
@@ -200,6 +209,18 @@ jobs:
           IT_ETH_CONSENSUS_RPC_URL: ${{ secrets.IT_ETH_CONSENSUS_RPC_URL }}
           IT_ETH_EXECUTION_RPC_URL: ${{ secrets.IT_ETH_EXECUTION_RPC_URL }}
 
+  # Placeholder twin: keeps the check reporting when gated out.
+  cluster-test-skipped:
+    needs: [changes]
+    if: needs.changes.outputs.core != 'true' && needs.changes.outputs.near != 'true' && needs.changes.outputs.eth != 'true' && needs.changes.outputs.solana != 'true' && needs.changes.outputs.hydration != 'true' && needs.changes.outputs.contract_eth != 'true'
+    name: Integration Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [warp-ubuntu-latest-x64-4x]
+    steps:
+      - run: echo "no relevant changes"
+
   # Anvil-backed integration tests (no docker cluster): real EVM + real contract bytecode
   anvil-integration-test:
     needs: [changes]
@@ -247,3 +268,12 @@ jobs:
 
       - name: Test
         run: just test-eth
+
+  # Placeholder twin: keeps the check reporting when gated out.
+  anvil-integration-test-skipped:
+    needs: [changes]
+    if: needs.changes.outputs.eth != 'true' && needs.changes.outputs.core != 'true' && needs.changes.outputs.contract_eth != 'true'
+    name: Anvil Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "no relevant changes"

--- a/.github/workflows/midnight-publisher-ts.yml
+++ b/.github/workflows/midnight-publisher-ts.yml
@@ -85,3 +85,12 @@ jobs:
       - name: Rust intent seam differential
         working-directory: .
         run: just test-midnight-seam
+
+  # Placeholder twin: keeps the check reporting when gated out.
+  test-skipped:
+    needs: [changes]
+    if: needs.changes.outputs.midnight_ts != 'true' && needs.changes.outputs.core != 'true'
+    name: Midnight Publisher TS Tests
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "no relevant changes"

--- a/.github/workflows/midnight.yml
+++ b/.github/workflows/midnight.yml
@@ -124,3 +124,12 @@ jobs:
           name: midnight-real-stack-logs
           path: target/tmp_*/midnight
           if-no-files-found: warn
+
+  # Placeholder twin: keeps the check reporting when gated out.
+  midnight-real-stack-skipped:
+    needs: [changes]
+    if: needs.changes.outputs.midnight != 'true' && needs.changes.outputs.core != 'true'
+    name: Midnight Real Stack
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "no relevant changes"

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -74,6 +74,15 @@ jobs:
       - name: Unit tests
         run: just test-unit
 
+  # Placeholder twin: keeps the check reporting when gated out.
+  test-skipped:
+    needs: [changes]
+    if: needs.changes.outputs.unit != 'true'
+    name: Check & Test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "no relevant changes"
+
   audit:
     needs: [changes]
     if: needs.changes.outputs.audit == 'true'
@@ -91,3 +100,12 @@ jobs:
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Placeholder twin: keeps the check reporting when gated out.
+  audit-skipped:
+    needs: [changes]
+    if: needs.changes.outputs.audit != 'true'
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "no relevant changes"


### PR DESCRIPTION
Since the change gate introduced at #1244, PRs rely on skipped jobs to satisfy required checks. This mechanism failed couple of times (#1251, #1255), each time PR got stuck at `Expected — Waiting for status to be reported`. 

This PR introduces placeholder twins with the same and inverse condition, so one of the two always runs (and check always reports).

```yml
canton-skipped:
    needs: [changes]
    if: needs.changes.outputs.canton != 'true' && needs.changes.outputs.core != 'true' && needs.changes.outputs.contract_eth != 'true'
    name: Canton ${{ matrix.suite.name }} Tests
    runs-on: ubuntu-latest
    strategy:
      fail-fast: false
      matrix:
        suite:
          - name: Stream
          - name: E2E
    steps:
      - run: echo "no relevant changes"
```

Also, Canton is now two static jobs (No more awkward `Canton Integration Tests / Canton ${{ matrix.suite.name }} Tests`)
