### PR TITLE
fix(ci): fix dead rust-cache + prefetch Docker images

### DIFF
--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -90,6 +90,8 @@ jobs:
           shared-key: workspace-release
           cache-targets: true
           cache-on-failure: false
+          # Prevent every PR from uploading multi-GB caches
+          save-if: ${{ github.event_name == 'merge_group' }}
 
       - name: Build eth contract
         run: just build eth

--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -17,10 +17,8 @@ jobs:
         suite:
           - name: Stream
             filter: canton_stream
-            cache-key: canton-test
           - name: E2E
             filter: cases::canton
-            cache-key: canton-e2e-test
 
     steps:
       - uses: actions/checkout@v6
@@ -87,7 +85,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ${{ matrix.suite.cache-key }}
+          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
+          shared-key: workspace
           cache-targets: true
           cache-on-failure: false
           # Prevent every PR from uploading multi-GB caches

--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -89,8 +89,6 @@ jobs:
           shared-key: workspace
           cache-targets: true
           cache-on-failure: false
-          # Prevent every PR from uploading multi-GB caches
-          save-if: ${{ github.event_name == 'merge_group' }}
 
       - name: Build eth contract
         run: just build eth

--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -38,8 +38,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull Redis
-        run: docker pull redis:7.4.2
+      # Pull the images in parallel. The images are used in Canton test harness
+      - name: Pull Redis and Foundry images
+        run: |
+          printf '%s\n' redis:7.4.2 ghcr.io/foundry-rs/foundry:nightly \
+            | xargs -P "$(nproc)" -n 1 docker pull
 
       - name: Install Java 21
         uses: actions/setup-java@v4

--- a/.github/workflows/canton.yml
+++ b/.github/workflows/canton.yml
@@ -85,8 +85,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
-          shared-key: workspace
+          # Shared by jobs that build the release mpc-node via setup.sh; dev-only jobs
+          # use "workspace" so their faster save cannot race away the release artifacts.
+          shared-key: workspace-release
           cache-targets: true
           cache-on-failure: false
 

--- a/.github/workflows/deploy-dev-contract.yml
+++ b/.github/workflows/deploy-dev-contract.yml
@@ -46,7 +46,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: deploy-dev-contract
+          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
+          shared-key: workspace
           cache-targets: true
           cache-on-failure: false
 

--- a/.github/workflows/deploy-dev-contract.yml
+++ b/.github/workflows/deploy-dev-contract.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
+          # Shared by dev-only jobs; release-building jobs use "workspace-release".
           shared-key: workspace
           cache-targets: true
           cache-on-failure: false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,7 +61,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: fixture-test
+          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
+          shared-key: workspace
           cache-targets: true
           cache-on-failure: false
           # Prevent every PR from uploading multi-GB caches
@@ -160,7 +161,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: integration-test
+          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
+          shared-key: workspace
           cache-targets: true
           cache-on-failure: false
           # Prevent every PR from uploading multi-GB caches
@@ -221,7 +223,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: anvil-integration-test
+          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
+          shared-key: workspace
           cache-targets: true
           save-if: ${{ github.event_name == 'merge_group' }}
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,8 +61,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
-          shared-key: workspace
+          # Shared by jobs that build the release mpc-node via setup.sh; dev-only jobs
+          # use "workspace" so their faster save cannot race away the release artifacts.
+          shared-key: workspace-release
           cache-targets: true
           cache-on-failure: false
 
@@ -159,8 +160,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
-          shared-key: workspace
+          # Shared by jobs that build the release mpc-node via setup.sh; dev-only jobs
+          # use "workspace" so their faster save cannot race away the release artifacts.
+          shared-key: workspace-release
           cache-targets: true
           cache-on-failure: false
 
@@ -219,7 +221,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
+          # Shared by dev-only jobs; release-building jobs use "workspace-release".
           shared-key: workspace
           cache-targets: true
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,9 +43,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull Relayer, Sandbox, Redis Docker Images
-        run: |
-          docker pull redis:7.4.2
+      - name: Pull Redis image
+        run: docker pull redis:7.4.2
 
       - name: Install Rust (1.93.0)
         uses: actions-rs/toolchain@v1
@@ -127,9 +126,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull Relayer, Sandbox, Redis Docker Images
+      # Pull the images in parallel.
+      - name: Pull Redis and Foundry images
         run: |
-          docker pull redis:7.4.2
+          printf '%s\n' redis:7.4.2 ghcr.io/foundry-rs/foundry:nightly \
+            | xargs -P "$(nproc)" -n 1 docker pull
 
       - name: Install Rust (1.93.0)
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -65,8 +65,6 @@ jobs:
           shared-key: workspace
           cache-targets: true
           cache-on-failure: false
-          # Prevent every PR from uploading multi-GB caches
-          save-if: ${{ github.event_name == 'merge_group' }}
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
@@ -165,8 +163,6 @@ jobs:
           shared-key: workspace
           cache-targets: true
           cache-on-failure: false
-          # Prevent every PR from uploading multi-GB caches
-          save-if: ${{ github.event_name == 'merge_group' }}
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
@@ -226,7 +222,6 @@ jobs:
           # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
           shared-key: workspace
           cache-targets: true
-          save-if: ${{ github.event_name == 'merge_group' }}
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -66,6 +66,8 @@ jobs:
           shared-key: workspace-release
           cache-targets: true
           cache-on-failure: false
+          # Prevent every PR from uploading multi-GB caches
+          save-if: ${{ github.event_name == 'merge_group' }}
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
@@ -165,6 +167,8 @@ jobs:
           shared-key: workspace-release
           cache-targets: true
           cache-on-failure: false
+          # Prevent every PR from uploading multi-GB caches
+          save-if: ${{ github.event_name == 'merge_group' }}
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
@@ -224,6 +228,8 @@ jobs:
           # Shared by dev-only jobs; release-building jobs use "workspace-release".
           shared-key: workspace
           cache-targets: true
+          # Prevent every PR from uploading multi-GB caches
+          save-if: ${{ github.event_name == 'merge_group' }}
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/midnight-publisher-ts.yml
+++ b/.github/workflows/midnight-publisher-ts.yml
@@ -69,8 +69,6 @@ jobs:
           shared-key: workspace
           cache-targets: true
           cache-on-failure: false
-          # Prevent every PR from uploading multi-GB caches
-          save-if: ${{ github.event_name == 'merge_group' }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
       # The filter names the test binary: the seam tests live in

--- a/.github/workflows/midnight-publisher-ts.yml
+++ b/.github/workflows/midnight-publisher-ts.yml
@@ -69,6 +69,9 @@ jobs:
           shared-key: workspace
           cache-targets: true
           cache-on-failure: false
+          # Prevent every PR from uploading multi-GB caches
+          save-if: ${{ github.event_name == 'merge_group' }}
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
       # The filter names the test binary: the seam tests live in

--- a/.github/workflows/midnight-publisher-ts.yml
+++ b/.github/workflows/midnight-publisher-ts.yml
@@ -65,7 +65,7 @@ jobs:
           toolchain: 1.93.0
       - uses: Swatinem/rust-cache@v2
         with:
-          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
+          # Shared by dev-only jobs; release-building jobs use "workspace-release".
           shared-key: workspace
           cache-targets: true
           cache-on-failure: false

--- a/.github/workflows/midnight-publisher-ts.yml
+++ b/.github/workflows/midnight-publisher-ts.yml
@@ -65,7 +65,8 @@ jobs:
           toolchain: 1.93.0
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: midnight-seam
+          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
+          shared-key: workspace
           cache-targets: true
           cache-on-failure: false
           # Prevent every PR from uploading multi-GB caches

--- a/.github/workflows/midnight.yml
+++ b/.github/workflows/midnight.yml
@@ -104,7 +104,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: midnight-real-stack
+          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
+          shared-key: workspace
           cache-targets: true
           cache-on-failure: false
           save-if: ${{ github.event_name == 'merge_group' }}

--- a/.github/workflows/midnight.yml
+++ b/.github/workflows/midnight.yml
@@ -22,6 +22,24 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSfL "https://github.com/casey/just/releases/download/1.54.0/just-1.54.0-x86_64-unknown-linux-musl.tar.gz" | tar zxf - -C "$HOME/.cargo/bin"
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Prefetch every image the real-stack test starts, in parallel
+      - name: Pull Docker images
+        run: |
+          {
+            echo 'redis:7.4.2'
+            echo 'ghcr.io/foundry-rs/foundry:nightly'
+            perl -0ne 'while (/const \w+_IMAGE: \(&str, &str\) = \(\s*"([^"]+)",\s*"([^"]+)",?/g) { print "$1:$2\n" }' \
+              integration-tests/src/midnight.rs
+          } | tee /tmp/images.txt | xargs -P "$(nproc)" -n 1 docker pull
+          test "$(wc -l < /tmp/images.txt)" -eq 5
+
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/midnight.yml
+++ b/.github/workflows/midnight.yml
@@ -108,7 +108,6 @@ jobs:
           shared-key: workspace
           cache-targets: true
           cache-on-failure: false
-          save-if: ${{ github.event_name == 'merge_group' }}
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest

--- a/.github/workflows/midnight.yml
+++ b/.github/workflows/midnight.yml
@@ -109,6 +109,8 @@ jobs:
           shared-key: workspace-release
           cache-targets: true
           cache-on-failure: false
+          # Prevent every PR from uploading multi-GB caches
+          save-if: ${{ github.event_name == 'merge_group' }}
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest

--- a/.github/workflows/midnight.yml
+++ b/.github/workflows/midnight.yml
@@ -104,8 +104,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
-          shared-key: workspace
+          # Shared by jobs that build the release mpc-node via setup.sh; dev-only jobs
+          # use "workspace" so their faster save cannot race away the release artifacts.
+          shared-key: workspace-release
           cache-targets: true
           cache-on-failure: false
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,9 +42,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull Relayer & Sandbox Docker Images
-        run: |
-          docker pull redis:7.4.2
+      - name: Pull Redis image
+        run: docker pull redis:7.4.2
 
       - name: Setup Solana and Anchor
         uses: metadaoproject/setup-anchor@v3.1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -71,7 +71,6 @@ jobs:
           shared-key: workspace
           cache-targets: true
           cache-on-failure: false
-          save-if: ${{ github.ref == 'refs/heads/develop' }}
 
       # Install system OpenSSL explicitly here so the build uses system OpenSSL instead of building OpenSSL from source
       - name: Install system OpenSSL

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,8 +67,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
-          shared-key: workspace
+          # Shared by jobs that build the release mpc-node via setup.sh; dev-only jobs
+          # use "workspace" so their faster save cannot race away the release artifacts.
+          shared-key: workspace-release
           cache-targets: true
           cache-on-failure: false
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,10 +67,10 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: nightly-test
+          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
+          shared-key: workspace
           cache-targets: true
           cache-on-failure: false
-          # Prevent every PR from uploading multi-GB caches
           save-if: ${{ github.ref == 'refs/heads/develop' }}
 
       # Install system OpenSSL explicitly here so the build uses system OpenSSL instead of building OpenSSL from source

--- a/.github/workflows/prod-compatibility.yml
+++ b/.github/workflows/prod-compatibility.yml
@@ -59,7 +59,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: compat-test
+          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
+          shared-key: workspace
           cache-targets: true
           cache-on-failure: false
 

--- a/.github/workflows/prod-compatibility.yml
+++ b/.github/workflows/prod-compatibility.yml
@@ -59,8 +59,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
-          shared-key: workspace
+          # Shared by jobs that build the release mpc-node via setup.sh; dev-only jobs
+          # use "workspace" so their faster save cannot race away the release artifacts.
+          shared-key: workspace-release
           cache-targets: true
           cache-on-failure: false
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -34,7 +34,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: unit-test
+          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
+          shared-key: workspace
           cache-targets: true
           cache-on-failure: false
           # Prevent every PR from uploading multi-GB caches

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -38,8 +38,6 @@ jobs:
           shared-key: workspace
           cache-targets: true
           cache-on-failure: false
-          # Prevent every PR from uploading multi-GB caches
-          save-if: ${{ github.event_name == 'merge_group' }}
       
       # Install system OpenSSL explicitly here so the build uses system OpenSSL instead of building OpenSSL from source
       - name: Install system OpenSSL

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -38,6 +38,8 @@ jobs:
           shared-key: workspace
           cache-targets: true
           cache-on-failure: false
+          # Prevent every PR from uploading multi-GB caches
+          save-if: ${{ github.event_name == 'merge_group' }}
       
       # Install system OpenSSL explicitly here so the build uses system OpenSSL instead of building OpenSSL from source
       - name: Install system OpenSSL

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          # Shared by all workflows; per-workflow keys exceeded the 10 GB repo cache quota.
+          # Shared by dev-only jobs; release-building jobs use "workspace-release".
           shared-key: workspace
           cache-targets: true
           cache-on-failure: false


### PR DESCRIPTION
This PR fixes rust-cache which was dead for a while: we have 9 workflows with separate ~2 GB cache key, which overflows 10 GB quota (one of the reasons CI got slower recently). 

### Changes

- Update cache keys: instead of key per workflow, only two shared keys are used: 
  - `workspace-release` - every job whose recipe runs `setup.sh` and builds the release node
  - `workspace` - rest jobs (`unit`, anvil tests, `deploy-dev-contract`, etc.)
- Minor Docker-related improvements for Midnight job: 
  - Add GHCR login
  - Parallel docker pull of all five images

### Benefits

- CI with warm cache now completes in ~16 min (~20-21 min cold)
- Reduce cache footprint 