### PR TITLE
ci(loadtests): run the bidirectional load test on arc-runner-set

### DIFF
--- a/.github/workflows/k6-bidirectional-loadtest.yml
+++ b/.github/workflows/k6-bidirectional-loadtest.yml
@@ -46,7 +46,11 @@ concurrency:
 
 jobs:
   loadtest:
-    runs-on: ubuntu-latest
+    # Self-hosted, as k6-ci-loadtest.yml does for its scheduled runs. That one
+    # keeps ubuntu-latest for push and pull_request because those finish in
+    # minutes; every run here occupies a runner for over an hour, so there is
+    # no short case to keep hosted.
+    runs-on: arc-runner-set
     # Submission runs for lt_duration, then the scenario's 45m gracefulStop
     # lets in-flight jobs finish, so a 1h run occupies the runner for ~1h45m.
     timeout-minutes: 120


### PR DESCRIPTION
Every run holds a runner for the submission window plus the graceful stop that lets the last round trips finish — over an hour at minimum, ~1h45m at `lt_duration: 1h`. On `ubuntu-latest` that is billed wall-clock, and a scheduled cadence would cost more than the gas and any metrics backend combined.

`k6-ci-loadtest.yml` already sends scheduled runs to `arc-runner-set`, keeping `ubuntu-latest` for push and pull_request where a run finishes in minutes. This workflow has no short case — it is dispatch-only and every dispatch is long — so the switch is unconditional.
