### PR TITLE
fix(node): verify signature before the idempotency check

### DIFF
--- a/chain-signatures/node/src/protocol/message/crypto.rs
+++ b/chain-signatures/node/src/protocol/message/crypto.rs
@@ -71,15 +71,17 @@ impl SignedMessage {
             .get(&from)
             .ok_or(MessageError::UnknownParticipant(from))?;
 
-        // Do external check before verifying the signature.
-        check(&sig)?;
-
         if !sig.verify(&msg, &info.sign_pk) {
             tracing::error!(?from, "signed message erred out with invalid signature");
             return Err(MessageError::Verification(
                 "invalid signature while verifying authenticity of encrypted protocol message",
             ));
         }
+
+        // Only after verifying: the caller dedups on this signature, so letting
+        // an unverified batch through would hand anyone able to reach us a way
+        // to fill or evict that cache with signatures of their choosing.
+        check(&sig)?;
 
         Ok((from, cbor_from_bytes(&msg)?))
     }

--- a/chain-signatures/node/src/protocol/message/inbox.rs
+++ b/chain-signatures/node/src/protocol/message/inbox.rs
@@ -724,12 +724,22 @@ mod tests {
         let batches = inbox.decrypt(&cipher_sk, &participants);
         assert!(MessageInbox::verify_senders(batches, Some(me)).is_empty());
 
-        // Wrong signing key: rejected at signature verification already.
+        // Wrong signing key: rejected at signature verification already, and it
+        // must not reach the dedup cache on the way out. That cache is keyed on
+        // the signature, and our cipher key is public, so anyone able to reach
+        // the node could otherwise flood it with signatures of their choosing
+        // and evict the entries that make real duplicates detectable.
         let forged_envelope = triple_batch(3, peer);
         let encrypted =
             SignedMessage::encrypt(&forged_envelope, peer, &my_sign_sk, &cipher_pk).unwrap();
         inbox.pending_decrypt.push_back((encrypted, Instant::now()));
+        let cached = inbox.idempotent.len();
         assert!(inbox.decrypt(&cipher_sk, &participants).is_empty());
+        assert_eq!(
+            inbox.idempotent.len(),
+            cached,
+            "unverified signature entered the dedup cache",
+        );
 
         // Control: consistent sender passes through.
         let valid = triple_batch(2, peer);


### PR DESCRIPTION
`decrypt_with` ran the caller's `check` callback before `sig.verify`, so any
batch that decrypted and deserialized reached the inbox's idempotency cache
whether or not its signature was valid. `/msg` is unauthenticated and the `from`
field is only checked for membership, not proven, so reaching that cache does
not require being a peer node, just network access to the endpoint plus the
node's cipher key and a participant id, both of which are on-chain.

The cache is keyed on the signature and holds 64k entries, so entries admitted
this way evict real ones and degrade duplicate detection. Duplicates are
tolerated by design (D1), so this is hardening rather than a safety fix.

Moves the check below the verification. Legitimate traffic is unaffected.

The added assertion in `test_inbox_drops_spoofed_and_self_sent_messages` fails
without the fix: the cache grows from 3 entries to 4 on a forged envelope.