### PR TITLE
feat(loadtests): schedule the bidirectional load test

### DIFF
--- a/.github/workflows/k6-bidirectional-loadtest.yml
+++ b/.github/workflows/k6-bidirectional-loadtest.yml
@@ -4,10 +4,8 @@ name: k6 Bidirectional Load Test
 # loadtests/k6-bidirectional.js.
 #
 # Every job spends gas from addresses only a funding sweep refills, so the
-# cadence is a standing cost: ~120 round trips a run at the scheduled defaults.
-#
-# Ticking every 20 minutes rather than once a run. A tick landing mid-run
-# creates nothing, so frequent ticks only shorten the wait for the next one.
+# cadence is a standing cost. A tick landing mid-run creates no run, so the
+# short interval only shortens the wait after one ends.
 on:
   schedule:
     - cron: '*/20 * * * *'
@@ -35,27 +33,38 @@ on:
         description: MPC network
         type: choice
         options:
+          - both
           - dev
           - testnet
-        default: dev
+        default: both
         required: true
 
 permissions:
   contents: read
 
-# One run at a time: overlapping runs would double the arrival rate a run
-# claims to apply. Queued rather than cancelled, since cancelling mid-flight
-# abandons jobs whose Ethereum transaction is already paid for.
-concurrency:
-  group: k6-bidirectional-loadtest
-  cancel-in-progress: false
-
 jobs:
   loadtest:
+    strategy:
+      # Add an option above without adding it here and the run fails rather
+      # than silently driving both. A schedule carries no inputs, hence ''.
+      matrix:
+        environment: ${{ (inputs.environment == 'dev' && fromJSON('["dev"]'))
+          || (inputs.environment == 'testnet' && fromJSON('["testnet"]'))
+          || ((inputs.environment == 'both' || inputs.environment == '')
+              && fromJSON('["dev","testnet"]'))
+          || fromJSON('["unmatched"]') }}
+      # The networks hold separate address pools and rate limits, so they
+      # need no max-parallel.
+      fail-fast: false
+    # Per network: overlapping runs would double the arrival rate one claims
+    # to apply. Queued, since cancelling abandons jobs already paid for.
+    concurrency:
+      group: k6-bidirectional-${{ matrix.environment }}
+      cancel-in-progress: false
     # Self-hosted: every run holds a runner for over an hour.
     runs-on: arc-runner-set
     # Submission runs for lt_duration, then the scenario's 45m gracefulStop
-    # lets in-flight jobs finish, so the scheduled 2h submits for ~2h45m.
+    # lets in-flight jobs finish.
     timeout-minutes: 200
     steps:
       - uses: actions/checkout@v6
@@ -67,8 +76,17 @@ jobs:
             echo "::error::Missing required secret: LT_PINGER_API_KEY"
             exit 1
           fi
+          # What the matrix yields for an unrecognised input.
+          case "${LT_CHAIN_ENV}" in
+            dev | testnet) ;;
+            *)
+              echo "::error::Unhandled environment '${LT_CHAIN_ENV}': add it to the matrix"
+              exit 1
+              ;;
+          esac
         env:
           LT_PINGER_API_KEY: ${{ secrets.LT_PINGER_API_KEY }}
+          LT_CHAIN_ENV: ${{ matrix.environment }}
 
       # near-dev-github holds secretAccessor on the three secrets below and
       # nothing else. The runner pods have no GCP identity of their own.
@@ -97,6 +115,7 @@ jobs:
         run: |
           set -euo pipefail
           k6 run -o experimental-prometheus-rw \
+            --tag env="${LT_CHAIN_ENV}" \
             loadtests/k6-bidirectional.js 2>&1 | tee k6-bidirectional.log
         env:
           K6_PROMETHEUS_RW_SERVER_URL: ${{ steps.grafana.outputs.push_url }}
@@ -106,9 +125,10 @@ jobs:
           # over any window but one scrape. Histograms are exact over any.
           K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM: 'true'
           # No run_id tag: runs are separated in time, so the range is the run,
-          # and the label would fragment every panel wider than one.
+          # and the label would fragment every panel wider than one. env is
+          # needed: without it both networks write the same series.
           LT_PINGER_API_KEY: ${{ secrets.LT_PINGER_API_KEY }}
-          LT_CHAIN_ENV: ${{ inputs.environment || 'dev' }}
+          LT_CHAIN_ENV: ${{ matrix.environment }}
           LT_STRATEGY: ${{ inputs.lt_strategy || 'rpm_1' }}
           LT_DURATION: ${{ inputs.lt_duration || '2h' }}
 
@@ -118,7 +138,7 @@ jobs:
           {
             echo "## k6 Bidirectional Load Test"
             echo
-            echo "- Network: \`${{ inputs.environment || 'dev' }}\`"
+            echo "- Network: \`${{ matrix.environment }}\`"
             echo "- Rate: \`${{ inputs.lt_strategy || 'rpm_1' }}\` submitting for \`${{ inputs.lt_duration || '2h' }}\`"
             echo
             if [ -f k6-bidirectional.log ]; then

--- a/.github/workflows/k6-bidirectional-loadtest.yml
+++ b/.github/workflows/k6-bidirectional-loadtest.yml
@@ -3,9 +3,14 @@ name: k6 Bidirectional Load Test
 # Drives the Solana -> Ethereum bidirectional round trip via
 # loadtests/k6-bidirectional.js.
 #
-# Dispatch only: every job broadcasts an Ethereum transaction and spends gas
-# from derived addresses that only a funding sweep refills.
+# Every job spends gas from addresses only a funding sweep refills, so the
+# cadence is a standing cost: ~120 round trips a run at the scheduled defaults.
+#
+# Ticking every 20 minutes rather than once a run. A tick landing mid-run
+# creates nothing, so frequent ticks only shorten the wait for the next one.
 on:
+  schedule:
+    - cron: '*/20 * * * *'
   workflow_dispatch:
     inputs:
       lt_strategy:
@@ -17,12 +22,13 @@ on:
         default: rpm_1
         required: true
       lt_duration:
-        description: How long to submit for, not how long the run takes
+        description: How long to submit for, not how long the run takes (cron uses 2h)
         type: choice
         options:
           - 5m
           - 20m
           - 1h
+          - 2h
         default: 20m
         required: true
       environment:
@@ -37,9 +43,9 @@ on:
 permissions:
   contents: read
 
-# The derived addresses are shared state: concurrent runs collide on their
-# nonces. Queued rather than cancelled, since cancelling mid-flight abandons
-# jobs whose Ethereum transaction is already paid for.
+# One run at a time: overlapping runs would double the arrival rate a run
+# claims to apply. Queued rather than cancelled, since cancelling mid-flight
+# abandons jobs whose Ethereum transaction is already paid for.
 concurrency:
   group: k6-bidirectional-loadtest
   cancel-in-progress: false
@@ -49,8 +55,8 @@ jobs:
     # Self-hosted: every run holds a runner for over an hour.
     runs-on: arc-runner-set
     # Submission runs for lt_duration, then the scenario's 45m gracefulStop
-    # lets in-flight jobs finish, so a 1h run occupies the runner for ~1h45m.
-    timeout-minutes: 120
+    # lets in-flight jobs finish, so the scheduled 2h submits for ~2h45m.
+    timeout-minutes: 200
     steps:
       - uses: actions/checkout@v6
 
@@ -102,9 +108,9 @@ jobs:
           # No run_id tag: runs are separated in time, so the range is the run,
           # and the label would fragment every panel wider than one.
           LT_PINGER_API_KEY: ${{ secrets.LT_PINGER_API_KEY }}
-          LT_CHAIN_ENV: ${{ inputs.environment }}
-          LT_STRATEGY: ${{ inputs.lt_strategy }}
-          LT_DURATION: ${{ inputs.lt_duration }}
+          LT_CHAIN_ENV: ${{ inputs.environment || 'dev' }}
+          LT_STRATEGY: ${{ inputs.lt_strategy || 'rpm_1' }}
+          LT_DURATION: ${{ inputs.lt_duration || '2h' }}
 
       - name: Write job summary
         if: always()
@@ -112,8 +118,8 @@ jobs:
           {
             echo "## k6 Bidirectional Load Test"
             echo
-            echo "- Network: \`${{ inputs.environment }}\`"
-            echo "- Rate: \`${{ inputs.lt_strategy }}\` submitting for \`${{ inputs.lt_duration }}\`"
+            echo "- Network: \`${{ inputs.environment || 'dev' }}\`"
+            echo "- Rate: \`${{ inputs.lt_strategy || 'rpm_1' }}\` submitting for \`${{ inputs.lt_duration || '2h' }}\`"
             echo
             if [ -f k6-bidirectional.log ]; then
               echo '```'

--- a/loadtests/k6-bidirectional.js
+++ b/loadtests/k6-bidirectional.js
@@ -160,10 +160,9 @@ export function setup() {
     console.warn(`  underfunded: ${w.path} ${w.address} holds ${w.balanceWei} wei`);
   }
 
-  // A lease is released at confirmation, so it lasts ~30s rather than the
-  // round trip: one address covers about a job a minute, and the pool only has
-  // to cover the arrival rate. Short addresses are skipped by the service, not
-  // fatal to it.
+  // A lease ends at confirmation, not at the round trip, so one address covers
+  // roughly a job a minute and the pool only has to cover the arrival rate.
+  // The service skips short addresses rather than failing on them.
   // options is k6's own by now; strategies is this module's.
   const perMinute = strategies[__ENV.LT_STRATEGY].scenarios.bidirectional.rate;
   const funded = workers.length - short.length;

--- a/loadtests/k6-bidirectional.js
+++ b/loadtests/k6-bidirectional.js
@@ -160,11 +160,16 @@ export function setup() {
     console.warn(`  underfunded: ${w.path} ${w.address} holds ${w.balanceWei} wei`);
   }
 
-  // Any shortfall, not merely a total one: the address count sets concurrency,
-  // so a partly funded pool measures a narrower pool than the run claims.
-  if (short.length > 0) {
+  // A lease is released at confirmation, so it lasts ~30s rather than the
+  // round trip: one address covers about a job a minute, and the pool only has
+  // to cover the arrival rate. Short addresses are skipped by the service, not
+  // fatal to it.
+  // options is k6's own by now; strategies is this module's.
+  const perMinute = strategies[__ENV.LT_STRATEGY].scenarios.bidirectional.rate;
+  const funded = workers.length - short.length;
+  if (funded < perMinute) {
     fail(
-      `${short.length}/${workers.length} addresses underfunded; fund them before running`
+      `${funded}/${workers.length} addresses funded, ${perMinute} needed at ${perMinute}/min`
     );
   }
   return { env };


### PR DESCRIPTION
- Adds `cron: '*/20 * * * *'`. A run keeps going ~35 min after it stops submitting, so a cron firing once per run leaves that long a hole. Ticks landing mid-run create nothing, so frequent ticks cost nothing and only shorten the wait.
- Whether the gap lands near zero or up to 20 min depends on whether GitHub drops those ticks or queues them. A day of runs will say; the interval is one line to tune.
- Schedule submits for 2h. The tail is fixed per run, so a longer window amortises it — 20m submits for 36% of a run, 2h for 77%.

Stacked on #1289.

