### PR TITLE
fix(protocol): announce posit START only after securing locally

### DIFF
--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -689,7 +689,6 @@ impl PresignatureSpawner {
         // Peers spend the pair as soon as START arrives. Announce only once our
         // own slot and commit have succeeded, so we cannot back out after they did.
         if let Err(err) = self.generate(id, positor, &participants, timeout).await {
-            self.ongoing_owned.remove(&id.id);
             tracing::warn!(
                 ?id,
                 ?participants,

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -684,26 +684,10 @@ impl PresignatureSpawner {
         participants: Vec<Participant>,
         timeout: Duration,
     ) {
-        if positor.is_proposer() {
-            for &p in &participants {
-                if p == self.me {
-                    continue;
-                }
-                self.msg
-                    .send(
-                        self.me,
-                        p,
-                        PositMessage {
-                            id: PositProtocolId::Presignature(id),
-                            from: self.me,
-                            action: PositAction::Start(participants.clone()),
-                        },
-                    )
-                    .await;
-            }
-        }
-
         let is_proposer = positor.is_proposer();
+
+        // Peers spend the pair as soon as START arrives. Announce only once our
+        // own slot and commit have succeeded, so we cannot back out after they did.
         if let Err(err) = self.generate(id, positor, &participants, timeout).await {
             self.ongoing_owned.remove(&id.id);
             tracing::warn!(
@@ -711,8 +695,30 @@ impl PresignatureSpawner {
                 ?participants,
                 is_proposer,
                 ?err,
-                "unable to start presignature generation on START"
+                "unable to start presignature generation"
             );
+            return;
+        }
+
+        if !is_proposer {
+            return;
+        }
+
+        for &p in &participants {
+            if p == self.me {
+                continue;
+            }
+            self.msg
+                .send(
+                    self.me,
+                    p,
+                    PositMessage {
+                        id: PositProtocolId::Presignature(id),
+                        from: self.me,
+                        action: PositAction::Start(participants.clone()),
+                    },
+                )
+                .await;
         }
     }
 

--- a/chain-signatures/node/src/protocol/request/mod.rs
+++ b/chain-signatures/node/src/protocol/request/mod.rs
@@ -13,7 +13,7 @@ use crate::protocol::presignature::PresignatureId;
 use crate::protocol::sync::{SyncKind, SyncReportSender};
 use crate::protocol::Chain;
 use crate::rpc::{ContractStateWatcher, GovernanceInfo, RpcChannel};
-use crate::storage::presignature_storage::PresignatureReservation;
+use crate::storage::presignature_storage::{PresignatureReservation, PresignatureTaken};
 use crate::storage::PresignatureStorage;
 use mpc_utils::{
     task::JoinMap,

--- a/chain-signatures/node/src/protocol/request/posit.rs
+++ b/chain-signatures/node/src/protocol/request/posit.rs
@@ -210,7 +210,7 @@ impl PositPhase {
         let proposer = self.proposer;
         let active = self.active.clone();
         let mut presignature_id = self.presignature_id;
-        let presignature = self.presignature.take();
+        let mut presignature = self.presignature.take();
 
         let sign_id = ctx.sign_id;
         let round = state.round();
@@ -260,7 +260,7 @@ impl PositPhase {
         tokio::pin!(accept_deadline);
         let mut accept_deadline_reached = false;
 
-        let accepted_participants = loop {
+        let (accepted_participants, committed_presignature) = loop {
             tokio::select! {
                 task_msg = mailbox.recv() => {
                     let SignPositMessage { round: peer_round , ..} = task_msg;
@@ -329,7 +329,7 @@ impl PositPhase {
                             }
 
                             tracing::info!(?sign_id, participant = ?ctx.governance.me, ?participants, "deliberator received Start");
-                            break participants;
+                            break (participants, None);
                         }
                     } else {
                         if !counter.process_action(from, &action) {
@@ -373,14 +373,17 @@ impl PositPhase {
                         // into the bad state.
                         let ready_to_go = counter.meets_totality() ||  accept_deadline_reached;
                         if ready_to_go && counter.enough_accepts(ctx.governance.threshold) {
-                            let participants = Self::start_with_current_accepts(
+                            let Some(started) = Self::commit_and_start(
                                 ctx,
                                 state,
                                 counter,
                                 sign_id,
-                                presignature_id
-                            ).await;
-                            break participants;
+                                presignature_id,
+                                presignature.take(),
+                            ).await else {
+                                return state.reorganize("failed to commit presignature reservation");
+                            };
+                            break started;
                         }
                     }
                 }
@@ -403,14 +406,17 @@ impl PositPhase {
                 _ = &mut accept_deadline, if is_proposer && !accept_deadline_reached => {
                     accept_deadline_reached = true;
                     if counter.enough_accepts(ctx.governance.threshold) {
-                        let participants = Self::start_with_current_accepts(
+                        let Some(started) = Self::commit_and_start(
                             ctx,
                             state,
                             counter,
                             sign_id,
-                            presignature_id
-                        ).await;
-                        break participants;
+                            presignature_id,
+                            presignature.take(),
+                        ).await else {
+                            return state.reorganize("failed to commit presignature reservation");
+                        };
+                        break started;
                     }
                 }
 
@@ -420,19 +426,28 @@ impl PositPhase {
         SignPhase::Generating(GeneratingPhase {
             proposer,
             presignature_id,
-            presignature,
+            presignature: committed_presignature,
             accepted_participants,
         })
     }
 
-    /// Proposer-only: broadcast Start to all Accepters and return that set.
-    async fn start_with_current_accepts(
+    /// Proposer-only: commit the presignature, broadcast Start to the accepters,
+    /// and return that set with the committed presignature. `None` if the commit
+    /// failed, in which case nothing was broadcast. Accepters spend the
+    /// presignature on Start, so commit before announcing, not after.
+    async fn commit_and_start(
         ctx: &SignTask,
         state: &mut SignState,
         counter: SinglePositCounter,
         sign_id: SignId,
         presignature_id: PresignatureId,
-    ) -> Vec<Participant> {
+        presignature: Option<PresignatureReservation>,
+    ) -> Option<(Vec<Participant>, Option<Box<PresignatureTaken>>)> {
+        let committed = match presignature {
+            Some(reservation) => Some(Box::new(reservation.commit().await?)),
+            None => None,
+        };
+
         let participants = counter.accepts.into_iter().collect::<Vec<_>>();
         tracing::info!(?sign_id, round=?state.round(), me = ?ctx.governance.me, ?participants, "proposer broadcasting Start");
 
@@ -452,7 +467,7 @@ impl PositPhase {
                 )
                 .await;
         }
-        participants
+        Some((participants, committed))
     }
 }
 

--- a/chain-signatures/node/src/protocol/request/task.rs
+++ b/chain-signatures/node/src/protocol/request/task.rs
@@ -11,7 +11,9 @@ use super::*;
 pub struct GeneratingPhase {
     pub proposer: Participant,
     pub presignature_id: PresignatureId,
-    pub presignature: Option<PresignatureReservation>,
+    /// The presignature the proposer already committed before announcing START.
+    /// `None` for deliberators, which fetch it from storage instead.
+    pub presignature: Option<Box<PresignatureTaken>>,
     pub accepted_participants: Vec<Participant>,
 }
 
@@ -62,14 +64,9 @@ impl GeneratingPhase {
             "posit complete, starting generation"
         );
 
-        let presignature_pending = if let Some(reservation) = self.presignature.take() {
-            // Commit: actually remove from Redis now that posit succeeded and generation starts
-            match reservation.commit().await {
-                Some(taken) => PendingPresignature::Available(Box::new(taken)),
-                None => {
-                    return state.reorganize("failed to commit presignature reservation");
-                }
-            }
+        // Already committed in the posit phase, before START went out.
+        let presignature_pending = if let Some(taken) = self.presignature.take() {
+            PendingPresignature::Available(taken)
         } else {
             PendingPresignature::InStorage(
                 self.presignature_id,

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -474,38 +474,44 @@ impl TripleSpawner {
         positor: Positor<()>,
         timeout: Duration,
     ) {
-        if positor.is_proposer() {
-            for &to in &participants {
-                if to == self.me {
-                    continue;
-                }
-                self.msg
-                    .send(
-                        self.me,
-                        to,
-                        PositMessage {
-                            id: PositProtocolId::Triple(id),
-                            from: self.me,
-                            action: PositAction::Start(participants.clone()),
-                        },
-                    )
-                    .await;
-            }
-            self.ongoing_owned.insert(id);
-        }
+        let is_proposer = positor.is_proposer();
 
+        // Peers start generating as soon as START arrives. Announce only once we
+        // hold the slot: without us they cannot converge and stall until timeout.
         if let Err(err) = self
             .generate_with_id(id, &participants, positor.id(), timeout)
             .await
         {
-            self.ongoing_owned.remove(&id);
             tracing::warn!(
                 id,
                 ?participants,
-                is_proposer = positor.is_proposer(),
+                is_proposer,
                 ?err,
-                "unable to start triple generation on START"
+                "unable to start triple generation"
             );
+            return;
+        }
+
+        if !is_proposer {
+            return;
+        }
+
+        self.ongoing_owned.insert(id);
+        for &to in &participants {
+            if to == self.me {
+                continue;
+            }
+            self.msg
+                .send(
+                    self.me,
+                    to,
+                    PositMessage {
+                        id: PositProtocolId::Triple(id),
+                        from: self.me,
+                        action: PositAction::Start(participants.clone()),
+                    },
+                )
+                .await;
         }
     }
 

--- a/doc/posit_state_machine.md
+++ b/doc/posit_state_machine.md
@@ -117,12 +117,13 @@ stateDiagram-v2
     state "Organizing" as OrgIn
     state "<b>Propose sent</b>
     1. tally ACCEPT and REJECT
-    2. once enough ACCEPTs send START to accepters" as ProposeSent
+    2. once enough ACCEPTs, commit the presignature
+    3. send START to accepters" as ProposeSent
     state "Generating" as GenOut
 
     OrgIn --> ProposeSent: proposer, PROPOSE sent
     ProposeSent --> GenOut: START sent
-    ProposeSent --> OrgIn: too many REJECTs, or timeout
+    ProposeSent --> OrgIn: too many REJECTs, timeout, or commit failed
 
     classDef outside fill:#eef1f4,stroke:#9aa4b0,color:#48525e,stroke-dasharray:5 3
     class OrgIn,GenOut outside
@@ -207,7 +208,7 @@ wasted rounds and the repeated reservations.
 
 ```mermaid
 stateDiagram-v2
-    state "<b>Acquiring</b><br/>1. proposer commits its reservation, deliberator fetches the presignature from storage<br/>2. build the generator" as Acquiring
+    state "<b>Acquiring</b><br/>1. the proposer already holds its committed presignature, the deliberator fetches it from storage<br/>2. build the generator" as Acquiring
     state "<b>Signing</b><br/>1. poke cait-sith, relay SendMany and SendPrivate<br/>2. answer late PROPOSE with REJECT AlreadyGenerating<br/>3. Action Return carries big_r and s" as Signing
     state "<b>Recording</b><br/>1. reconstruct against the derived key<br/>2. mark the request publishing in the backlog<br/>3. proposer submits it" as Recording
     state "Posit" as PositIn
@@ -220,7 +221,7 @@ stateDiagram-v2
     Signing --> Recording: Action Return
     Recording --> DoneOut: Complete Ok
 
-    Acquiring --> OrgOut: commit failed, or generator build failed
+    Acquiring --> OrgOut: generator build failed
     Signing --> OrgOut: poke error, receive timeout, or inbox closed
 
     classDef outside fill:#eef1f4,stroke:#9aa4b0,color:#48525e,stroke-dasharray:5 3
@@ -341,6 +342,10 @@ because the round timeout ran out.
   `Propose received`; a deliberator that never gets a `PROPOSE` sends nothing.
 - **The proposer's `START` set is a subset of the accepters**, so every node in
   `Generating` has agreed to the same presignature for the same round.
+- **The proposer commits its presignature before `START` goes out.** Accepters
+  take theirs from storage the moment they see `START`, so a proposer that
+  announced first and then failed to commit would spend their copies on a round
+  it had already left.
 - **`Generating` is not preempted by a new round**; a node only leaves it by
   finishing or failing.
 


### PR DESCRIPTION
**Problem**: All three posit paths broadcast START before the work that can still fail, so a proposer that drops out after announcing leaves peers acting on a round it has abandoned. Presignature and signature lose the artifact on every peer but the owner.

**Fix**: Do the local work first, announce START on success. A failure now ends the round before peers hear about it, leaving them on the deliberator expiry path they already handle.

This makes the waste one-time instead of recurring, it does not remove it: the artifact is now orphaned on the holders rather than destroyed there while the proposer keeps re-serving it. Nothing prunes an artifact whose owner no longer holds it.