### PR TITLE
feat(loadtests): remote-write the bidirectional metrics to Prometheus

### DIFF
--- a/.github/workflows/k6-bidirectional-loadtest.yml
+++ b/.github/workflows/k6-bidirectional-loadtest.yml
@@ -46,8 +46,7 @@ concurrency:
 
 jobs:
   loadtest:
-    # Self-hosted: every run holds a runner for over an hour, and only this
-    # pool has the workload identity that reaches Secret Manager below.
+    # Self-hosted: every run holds a runner for over an hour.
     runs-on: arc-runner-set
     # Submission runs for lt_duration, then the scenario's 45m gracefulStop
     # lets in-flight jobs finish, so a 1h run occupies the runner for ~1h45m.
@@ -65,22 +64,15 @@ jobs:
         env:
           LT_PINGER_API_KEY: ${{ secrets.LT_PINGER_API_KEY }}
 
-      # The same three values the grafana-agent collectors remote-write with,
-      # read at run time rather than mirrored into repo secrets, so there is no
-      # second copy to keep level with the collectors'.
-      #
-      # Authenticated as near-dev-github, which holds secretAccessor on these
-      # three secrets and nothing else. The runner pods themselves have no GCP
-      # identity: they run as the arc-runners default service account, and the
-      # k8s-sa in that namespace belongs to the External Secrets controller
-      # rather than to jobs.
+      # near-dev-github holds secretAccessor on the three secrets below and
+      # nothing else. The runner pods have no GCP identity of their own.
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.SIG_CREDENTIALS_DEV }}'
 
-      # Masked outputs. `gcloud secrets versions access` into GITHUB_ENV would
-      # not mask, and would print them on any step that dumps the environment.
+      # The collectors' own credentials, read at run time so there is no second
+      # copy to keep level. Masked, which `gcloud ... >> GITHUB_ENV` is not.
       - name: Read Grafana credentials
         id: grafana
         uses: google-github-actions/get-secretmanager-secrets@v2
@@ -101,20 +93,14 @@ jobs:
           k6 run -o experimental-prometheus-rw \
             loadtests/k6-bidirectional.js 2>&1 | tee k6-bidirectional.log
         env:
-          # Metrics outlive the runner. Everything else here dies with the job:
-          # the summary is scraped into the step summary and then discarded.
           K6_PROMETHEUS_RW_SERVER_URL: ${{ steps.grafana.outputs.push_url }}
           K6_PROMETHEUS_RW_USERNAME: ${{ steps.grafana.outputs.username }}
           K6_PROMETHEUS_RW_PASSWORD: ${{ steps.grafana.outputs.password }}
-          # One series per trend instead of one per quantile, and the quantile
-          # is chosen at query time. Percentiles cannot be averaged, so with
-          # pre-computed stats any panel spanning more than one scrape is
-          # approximating; with histograms histogram_quantile() is exact over
-          # whatever window is asked for.
+          # Percentiles cannot be averaged, so pre-computed stats are wrong
+          # over any window but one scrape. Histograms are exact over any.
           K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM: 'true'
-          # No run_id tag on purpose: it would mint a fresh set of series every
-          # run and fragment every panel wider than one run. Runs are separated
-          # in time, so the time range is the run.
+          # No run_id tag: runs are separated in time, so the range is the run,
+          # and the label would fragment every panel wider than one.
           LT_PINGER_API_KEY: ${{ secrets.LT_PINGER_API_KEY }}
           LT_CHAIN_ENV: ${{ inputs.environment }}
           LT_STRATEGY: ${{ inputs.lt_strategy }}

--- a/.github/workflows/k6-bidirectional-loadtest.yml
+++ b/.github/workflows/k6-bidirectional-loadtest.yml
@@ -66,13 +66,21 @@ jobs:
           LT_PINGER_API_KEY: ${{ secrets.LT_PINGER_API_KEY }}
 
       # The same three values the grafana-agent collectors remote-write with,
-      # read at run time rather than mirrored into repo secrets. The runner's
-      # Kubernetes service account already reaches Secret Manager, so there is
-      # no second copy to keep level with the collectors'.
+      # read at run time rather than mirrored into repo secrets, so there is no
+      # second copy to keep level with the collectors'.
       #
-      # This action registers them as masked outputs; `gcloud secrets versions
-      # access` into GITHUB_ENV would not, and would print them on any step
-      # that dumps the environment.
+      # Authenticated as near-dev-github, which holds secretAccessor on these
+      # three secrets and nothing else. The runner pods themselves have no GCP
+      # identity: they run as the arc-runners default service account, and the
+      # k8s-sa in that namespace belongs to the External Secrets controller
+      # rather than to jobs.
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.SIG_CREDENTIALS_DEV }}'
+
+      # Masked outputs. `gcloud secrets versions access` into GITHUB_ENV would
+      # not mask, and would print them on any step that dumps the environment.
       - name: Read Grafana credentials
         id: grafana
         uses: google-github-actions/get-secretmanager-secrets@v2

--- a/.github/workflows/k6-bidirectional-loadtest.yml
+++ b/.github/workflows/k6-bidirectional-loadtest.yml
@@ -46,7 +46,9 @@ concurrency:
 
 jobs:
   loadtest:
-    runs-on: ubuntu-latest
+    # Self-hosted: every run holds a runner for over an hour, and only this
+    # pool has the workload identity that reaches Secret Manager below.
+    runs-on: arc-runner-set
     # Submission runs for lt_duration, then the scenario's 45m gracefulStop
     # lets in-flight jobs finish, so a 1h run occupies the runner for ~1h45m.
     timeout-minutes: 120
@@ -63,6 +65,23 @@ jobs:
         env:
           LT_PINGER_API_KEY: ${{ secrets.LT_PINGER_API_KEY }}
 
+      # The same three values the grafana-agent collectors remote-write with,
+      # read at run time rather than mirrored into repo secrets. The runner's
+      # Kubernetes service account already reaches Secret Manager, so there is
+      # no second copy to keep level with the collectors'.
+      #
+      # This action registers them as masked outputs; `gcloud secrets versions
+      # access` into GITHUB_ENV would not, and would print them on any step
+      # that dumps the environment.
+      - name: Read Grafana credentials
+        id: grafana
+        uses: google-github-actions/get-secretmanager-secrets@v2
+        with:
+          secrets: |-
+            push_url:near-cs-dev/prom-push-url
+            username:near-cs-dev/grafana-username
+            password:near-cs-dev/grafana_cloud_pswd
+
       - uses: grafana/setup-k6-action@v1
 
       # Run k6 directly, not through run-k6-action: the script's thresholds are
@@ -71,8 +90,23 @@ jobs:
       - name: Run k6
         run: |
           set -euo pipefail
-          k6 run loadtests/k6-bidirectional.js 2>&1 | tee k6-bidirectional.log
+          k6 run -o experimental-prometheus-rw \
+            loadtests/k6-bidirectional.js 2>&1 | tee k6-bidirectional.log
         env:
+          # Metrics outlive the runner. Everything else here dies with the job:
+          # the summary is scraped into the step summary and then discarded.
+          K6_PROMETHEUS_RW_SERVER_URL: ${{ steps.grafana.outputs.push_url }}
+          K6_PROMETHEUS_RW_USERNAME: ${{ steps.grafana.outputs.username }}
+          K6_PROMETHEUS_RW_PASSWORD: ${{ steps.grafana.outputs.password }}
+          # One series per trend instead of one per quantile, and the quantile
+          # is chosen at query time. Percentiles cannot be averaged, so with
+          # pre-computed stats any panel spanning more than one scrape is
+          # approximating; with histograms histogram_quantile() is exact over
+          # whatever window is asked for.
+          K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM: 'true'
+          # No run_id tag on purpose: it would mint a fresh set of series every
+          # run and fragment every panel wider than one run. Runs are separated
+          # in time, so the time range is the run.
           LT_PINGER_API_KEY: ${{ secrets.LT_PINGER_API_KEY }}
           LT_CHAIN_ENV: ${{ inputs.environment }}
           LT_STRATEGY: ${{ inputs.lt_strategy }}

--- a/loadtests/k6-bidirectional.js
+++ b/loadtests/k6-bidirectional.js
@@ -1,6 +1,6 @@
 import http from 'k6/http';
 import { check, fail, sleep } from 'k6';
-import { Trend, Rate, Counter } from 'k6/metrics';
+import { Trend, Rate, Counter, Gauge } from 'k6/metrics';
 
 // Load test for the Solana -> Ethereum bidirectional round trip.
 //
@@ -13,11 +13,23 @@ const BASE_URL = __ENV.LT_PINGER_URL || 'https://contract-ping.sig.network';
 
 // The service's own phase timings, not wall-clock around our polling, which
 // would fold the poll interval into whichever phase ended between two polls.
-const leaseWait = new Trend('bidi_lease_wait_ms', true);
-const signature = new Trend('bidi_signature_ms', true);
-const confirmation = new Trend('bidi_confirmation_ms', true);
-const respond = new Trend('bidi_respond_ms', true);
-const total = new Trend('bidi_total_ms', true);
+//
+// Seconds, not the milliseconds the API returns: these are remote-written to
+// Prometheus, which expects base units and a _seconds suffix. That also costs
+// the summary's "17m30s" formatting, since k6 only pretty-prints times it is
+// told are milliseconds — the suffix is the unit now.
+const SEC = 1000;
+const leaseWait = new Trend('bidi_lease_wait_seconds');
+const signature = new Trend('bidi_signature_seconds');
+const confirmation = new Trend('bidi_confirmation_seconds');
+const respond = new Trend('bidi_respond_seconds');
+const total = new Trend('bidi_total_seconds');
+
+// Read once in setup(), so a run records the pool it actually ran against
+// rather than leaving that in a log line nothing can query later.
+const workersTotal = new Gauge('bidi_workers_total');
+const workersUnderfunded = new Gauge('bidi_workers_underfunded');
+const workerBalanceMin = new Gauge('bidi_worker_balance_min_eth');
 
 const success = new Rate('bidi_success');
 
@@ -136,6 +148,14 @@ export function setup() {
 
   const workers = res.json('workers') || [];
   const short = workers.filter(w => w.underfunded);
+
+  // Recorded before the shortfall check below, so an aborted run still says
+  // how short the pool was rather than only that it was short.
+  const balances = workers.map(w => Number(w.balanceWei) / 1e18);
+  workersTotal.add(workers.length);
+  workersUnderfunded.add(short.length);
+  if (balances.length > 0) workerBalanceMin.add(Math.min(...balances));
+
   console.log(
     `${workers.length} derived addresses, ${short.length} below the minimum`
   );
@@ -205,11 +225,11 @@ export default function () {
     if (state !== 'responded' && state !== 'failed') continue;
 
     const d = view.json('durations') || {};
-    if (d.leaseWaitMs !== undefined) leaseWait.add(d.leaseWaitMs);
-    if (d.signatureMs !== undefined) signature.add(d.signatureMs);
-    if (d.confirmationMs !== undefined) confirmation.add(d.confirmationMs);
-    if (d.respondMs !== undefined) respond.add(d.respondMs);
-    if (d.totalMs !== undefined) total.add(d.totalMs);
+    if (d.leaseWaitMs !== undefined) leaseWait.add(d.leaseWaitMs / SEC);
+    if (d.signatureMs !== undefined) signature.add(d.signatureMs / SEC);
+    if (d.confirmationMs !== undefined) confirmation.add(d.confirmationMs / SEC);
+    if (d.respondMs !== undefined) respond.add(d.respondMs / SEC);
+    if (d.totalMs !== undefined) total.add(d.totalMs / SEC);
 
     if (state === 'responded') {
       success.add(true);

--- a/loadtests/k6-bidirectional.js
+++ b/loadtests/k6-bidirectional.js
@@ -14,10 +14,8 @@ const BASE_URL = __ENV.LT_PINGER_URL || 'https://contract-ping.sig.network';
 // The service's own phase timings, not wall-clock around our polling, which
 // would fold the poll interval into whichever phase ended between two polls.
 //
-// Seconds, not the milliseconds the API returns: these are remote-written to
-// Prometheus, which expects base units and a _seconds suffix. That also costs
-// the summary's "17m30s" formatting, since k6 only pretty-prints times it is
-// told are milliseconds — the suffix is the unit now.
+// Seconds, not the milliseconds the API returns: Prometheus expects base units.
+// That costs the summary's "17m30s" formatting, which only applies to ms.
 const SEC = 1000;
 const leaseWait = new Trend('bidi_lease_wait_seconds');
 const signature = new Trend('bidi_signature_seconds');
@@ -25,8 +23,8 @@ const confirmation = new Trend('bidi_confirmation_seconds');
 const respond = new Trend('bidi_respond_seconds');
 const total = new Trend('bidi_total_seconds');
 
-// Read once in setup(), so a run records the pool it actually ran against
-// rather than leaving that in a log line nothing can query later.
+// Read once in setup(): the pool a run actually ran against, rather than a log
+// line nothing can query later.
 const workersTotal = new Gauge('bidi_workers_total');
 const workersUnderfunded = new Gauge('bidi_workers_underfunded');
 const workerBalanceMin = new Gauge('bidi_worker_balance_min_eth');
@@ -149,8 +147,7 @@ export function setup() {
   const workers = res.json('workers') || [];
   const short = workers.filter(w => w.underfunded);
 
-  // Recorded before the shortfall check below, so an aborted run still says
-  // how short the pool was rather than only that it was short.
+  // Before the shortfall check, so an aborted run still records how short.
   const balances = workers.map(w => Number(w.balanceWei) / 1e18);
   workersTotal.add(workers.length);
   workersUnderfunded.add(short.length);


### PR DESCRIPTION
[Issue #1276](https://github.com/sig-net/mpc/issues/1276)
The run's numbers died with the runner, so "has the respond leg drifted since last week" had no way to be asked. 

- This streams them to the same Grafana Cloud endpoint the collectors already write to.

- Credentials come from Secret Manager at run time rather than a mirrored repo secret — `near-dev-github` now holds `secretAccessor` on those three secrets and nothing else. 

- switched to Arc runner set for cost efficiency and it is the option with access to the credentials above

Verified on a live run: all ten `k6_bidi_*` series land and `histogram_quantile` matches the k6 summary.